### PR TITLE
Duplicate Pagination Controls Above List

### DIFF
--- a/jobserver/templates/_job_request_pagination.html
+++ b/jobserver/templates/_job_request_pagination.html
@@ -1,0 +1,29 @@
+{% load querystring_tools %}
+
+<div class="d-flex justify-content-between my-3">
+
+  <div>
+    <span class="{% if not page_obj.has_previous %}d-none{% endif %}">
+      {% if page_obj.has_previous %}
+      <a class="btn btn-secondary btn-sm" href="{% url_with_querystring page=page_obj.previous_page_number %}">
+        Previous
+      </a>
+      {% endif %}
+    </span>
+  </div>
+
+  <div class="current">
+    Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+  </div>
+
+  <div>
+    <span class="{% if not page_obj.has_next %}d-none{% endif %}">
+      {% if page_obj.has_next %}
+      <a class="btn btn-secondary btn-sm" href="{% url_with_querystring page=page_obj.next_page_number %}">
+        Next
+      </a>
+      {% endif %}
+    </span>
+  </div>
+
+</div>

--- a/jobserver/templates/_job_requests.html
+++ b/jobserver/templates/_job_requests.html
@@ -1,5 +1,4 @@
 {% load humanize %}
-{% load querystring_tools %}
 {% load runtime %}
 
 <div class="job-requests">
@@ -86,30 +85,4 @@
 
 </div>
 
-<div class="d-flex justify-content-between my-3">
-
-  <div>
-    <span class="{% if not page_obj.has_previous %}d-none{% endif %}">
-      {% if page_obj.has_previous %}
-      <a class="btn btn-secondary btn-sm" href="{% url_with_querystring page=page_obj.previous_page_number %}">
-        Previous
-      </a>
-      {% endif %}
-    </span>
-  </div>
-
-  <div class="current">
-    Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
-  </div>
-
-  <div>
-    <span class="{% if not page_obj.has_next %}d-none{% endif %}">
-      {% if page_obj.has_next %}
-      <a class="btn btn-secondary btn-sm" href="{% url_with_querystring page=page_obj.next_page_number %}">
-        Next
-      </a>
-      {% endif %}
-    </span>
-  </div>
-
-</div>
+{% include "_job_request_pagination.html" %}

--- a/jobserver/templates/_job_requests.html
+++ b/jobserver/templates/_job_requests.html
@@ -1,6 +1,8 @@
 {% load humanize %}
 {% load runtime %}
 
+{% include "_job_request_pagination.html" %}
+
 <div class="job-requests">
   <div class="d-flex">
     <div class="status"></div>


### PR DESCRIPTION
This duplicates the pagination controls for a list of JobRequests (used on the Event Log & Workspace Logs pages) to the top of that list, saving a User the need to scroll to the bottom of the list each time they want to go to the next page.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/2NuERLJq/11195531-ea44-490a-9a52-4e385a7ac073.jpg?v=ca0e90b3860438453df9d1b4a3eb8621)