### PR TITLE
Look Up JobRequest by Identifier

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -33,6 +33,10 @@ class JobRequestCreateForm(forms.ModelForm):
             )
 
 
+class JobRequestSearchForm(forms.Form):
+    identifier = forms.CharField()
+
+
 class SettingsForm(forms.ModelForm):
     class Meta:
         fields = [

--- a/jobserver/templates/job_request_list.html
+++ b/jobserver/templates/job_request_list.html
@@ -27,6 +27,36 @@
     </form>
 
 
+      {% if request.user.is_superuser %}
+      <div class="mb-4">
+
+        {% if form.non_field_errors %}
+        <ul>
+          {% for error in form.non_field_errors %}
+          <li class="text-danger">{{ error }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+        <form class="form d-flex align-items-center mb-1" method="POST">
+          {% csrf_token %}
+          <input
+            class="form-control mr-2"
+            type="search"
+            placeholder="Look up JobRequest by Identifier"
+            aria-label="Go"
+            name="identifier" />
+          <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Go</button>
+
+        </form>
+
+        {% for error in form.identifier.errors %}
+        <p class="text-danger" style="margin-left:.75rem">{{ error }}</p>
+        {% endfor %}
+
+      </div>
+      {% endif %}
+
       {% if not page_obj %}
       <div class="text-center">
         <p>No results found.</p>

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -282,6 +282,41 @@ def test_jobrequestlist_filter_by_workspace(rf):
 
 
 @pytest.mark.django_db
+def test_jobrequestlist_find_job_request_by_identifier_form_invalid(rf):
+    request = rf.post(MEANINGLESS_URL, {"test-key": "test-value"})
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 200
+
+    expected = {"identifier": ["This field is required."]}
+    assert response.context_data["form"].errors == expected
+
+
+@pytest.mark.django_db
+def test_jobrequestlist_find_job_request_by_identifier_success(rf):
+    job_request = JobRequestFactory(identifier="test-identifier")
+
+    request = rf.post(MEANINGLESS_URL, {"identifier": job_request.identifier})
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 302
+    assert response.url == job_request.get_absolute_url()
+
+
+@pytest.mark.django_db
+def test_jobrequestlist_find_job_request_by_identifier_unknown_job_request(rf):
+    request = rf.post(MEANINGLESS_URL, {"identifier": "test-value"})
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 200
+
+    expected = {
+        "identifier": ["Could not find a JobRequest with the identfier 'test-value'"],
+    }
+    assert response.context_data["form"].errors == expected
+
+
+@pytest.mark.django_db
 def test_jobrequestlist_search_by_action(rf):
     job_request1 = JobRequestFactory()
     JobFactory(job_request=job_request1, action="run")


### PR DESCRIPTION
This adds an input the Event Log page to jump to a JobRequest by its Identifier field (which we expose in the job-runner logs).  It's only shown to superusers as we don't use identifiers to reference JobRequests for Users.

The Event Log page doesn't feel like the best possible place (suggestions welcome!), but given that page is a list of JobRequests it felt like the obvious place until a better one is found.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/xQunpXez/6e4dc5d4-e2e4-4ebc-ac00-248b9d02428f.jpg?v=a94b138dbb1c680276153ed8478ce610)

Fixes #338 