### PR TITLE
Expose JobRequest Errors

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -242,6 +242,20 @@ class JobRequest(models.Model):
         return f.url
 
     @property
+    def is_invalid(self):
+        """
+        Is this JobRequest invalid?
+
+        JobRequests are a request for a given configuration to be run on a
+        Backend.  That configuration could be unprocessable for a variety of
+        reasons when the Backend looks at it.  We currently surface that to
+        job-server by job-runner creating a Job with the action `__error__`.
+        This property finds Jobs with that action so we can easily see if this
+        particular request was valid or not.
+        """
+        return self.jobs.filter(action="__error__").exists()
+
+    @property
     def num_completed(self):
         return len([j for j in self.jobs.all() if j.status == "succeeded"])
 

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -55,7 +55,7 @@
       <div>
         <strong>Status Message:</strong>
         {% if job.status_message %}
-        <pre>{{ job.status_message }}</pre>
+        <pre class="text-wrap">{{ job.status_message }}</pre>
         {% else %}-{% endif %}
 
         {% status_hint job %}

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -157,6 +157,7 @@
 
 </div>
 
+{% if not jobrequest.is_invalid %}
 <div class="row mb-3">
   <div class="col-md-9 col-lg-8 offset-lg-2">
 
@@ -184,5 +185,6 @@
 
   </div>
 </div>
+{% endif %}
 
 {% endblock content %}

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -46,6 +46,11 @@
         <strong>Status:</strong>
         <code>{{ jobrequest.status }}</code>
       </div>
+
+      {% if jobrequest.is_invalid %}
+      <pre class="text-wrap">{{ jobrequest.jobs.first.status_message }}</pre>
+      {% endif %}
+
     </div>
 
     <div class="mb-4">

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -176,7 +176,8 @@
         {% endfor %}
       </tbody>
     </table>
-    {% endblock content %}
 
   </div>
 </div>
+
+{% endblock content %}

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -128,7 +128,9 @@ class JobZombify(View):
 
 class JobRequestDetail(DetailView):
     model = JobRequest
-    queryset = JobRequest.objects.select_related("workspace").prefetch_related("jobs")
+    queryset = JobRequest.objects.select_related(
+        "created_by", "workspace"
+    ).prefetch_related("jobs")
     template_name = "job_request_detail.html"
 
 


### PR DESCRIPTION
This hides the non-standard `__error__` Jobs from Users and bubbles their status message up to the JobRequest page.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/rRukEyw4/c589e1aa-ec2f-4124-80df-fd8c2d7bd108.jpg?v=c5260a4f08f7d0205fcc0f21da8f0158)

Fixes #275