### PR TITLE
Master -> Main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,3 +130,4 @@ jobs:
           app-name: "job-server"
           dokku-host: ${{ secrets.DOKKU_HOST }}
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          remote-branch: "main"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
     needs: [test, lint-dockerfile]
     runs-on: ubuntu-latest
 
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 
 .PHONY: deploy
 deploy:
-	git push dokku master
+	git push dokku main
 
 .PHONY: fix
 fix:

--- a/tests/jobserver/test_github.py
+++ b/tests/jobserver/test_github.py
@@ -14,10 +14,10 @@ from jobserver.github import (
 
 @responses.activate
 def test_get_branch():
-    expected_url = "https://api.github.com/repos/opensafely/some_repo/branches/master"
+    expected_url = "https://api.github.com/repos/opensafely/some_repo/branches/main"
     responses.add(responses.GET, expected_url, json={"test": "test"}, status=200)
 
-    output = get_branch("some_repo", "master")
+    output = get_branch("some_repo", "main")
 
     assert len(responses.calls) == 1
 
@@ -33,10 +33,10 @@ def test_get_branch():
 
 @responses.activate
 def test_get_branch_with_missing_branch():
-    expected_url = "https://api.github.com/repos/opensafely/some_repo/branches/master"
+    expected_url = "https://api.github.com/repos/opensafely/some_repo/branches/main"
     responses.add(responses.GET, expected_url, status=404)
 
-    output = get_branch("some_repo", "master")
+    output = get_branch("some_repo", "main")
 
     assert len(responses.calls) == 1
     assert output is None
@@ -50,24 +50,24 @@ def test_get_branch_sha():
     }
 
     with patch("jobserver.github.get_branch", lambda r, b: data):
-        output = get_branch_sha("some_repo", "master")
+        output = get_branch_sha("some_repo", "main")
 
     assert output == "abc123"
 
 
 def test_get_branch_sha_with_missing_branch():
     with patch("jobserver.github.get_branch", lambda r, b: None):
-        output = get_branch_sha("some_repo", "master")
+        output = get_branch_sha("some_repo", "main")
 
     assert output is None
 
 
 @responses.activate
 def test_get_file():
-    expected_url = "https://api.github.com/repos/opensafely/some_repo/contents/project.yaml?ref=master"
+    expected_url = "https://api.github.com/repos/opensafely/some_repo/contents/project.yaml?ref=main"
     responses.add(responses.GET, expected_url, body="a file!", status=200)
 
-    get_file("some_repo", "master")
+    get_file("some_repo", "main")
 
     assert len(responses.calls) == 1
 

--- a/tests/jobserver/test_project.py
+++ b/tests/jobserver/test_project.py
@@ -14,7 +14,7 @@ def test_get_actions_empty_needs():
     """
 
     with patch("jobserver.project.get_file", lambda r, b: dummy_yaml):
-        output = list(get_actions("test", "master", {"frobnicate": "test"}))
+        output = list(get_actions("test", "main", {"frobnicate": "test"}))
 
     expected = [
         {"name": "frobnicate", "needs": [], "status": "test"},
@@ -26,15 +26,15 @@ def test_get_actions_empty_needs():
 def test_get_actions_no_branch():
     with patch("jobserver.project.get_file", lambda r, b: None), patch(
         "jobserver.project.get_branch", lambda r, b: None
-    ), pytest.raises(Exception, match="Missing branch: 'master'"):
-        list(get_actions("test", "master", {}))
+    ), pytest.raises(Exception, match="Missing branch: 'main'"):
+        list(get_actions("test", "main", {}))
 
 
 def test_get_actions_no_project_yaml():
     with patch("jobserver.project.get_file", lambda r, b: None), patch(
         "jobserver.project.get_branch", lambda r, b: True
     ), pytest.raises(Exception, match="Could not find project.yaml"):
-        list(get_actions("test", "master", {}))
+        list(get_actions("test", "main", {}))
 
 
 def test_get_actions_no_run_all():
@@ -51,7 +51,7 @@ def test_get_actions_no_run_all():
     }
 
     with patch("jobserver.project.get_file", lambda r, b: dummy_yaml):
-        output = list(get_actions("test", "master", action_status_lut))
+        output = list(get_actions("test", "main", action_status_lut))
 
     expected = [
         {"name": "frobnicate", "needs": [], "status": "running"},
@@ -70,7 +70,7 @@ def test_get_actions_invalid_yaml():
     with patch("jobserver.project.get_file", lambda r, b: dummy_yaml), pytest.raises(
         ScannerError
     ):
-        list(get_actions("test", "master", {}))
+        list(get_actions("test", "main", {}))
 
 
 def test_get_actions_success():
@@ -80,7 +80,7 @@ def test_get_actions_success():
     """
 
     with patch("jobserver.project.get_file", lambda r, b: dummy_yaml):
-        output = list(get_actions("test", "master", {"frobnicate": "test"}))
+        output = list(get_actions("test", "main", {"frobnicate": "test"}))
 
     expected = [
         {"name": "frobnicate", "needs": [], "status": "test"},


### PR DESCRIPTION
This replaces references to the branch `master` with `main`, including fixing the deploy related bits to do the same.