### PR TITLE
Clean up DB Connection Config

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -99,9 +99,7 @@ WSGI_APPLICATION = "jobserver.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
-DATABASES = {
-    "default": dj_database_url.config(default="sqlite:///db.sqlite3", conn_max_age=600)
-}
+DATABASES = {"default": dj_database_url.config(default="sqlite:///db.sqlite3")}
 
 
 # Password validation

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 import os
 
-import dj_database_url
 from django.contrib.messages import constants as messages
 from django.urls import reverse_lazy
 from environs import Env
@@ -99,7 +98,7 @@ WSGI_APPLICATION = "jobserver.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
-DATABASES = {"default": dj_database_url.config(default="sqlite:///db.sqlite3")}
+DATABASES = {"default": env.dj_db_url("DATABASE_URL", default="sqlite:///db.sqlite3")}
 
 
 # Password validation

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,9 @@
 attrs
-dj-database-url
 django-anymail[mailgun]
 django-crispy-forms
 django-rest-framework
 django-structlog
-environs
+environs[django]
 first
 furl
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,9 +47,13 @@ defusedxml==0.6.0
 distlib==0.3.1
     # via virtualenv
 dj-database-url==0.5.0
-    # via -r requirements.in
+    # via environs
+dj-email-url==1.0.2
+    # via environs
 django-anymail[mailgun]==8.2
     # via -r requirements.in
+django-cache-url==3.2.3
+    # via environs
 django-crispy-forms==1.11.0
     # via -r requirements.in
 django-debug-toolbar==3.2
@@ -70,7 +74,7 @@ django==3.1.2
     #   djangorestframework
 djangorestframework==3.11.0
     # via django-rest-framework
-environs==9.3.1
+environs[django]==9.3.1
     # via -r requirements.in
 factory-boy==3.2.0
     # via -r requirements.in


### PR DESCRIPTION
`environs` ships with Django "support" (via setuptools' extras_require), which is `dj_database_url` under the hood.

This switches to the environs function for consistency.

It also removes the database connection max age configuration, which kept database connections open for 10 minutes, since we're not making use of it.