### PR TITLE
Remove GitHub Organisation Requirement for Registration

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -148,3 +148,24 @@ def get_repos_with_branches():
 
         # update the cursor we pass into the GraphQL query
         cursor = data["pageInfo"]["endCursor"]
+
+
+def is_member_of_org(org, username):
+    # https://docs.github.com/en/free-pro-team@latest/rest/reference/orgs#check-organization-membership-for-a-user
+    f = furl(BASE_URL)
+    f.path.segments += [
+        "orgs",
+        "opensafely",
+        "members",
+        username,
+    ]
+
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": f"token {TOKEN}",
+        "User-Agent": "OpenSAFELY Jobs",
+    }
+
+    r = requests.get(f.url, headers=headers)
+
+    return r.status_code == 204

--- a/jobserver/roles.py
+++ b/jobserver/roles.py
@@ -1,0 +1,15 @@
+from .github import is_member_of_org
+
+
+def can_run_jobs(user):
+    """
+    Given User can run Jobs on the platform
+
+    This is a short term (🤞) hack-adjacent way to enable our demo workflow
+    before we can introduce proper role support (blocked by onboarding not
+    having been built yet), and drive GitHub Org membership from job-server.
+    """
+    if not user.is_authenticated:
+        return False
+
+    return is_member_of_org("opensafely", user.username)

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -146,7 +146,7 @@ LOGGING = logging_config_dict
 
 # Auth
 AUTHENTICATION_BACKENDS = [
-    "jobserver.github.GithubOrganizationOAuth2",
+    "social_core.backends.github.GithubOAuth2",
     "django.contrib.auth.backends.ModelBackend",
 ]
 AUTH_USER_MODEL = "jobserver.User"

--- a/jobserver/templates/index.html
+++ b/jobserver/templates/index.html
@@ -42,7 +42,7 @@
       {% endfor %}
     </div>
 
-    {% if request.user.is_authenticated %}
+    {% if user_can_run_jobs %}
     <div class="d-flex justify-content-center">
       <a class="btn btn-lg btn-primary" href="{% url 'workspace-create' %}">
         Or Add a New Workspace

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -70,7 +70,7 @@
         </div>
 
         <div class="col-lg-3 text-right">
-          {% if request.user.is_authenticated %}
+          {% if user_can_run_jobs %}
           <form method="POST" action="{{ workspace.get_archive_toggle_url }}" class="my-2">
             {% csrf_token %}
 

--- a/jobserver/templates/workspace_log.html
+++ b/jobserver/templates/workspace_log.html
@@ -15,7 +15,7 @@
 
     <h2>{{ workspace.name }}</h2>
 
-    {% if user.is_authenticated and not workspace.is_archived %}
+    {% if user_can_run_jobs and not workspace.is_archived %}
     <div>
       <a class="btn btn-primary" href="{{ workspace.get_absolute_url }}">
         Add Job

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ skip_glob = [".direnv", "venv", ".venv"]
 use_parentheses = true
 
 [tool.pytest.ini_options]
+addopts = "--disable-network"
 DJANGO_SETTINGS_MODULE = "jobserver.settings"
 env = [
   "GITHUB_TOKEN=dummy_token",

--- a/requirements.in
+++ b/requirements.in
@@ -27,5 +27,6 @@ pytest-cov
 pytest-django
 pytest-env
 pytest-freezegun
+pytest-network
 pytest-subtests
 responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -154,6 +154,8 @@ pytest-env==0.6.2
     # via -r requirements.in
 pytest-freezegun==0.4.2
     # via -r requirements.in
+pytest-network==0.0.1
+    # via -r requirements.in
 pytest-subtests==0.4.0
     # via -r requirements.in
 pytest==6.0.2
@@ -162,6 +164,7 @@ pytest==6.0.2
     #   pytest-django
     #   pytest-env
     #   pytest-freezegun
+    #   pytest-network
     #   pytest-subtests
 python-dateutil==2.8.1
     # via

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,27 +1,8 @@
 import pytest
 
-from jobserver.github import GithubOrganizationOAuth2
-
 
 @pytest.fixture
 def api_rf():
     from rest_framework.test import APIRequestFactory
 
     return APIRequestFactory()
-
-
-@pytest.fixture
-def dummy_backend():
-    """
-    Create a DummyBackend instance
-
-    Our GithubOrganizationOAuth2 backend will be instantiated in practice.
-    This allows us to test instances of it with _user_data() set (as it would
-    be in practice).
-    """
-
-    class DummyBackend(GithubOrganizationOAuth2):
-        def _user_data(self, *args, **kwargs):
-            return {"email": "test-email", "login": "test-username"}
-
-    return DummyBackend()

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -48,9 +48,6 @@ def test_login_pipeline(client):
         ]
         rsps.add(responses.GET, emails_url, json=emails_data, status=200)
 
-        membership_url = "https://api.github.com/orgs/opensafely/members/dummy-user"
-        rsps.add(responses.GET, membership_url, status=204)
-
         # set a dummy state value in the test Client's session to match the
         # value in redirect_url below
         session = client.session

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -66,10 +66,10 @@ def test_login_pipeline(client):
             + "?code=test-code&state=test-state"
         )
 
-        response = client.get(redirect_url, follow=True, secure=True)
+        response = client.get(redirect_url, follow=False, secure=True)
 
-    assert response.status_code == 200
-    assert response.redirect_chain == [("/", 302)]
+    assert response.status_code == 302
+    assert response.url == "/"
 
     # ensure we only have one User and it's constructed as expected
     assert User.objects.count() == 1

--- a/tests/jobserver/test_github.py
+++ b/tests/jobserver/test_github.py
@@ -1,8 +1,6 @@
 from unittest.mock import patch
 
-import pytest
 import responses
-from social_core.exceptions import AuthFailed
 
 from jobserver.github import (
     get_branch,
@@ -146,39 +144,3 @@ def test_get_repos_with_branches():
     assert len(output) == 2
     assert output[0]["name"] == "test-repo"
     assert output[0]["branches"][0] == "branch1"
-
-
-@responses.activate
-def test_githuborganizationoauth2_user_data_204(dummy_backend):
-    expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
-    responses.add(responses.GET, url=expected_url, status=204)
-
-    dummy_backend.user_data("access-token")
-
-    assert len(responses.calls) == 1
-
-
-@responses.activate
-def test_githuborganizationoauth2_user_data_302(dummy_backend):
-    expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
-    responses.add(responses.GET, url=expected_url, status=302)
-
-    match = (
-        '"test-username" is not part of the OpenSAFELY GitHub Organization. '
-        '<a href="https://opensafely.org/contact/">Contact us</a> to request access.'
-    )
-    with pytest.raises(AuthFailed, match=match):
-        dummy_backend.user_data("access-token")
-
-
-@responses.activate
-def test_githuborganizationoauth2_user_data_404(dummy_backend):
-    expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
-    responses.add(responses.GET, url=expected_url, status=404)
-
-    match = (
-        '"test-username" is not part of the OpenSAFELY GitHub Organization. '
-        '<a href="https://opensafely.org/contact/">Contact us</a> to request access.'
-    )
-    with pytest.raises(AuthFailed, match=match):
-        dummy_backend.user_data("access-token")

--- a/tests/jobserver/test_roles.py
+++ b/tests/jobserver/test_roles.py
@@ -1,0 +1,25 @@
+from unittest.mock import patch
+
+import pytest
+
+from jobserver.roles import can_run_jobs
+
+from ..factories import UserFactory
+
+
+@pytest.mark.django_db
+def test_can_run_jobs_with_authenticated_user_in_org():
+    with patch("jobserver.roles.is_member_of_org", return_value=True):
+        assert can_run_jobs(UserFactory())
+
+
+@pytest.mark.django_db
+def test_can_run_jobs_with_authenticated_user_not_in_org():
+    with patch("jobserver.roles.is_member_of_org", return_value=False):
+        assert not can_run_jobs(UserFactory())
+
+
+@pytest.mark.django_db
+def test_can_run_jobs_with_unauthenticated_user():
+    with patch("jobserver.roles.is_member_of_org", return_value=False):
+        assert not can_run_jobs(UserFactory())


### PR DESCRIPTION
This removes the requirement to be in the OpenSAFELY GitHub Org when signing up, shifting it to the views where the difference between [un]authenticated users are displayed.

This is a preparatory step towards adding a demo of the platform (with the expectations backend), and the very beginnings (more in intent rather than implementation) of roles based permissions.