### PR TITLE
fix: require manifest in uploaded zip

### DIFF
--- a/jobserver/api.py
+++ b/jobserver/api.py
@@ -295,7 +295,7 @@ class ReleaseUploadAPI(APIView):
             raise NotAuthenticated("Backend-User not valid")
 
         if "file" not in request.data:
-            raise ValidationError("No data uploaded")
+            raise ValidationError({"detail": "No data uploaded"})
 
         upload = request.data["file"]
         release, created = handle_release(
@@ -303,12 +303,14 @@ class ReleaseUploadAPI(APIView):
         )
 
         response = Response(status=201 if created else 303)
-        response["Location"] = reverse(
-            "workspace-release",
-            kwargs={
-                "name": workspace.name,
-                "release": release.id,
-            },
+        response["Location"] = request.build_absolute_uri(
+            reverse(
+                "workspace-release",
+                kwargs={
+                    "name": workspace.name,
+                    "release": release.id,
+                },
+            )
         )
         response["Release-Id"] = release.id
         return response

--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -425,7 +425,7 @@ class Release(models.Model):
 
     @property
     def manifest(self):
-        return json.load(self.file_path("metadata/manifest.json").open())
+        return json.loads(self.file_path("metadata/manifest.json").read_text())
 
 
 class Stats(models.Model):

--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -1,5 +1,6 @@
 import base64
 import binascii
+import json
 import os
 import secrets
 from datetime import timedelta
@@ -421,6 +422,10 @@ class Release(models.Model):
 
     def file_path(self, filename):
         return settings.RELEASE_STORAGE / self.upload_dir / filename
+
+    @property
+    def manifest(self):
+        return json.load(self.file_path("metadata/manifest.json").open())
 
 
 class Stats(models.Model):

--- a/tests/jobserver/test_api.py
+++ b/tests/jobserver/test_api.py
@@ -594,7 +594,7 @@ def test_release_api_no_files(api_rf):
     )
 
     assert response.status_code == 400
-    assert "No data" in response.data[0]
+    assert "No data" in response.data["detail"]
 
 
 @pytest.mark.django_db
@@ -616,7 +616,10 @@ def test_release_api_created(api_rf, tmp_path, monkeypatch):
 
     assert response.status_code == 201
     release_id = response["Release-Id"]
-    assert response["Location"] == f"/{workspace.name}/releases/{release_id}"
+    assert (
+        response["Location"]
+        == f"http://testserver/{workspace.name}/releases/{release_id}"
+    )
 
 
 @pytest.mark.django_db
@@ -640,4 +643,7 @@ def test_release_api_redirected(api_rf, tmp_path, monkeypatch):
 
     assert response.status_code == 303
     release_id = response["Release-Id"]
-    assert response["Location"] == f"/{workspace.name}/releases/{release_id}"
+    assert (
+        response["Location"]
+        == f"http://testserver/{workspace.name}/releases/{release_id}"
+    )


### PR DESCRIPTION
 - require valid manifest.json in zip
 - fix bug in Release.files listing (via list_files())
 - refactor hash_files logic to use list_files()

And some minor fixes:
 
 - fix raising ValidationError() for consistent error formatting
 - return full urls in the Location header from release api.