### PR TITLE
Enable cancel button for all users

### DIFF
--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -146,7 +146,7 @@
 
   <div class="col-md-3 col-lg-2">
 
-    {% if request.user.is_superuser %}
+    {% if user_can_run_jobs %}
     <h3 class="text-center">Tools</h3>
 
     <form class="mb-3" method="POST" action="{{ job.get_cancel_url }}">
@@ -158,15 +158,17 @@
         disabled
         {% endif %}
         type="submit">
-        Cancel (not working yet!)
+        Cancel
       </button>
     </form>
 
+    {% if request.user.is_superuser %}
     <form class="mb-3" method="POST" action="{{ job.get_zombify_url }}">
       {% csrf_token %}
 
       <button class="btn btn-block btn-danger" type="submit">Zombify</button>
     </form>
+    {% endif %}
     {% endif %}
 
   </div>

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -126,6 +126,11 @@ class JobDetail(DetailView):
     )
     template_name = "job_detail.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["can_run_jobs"] = can_run_jobs(self.request.user)
+        return context
+
 
 class JobZombify(View):
     def dispatch(self, request, *args, **kwargs):

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -231,7 +231,9 @@ def test_jobdetail_with_post_jobrequest_job(rf):
 
     # Build a RequestFactory instance
     request = rf.get(MEANINGLESS_URL)
-    response = JobDetail.as_view()(request, identifier=job.identifier)
+    request.user = UserFactory()
+    with patch("jobserver.views.can_run_jobs", return_value=False):
+        response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
 
@@ -243,7 +245,9 @@ def test_jobdetail_with_pre_jobrequest_job(rf):
 
     # Build a RequestFactory instance
     request = rf.get(MEANINGLESS_URL)
-    response = JobDetail.as_view()(request, identifier=job.identifier)
+    request.user = UserFactory()
+    with patch("jobserver.views.can_run_jobs", return_value=False):
+        response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
 
@@ -261,7 +265,8 @@ def test_jobzombify_not_superuser(client):
     job = JobFactory(completed_at=None)
 
     client.force_login(UserFactory(is_superuser=False))
-    response = client.post(f"/jobs/{job.identifier}/zombify/", follow=True)
+    with patch("jobserver.views.can_run_jobs", return_value=False):
+        response = client.post(f"/jobs/{job.identifier}/zombify/", follow=True)
 
     assert response.status_code == 200
 


### PR DESCRIPTION
This has now been wired up on the job-runner side and tested:
https://github.com/opensafely-core/job-runner/pull/186