### PR TITLE
Require GH Org Membership  for Some Actions

### DIFF
--- a/jobserver/roles.py
+++ b/jobserver/roles.py
@@ -1,3 +1,8 @@
+from functools import wraps
+
+from django.contrib import messages
+from django.shortcuts import redirect
+
 from .github import is_member_of_org
 
 
@@ -13,3 +18,21 @@ def can_run_jobs(user):
         return False
 
     return is_member_of_org("opensafely", user.username)
+
+
+def superuser_required(f):
+    """
+    Decorator for views which require a Superuser
+
+    User.is_superuser implies the User is authenticated.
+    """
+
+    @wraps(f)
+    def wrapper(request, *args, **kwargs):
+        if request.user.is_superuser:
+            return f(request, *args, **kwargs)
+
+        messages.error(request, "Only admins can view Backends.")
+        return redirect("/")
+
+    return wrapper

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required, user_passes_test
+from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
@@ -57,6 +57,12 @@ def filter_by_status(job_requests, status):
 
 
 def superuser_required(f):
+    """
+    Decorator for views which require a Superuser
+
+    User.is_superuser implies the User is authenticated.
+    """
+
     @wraps(f)
     def wrapper(request, *args, **kwargs):
         if request.user.is_superuser:
@@ -259,8 +265,7 @@ class JobRequestZombify(View):
         return redirect(job_request)
 
 
-@method_decorator(login_required, name="dispatch")
-@method_decorator(user_passes_test(lambda u: u.is_superuser), name="dispatch")
+@method_decorator(superuser_required, name="dispatch")
 class OrgCreate(CreateView):
     form_class = OrgCreateForm
     model = Org
@@ -275,23 +280,20 @@ class OrgCreate(CreateView):
         return self.object.get_absolute_url()
 
 
-@method_decorator(login_required, name="dispatch")
-@method_decorator(user_passes_test(lambda u: u.is_superuser), name="dispatch")
+@method_decorator(superuser_required, name="dispatch")
 class OrgDetail(DetailView):
     model = Org
     slug_url_kwarg = "org_slug"
     template_name = "org_detail.html"
 
 
-@method_decorator(login_required, name="dispatch")
-@method_decorator(user_passes_test(lambda u: u.is_superuser), name="dispatch")
+@method_decorator(superuser_required, name="dispatch")
 class OrgList(ListView):
     model = Org
     template_name = "org_list.html"
 
 
-@method_decorator(login_required, name="dispatch")
-@method_decorator(user_passes_test(lambda u: u.is_superuser), name="dispatch")
+@method_decorator(superuser_required, name="dispatch")
 class ProjectCreate(CreateView):
     form_class = ProjectCreateForm
     model = Project
@@ -338,8 +340,7 @@ class ProjectCreate(CreateView):
         return redirect(project)
 
 
-@method_decorator(login_required, name="dispatch")
-@method_decorator(user_passes_test(lambda u: u.is_superuser), name="dispatch")
+@method_decorator(superuser_required, name="dispatch")
 class ProjectDetail(DetailView):
     template_name = "project_detail.html"
 

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, user_passes_test
 from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
@@ -92,7 +92,7 @@ class Index(TemplateView):
         return context
 
 
-@method_decorator(login_required, name="dispatch")
+@method_decorator(user_passes_test(can_run_jobs), name="dispatch")
 class JobCancel(View):
     def post(self, request, *args, **kwargs):
         job = get_object_or_404(Job, identifier=self.kwargs["identifier"])
@@ -384,7 +384,7 @@ class Status(View):
         return TemplateResponse(request, "status.html", context)
 
 
-@method_decorator(login_required, name="dispatch")
+@method_decorator(user_passes_test(can_run_jobs), name="dispatch")
 class WorkspaceArchiveToggle(View):
     def post(self, request, *args, **kwargs):
         workspace = get_object_or_404(Workspace, name=self.kwargs["name"])
@@ -398,7 +398,7 @@ class WorkspaceArchiveToggle(View):
         return redirect("/")
 
 
-@method_decorator(login_required, name="dispatch")
+@method_decorator(user_passes_test(can_run_jobs), name="dispatch")
 class WorkspaceCreate(CreateView):
     form_class = WorkspaceCreateForm
     model = Workspace
@@ -590,7 +590,7 @@ class WorkspaceLog(ListView):
         return qs
 
 
-@method_decorator(login_required, name="dispatch")
+@method_decorator(user_passes_test(can_run_jobs), name="dispatch")
 class WorkspaceNotificationsToggle(View):
     def post(self, request, *args, **kwargs):
         workspace = get_object_or_404(Workspace, name=self.kwargs["name"])
@@ -604,7 +604,7 @@ class WorkspaceNotificationsToggle(View):
         return redirect(workspace)
 
 
-@method_decorator(login_required, name="dispatch")
+@method_decorator(user_passes_test(can_run_jobs), name="dispatch")
 class WorkspaceReleaseView(View):
     def get(self, request, name, release):
         return f"release page for {name}/{release}"  # pragma: no cover

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -1,5 +1,3 @@
-from functools import wraps
-
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
@@ -32,7 +30,7 @@ from .forms import (
 from .github import get_branch_sha, get_repos_with_branches
 from .models import Backend, Job, JobRequest, Org, Project, User, Workspace
 from .project import get_actions
-from .roles import can_run_jobs
+from .roles import can_run_jobs, superuser_required
 
 
 def filter_by_status(job_requests, status):
@@ -54,24 +52,6 @@ def filter_by_status(job_requests, status):
     }
     func = status_lut[status]
     return list(filter(func, job_requests))
-
-
-def superuser_required(f):
-    """
-    Decorator for views which require a Superuser
-
-    User.is_superuser implies the User is authenticated.
-    """
-
-    @wraps(f)
-    def wrapper(request, *args, **kwargs):
-        if request.user.is_superuser:
-            return f(request, *args, **kwargs)
-
-        messages.error(request, "Only admins can view Backends.")
-        return redirect("/")
-
-    return wrapper
 
 
 @method_decorator(superuser_required, name="dispatch")


### PR DESCRIPTION
This consolidates how we check for superusers and makes use of our `can_run_jobs` function to gate access to views where a User must be part of our GitHub organisation.