### PR TITLE
Add disclaimer to homepage about links to private repos

### DIFF
--- a/jobserver/templates/index.html
+++ b/jobserver/templates/index.html
@@ -7,10 +7,22 @@
 <div class="row mb-3">
   <div class="col-lg-8 offset-lg-2">
     <p>
-    Welcome to the <a href="https://opensafely.org">OpenSAFELY</a> Jobs site.
-    Pick a Workspace below to get started running your research on the
-    OpenSafely platform or look at some of the existing research tasks below
-    that which have been created to run on it.
+      Welcome to the <a href="https://opensafely.org">OpenSAFELY</a> Jobs site.
+    </p>
+    <p>
+      This site logs all jobs executed on production data as they happen, with a link to
+      the github repository and commit reference that uniquely identifies the exact code
+      that was run. However, in accordance with the <a
+      href="https://opensafely.org/principles/">Principles of OpenSAFELY</a> some Github
+      repositories are kept private until the results are shared publicly - at which point
+      we require the entire repository to be made public. If the repository is currently
+      private, any links to it from this site will return 404 unless you are logged in
+      and have the relevant permissions.
+    </p>
+    <p>
+      Pick a Workspace below to get started running your research on the OpenSAFELY
+      platform or look at some of the existing research tasks that have been created to
+      run on it.
     </p>
   </div>
 </div>

--- a/jobserver/templates/index.html
+++ b/jobserver/templates/index.html
@@ -11,13 +11,14 @@
     </p>
     <p>
       This site logs all jobs executed on production data as they happen, with a link to
-      the github repository and commit reference that uniquely identifies the exact code
+      the Github repository and commit reference that uniquely identifies the exact code
       that was run. However, in accordance with the <a
       href="https://opensafely.org/principles/">Principles of OpenSAFELY</a> some Github
-      repositories are kept private until the results are shared publicly - at which point
-      we require the entire repository to be made public. If the repository is currently
-      private, any links to it from this site will return 404 unless you are logged in
-      and have the relevant permissions.
+      repositories are kept private until the results are shared publicly - at which
+      point we require the entire repository to be made public. If the repository is
+      currently private, any links to it from this site will return a "404 Not Found"
+      error unless you are logged in and have the relevant permissions.
+
     </p>
     <p>
       Pick a Workspace below to get started running your research on the OpenSAFELY


### PR DESCRIPTION
* in response to public feedback
mockup:
![Screenshot 2021-03-31 at 16 43 25](https://user-images.githubusercontent.com/2082895/113172349-42ba4d00-9240-11eb-81d7-7ea19e414617.png)
* part of https://github.com/opensafely-core/job-server/issues/442