### PR TITLE
Roles & Permissions API

### DIFF
--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -19,7 +19,13 @@ from django.contrib.auth.views import LogoutView
 from django.urls import include, path
 from django.views.generic import RedirectView
 
-from .api import JobAPIUpdate, JobRequestAPIList, ReleaseUploadAPI, WorkspaceStatusesAPI
+from .api import (
+    JobAPIUpdate,
+    JobRequestAPIList,
+    ReleaseUploadAPI,
+    UserAPIDetail,
+    WorkspaceStatusesAPI,
+)
 from .views import (
     BackendDetail,
     BackendList,
@@ -51,6 +57,7 @@ from .views import (
 api_urls = [
     path("job-requests/", JobRequestAPIList.as_view()),
     path("jobs/", JobAPIUpdate.as_view()),
+    path("users/<username>/", UserAPIDetail.as_view(), name="user-detail"),
     path(
         "workspaces/<name>/statuses/",
         WorkspaceStatusesAPI.as_view(),

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -48,22 +48,26 @@ from .views import (
 )
 
 
-urlpatterns = [
-    path("", Index.as_view()),
-    path("", include("social_django.urls", namespace="social")),
-    path("admin/", admin.site.urls),
-    path("api/v2/job-requests/", JobRequestAPIList.as_view()),
-    path("api/v2/jobs/", JobAPIUpdate.as_view()),
+api_urls = [
+    path("job-requests/", JobRequestAPIList.as_view()),
+    path("jobs/", JobAPIUpdate.as_view()),
     path(
-        "api/v2/workspaces/<name>/statuses/",
+        "workspaces/<name>/statuses/",
         WorkspaceStatusesAPI.as_view(),
         name="workspace-statuses",
     ),
     path(
-        "api/v2/workspaces/<workspace_name>/releases/<release_hash>",
+        "workspaces/<workspace_name>/releases/<release_hash>",
         ReleaseUploadAPI.as_view(),
         name="workspace-upload-release",
     ),
+]
+
+urlpatterns = [
+    path("", Index.as_view()),
+    path("", include("social_django.urls", namespace="social")),
+    path("admin/", admin.site.urls),
+    path("api/v2/", include(api_urls)),
     path("backends/", BackendList.as_view(), name="backend-list"),
     path("backends/<pk>/", BackendDetail.as_view(), name="backend-detail"),
     path(


### PR DESCRIPTION
This adds an authenticated API for Users listing their roles and permissions, with context for any Local Roles (and thus Permissions) as part of the output.

The output for a given User is:

```
{
    "permissions": {
        "global": ["cancel-job", "run-job"],
        "orgs": [],
        "projects": [
            {
                "slug": "great-project",
                "permissions": [
                    "cancel-job",
                    "check-output",
                    "run-job",
                ],
            }
        ],
    },
    "roles": {
        "global": ["CoreDeveloper"],
        "orgs": [],
        "projects": [
            {
                "slug": "great-project",
                "roles": [
                    "ProjectCollaborator",
                ],
            }
        ],
    },
}
```

The output for `orgs` mirrors that of `projects` with a slug and related permissions/roles.