### PR TITLE
Selectively Show Cancel Button

### DIFF
--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -154,7 +154,7 @@
 
       <button
         class="btn btn-block btn-danger"
-        {% if job.action in job.job_request.cancelled_actions %}
+        {% if job.is_finished or job.action in job.job_request.cancelled_actions %}
         disabled
         {% endif %}
         type="submit">

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -98,10 +98,11 @@ class JobCancel(View):
     def post(self, request, *args, **kwargs):
         job = get_object_or_404(Job, identifier=self.kwargs["identifier"])
 
-        if job.action not in job.job_request.cancelled_actions:
-            job.job_request.cancelled_actions.append(job.action)
-            job.job_request.save()
+        if job.is_finished or job.action in job.job_request.cancelled_actions:
+            return redirect(job)
 
+        job.job_request.cancelled_actions.append(job.action)
+        job.job_request.save()
         return redirect(job)
 
 


### PR DESCRIPTION
This disables the cancel button when a Job has already finished, and makes the handler view a noop in that situation too.

Fixes #438 