### PR TITLE
Cancel All Jobs in a JobRequest

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -231,6 +231,9 @@ class JobRequest(models.Model):
 
         return last_job.completed_at
 
+    def get_cancel_url(self):
+        return reverse("job-request-cancel", kwargs={"pk": self.pk})
+
     def get_file_url(self, path):
         f = furl(self.workspace.repo)
 

--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -253,6 +253,10 @@ class JobRequest(models.Model):
         return f.url
 
     @property
+    def is_finished(self):
+        return self.status in ["failed", "succeeded"]
+
+    @property
     def is_invalid(self):
         """
         Is this JobRequest invalid?

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -153,6 +153,21 @@
       </a>
     </div>
 
+    {% if user_can_run_jobs %}
+    <form class="mb-2" method="POST" action="{{ jobrequest.get_cancel_url }}">
+      {% csrf_token %}
+
+      <button
+        class="btn btn-block btn-danger"
+        {% if jobrequest.is_finished %}
+        disabled
+        {% endif %}
+        type="submit">
+        Cancel
+      </button>
+    </form>
+    {% endif %}
+
     {% if is_superuser %}
     <div class="mb-2">
       <form method="POST" action="{% url 'job-request-zombify' pk=jobrequest.pk %}">

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -27,6 +27,7 @@ from .views import (
     Index,
     JobCancel,
     JobDetail,
+    JobRequestCancel,
     JobRequestDetail,
     JobRequestList,
     JobRequestZombify,
@@ -73,6 +74,11 @@ urlpatterns = [
     path("jobs/", JobRequestList.as_view(), name="job-list"),
     path("job-requests/", RedirectView.as_view(pattern_name="job-list")),
     path("job-requests/<pk>/", JobRequestDetail.as_view(), name="job-request-detail"),
+    path(
+        "job-requests/<pk>/cancel/",
+        JobRequestCancel.as_view(),
+        name="job-request-cancel",
+    ),
     path(
         "job-requests/<pk>/zombify/",
         JobRequestZombify.as_view(),

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -198,6 +198,13 @@ def test_jobrequest_get_absolute_url():
 
 
 @pytest.mark.django_db
+def test_jobrequest_get_cancel_url():
+    job_request = JobRequestFactory()
+    url = job_request.get_cancel_url()
+    assert url == reverse("job-request-cancel", kwargs={"pk": job_request.pk})
+
+
+@pytest.mark.django_db
 def test_jobrequest_get_project_yaml_url_no_sha():
     workspace = WorkspaceFactory(repo="http://example.com/opensafely/some_repo")
     job_request = JobRequestFactory(workspace=workspace)
@@ -244,6 +251,14 @@ def test_jobrequest_is_finished():
     JobFactory(job_request=job_request, status="succeeded")
 
     assert job_request.is_finished
+
+
+@pytest.mark.django_db
+def test_jobrequest_is_invalid():
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, action="__error__")
+
+    assert job_request.is_invalid
 
 
 @pytest.mark.django_db

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -238,6 +238,15 @@ def test_jobrequest_get_repo_url_success():
 
 
 @pytest.mark.django_db
+def test_jobrequest_is_finished():
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, status="failed")
+    JobFactory(job_request=job_request, status="succeeded")
+
+    assert job_request.is_finished
+
+
+@pytest.mark.django_db
 def test_jobrequest_num_completed_no_jobs():
     assert JobRequestFactory().num_completed == 0
 


### PR DESCRIPTION
This bring the mighty Cancel button to the JobRequestDetail page.

fixes #437 