### PR TITLE
Remove Some Fields from Admin Page

### DIFF
--- a/jobserver/admin.py
+++ b/jobserver/admin.py
@@ -156,6 +156,12 @@ class ProjectAdmin(admin.ModelAdmin):
 
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):
+    exclude = [
+        "password",
+        "groups",
+        "user_permissions",
+        "roles",
+    ]
     list_display = [
         "username",
         "date_joined",


### PR DESCRIPTION
This removes a selection of fields from the User change page in the Admin:

* **password**: We're using social auth so this is an intentially broken password.
* **groups**: We're not using this.
* **user_permissions**: We're not using this.
* **roles**: This field (because it returns Classes) breaks the Admin, and we don't want this configurable from the Admin, which is going away soon-ish™.