### PR TITLE
Stop using User.is_superuser in Templates

### DIFF
--- a/jobserver/authorization/admins.py
+++ b/jobserver/authorization/admins.py
@@ -21,7 +21,7 @@ def get_admins():
 
 def ensure_admins(usernames):
     """
-    Given an iterable of username strings, set the is_superuser bit
+    Given an iterable of username strings, ensure they have the SuperUser role
     """
     if not usernames:
         raise Exception("No admin users configured, aborting")

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -162,7 +162,7 @@
       </button>
     </form>
 
-    {% if request.user.is_superuser %}
+    {% if is_superuser %}
     <form class="mb-3" method="POST" action="{{ job.get_zombify_url }}">
       {% csrf_token %}
 

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -153,7 +153,7 @@
       </a>
     </div>
 
-    {% if request.user.is_superuser %}
+    {% if is_superuser %}
     <div class="mb-2">
       <form method="POST" action="{% url 'job-request-zombify' pk=jobrequest.pk %}">
         {% csrf_token %}

--- a/jobserver/templates/job_request_list.html
+++ b/jobserver/templates/job_request_list.html
@@ -26,7 +26,7 @@
         <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
       </form>
 
-      {% if request.user.is_superuser %}
+      {% if is_superuser %}
       <div class="mb-4">
 
         {% if form.non_field_errors %}

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -148,7 +148,7 @@
       </ul>
       {% endif %}
 
-      {% if request.user.is_superuser %}
+      {% if is_superuser %}
       <p>Pick a backend to run your Jobs in:</p>
 
       <div class="form-group">

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -118,6 +118,7 @@ class JobDetail(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["is_superuser"] = has_role(self.request.user, SuperUser)
         context["user_can_run_jobs"] = can_run_jobs(self.request.user)
         return context
 

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -180,6 +180,7 @@ class JobRequestList(FormMixin, ListView):
         context = super().get_context_data(object_list=filtered_object_list, **kwargs)
 
         context["backends"] = Backend.objects.order_by("name")
+        context["is_superuser"] = has_role(self.request.user, SuperUser)
         context["statuses"] = ["failed", "running", "pending", "succeeded"]
         context["users"] = {u.username: u.name for u in users}
         context["workspaces"] = workspaces

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -518,6 +518,7 @@ class WorkspaceDetail(CreateView):
         context["actions"] = self.actions
         context["branch"] = self.workspace.branch
         context["latest_job_request"] = self.get_latest_job_request()
+        context["is_superuser"] = has_role(self.request.user, SuperUser)
         context["show_details"] = self.show_details
         context["user_can_run_jobs"] = self.user_can_run_jobs
         context["workspace"] = self.workspace

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -149,6 +149,7 @@ class JobRequestDetail(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["is_superuser"] = has_role(self.request.user, SuperUser)
         context["project_definition"] = mark_safe(
             render_definition(
                 self.object.project_definition,

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -19,6 +19,7 @@ from jobserver.views import (
     Index,
     JobCancel,
     JobDetail,
+    JobRequestDetail,
     JobRequestList,
     JobRequestZombify,
     JobZombify,
@@ -342,6 +343,42 @@ def test_jobzombify_unknown_job(rf, superuser):
 
     with pytest.raises(Http404):
         JobZombify.as_view()(request, identifier="")
+
+
+@pytest.mark.django_db
+def test_jobrequestdetail_with_authenticated_user(rf):
+    job_request = JobRequestFactory()
+
+    request = rf.get(MEANINGLESS_URL)
+    request.user = UserFactory(is_superuser=False, roles=[])
+    response = JobRequestDetail.as_view()(request, pk=job_request.pk)
+
+    assert response.status_code == 200
+    assert "Zombify" not in response.rendered_content
+
+
+@pytest.mark.django_db
+def test_jobrequestdetail_with_superuser(rf, superuser):
+    job_request = JobRequestFactory()
+
+    request = rf.get(MEANINGLESS_URL)
+    request.user = superuser
+    response = JobRequestDetail.as_view()(request, pk=job_request.pk)
+
+    assert response.status_code == 200
+    assert "Zombify" in response.rendered_content
+
+
+@pytest.mark.django_db
+def test_jobrequestdetail_with_unauthenticated_user(rf):
+    job_request = JobRequestFactory()
+
+    request = rf.get(MEANINGLESS_URL)
+    request.user = AnonymousUser()
+    response = JobRequestDetail.as_view()(request, pk=job_request.pk)
+
+    assert response.status_code == 200
+    assert "Zombify" not in response.rendered_content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This converts all our uses of `User.is_superuser` for checks in templates to booleans from the `has_role()` function.