### PR TITLE
Filter by Backend

### DIFF
--- a/jobserver/templates/job_request_list.html
+++ b/jobserver/templates/job_request_list.html
@@ -129,6 +129,33 @@
       </ul>
       {% endif %}
 
+      {% if backends %}
+      <h5>Backends</h5>
+      <ul class="list-group list-unstyled mb-4">
+        {% for backend in backends %}
+        {% is_filter_selected key="backend" value=backend.pk as is_active %}
+        <li class="list-group-item d-flex{% if is_active %} active{% endif %}">
+
+          <a class="text-truncate flex-grow-1" href="{% url_with_querystring backend=backend.pk %}">
+            {{ backend.name }}
+          </a>
+
+          {% if is_active %}
+          <a
+            type="button"
+            class="close"
+            aria-label="Close"
+            href="{% url_without_querystring backend=backend.pk %}"
+            >
+            <span aria-hidden="true">&times;</span>
+          </a>
+          {% endif %}
+
+        </li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+
       {% if workspaces %}
       <h5>Workspaces</h5>
       <ul class="list-group list-unstyled">

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -177,6 +177,7 @@ class JobRequestList(FormMixin, ListView):
         )
         context = super().get_context_data(object_list=filtered_object_list, **kwargs)
 
+        context["backends"] = Backend.objects.order_by("name")
         context["statuses"] = ["failed", "running", "pending", "succeeded"]
         context["users"] = {u.username: u.name for u in users}
         context["workspaces"] = workspaces
@@ -200,6 +201,10 @@ class JobRequestList(FormMixin, ListView):
                 # if the query looks enough like a number for int() to handle
                 # it then we can look for a job number
                 qs = qs.filter(qwargs | Q(jobs__pk=q))
+
+        backend = self.request.GET.get("backend")
+        if backend:
+            qs = qs.filter(backend_id=backend)
 
         username = self.request.GET.get("username")
         if username:

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -355,6 +355,23 @@ def test_jobrequestlist_filters_exist(rf):
 
 
 @pytest.mark.django_db
+def test_jobrequestlist_filter_by_backend(rf):
+    emis = Backend.objects.get(name="emis")
+    job_request = JobRequestFactory(backend=emis)
+    JobFactory.create_batch(2, job_request=job_request)
+
+    tpp = Backend.objects.get(name="tpp")
+    job_request = JobRequestFactory(backend=tpp)
+    JobFactory.create_batch(2, job_request=job_request)
+
+    # Build a RequestFactory instance
+    request = rf.get(f"/?backend={emis.pk}")
+    response = JobRequestList.as_view()(request)
+
+    assert len(response.context_data["page_obj"]) == 1
+
+
+@pytest.mark.django_db
 def test_jobrequestlist_filter_by_status(rf):
     JobFactory(job_request=JobRequestFactory(), status="failed")
 


### PR DESCRIPTION
This adds a new filter to the JobRequest listing page to limit results to Backend.

I've opted to not put the visibility and functionality of this filter behind a Permission as I don't think it adds anything here.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/4gu29kE6/59853ec1-7371-4b8f-9141-ba7ef2305a0a.jpg?v=61dd20cdeb4e40f2c8f88ac15733a368)

Fixes #455 