### PR TITLE
Improve UX for Initial Project Use

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ This is the Web UI for requesting Jobs are run within the [OpenSAFELY platform](
 It provides an API to [job-runner](https://github.com/opensafely-core/job-runner) which executes those Jobs in high-security environments.
 
 
+## Stack
+This is a [Django](https://www.djangoproject.com) project.
+It uses [Django Rest Framework](https://www.django-rest-framework.org) for the API and [SQLite](https://www.sqlite.org/index.html) for the database.
+It is deployed via [dokku](https://dokku.com), serves static files using the [whitenoise](http://whitenoise.evans.io) package, and is itself served by [gunicorn](https://gunicorn.org).
+We authenticate Users with the [Python Social Auth](https://python-social-auth.readthedocs.io) Django-specific package, using [GitHub]() as the OAuth Provider backend.
+
+Tests are run with [pytest](https://docs.pytest.org) and a selection of plug-ins.
+
+We use [black](https://black.readthedocs.io) and [isort](https://pycqa.github.io/isort/) to automatically format the codebase, with [flake8](https://flake8.pycqa.org) for linting.
+Each tool, including pytest, has been configured via config files, but a Makefile also exists to script common use cases (eg check and fix formatting).
+[pre-commit](https://pre-commit.com) is configured to run the same checks via git hooks.
+
+CI is handled by [GitHub Actions](https://github.com/features/actions) where the tests and tooling are run.
+After a successful merge to `main` a deployment is run.
+
+Errors are logged to the DataLab [Sentry](https://sentry.io) account.
+
+
 
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -22,6 +22,40 @@ After a successful merge to `main` a deployment is run.
 Errors are logged to the DataLab [Sentry](https://sentry.io) account.
 
 
+## Local Development Set Up
+### Native
+Create a virtualenv with your preferred tool and install the dependencies with:
+
+    pip install -r requirements.txt
+
+
+Run migrations:
+
+    python manage.py migrate
+
+
+Set up the environment variables listed in `dotenv-sample` with your tool of choice.
+
+
+Optionally set up 1 or more administrators by setting `ADMIN_USERS` to a list of strings.
+eg `ADMIN_USERS=ghickman,ingelsp`.
+
+**Note:** this can only contain usernames which exist in the database.
+
+Then update their User records with:
+
+    python manage.py ensure_admins
+
+
+Run the dev server:
+
+    python manage.py runserver
+
+
+### Docker Compose
+Copy `dotenv-sample` to `.env` and run `docker-compose up`.
+
+*Note:* The dev server inside the container does not currently reload when changes are saved.
 
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # OpenSAFELY Job Server
+This is the Web UI for requesting Jobs are run within the [OpenSAFELY platform](https://opensafely.org), and viewing their logs.
 
-This Django app provides a simple REST API which provides a channel
-for communicating between low-security environments (which can request
-that jobs be run) and high-security environments (where jobs are run).
+It provides an API to [job-runner](https://github.com/opensafely-core/job-runner) which executes those Jobs in high-security environments.
+
+
 
 
 ## Deployment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ version: "3.6"
 services:
   job-server:
     build: .
+    command: /app/manage.py runserver 0.0.0.0:8000
     environment:
       - ADMIN_USERS
       - DATABASE_URL
@@ -14,4 +15,5 @@ services:
       - SOCIAL_AUTH_GITHUB_SECRET
     ports:
       - "8000:8000"
-    command: /app/manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/app

--- a/jobserver/authorization/admins.py
+++ b/jobserver/authorization/admins.py
@@ -13,7 +13,7 @@ def get_admins():
 
     Auth is handled via GitHub OAuth so these are GitHub usernames.
     """
-    admin_users = env.list("ADMIN_USERS")
+    admin_users = env.list("ADMIN_USERS", default=[])
 
     # remove whitespace and only return non-empty strings
     return [u.strip() for u in admin_users if u]

--- a/jobserver/authorization/admins.py
+++ b/jobserver/authorization/admins.py
@@ -28,7 +28,7 @@ def ensure_admins(usernames):
     missing = set(usernames) - {u.username for u in admins}
     if missing:
         sorted_missing = sorted(missing)
-        raise Exception(f"Unknown users: {', '.join(sorted_missing)}")
+        raise Exception(f"Unknown admin usernames: {', '.join(sorted_missing)}")
 
     for admin in admins:
         admin.roles.append(SuperUser)

--- a/jobserver/authorization/admins.py
+++ b/jobserver/authorization/admins.py
@@ -23,9 +23,6 @@ def ensure_admins(usernames):
     """
     Given an iterable of username strings, ensure they have the SuperUser role
     """
-    if not usernames:
-        raise Exception("No admin users configured, aborting")
-
     admins = User.objects.filter(username__in=usernames)
 
     missing = set(usernames) - {u.username for u in admins}

--- a/tests/jobserver/authorization/test_admins.py
+++ b/tests/jobserver/authorization/test_admins.py
@@ -22,7 +22,7 @@ def test_ensure_admins_unknown_user():
     user = UserFactory(username="ghickman")
     assert SuperUser not in user.roles
 
-    with pytest.raises(Exception, match="Unknown users: test"):
+    with pytest.raises(Exception, match="Unknown admin usernames: test"):
         ensure_admins(["ghickman", "test"])
 
 
@@ -31,7 +31,7 @@ def test_ensure_admins_unknown_users():
     user = UserFactory(username="ghickman")
     assert SuperUser not in user.roles
 
-    with pytest.raises(Exception, match="Unknown users: foo, test"):
+    with pytest.raises(Exception, match="Unknown admin usernames: foo, test"):
         ensure_admins(["ghickman", "foo", "test"])
 
 

--- a/tests/jobserver/authorization/test_admins.py
+++ b/tests/jobserver/authorization/test_admins.py
@@ -7,12 +7,6 @@ from ...factories import UserFactory
 
 
 @pytest.mark.django_db
-def test_ensure_admins_no_users_configured():
-    with pytest.raises(Exception, match="No admin users configured, aborting"):
-        ensure_admins([])
-
-
-@pytest.mark.django_db
 def test_ensure_admins_success():
     user = UserFactory(username="ghickman")
     assert SuperUser not in user.roles


### PR DESCRIPTION
A collection of improvements to the project UX when setting up from scratch.

In particular one no longer has to set `ENSURE_ADMINS`, and its error message is now clearer.

Fixes #398 