### PR TITLE
Hide Backend Warning Banners in Debug

### DIFF
--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -1,6 +1,7 @@
 import functools
 
 import structlog
+from django.conf import settings
 from django.urls import reverse
 
 from .authorization import SuperUser, has_role
@@ -17,6 +18,9 @@ def _is_active(request, prefix):
 
 def backend_warnings(request):
     def iter_warnings(backends):
+        if settings.DEBUG:
+            return
+
         for backend in backends:
             try:
                 last_seen = (

--- a/tests/jobserver/test_context_processors.py
+++ b/tests/jobserver/test_context_processors.py
@@ -11,6 +11,24 @@ from ..factories import JobRequestFactory, StatsFactory, UserFactory
 
 
 @pytest.mark.django_db
+def test_backend_warnings_with_debug_on(rf, settings):
+    settings.DEBUG = True
+
+    # set up some stats which should show up a warning in normal circumstances
+    tpp = Backend.objects.get(name="tpp")
+
+    JobRequestFactory(backend=tpp)
+
+    last_seen = timezone.now() - timedelta(minutes=10)
+    StatsFactory(backend=tpp, api_last_seen=last_seen)
+
+    request = rf.get("/")
+    output = backend_warnings(request)
+
+    assert output["backend_warnings"] == []
+
+
+@pytest.mark.django_db
 def test_backend_warnings_with_no_warnings(rf):
     last_seen = timezone.now() - timedelta(minutes=1)
     StatsFactory(api_last_seen=last_seen)


### PR DESCRIPTION
This hides the backend warning banners when DEBUG is on.

The warning banners are shown when a backend's job-runner hasn't talked to the API in over 5 minutes.  During development this happens most of the time and one ends up with two red banners on every page.  I am very done with this.