### PR TITLE
Bump Django to 3.2

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -101,6 +101,10 @@ WSGI_APPLICATION = "jobserver.wsgi.application"
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
 DATABASES = {"default": env.dj_db_url("DATABASE_URL", default="sqlite:///db.sqlite3")}
 
+# Default primary key field type
+# https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-asgiref==3.2.10
+asgiref==3.3.4
     # via django
 attrs==20.3.0
     # via
@@ -66,7 +66,7 @@ django-rest-framework==0.1.0
     # via -r requirements.in
 django-structlog==2.1.0
     # via -r requirements.in
-django==3.1.8
+django==3.2
     # via
     #   django-anymail
     #   django-debug-toolbar


### PR DESCRIPTION
This updates Django to 3.2 and sets a `DEFAULT_AUTO_FIELD` as per the warning Django emits.