### PR TITLE
Update or Create ProjectMemberships in link_user_to_project

### DIFF
--- a/jobserver/management/commands/link_user_to_project.py
+++ b/jobserver/management/commands/link_user_to_project.py
@@ -34,6 +34,8 @@ class Command(BaseCommand):
             self.stderr.write(str(e))
             sys.exit(1)
 
-        ProjectMembership.objects.create(
-            project=project, user=user, roles=selected_roles
+        ProjectMembership.objects.update_or_create(
+            project=project,
+            user=user,
+            defaults={"roles": selected_roles},
         )


### PR DESCRIPTION
This switches to `update_or_create` in the `link_user_to_project` script so we can change the Roles of an existing Project member without having to delete them first.