### PR TITLE
Link Multiple Workspaces to Project

### DIFF
--- a/jobserver/management/commands/create_project_from_workspace.py
+++ b/jobserver/management/commands/create_project_from_workspace.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         # generate a name from the slug
         name = " ".join(word.capitalize() for word in slug.split("-"))
 
-        project = Project.objects.create(org=org, name=name, slug=slug)
+        project, _ = Project.objects.get_or_create(org=org, name=name, slug=slug)
 
         # tell the User what was made and where they can view it
         f = furl(settings.BASE_URL)

--- a/jobserver/management/commands/create_project_from_workspace.py
+++ b/jobserver/management/commands/create_project_from_workspace.py
@@ -32,9 +32,7 @@ class Command(BaseCommand):
         # tell the User what was made and where they can view it
         f = furl(settings.BASE_URL)
         f.path = project.get_absolute_url()
-        self.stdout.write(
-            f"Name: {project.name}\nSlug: {project.slug}\nURL:  ({f.url})"
-        )
+        self.stdout.write(f"Name: {project.name}\nURL:  {f.url}")
 
         return project
 


### PR DESCRIPTION
Some workspace names normalise in such a way that they end up with the same Project, during initial roll-out testing it's ideal to combine them into the same Project (famous last words probably).