### PR TITLE
Limit Concurrency on the Deploy Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,8 @@ jobs:
 
     if: github.ref == 'refs/heads/main'
 
+    concurrency: deploy-production
+
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This sets up [job-level concurrency](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency) for the `deploy` job.

I'm not quite sure how to test this does what we want without just using it…

My hope is it blocks just the `deploy` job in the CI workflow on the `main` branch, however I could see it blocking the entire CI workflow while another one ran on `main`, which I don't think would be the worst, just a bit slower than we'd like.

However if this blocks PR branches from running CI then we'll have to roll it back.

Ref #433