### PR TITLE
Disable FLoC

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -205,6 +205,11 @@ INTERNAL_IPS = [
     "127.0.0.1",
 ]
 
+# Permissions Policy
+PERMISSIONS_POLICY = {
+    "interest-cohort": [],
+}
+
 # Python/Django Social Auth
 SOCIAL_AUTH_PIPELINE = [
     "social_core.pipeline.social_auth.social_details",

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 attrs
 django-anymail[mailgun]
 django-crispy-forms
+django-permissions-policy
 django-rest-framework
 django-structlog
 environs[django]

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,8 @@ django-extensions==3.1.3
     # via -r requirements.in
 django-ipware==3.0.1
     # via django-structlog
+django-permissions-policy==4.0.1
+    # via -r requirements.in
 django-rest-framework==0.1.0
     # via -r requirements.in
 django-structlog==2.1.0
@@ -71,6 +73,7 @@ django==3.2
     #   django-anymail
     #   django-debug-toolbar
     #   django-extensions
+    #   django-permissions-policy
     #   django-structlog
     #   djangorestframework
 djangorestframework==3.11.2


### PR DESCRIPTION
This disables Google's FLoC for the site using [django-permissions-policy](https://pypi.org/project/django-permissions-policy/).

[This article](https://adamj.eu/tech/2021/05/04/disabling-floc-googles-new-advertising-technology/) gives a great overview of why we might want this change.