### PR TITLE
Add Full Name in Project Invitation Selection UI

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -80,12 +80,19 @@ class ProjectCreateForm(forms.ModelForm):
 
 
 class ProjectInvitationForm(RolesForm):
-    users = forms.ModelMultipleChoiceField(queryset=User.objects.none())
-
     def __init__(self, users, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields["users"].queryset = users
+        self.fields["users"] = forms.MultipleChoiceField(
+            choices=list(self.build_user_choices(users)),
+        )
+
+    def build_user_choices(self, users):
+        for user in users:
+            full_name = user.get_full_name()
+            label = f"{user.username} ({full_name})" if full_name else user.username
+
+            yield user.pk, label
 
 
 class ProjectMembershipForm(RolesForm):

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -276,10 +276,11 @@ class ProjectSettings(CreateView):
 
     def form_valid(self, form):
         roles = form.cleaned_data["roles"]
-        users = form.cleaned_data["users"]
+        user_pks = form.cleaned_data["users"]
 
         failed_to_invite = []
 
+        users = User.objects.filter(pk__in=user_pks)
         for user in users:
             try:
                 with transaction.atomic():

--- a/tests/jobserver/views/test_projects.py
+++ b/tests/jobserver/views/test_projects.py
@@ -611,7 +611,7 @@ def test_projectsettings_post_with_incorrect_form(rf, superuser):
     # check the number of invitations hasn't changed
     assert ProjectInvitation.objects.filter(project=project).count() == 1
 
-    assert "“not_a_pk” is not a valid value." in response.rendered_content
+    assert "not_a_pk is not one of the available choices." in response.rendered_content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This adds the full name of a User, if we have that, to the User select2 picker when creating an Invitation to a Project.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/yAuDzZWk/304a9a57-402e-461e-a70e-ffb340899eac.jpg?v=b5c37eaac7330b2ed6652be64ba48cc9)

Fixes #484 