### PR TITLE
Edit Project Name

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -452,6 +452,12 @@ class Project(models.Model):
             kwargs={"org_slug": self.org.slug, "project_slug": self.slug},
         )
 
+    def get_invitation_url(self):
+        return reverse(
+            "project-invitation-create",
+            kwargs={"org_slug": self.org.slug, "project_slug": self.slug},
+        )
+
     def get_settings_url(self):
         return reverse(
             "project-settings",

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -35,7 +35,7 @@
     <h3>Workspaces</h3>
     <ul class="list-unstyled">
       {% for workspace in workspaces %}
-      <li class="d-flex justify-content-between align-items-center">
+      <li class="d-flex justify-content-between align-items-center mb-3">
 
         <div>
           <a href="{% url 'project-workspace-detail' org_slug=project.org.slug project_slug=project.slug workspace_slug=workspace.name %}">
@@ -49,7 +49,7 @@
 
           <input type="hidden" name="id" value="{{ workspace.pk }}" />
 
-          <button class="btn btn-block btn-danger" type="submit">Disconnect</button>
+          <button class="btn btn-block btn-sm btn-danger" type="submit">Disconnect</button>
         </form>
         {% endif %}
 

--- a/jobserver/templates/project_invitation_create.html
+++ b/jobserver/templates/project_invitation_create.html
@@ -1,0 +1,131 @@
+{% extends "base.html" %}
+
+{% load roles %}
+{% load static %}
+
+{% block extra_styles %}
+<link rel="stylesheet" href="{% static 'css/select2-4.0.13.min.css' %}">
+{% endblock %}
+
+{% block content %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+
+    <li class="breadcrumb-item"><a href="/">Home</a></li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ project.org.get_absolute_url }}">
+        {{ project.org.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ project.get_absolute_url }}">
+        {{ project.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ project.get_settings_url }}">
+        Settings
+      </a>
+    </li>
+
+    <li class="breadcrumb-item active" aria-current="page">Invite Users</li>
+
+  </ol>
+</nav>
+
+<div class="row mb-5">
+  <div class="col-lg-8 offset-lg-2">
+
+    <h2>Invite Users</h2>
+
+    <p>
+      Invite users to collaborate on {{ project.name }}.  They will be emailed
+      an invitation link.  You will be able to assign them roles once they
+      accept your invitation.
+    </p>
+
+    <form method="POST" class="mb-4">
+      {% csrf_token %}
+
+      {% if form.non_field_errors %}
+      <ul>
+        {% for error in form.non_field_errors %}
+        <li class="text-danger">{{ error }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+
+      <div class="form-group">
+        <select id="id_users" name="users" class="w-100" multiple required>
+          {% for value, label in form.fields.users.choices %}
+          <option value="{{ value }}">{{ label }}</option>
+          {% endfor %}
+        </select>
+
+        {% for error in form.users.errors %}
+        <p class="text-danger">{{ error }}</p>
+        {% endfor %}
+      </div>
+
+      <div class="form-group mb-3">
+        <p>Select one or more roles for the user(s) you are inviting.</p>
+
+        <ul class="list-group mb-1">
+          {% for value, label in form.roles.field.choices %}
+          <li class="list-group-item">
+            <div class="custom-control custom-checkbox">
+              <input
+                type="checkbox"
+                class="custom-control-input"
+                id="id_roles_{{ forloop.counter0 }}"
+                name="roles"
+                value="{{ value }}"
+                {% if value in form.roles.value %}
+                checked
+                {% endif %}
+              />
+              <label class="custom-control-label" for="id_roles_{{ forloop.counter0 }}">
+                <span class="d-block"><strong>{{ label }}</strong></span>
+                <span>{{ value|role_description|linebreaksbr }}</span>
+              </label>
+            </div>
+          </li>
+          {% endfor %}
+        </ul>
+
+        {% if form.roles.errors %}
+        <ul class="pl-3">
+          {% for error in form.roles.errors %}
+          <li class="text-danger">{{ error }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+      </div>
+
+      <div class="form-group mb-3">
+        <button type="submit" class="btn btn-sm btn-primary">Invite</button>
+      </div>
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}
+
+{% block extra_js %}
+<script type="text/javascript" src="{% static 'js/select2-4.0.13.min.js' %}"></script>
+<script type="text/javascript">
+  $(document).ready(function() {
+    $('#id_users').select2({
+      placeholder: "Select 1 or more Users to invite",
+      selectionCssClass: ":all:",
+    });
+  });
+</script>
+{% endblock %}

--- a/jobserver/templates/project_settings.html
+++ b/jobserver/templates/project_settings.html
@@ -35,25 +35,23 @@
     {% if members %}
     <ul class="list-unstyled">
       {% for member in members %}
-      <li class="mb-3">
+      <li class="mb-3 p-2 border rounded d-flex justify-content-between align-items-center">
         <div>
-          <div class="d-flex justify-content-between align-items-center">
-            <strong>{{ member.user.name }}</strong>
+          <strong class="mr-3">{{ member.user.name }}</strong>
 
-            {% if can_manage_members %}
-            <a class="btn btn-sm btn-primary" href="{{ member.get_edit_url }}">
-              Edit
-            </a>
-            {% endif %}
-          </div>
+          {% for role in member.roles %}
+          <span class="badge badge-secondary">{{ role.display_name }}</span>
+          {% endfor %}
 
-          <p>Roles:</p>
-          <ul>
-            {% for role in member.roles %}
-            <li>{{ role.display_name }}</li>
-            {% endfor %}
-          </ul>
         </div>
+
+        {% if can_manage_members %}
+        <div>
+          <a class="btn btn-sm btn-primary" href="{{ member.get_edit_url }}">
+            Edit
+          </a>
+        </div>
+        {% endif %}
       </li>
       {% endfor %}
     </ul>

--- a/jobserver/templates/project_settings.html
+++ b/jobserver/templates/project_settings.html
@@ -2,11 +2,6 @@
 
 {% load humanize %}
 {% load roles %}
-{% load static %}
-
-{% block extra_styles %}
-<link rel="stylesheet" href="{% static 'css/select2-4.0.13.min.css' %}">
-{% endblock %}
 
 {% block content %}
 
@@ -75,76 +70,11 @@
 <div class="row">
   <div class="col-lg-8 offset-lg-2">
 
-    <h3>Invitations</h3>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h3>Invitations</h3>
 
-    <p>
-      Invite users to collaborate on {{ project.name }}.  They will be emailed
-      an invitation link.  You will be able to assign them roles once they
-      accept your invitation.
-    </p>
-
-    <form method="POST" class="mb-4">
-      {% csrf_token %}
-
-      {% if form.non_field_errors %}
-      <ul>
-        {% for error in form.non_field_errors %}
-        <li class="text-danger">{{ error }}</li>
-        {% endfor %}
-      </ul>
-      {% endif %}
-
-      <div class="form-group">
-        <select id="id_users" name="users" class="w-100" multiple required>
-          {% for value, label in form.fields.users.choices %}
-          <option value="{{ value }}">{{ label }}</option>
-          {% endfor %}
-        </select>
-
-        {% for error in form.users.errors %}
-        <p class="text-danger">{{ error }}</p>
-        {% endfor %}
-      </div>
-
-      <div class="form-group mb-3">
-        <p>Select one or more roles for the user(s) you are inviting.</p>
-
-        <ul class="list-group mb-1">
-          {% for value, label in form.roles.field.choices %}
-          <li class="list-group-item">
-            <div class="custom-control custom-checkbox">
-              <input
-                type="checkbox"
-                class="custom-control-input"
-                id="id_roles_{{ forloop.counter0 }}"
-                name="roles"
-                value="{{ value }}"
-                {% if value in form.roles.value %}
-                checked
-                {% endif %}
-              />
-              <label class="custom-control-label" for="id_roles_{{ forloop.counter0 }}">
-                <span class="d-block"><strong>{{ label }}</strong></span>
-                <span>{{ value|role_description|linebreaksbr }}</span>
-              </label>
-            </div>
-          </li>
-          {% endfor %}
-        </ul>
-
-        {% if form.roles.errors %}
-        <ul class="pl-3">
-          {% for error in form.roles.errors %}
-          <li class="text-danger">{{ error }}</li>
-          {% endfor %}
-        </ul>
-        {% endif %}
-
-        <button type="submit" class="btn btn-sm btn-primary">Invite</button>
-
-      </div>
-
-    </form>
+      <a class="btn btn-sm btn-primary" href="{{ project.get_invitation_url }}">Invite Users</a>
+    </div>
 
     {% if invitations %}
     <h4>Pending</h4>
@@ -178,22 +108,10 @@
       {% endfor %}
     </ul>
     {% else %}
-    <p class="mt-5">There are no pending invitations for this project.</p>
+    <p class="mb-5">There are no pending invitations for this project.</p>
     {% endif %}
 
   </div>
 </div>
 
-{% endblock %}
-
-{% block extra_js %}
-<script type="text/javascript" src="{% static 'js/select2-4.0.13.min.js' %}"></script>
-<script type="text/javascript">
-  $(document).ready(function() {
-    $('#id_users').select2({
-      placeholder: "Select 1 or more Users to invite",
-      selectionCssClass: ":all:",
-    });
-  });
-</script>
 {% endblock %}

--- a/jobserver/templates/project_settings.html
+++ b/jobserver/templates/project_settings.html
@@ -30,84 +30,85 @@
 <div class="row mb-5">
   <div class="col-lg-8 offset-lg-2">
 
-    <h3>Members</h3>
+    <div class="mb-5">
+      <h3>Members</h3>
 
-    {% if members %}
-    <ul class="list-unstyled">
-      {% for member in members %}
-      <li class="mb-3 p-2 border rounded d-flex justify-content-between align-items-center">
-        <div>
-          <strong class="mr-3">{{ member.user.name }}</strong>
+      {% if members %}
+      <ul class="list-unstyled">
+        {% for member in members %}
+        <li class="mb-3 p-2 border rounded d-flex justify-content-between align-items-center">
+          <div>
+            <strong class="mr-3">{{ member.user.name }}</strong>
 
-          {% for role in member.roles %}
-          <span class="badge badge-secondary">{{ role.display_name }}</span>
-          {% endfor %}
+            {% for role in member.roles %}
+            <span class="badge badge-secondary">{{ role.display_name }}</span>
+            {% endfor %}
 
-        </div>
+          </div>
 
-        {% if can_manage_members %}
-        <div>
-          <a class="btn btn-sm btn-primary" href="{{ member.get_edit_url }}">
-            Edit
-          </a>
-        </div>
-        {% endif %}
-      </li>
-      {% endfor %}
-    </ul>
-    {% else %}
-    <p class="mt-5">
-      There are no members for this organisation yet, you can invite some
-      below.
-    </p>
-    {% endif %}
+          {% if can_manage_members %}
+          <div>
+            <a class="btn btn-sm btn-primary" href="{{ member.get_edit_url }}">
+              Edit
+            </a>
+          </div>
+          {% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="mt-5">
+        There are no members for this organisation yet, you can invite some
+        below.
+      </p>
+      {% endif %}
 
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-lg-8 offset-lg-2">
-
-    <div class="d-flex justify-content-between align-items-center mb-3">
-      <h3>Invitations</h3>
-
-      <a class="btn btn-sm btn-primary" href="{{ project.get_invitation_url }}">Invite Users</a>
     </div>
 
-    {% if invitations %}
-    <h4>Pending</h4>
-    <ul class="list-unstyled">
-      {% for invite in invitations %}
-      <li class="mb-3 p-2 border rounded d-flex justify-content-between align-items-center">
+    <div class="mb-3">
 
-        <div>
-          <span class="mr-3">
-            {{ invite.user.username }}
-            <small class="text-muted">({{ invite.user.name }})</small>
-          </span>
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h3>Invitations</h3>
 
-          {% for role in invite.roles %}
-          <span class="badge badge-secondary">{{ role.display_name }}</span>
-          {% endfor %}
+        <a class="btn btn-sm btn-primary" href="{{ project.get_invitation_url }}">Invite Users</a>
+      </div>
 
-        </div>
+      {% if invitations %}
+      <h4>Pending</h4>
+      <ul class="list-unstyled">
+        {% for invite in invitations %}
+        <li class="mb-3 p-2 border rounded d-flex justify-content-between align-items-center">
 
-        {% if can_manage_members %}
-        <form method="POST" action="{{ invite.get_cancel_url }}">
-          {% csrf_token %}
+          <div>
+            <span class="mr-3">
+              {{ invite.user.username }}
+              <small class="text-muted">({{ invite.user.name }})</small>
+            </span>
 
-          <input type="hidden" name="invite_pk" value="{{ invite.pk }}" />
+            {% for role in invite.roles %}
+            <span class="badge badge-secondary">{{ role.display_name }}</span>
+            {% endfor %}
 
-          <button class="btn btn-block btn-sm btn-danger" type="submit">Delete</button>
-        </form>
-        {% endif %}
+          </div>
 
-      </li>
-      {% endfor %}
-    </ul>
-    {% else %}
-    <p class="mb-5">There are no pending invitations for this project.</p>
-    {% endif %}
+          {% if can_manage_members %}
+          <form method="POST" action="{{ invite.get_cancel_url }}">
+            {% csrf_token %}
+
+            <input type="hidden" name="invite_pk" value="{{ invite.pk }}" />
+
+            <button class="btn btn-block btn-sm btn-danger" type="submit">Delete</button>
+          </form>
+          {% endif %}
+
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="mb-5">There are no pending invitations for this project.</p>
+      {% endif %}
+
+    </div>
 
   </div>
 </div>

--- a/jobserver/templates/project_settings.html
+++ b/jobserver/templates/project_settings.html
@@ -30,6 +30,43 @@
 <div class="row mb-5">
   <div class="col-lg-8 offset-lg-2">
 
+    <h2>Settings</h2>
+
+    <div class="mb-5">
+      <form method="POST">
+        {% csrf_token %}
+
+        {% if form.non_field_errors %}
+        <ul>
+          {% for error in form.non_field_errors %}
+          <li class="text-danger">{{ error }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+        <div class="d-flex justify-content-between align-items-center">
+          <div class="form-group flex-grow-1 mb-0 mr-3">
+            <input
+              type="text"
+              class="form-control"
+              name="name"
+              id="id_name"
+              value="{{ project.name }}"
+              aria-describedby="name_help"
+            />
+            {% for error in form.name.errors %}
+            <p class="text-danger">{{ error }}</p>
+            {% endfor %}
+          </div>
+
+          <div class="form-group mb-0">
+            <button type="submit" class="btn btn-sm btn-primary float-right">Save</button>
+          </div>
+        </div>
+
+      </form>
+    </div>
+
     <div class="mb-5">
       <h3>Members</h3>
 

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -43,6 +43,7 @@ from .views.projects import (
     ProjectCreate,
     ProjectDetail,
     ProjectDisconnectWorkspace,
+    ProjectInvitationCreate,
     ProjectMembershipEdit,
     ProjectRemoveMember,
     ProjectSettings,
@@ -114,6 +115,11 @@ org_urls = [
         "<org_slug>/<project_slug>/disconnect/",
         ProjectDisconnectWorkspace.as_view(),
         name="project-disconnect-workspace",
+    ),
+    path(
+        "<org_slug>/<project_slug>/invite-users/",
+        ProjectInvitationCreate.as_view(),
+        name="project-invitation-create",
     ),
     path(
         "<org_slug>/<project_slug>/members/<pk>/edit",

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -6,7 +6,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
 from django.utils.html import escape
-from django.views.generic import CreateView, DetailView, TemplateView, UpdateView, View
+from django.views.generic import CreateView, DetailView, UpdateView, View
 from sentry_sdk import capture_exception
 
 from ..authorization import has_permission, roles_for
@@ -350,7 +350,10 @@ class ProjectRemoveMember(View):
         return redirect(membership.project.get_settings_url())
 
 
-class ProjectSettings(TemplateView):
+class ProjectSettings(UpdateView):
+    fields = ["name"]
+    model = Project
+    slug_url_kwarg = "project_slug"
     template_name = "project_settings.html"
 
     def dispatch(self, request, *args, **kwargs):

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -6,7 +6,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
 from django.utils.html import escape
-from django.views.generic import CreateView, DetailView, UpdateView, View
+from django.views.generic import CreateView, DetailView, TemplateView, UpdateView, View
 from sentry_sdk import capture_exception
 
 from ..authorization import has_permission, roles_for
@@ -168,94 +168,10 @@ class ProjectDisconnectWorkspace(View):
         return redirect(project)
 
 
-class ProjectMembershipEdit(UpdateView):
-    context_object_name = "membership"
-    form_class = ProjectMembershipForm
-    model = ProjectMembership
-    template_name = "project_membership_edit.html"
-
-    def dispatch(self, request, *args, **kwargs):
-        self.project = get_object_or_404(
-            Project,
-            org__slug=self.kwargs["org_slug"],
-            slug=self.kwargs["project_slug"],
-        )
-
-        self.can_manage_members = has_permission(
-            self.request.user,
-            "manage_project_members",
-            project=self.project,
-        )
-
-        if not self.can_manage_members:
-            return redirect(self.project.get_settings_url())
-
-        return super().dispatch(request, *args, **kwargs)
-
-    def form_valid(self, form):
-        self.object.roles = form.cleaned_data["roles"]
-        self.object.save()
-
-        return redirect(self.project.get_settings_url())
-
-    def get_form_kwargs(self, **kwargs):
-        kwargs = super().get_form_kwargs(**kwargs)
-
-        # ProjectMembershipForm isn't a ModelForm so don't pass instance to it
-        del kwargs["instance"]
-
-        kwargs["available_roles"] = roles_for(ProjectMembership)
-
-        return kwargs
-
-    def get_initial(self):
-        return super().get_initial() | {
-            "roles": self.object.roles,
-        }
-
-    def get_object(self):
-        return get_object_or_404(
-            ProjectMembership,
-            project__org__slug=self.kwargs["org_slug"],
-            project__slug=self.kwargs["project_slug"],
-            pk=self.kwargs["pk"],
-        )
-
-
-@method_decorator(require_superuser, name="dispatch")
-class ProjectRemoveMember(View):
-    model = ProjectMembership
-
-    def post(self, request, *args, **kwargs):
-        try:
-            membership = ProjectMembership.objects.select_related("project").get(
-                project__org__slug=self.kwargs["org_slug"],
-                project__slug=self.kwargs["project_slug"],
-                user__username=self.request.POST.get("username"),
-            )
-        except ProjectMembership.DoesNotExist:
-            raise Http404
-
-        can_manage_members = has_permission(
-            self.request.user,
-            "manage_project_members",
-            project=membership.project,
-        )
-        if can_manage_members:
-            membership.delete()
-        else:
-            messages.error(
-                request, "You do not have permission to remove Project members."
-            )
-
-        return redirect(membership.project.get_settings_url())
-
-
-@method_decorator(require_superuser, name="dispatch")
-class ProjectSettings(CreateView):
+class ProjectInvitationCreate(CreateView):
     form_class = ProjectInvitationForm
     model = ProjectInvitation
-    template_name = "project_settings.html"
+    template_name = "project_invitation_create.html"
 
     def dispatch(self, request, *args, **kwargs):
         self.project = get_object_or_404(
@@ -349,3 +265,123 @@ class ProjectSettings(CreateView):
         del kwargs["instance"]
 
         return kwargs
+
+
+class ProjectMembershipEdit(UpdateView):
+    context_object_name = "membership"
+    form_class = ProjectMembershipForm
+    model = ProjectMembership
+    template_name = "project_membership_edit.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        self.project = get_object_or_404(
+            Project,
+            org__slug=self.kwargs["org_slug"],
+            slug=self.kwargs["project_slug"],
+        )
+
+        self.can_manage_members = has_permission(
+            self.request.user,
+            "manage_project_members",
+            project=self.project,
+        )
+
+        if not self.can_manage_members:
+            return redirect(self.project.get_settings_url())
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def form_valid(self, form):
+        self.object.roles = form.cleaned_data["roles"]
+        self.object.save()
+
+        return redirect(self.project.get_settings_url())
+
+    def get_form_kwargs(self, **kwargs):
+        kwargs = super().get_form_kwargs(**kwargs)
+
+        # ProjectMembershipForm isn't a ModelForm so don't pass instance to it
+        del kwargs["instance"]
+
+        kwargs["available_roles"] = roles_for(ProjectMembership)
+
+        return kwargs
+
+    def get_initial(self):
+        return super().get_initial() | {
+            "roles": self.object.roles,
+        }
+
+    def get_object(self):
+        return get_object_or_404(
+            ProjectMembership,
+            project__org__slug=self.kwargs["org_slug"],
+            project__slug=self.kwargs["project_slug"],
+            pk=self.kwargs["pk"],
+        )
+
+
+@method_decorator(require_superuser, name="dispatch")
+class ProjectRemoveMember(View):
+    model = ProjectMembership
+
+    def post(self, request, *args, **kwargs):
+        try:
+            membership = ProjectMembership.objects.select_related("project").get(
+                project__org__slug=self.kwargs["org_slug"],
+                project__slug=self.kwargs["project_slug"],
+                user__username=self.request.POST.get("username"),
+            )
+        except ProjectMembership.DoesNotExist:
+            raise Http404
+
+        can_manage_members = has_permission(
+            self.request.user,
+            "manage_project_members",
+            project=membership.project,
+        )
+        if can_manage_members:
+            membership.delete()
+        else:
+            messages.error(
+                request, "You do not have permission to remove Project members."
+            )
+
+        return redirect(membership.project.get_settings_url())
+
+
+@method_decorator(require_superuser, name="dispatch")
+class ProjectSettings(TemplateView):
+    template_name = "project_settings.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        self.project = get_object_or_404(
+            Project,
+            org__slug=self.kwargs["org_slug"],
+            slug=self.kwargs["project_slug"],
+        )
+
+        self.can_manage_members = has_permission(
+            self.request.user,
+            "manage_project_members",
+            project=self.project,
+        )
+        if not self.can_manage_members:
+            raise Http404
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        members = self.project.members.select_related("user").order_by("user__username")
+        invitations = (
+            self.project.invitations.filter(membership=None)
+            .select_related("user")
+            .order_by("user__username")
+        )
+
+        context = super().get_context_data(**kwargs)
+        context["can_manage_members"] = self.can_manage_members
+        context["invitations"] = invitations
+        context["members"] = members
+        context["project"] = self.project
+        return context

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -350,7 +350,6 @@ class ProjectRemoveMember(View):
         return redirect(membership.project.get_settings_url())
 
 
-@method_decorator(require_superuser, name="dispatch")
 class ProjectSettings(TemplateView):
     template_name = "project_settings.html"
 

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -538,6 +538,17 @@ def test_projectmembership_get_edit_url():
 
 
 @pytest.mark.django_db
+def test_project_get_invitation_url():
+    org = OrgFactory(name="test-org")
+    project = ProjectFactory(org=org)
+    url = project.get_invitation_url()
+    assert url == reverse(
+        "project-invitation-create",
+        kwargs={"org_slug": org.slug, "project_slug": project.slug},
+    )
+
+
+@pytest.mark.django_db
 def test_project_get_settings_url():
     org = OrgFactory(name="test-org")
     project = ProjectFactory(org=org)

--- a/tests/jobserver/views/test_projects.py
+++ b/tests/jobserver/views/test_projects.py
@@ -627,16 +627,17 @@ def test_projectremovemember_without_permission(rf, superuser):
 
 
 @pytest.mark.django_db
-def test_projectsettings_success(rf, superuser):
+def test_projectsettings_success(rf):
     org = OrgFactory()
     project = ProjectFactory(org=org)
+    coordinator = UserFactory()
 
     ProjectMembershipFactory(
-        project=project, user=superuser, roles=[ProjectCoordinator]
+        project=project, user=coordinator, roles=[ProjectCoordinator]
     )
 
     request = rf.get(MEANINGLESS_URL)
-    request.user = superuser
+    request.user = coordinator
 
     response = ProjectSettings.as_view()(
         request, org_slug=org.slug, project_slug=project.slug
@@ -649,19 +650,19 @@ def test_projectsettings_success(rf, superuser):
 
 
 @pytest.mark.django_db
-def test_projectsettings_unknown_project(rf, superuser):
+def test_projectsettings_unknown_project(rf):
     request = rf.get(MEANINGLESS_URL)
-    request.user = superuser
+    request.user = UserFactory()
     with pytest.raises(Http404):
         ProjectSettings.as_view()(request, org_slug="", project_slug="")
 
 
 @pytest.mark.django_db
-def test_projectsettings_without_permission(rf, superuser):
+def test_projectsettings_without_permission(rf):
     org = OrgFactory()
     project = ProjectFactory(org=org)
 
     request = rf.get(MEANINGLESS_URL)
-    request.user = superuser
+    request.user = UserFactory()
     with pytest.raises(Http404):
         ProjectSettings.as_view()(request, org_slug=org.slug, project_slug=project.slug)


### PR DESCRIPTION
This makes a Project's name editable on the settings page, moving ProjectInvitationForm to a new page.  I've also tightened up the UI a little for consistency.

**Settings Page**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/WnuY5OX5/a1cf8164-8add-487f-873b-186556218579.jpg?v=5726024b8172c32d9b74f1dab9dca7f2)

**ProjectInvitationForm**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/Jru4Q2R6/bcde5b13-2744-4477-b137-dd454bb84ca0.jpg?v=15b80250f4ad08ee7673969153bcb6b2)