### PR TITLE
Fix Membership Removal

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -593,6 +593,16 @@ class ProjectMembership(models.Model):
             },
         )
 
+    def get_remove_url(self):
+        return reverse(
+            "project-membership-remove",
+            kwargs={
+                "org_slug": self.project.org.slug,
+                "project_slug": self.project.slug,
+                "pk": self.pk,
+            },
+        )
+
 
 class Release(models.Model):
     # No value in the default Autoid as we are using a content-addressable hash

--- a/jobserver/templates/project_membership_edit.html
+++ b/jobserver/templates/project_membership_edit.html
@@ -102,7 +102,7 @@
       <form method="POST" action="{{ membership.get_remove_url }}">
         {% csrf_token %}
 
-        <input type="hidden" name="member_pk" value="{{ member.pk }}" />
+        <input type="hidden" name="member_pk" value="{{ membership.pk }}" />
 
         <button class="btn btn-danger" type="submit">Remove</button>
 

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -45,7 +45,7 @@ from .views.projects import (
     ProjectDisconnectWorkspace,
     ProjectInvitationCreate,
     ProjectMembershipEdit,
-    ProjectRemoveMember,
+    ProjectMembershipRemove,
     ProjectSettings,
 )
 from .views.status import Status
@@ -127,9 +127,9 @@ org_urls = [
         name="project-membership-edit",
     ),
     path(
-        "<org_slug>/<project_slug>/remove-member/",
-        ProjectRemoveMember.as_view(),
-        name="project-remove-member",
+        "<org_slug>/<project_slug>/members/<pk>/remove",
+        ProjectMembershipRemove.as_view(),
+        name="project-membership-remove",
     ),
     path(
         "<org_slug>/<project_slug>/settings/",

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -329,7 +329,7 @@ class ProjectMembershipRemove(View):
             membership = ProjectMembership.objects.select_related("project").get(
                 project__org__slug=self.kwargs["org_slug"],
                 project__slug=self.kwargs["project_slug"],
-                user__username=self.request.POST.get("username"),
+                pk=self.request.POST.get("member_pk"),
             )
         except ProjectMembership.DoesNotExist:
             raise Http404

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -322,7 +322,7 @@ class ProjectMembershipEdit(UpdateView):
 
 
 @method_decorator(require_superuser, name="dispatch")
-class ProjectRemoveMember(View):
+class ProjectMembershipRemove(View):
     model = ProjectMembership
 
     def post(self, request, *args, **kwargs):

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -321,7 +321,6 @@ class ProjectMembershipEdit(UpdateView):
         )
 
 
-@method_decorator(require_superuser, name="dispatch")
 class ProjectMembershipRemove(View):
     model = ProjectMembership
 

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -538,6 +538,25 @@ def test_projectmembership_get_edit_url():
 
 
 @pytest.mark.django_db
+def test_projectmembership_get_remove_url():
+    org = OrgFactory(name="test-org")
+    project = ProjectFactory(org=org)
+    user = UserFactory()
+
+    membership = ProjectMembershipFactory(project=project, user=user)
+
+    url = membership.get_remove_url()
+    assert url == reverse(
+        "project-membership-remove",
+        kwargs={
+            "org_slug": org.slug,
+            "project_slug": project.slug,
+            "pk": membership.pk,
+        },
+    )
+
+
+@pytest.mark.django_db
 def test_project_get_invitation_url():
     org = OrgFactory(name="test-org")
     project = ProjectFactory(org=org)

--- a/tests/jobserver/views/test_projects.py
+++ b/tests/jobserver/views/test_projects.py
@@ -564,7 +564,7 @@ def test_projectmembershipremove_success(rf):
     )
     membership = ProjectMembershipFactory(project=project, user=member)
 
-    request = rf.post("/", {"username": member.username})
+    request = rf.post("/", {"member_pk": membership.pk})
     request.user = coordinator
 
     response = ProjectMembershipRemove.as_view()(
@@ -582,7 +582,7 @@ def test_projectmembershipremove_unknown_project_membership(rf):
     org = OrgFactory()
     project = ProjectFactory(org=org)
 
-    request = rf.post("/", {"username": "test"})
+    request = rf.post("/", {"member_pk": 0})
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -599,7 +599,7 @@ def test_projectmembershipremove_without_permission(rf):
 
     membership = ProjectMembershipFactory(project=project, user=member)
 
-    request = rf.post("/", {"username": member.username})
+    request = rf.post("/", {"member_pk": membership.pk})
     request.user = UserFactory()
 
     # set up messages framework

--- a/tests/jobserver/views/test_projects.py
+++ b/tests/jobserver/views/test_projects.py
@@ -17,7 +17,7 @@ from jobserver.views.projects import (
     ProjectDisconnectWorkspace,
     ProjectInvitationCreate,
     ProjectMembershipEdit,
-    ProjectRemoveMember,
+    ProjectMembershipRemove,
     ProjectSettings,
 )
 
@@ -553,7 +553,7 @@ def test_projectmembershipedit_without_permission(rf):
 
 
 @pytest.mark.django_db
-def test_projectremovemember_success(rf, superuser):
+def test_projectmembershipremove_success(rf):
     org = OrgFactory()
     project = ProjectFactory(org=org)
     member = UserFactory()
@@ -566,7 +566,7 @@ def test_projectremovemember_success(rf, superuser):
     request = rf.post("/", {"username": member.username})
     request.user = superuser
 
-    response = ProjectRemoveMember.as_view()(
+    response = ProjectMembershipRemove.as_view()(
         request, org_slug=org.slug, project_slug=project.slug
     )
 
@@ -577,7 +577,7 @@ def test_projectremovemember_success(rf, superuser):
 
 
 @pytest.mark.django_db
-def test_projectremovemember_unknown_project_membership(rf, superuser):
+def test_projectmembershipremove_unknown_project_membership(rf, superuser):
     org = OrgFactory()
     project = ProjectFactory(org=org)
 
@@ -589,13 +589,13 @@ def test_projectremovemember_unknown_project_membership(rf, superuser):
     request.user = superuser
 
     with pytest.raises(Http404):
-        ProjectRemoveMember.as_view()(
+        ProjectMembershipRemove.as_view()(
             request, org_slug=org.slug, project_slug=project.slug
         )
 
 
 @pytest.mark.django_db
-def test_projectremovemember_without_permission(rf, superuser):
+def test_projectmembershipremove_without_permission(rf, superuser):
     org = OrgFactory()
     project = ProjectFactory(org=org)
     member = UserFactory()
@@ -610,7 +610,7 @@ def test_projectremovemember_without_permission(rf, superuser):
     messages = FallbackStorage(request)
     request._messages = messages
 
-    response = ProjectRemoveMember.as_view()(
+    response = ProjectMembershipRemove.as_view()(
         request, org_slug=org.slug, project_slug=project.slug
     )
 

--- a/tests/jobserver/views/test_projects.py
+++ b/tests/jobserver/views/test_projects.py
@@ -556,15 +556,16 @@ def test_projectmembershipedit_without_permission(rf):
 def test_projectmembershipremove_success(rf):
     org = OrgFactory()
     project = ProjectFactory(org=org)
+    coordinator = UserFactory()
     member = UserFactory()
 
     ProjectMembershipFactory(
-        project=project, user=superuser, roles=[ProjectCoordinator]
+        project=project, user=coordinator, roles=[ProjectCoordinator]
     )
     membership = ProjectMembershipFactory(project=project, user=member)
 
     request = rf.post("/", {"username": member.username})
-    request.user = superuser
+    request.user = coordinator
 
     response = ProjectMembershipRemove.as_view()(
         request, org_slug=org.slug, project_slug=project.slug
@@ -577,16 +578,12 @@ def test_projectmembershipremove_success(rf):
 
 
 @pytest.mark.django_db
-def test_projectmembershipremove_unknown_project_membership(rf, superuser):
+def test_projectmembershipremove_unknown_project_membership(rf):
     org = OrgFactory()
     project = ProjectFactory(org=org)
 
-    ProjectMembershipFactory(
-        project=project, user=superuser, roles=[ProjectCoordinator]
-    )
-
     request = rf.post("/", {"username": "test"})
-    request.user = superuser
+    request.user = UserFactory()
 
     with pytest.raises(Http404):
         ProjectMembershipRemove.as_view()(
@@ -595,7 +592,7 @@ def test_projectmembershipremove_unknown_project_membership(rf, superuser):
 
 
 @pytest.mark.django_db
-def test_projectmembershipremove_without_permission(rf, superuser):
+def test_projectmembershipremove_without_permission(rf):
     org = OrgFactory()
     project = ProjectFactory(org=org)
     member = UserFactory()
@@ -603,7 +600,7 @@ def test_projectmembershipremove_without_permission(rf, superuser):
     membership = ProjectMembershipFactory(project=project, user=member)
 
     request = rf.post("/", {"username": member.username})
-    request.user = superuser
+    request.user = UserFactory()
 
     # set up messages framework
     request.session = "session"


### PR DESCRIPTION
This fixes the membership removal button form whose view was tested… but still very broken.  This also normalises the view name to match the related view.