### PR TITLE
Move SecurityMiddleware to first position

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -61,9 +61,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",
-    "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",


### PR DESCRIPTION
The Whitenoise docs say that it should come after SecurityMiddleware [1]
and the Debug Toolbar docs say that it should come after any middleware
that encodes the response [2].  Since Whitenoise could be configured to
do that it makes sense to keep Debug Toolbar after it in the order.

[1]: http://whitenoise.evans.io/en/stable/#quickstart-for-django-apps
[2]: https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#enabling-middleware