### PR TITLE
Handle Release Notifications

### DIFF
--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -23,6 +23,7 @@ from django.views.generic import RedirectView
 from .api import (
     JobAPIUpdate,
     JobRequestAPIList,
+    ReleaseNotificationAPICreate,
     ReleaseUploadAPI,
     UserAPIDetail,
     WorkspaceStatusesAPI,
@@ -64,6 +65,7 @@ from .views.workspaces import (
 api_urls = [
     path("job-requests/", JobRequestAPIList.as_view()),
     path("jobs/", JobAPIUpdate.as_view()),
+    path("release-notifications/", ReleaseNotificationAPICreate.as_view()),
     path("users/<username>/", UserAPIDetail.as_view(), name="user-detail"),
     path(
         "workspaces/<name>/statuses/",

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -557,6 +557,12 @@ six==1.15.0 \
     #   responses
     #   social-auth-app-django
     #   virtualenv
+slack-sdk==3.5.1 \
+    --hash=sha256:4d3f9f1a984fe828260010fc66ebcd1aeb63b78e6e47d366a9e7177ccc529e84 \
+    --hash=sha256:8ceb46f7989d2ba1694dec8555dbda7f750b9216e453da4ad3e32a498bc9ea9a
+    # via
+    #   -c requirements.in
+    #   -r requirements.in
 social-auth-app-django==4.0.0 \
     --hash=sha256:2c69e57df0b30c9c1823519c5f1992cbe4f3f98fdc7d95c840e091a752708840 \
     --hash=sha256:567ad0e028311541d7dfed51d3bf2c60440a6fd236d5d4d06c5a618b3d6c57c5 \

--- a/requirements.in
+++ b/requirements.in
@@ -15,5 +15,6 @@ litecli
 pyyaml
 requests
 sentry-sdk
+slack-sdk
 social-auth-app-django
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -282,6 +282,10 @@ six==1.15.0 \
     #   social-auth-app-django
     #   social-auth-core
     #   structlog
+slack-sdk==3.5.1 \
+    --hash=sha256:4d3f9f1a984fe828260010fc66ebcd1aeb63b78e6e47d366a9e7177ccc529e84 \
+    --hash=sha256:8ceb46f7989d2ba1694dec8555dbda7f750b9216e453da4ad3e32a498bc9ea9a
+    # via -r requirements.in
 social-auth-app-django==4.0.0 \
     --hash=sha256:2c69e57df0b30c9c1823519c5f1992cbe4f3f98fdc7d95c840e091a752708840 \
     --hash=sha256:567ad0e028311541d7dfed51d3bf2c60440a6fd236d5d4d06c5a618b3d6c57c5 \

--- a/services/logging.py
+++ b/services/logging.py
@@ -47,7 +47,6 @@ structlog.configure(
     context_class=structlog.threadlocal.wrap_dict(dict),
     logger_factory=structlog.stdlib.LoggerFactory(),
     wrapper_class=structlog.stdlib.BoundLogger,
-    cache_logger_on_first_use=True,
 )
 
 logging_config_dict = {

--- a/services/slack.py
+++ b/services/slack.py
@@ -1,0 +1,9 @@
+from environs import Env
+from slack_sdk import WebClient
+
+
+env = Env()
+
+slack_token = env.str("SLACK_BOT_TOKEN", default="")
+
+client = WebClient(token=slack_token)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+import structlog
+from structlog.testing import LogCapture
 
 from jobserver.authorization.roles import SuperUser
 
@@ -10,6 +12,16 @@ def api_rf():
     from rest_framework.test import APIRequestFactory
 
     return APIRequestFactory()
+
+
+@pytest.fixture(name="log_output")
+def fixture_log_output():
+    return LogCapture()
+
+
+@pytest.fixture(autouse=True)
+def fixture_configure_structlog(log_output):
+    structlog.configure(processors=[log_output])
 
 
 @pytest.fixture


### PR DESCRIPTION
This sets up the API for handling Release Notifications from osrelease, and pushing them into a Slack channel.

Example (created by running locally):
![](https://p198.p4.n0.cdn.getcloudapp.com/items/7KuP5YEG/16d45ea6-f384-44a4-9458-db82701096f8.jpg?v=9b5afa392f27da428c00e439cc4f409f)

Related PR: opensafely-core/output-publisher#21