### PR TITLE
Switch to Org-level SSH Deploy Key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy to dokku
-        uses: idoberko2/dokku-deploy-github-action@v1
+        uses: idoberko2/dokku-deploy-github-action@4b326b3
         with:
           app-name: "job-server"
           dokku-host: ${{ secrets.DOKKU_HOST }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,5 +112,5 @@ jobs:
         with:
           app-name: "job-server"
           dokku-host: ${{ secrets.DOKKU_HOST }}
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key: ${{ secrets.DOKKU2_DEPLOY_SSH_KEY }}
           remote-branch: "main"


### PR DESCRIPTION
This switches the deploy action to use the SSH key stored at the Org level.