### PR TITLE
Update pytest Warning Filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,5 +52,6 @@ env = [
 ]
 filterwarnings = [
     'ignore:django.conf.urls.url\(\) is deprecated:django.utils.deprecation.RemovedInDjango40Warning:rest_framework|social_django',
-    "ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working:DeprecationWarning:social_core",
+    "ignore::django.utils.deprecation.RemovedInDjango41Warning:django",
+    "ignore:A private pytest class or function was used.:pytest.PytestDeprecationWarning:pytest_subtests",
 ]


### PR DESCRIPTION
This updates the warning filters, mostly to catch Django 4.1 warnings.