### PR TITLE
Switch to our fork of deploy action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy to dokku
-        uses: idoberko2/dokku-deploy-github-action@4b326b3
+        uses: opensafely-core/dokku-deploy-github-action@v1
         with:
           app-name: "job-server"
           dokku-host: ${{ secrets.DOKKU_HOST }}


### PR DESCRIPTION
GitHub Actions doesn't let you address an action version (release) with a short SHA, so taking the opportunity to switch over to our fork of the action.