### PR TITLE
Quieten Logging in JobUpdateAPI

### DIFF
--- a/jobserver/api.py
+++ b/jobserver/api.py
@@ -125,19 +125,12 @@ class JobAPIUpdate(APIView):
 
             # get the current Jobs for the JobRequest, keyed on their identifier
             jobs_by_identifier = {j.identifier: j for j in database_jobs}
-            log.info(
-                f"Jobs in database: {','.join(jobs_by_identifier.keys())}",
-            )
 
             payload_identifiers = {j["identifier"] for j in jobs}
-            log.info(f"Jobs in payload: {','.join(payload_identifiers)}")
 
             # delete local jobs not in the payload
             identifiers_to_delete = set(jobs_by_identifier.keys()) - payload_identifiers
             if identifiers_to_delete:
-                log.info(
-                    f"About to delete jobs with identifiers: {','.join(identifiers_to_delete)}",
-                )
                 job_request.jobs.filter(identifier__in=identifiers_to_delete).delete()
 
             # grab Job IDs instead of logging for every Job in the payload (which gets very noisy)

--- a/jobserver/api.py
+++ b/jobserver/api.py
@@ -86,6 +86,8 @@ class JobAPIUpdate(APIView):
 
     @transaction.atomic
     def post(self, request, *args, **kwargs):
+        log = logger.new()
+
         serializer = self.serializer_class(data=request.data, many=True)
         serializer.is_valid(raise_exception=True)
 
@@ -119,7 +121,7 @@ class JobAPIUpdate(APIView):
             job_request = job_request_lut[jr_identifier]
 
             # bind the job request ID to further logs so looking them up in the UI is easier
-            log = logger.bind(job_request=job_request.id)
+            log = log.bind(job_request=job_request.id)
 
             database_jobs = job_request.jobs.all()
 

--- a/tests/jobserver/test_api.py
+++ b/tests/jobserver/test_api.py
@@ -594,7 +594,6 @@ def test_releasenotificationapicreate_with_failed_slack_update(
     assert log_output.entries[0] == {
         "exc_info": True,
         "event": "Failed to notify slack",
-        "job_request": 1,  # why is this being added?!
         "log_level": "error",
     }
 


### PR DESCRIPTION
This greatly reduces the noise from POSTing to the JobUpdateAPI view by removing a selection of the log calls and combining the most useful ones (which Jobs got created or updated) into a single line.

Note: You'll notice I also removed some logging context from a ReleaseNotificationAPICreate unit test.  I finally tracked down a way to stop the context bound in JobUpdateAPI from leaking into that view&test.  I still don't know how it got in there given the bind call was assigned to a new variable in another class instance.  The django-structlog middleware isn't in effect because I'm using [a derivative of] RequestFactory.  More digging for another time.