### PR TITLE
Per Backend Statuses Icons

### DIFF
--- a/jobserver/api.py
+++ b/jobserver/api.py
@@ -307,7 +307,9 @@ class WorkspaceStatusesAPI(APIView):
         except Workspace.DoesNotExist:
             return Response(status=404)
 
-        actions_with_status = workspace.get_action_status_lut()
+        backend = request.GET.get("backend", None)
+
+        actions_with_status = workspace.get_action_status_lut(backend)
         return Response(actions_with_status, status=200)
 
 

--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -804,7 +804,7 @@ class Workspace(models.Model):
     def get_statuses_url(self):
         return reverse("workspace-statuses", kwargs={"name": self.name})
 
-    def get_action_status_lut(self):
+    def get_action_status_lut(self, backend=None):
         """
         Build a lookup table of action -> status
 
@@ -812,6 +812,9 @@ class Workspace(models.Model):
         Workspace.
         """
         jobs = Job.objects.filter(job_request__workspace=self)
+
+        if backend:
+            jobs = jobs.filter(job_request__backend__name=backend)
 
         # get all known actions
         actions = set(jobs.values_list("action", flat=True))

--- a/static/js/workspace_detail.js
+++ b/static/js/workspace_detail.js
@@ -1,27 +1,41 @@
-const updateStatuses = (url) => {
+const updateStatuses = (urlBase) => {
   /**
    * Update statuses for the current Workspace
    */
+
+  // if a backend radio button has been checked use it filter the API query
+  const checkedBackends = Array.from(document.getElementsByName('backend')).filter(e => e.checked);
+  let backendQuery = "";
+  if (checkedBackends.length > 0) {
+    backendQuery = `?backend=${checkedBackends[0].value}`;
+  }
+
+  const url = `${urlBase}${backendQuery}`;
   fetch(url)
     .then(response => response.json())
     .then(data => {
-      for (const [action, status] of Object.entries(data)) {
-        const icon = document.querySelector(`#heading-${action} .status-icon`);
+      const actions = document.querySelectorAll("#actions .card>.card-header");
 
-        if (icon === null) {
-          // icon can be null when we have jobs for an action which was
-          // previously in the project.yaml but has since been removed.
-          continue;
+      // loop the actions we've loaded from GitHub clearing their icon then
+      // setting an icon if we get a status for them
+      for (const action of actions) {
+        // reset status icon
+        const icon = action.querySelector(".status-icon");
+        icon.className = "status-icon";
+
+        const actionName = action.querySelector("code").title;
+        const status = data[actionName];
+        if (status) {
+          // the API has a status for this action, update the icon
+          icon.setAttribute("title", status);
+          icon.className = `status-icon ${status}`;
         }
-
-        icon.setAttribute("title", status);
-        icon.className = `status-icon ${status}`;
       }
     });
 }
 window.addEventListener("DOMContentLoaded", () => {
-  const url = document.getElementById("apiUrl").textContent;
+  const urlBase = document.getElementById("apiUrl").textContent;
 
   // poll the backend every 10s
-  window.setInterval(updateStatuses, 10000, url);
+  window.setInterval(updateStatuses, 10000, urlBase);
 });


### PR DESCRIPTION
This rebuilds the status watching script to use the selected Backend in the form (if one is selected), switching the script to loop the actions in the DOM instead of the actions in the returned data so we can clear each icon before trying to pull it from the data.

This is by no means a polished solution since the status script only runs every 10s so there's up to a 10s wait to see changes come through.

Ref #526