### PR TITLE
Only load the status polling JS when a user is authenticated

### DIFF
--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -393,6 +393,8 @@
 {% endblock content %}
 
 {% block extra_js %}
+{% if request.user.is_authenticated %}
 <div id="apiUrl" class="d-none">{{ workspace.get_statuses_url }}</div>
 <script type="text/javascript" src="{% static 'js/workspace_detail.js' %}"></script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
This script works on DOM elements which are only present when a User is
logged in so lets save some requests to the backend.