### PR TITLE
Add an Approve Action

### DIFF
--- a/jobserver/admin.py
+++ b/jobserver/admin.py
@@ -3,6 +3,9 @@ import social_django.admin  # noqa: F401
 from django import forms
 from django.contrib import admin
 from django.contrib.auth.models import Group
+from django.shortcuts import redirect
+from django.urls import reverse
+from furl import furl
 from social_django.models import Association, Nonce, UserSocialAuth
 
 from .models import Org, Project, User
@@ -176,6 +179,7 @@ class ProjectAdmin(admin.ModelAdmin):
 
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):
+    actions = ["approve_users"]
     exclude = [
         "password",
         "groups",
@@ -191,3 +195,13 @@ class UserAdmin(admin.ModelAdmin):
         "is_approved",
     ]
     ordering = ["username"]
+
+    @admin.action(description="Approve selected users")
+    def approve_users(self, request, queryset):
+        url = reverse("approve-users")
+        f = furl(url)
+
+        for user in queryset:
+            f.add({"user": user.id})
+
+        return redirect(f.url)

--- a/jobserver/templates/approve_users.html
+++ b/jobserver/templates/approve_users.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="row">
+  <div class="col-lg-8 offset-lg-2">
+
+    <h3 class="mb-3">Approve Users</h3>
+
+    <p>
+      The following Users will be added to the Organisations and Backends you
+      select, thus approving them to use the OpenSAFELY platform:
+    </p>
+
+    <ul class="mb-4">
+      {% for user in users %}
+      <li>{{ user.name }}</li>
+      {% endfor %}
+    </ul>
+
+    <form method="POST">
+      {% csrf_token %}
+
+      {% if form.non_field_errors %}
+      <ul>
+        {% for error in form.non_field_errors %}
+        <li class="text-danger">{{ error }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+
+      <div class="row">
+
+        <div class="col-lg-4">
+          <div class="form-group">
+            <h4>Backends</h4>
+
+            {% for value, label in form.backends.field.choices %}
+            <div class="form-check">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                name="backends"
+                id="id_backends{{ forloop.counter }}"
+                value="{{ value }}"
+                {% if form.backends.value == value %}checked{% endif %}
+                />
+              <label class="form-check-label" for="id_backends{{ forloop.counter }}">
+                {{ label }}
+              </label>
+            </div>
+            {% endfor %}
+
+            {% if form.backends.errors %}
+            <ul class="pl-3 mb-1">
+              {% for error in form.backends.errors %}
+              <li class="text-danger">{{ error }}</li>
+              {% endfor %}
+            </ul>
+            {% endif %}
+
+          </div>
+        </div>
+
+        <div class="col-lg-8">
+          <div class="form-group">
+            <h4>Orgnisations</h4>
+
+            {% for value, label in form.orgs.field.choices %}
+            <div class="form-check">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                name="orgs"
+                id="id_orgs{{ forloop.counter }}"
+                value="{{ value }}"
+                {% if form.orgs.value == value %}checked{% endif %}
+                />
+              <label class="form-check-label" for="id_orgs{{ forloop.counter }}">
+                {{ label }}
+              </label>
+            </div>
+            {% endfor %}
+
+            {% if form.orgs.errors %}
+            <ul class="pl-3 mb-1">
+              {% for error in form.orgs.errors %}
+              <li class="text-danger">{{ error }}</li>
+              {% endfor %}
+            </ul>
+            {% endif %}
+
+          </div>
+        </div>
+
+      </div>
+
+      <div class="form-group">
+        <div class="d-flex justify-content-between">
+
+          <a
+            class="btn btn-secondary"
+            href="{% url 'admin:jobserver_user_changelist' %}">
+            Back to Admin
+          </a>
+
+          <button type="submit" class="btn btn-primary">Approve</button>
+
+        </div>
+      </div>
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock content %}

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -28,6 +28,7 @@ from .api import (
     UserAPIDetail,
     WorkspaceStatusesAPI,
 )
+from .views.admin import ApproveUsers
 from .views.backends import BackendDetail, BackendList, BackendRotateToken
 from .views.index import Index
 from .views.job_requests import JobRequestCancel, JobRequestDetail, JobRequestList
@@ -144,6 +145,7 @@ urlpatterns = [
     path("", Index.as_view()),
     path("", include("social_django.urls", namespace="social")),
     path("favicon.ico", RedirectView.as_view(url=settings.STATIC_URL + "favicon.ico")),
+    path("admin/approve-users", ApproveUsers.as_view(), name="approve-users"),
     path("admin/", admin.site.urls),
     path("api/v2/", include(api_urls)),
     path("backends/", include(backend_urls)),

--- a/jobserver/views/admin.py
+++ b/jobserver/views/admin.py
@@ -1,0 +1,64 @@
+from django import forms
+from django.contrib import messages
+from django.db import transaction
+from django.shortcuts import redirect
+from django.urls import reverse_lazy
+from django.utils.decorators import method_decorator
+from django.views.generic import FormView
+
+from ..authorization.decorators import require_superuser
+from ..models import Backend, BackendMembership, Org, OrgMembership, User
+
+
+class ApprovalForm(forms.Form):
+    def __init__(self, backends, orgs, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # bulid the backends and orgs fields based on the values passed in
+        self.fields["backends"] = forms.ModelMultipleChoiceField(queryset=backends)
+        self.fields["orgs"] = forms.ModelMultipleChoiceField(queryset=orgs)
+
+
+@method_decorator(require_superuser, name="dispatch")
+class ApproveUsers(FormView):
+    form_class = ApprovalForm
+    success_url = reverse_lazy("admin:jobserver_user_changelist")
+    template_name = "approve_users.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        pks = self.request.GET.getlist("user")
+
+        if not pks:
+            messages.error(request, "One or more users must be selected")
+            return redirect(self.success_url)
+
+        self.users = User.objects.filter(pk__in=pks)
+
+        return super().dispatch(request, *args, **kwargs)
+
+    @transaction.atomic()
+    def form_valid(self, form):
+        backends = form.cleaned_data["backends"]
+        orgs = form.cleaned_data["orgs"]
+
+        for user in self.users:
+            for backend in backends:
+                BackendMembership.objects.get_or_create(backend=backend, user=user)
+
+            for org in orgs:
+                OrgMembership.objects.get_or_create(org=org, user=user)
+
+        messages.info(self.request, "Connected Users to selected Backends & Orgs")
+        return redirect(self.success_url)
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(
+            users=self.users,
+            **kwargs,
+        )
+
+    def get_form_kwargs(self):
+        return super().get_form_kwargs() | {
+            "backends": Backend.objects.order_by("name"),
+            "orgs": Org.objects.order_by("name"),
+        }

--- a/tests/jobserver/test_admin.py
+++ b/tests/jobserver/test_admin.py
@@ -1,0 +1,31 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.urls import reverse
+
+from jobserver.admin import UserAdmin
+from jobserver.models import User
+
+from ..factories import UserFactory
+
+
+@pytest.mark.django_db
+def test_useradmin_approve_users(rf, superuser):
+    UserFactory.create_batch(5)
+
+    # only work with a subset of created users to ensure we don't somehow
+    # address all users
+    users = User.objects.order_by("pk")[:2]
+
+    user_admin = UserAdmin(model=User, admin_site=AdminSite())
+
+    request = rf.get("/")
+    request.user = superuser
+
+    response = user_admin.approve_users(request, users)
+
+    assert response.status_code == 302
+
+    base = reverse("approve-users")
+    query = [f"user={u.pk}" for u in users]
+    url = f"{base}?{'&'.join(query)}"
+    assert response.url == url

--- a/tests/jobserver/views/test_admin.py
+++ b/tests/jobserver/views/test_admin.py
@@ -1,0 +1,101 @@
+import pytest
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.urls import reverse
+
+from jobserver.models import Backend
+from jobserver.views.admin import ApproveUsers
+
+from ...factories import OrgFactory, UserFactory
+
+
+@pytest.mark.django_db
+def test_approveusers_as_non_superuser(rf):
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    response = ApproveUsers.as_view()(request)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_approveusers_get_success(rf, superuser):
+    request = rf.get(f"/?user={superuser.pk}")
+    request.user = superuser
+
+    response = ApproveUsers.as_view()(request)
+
+    assert response.status_code == 200
+
+    assert list(response.context_data["users"]) == [superuser]
+
+
+@pytest.mark.django_db
+def test_approveusers_post_success(rf, superuser):
+    user1 = UserFactory()
+    user2 = UserFactory()
+
+    org1 = OrgFactory()
+
+    # create a second Org to check assignment is only being done for the
+    # selected orgs
+    OrgFactory()
+
+    test = Backend.objects.get(name="test")
+    tpp = Backend.objects.get(name="tpp")
+
+    data = {
+        "backends": [test.pk, tpp.pk],
+        "orgs": [org1.pk],
+    }
+    request = rf.post(f"/?user={user1.pk}&user={user2.pk}", data)
+    request.user = superuser
+
+    # set up messages framework
+    request.session = "session"
+    request._messages = FallbackStorage(request)
+
+    response = ApproveUsers.as_view()(request)
+
+    assert response.status_code == 302
+    assert response.url == reverse("admin:jobserver_user_changelist")
+
+    user1.refresh_from_db()
+    assert set(user1.backends.all()) == {test, tpp}
+    assert list(user1.orgs.all()) == [org1]
+
+    user2.refresh_from_db()
+    assert set(user2.backends.all()) == {test, tpp}
+    assert list(user2.orgs.all()) == [org1]
+
+
+@pytest.mark.django_db
+def test_approveusers_with_invalid_form(rf, superuser):
+    request = rf.post(f"/?user={superuser.pk}")
+    request.user = superuser
+
+    response = ApproveUsers.as_view()(request)
+
+    assert response.status_code == 200
+    assert response.context_data["form"].errors
+
+
+@pytest.mark.django_db
+def test_approveusers_with_no_users(rf, superuser):
+    request = rf.get("/")
+    request.user = superuser
+
+    # set up messages framework
+    request.session = "session"
+    messages = FallbackStorage(request)
+    request._messages = messages
+
+    response = ApproveUsers.as_view()(request)
+
+    assert response.status_code == 302
+    assert response.url == reverse("admin:jobserver_user_changelist")
+
+    # check we have a message for the user
+    messages = list(messages)
+    assert len(messages) == 1
+    assert str(messages[0]) == "One or more users must be selected"


### PR DESCRIPTION
This adds an action to the User section of the admin to approve 1 or more Users.  In this context "approval" is simply connecting the Users to 1 or more Backends and Orgs.

This will be superseded later as the onboarding process is built out but for now it allows us to approve users after the changes in #534 and #537.