### PR TITLE
Better Mocks

### DIFF
--- a/tests/jobserver/templatetags/test_querystring_tools.py
+++ b/tests/jobserver/templatetags/test_querystring_tools.py
@@ -10,7 +10,9 @@ def test_redirect_with_querystring(rf, mocker):
 
     # patch here so we don't couple this test to any configured URL
     mocker.patch(
-        "jobserver.templatetags.querystring_tools.reverse", new=lambda *args: "/an_url"
+        "jobserver.templatetags.querystring_tools.reverse",
+        autospec=True,
+        return_value="/an_url",
     )
     output = redirect_with_querystring(context, view_name="derp")
 

--- a/tests/jobserver/templatetags/test_querystring_tools.py
+++ b/tests/jobserver/templatetags/test_querystring_tools.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from jobserver.templatetags.querystring_tools import (
     redirect_with_querystring,
     url_with_querystring,
@@ -7,14 +5,14 @@ from jobserver.templatetags.querystring_tools import (
 )
 
 
-def test_redirect_with_querystring(rf):
+def test_redirect_with_querystring(rf, mocker):
     context = {"request": rf.get("/?foo=bar")}
 
     # patch here so we don't couple this test to any configured URL
-    with patch(
+    mocker.patch(
         "jobserver.templatetags.querystring_tools.reverse", new=lambda *args: "/an_url"
-    ):
-        output = redirect_with_querystring(context, view_name="derp")
+    )
+    output = redirect_with_querystring(context, view_name="derp")
 
     assert output == "/an_url?foo=bar"
 

--- a/tests/jobserver/templatetags/test_querystring_tools.py
+++ b/tests/jobserver/templatetags/test_querystring_tools.py
@@ -6,14 +6,14 @@ from jobserver.templatetags.querystring_tools import (
 
 
 def test_redirect_with_querystring(rf, mocker):
-    context = {"request": rf.get("/?foo=bar")}
-
     # patch here so we don't couple this test to any configured URL
     mocker.patch(
         "jobserver.templatetags.querystring_tools.reverse",
         autospec=True,
         return_value="/an_url",
     )
+
+    context = {"request": rf.get("/?foo=bar")}
     output = redirect_with_querystring(context, view_name="derp")
 
     assert output == "/an_url?foo=bar"

--- a/tests/jobserver/test_api.py
+++ b/tests/jobserver/test_api.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from unittest.mock import patch
 
 import pytest
 from django.conf import settings
@@ -347,7 +346,7 @@ def test_jobapiupdate_mixture(api_rf, freezer):
 
 
 @pytest.mark.django_db
-def test_jobapiupdate_notifications_on_with_move_to_finished(api_rf):
+def test_jobapiupdate_notifications_on_with_move_to_finished(api_rf, mocker):
     workspace = WorkspaceFactory()
     job_request = JobRequestFactory(workspace=workspace, will_notify=True)
     job = JobFactory(job_request=job_request, status="running")
@@ -373,15 +372,15 @@ def test_jobapiupdate_notifications_on_with_move_to_finished(api_rf):
         data=data,
         format="json",
     )
-    with patch("jobserver.api.send_finished_notification") as mocked_send:
-        response = JobAPIUpdate.as_view()(request)
+    mocked_send = mocker.patch("jobserver.api.send_finished_notification")
+    response = JobAPIUpdate.as_view()(request)
 
     mocked_send.assert_called_once()
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-def test_jobapiupdate_notifications_on_without_move_to_finished(api_rf):
+def test_jobapiupdate_notifications_on_without_move_to_finished(api_rf, mocker):
     workspace = WorkspaceFactory()
     job_request = JobRequestFactory(workspace=workspace, will_notify=True)
     job = JobFactory(job_request=job_request, status="succeeded")
@@ -407,8 +406,8 @@ def test_jobapiupdate_notifications_on_without_move_to_finished(api_rf):
         data=data,
         format="json",
     )
-    with patch("jobserver.api.send_finished_notification") as mocked_send:
-        response = JobAPIUpdate.as_view()(request)
+    mocked_send = mocker.patch("jobserver.api.send_finished_notification")
+    response = JobAPIUpdate.as_view()(request)
 
     mocked_send.assert_not_called()
     assert response.status_code == 200

--- a/tests/jobserver/test_api.py
+++ b/tests/jobserver/test_api.py
@@ -372,7 +372,9 @@ def test_jobapiupdate_notifications_on_with_move_to_finished(api_rf, mocker):
         data=data,
         format="json",
     )
-    mocked_send = mocker.patch("jobserver.api.send_finished_notification")
+    mocked_send = mocker.patch(
+        "jobserver.api.send_finished_notification", autospec=True
+    )
     response = JobAPIUpdate.as_view()(request)
 
     mocked_send.assert_called_once()
@@ -406,7 +408,9 @@ def test_jobapiupdate_notifications_on_without_move_to_finished(api_rf, mocker):
         data=data,
         format="json",
     )
-    mocked_send = mocker.patch("jobserver.api.send_finished_notification")
+    mocked_send = mocker.patch(
+        "jobserver.api.send_finished_notification", autospec=True
+    )
     response = JobAPIUpdate.as_view()(request)
 
     mocked_send.assert_not_called()
@@ -544,7 +548,7 @@ def test_releasenotificationapicreate_success(api_rf, mocker):
     request = api_rf.post("/", data, HTTP_AUTHORIZATION=backend.auth_token)
     request.user = UserFactory()
 
-    mock = mocker.patch("jobserver.api.slack_client", auto_spec=True)
+    mock = mocker.patch("jobserver.api.slack_client", autospec=True)
     response = ReleaseNotificationAPICreate.as_view()(request)
 
     assert response.status_code == 201, response.data
@@ -573,7 +577,7 @@ def test_releasenotificationapicreate_with_failed_slack_update(
     request.user = UserFactory()
 
     # have the slack API client raise an exception
-    mock = mocker.patch("jobserver.api.slack_client", auto_spec=True)
+    mock = mocker.patch("jobserver.api.slack_client", autospec=True)
     mock.chat_postMessage.side_effect = SlackApiError(
         message="an error", response={"error": "an error occurred"}
     )

--- a/tests/jobserver/test_github.py
+++ b/tests/jobserver/test_github.py
@@ -47,14 +47,14 @@ def test_get_branch_sha(mocker):
         }
     }
 
-    mocker.patch("jobserver.github.get_branch", lambda *args: data)
+    mocker.patch("jobserver.github.get_branch", autospec=True, return_value=data)
     output = get_branch_sha("opensafely", "some_repo", "main")
 
     assert output == "abc123"
 
 
 def test_get_branch_sha_with_missing_branch(mocker):
-    mocker.patch("jobserver.github.get_branch", lambda *args: None)
+    mocker.patch("jobserver.github.get_branch", autospec=True, return_value=None)
     output = get_branch_sha("opensafely", "some_repo", "main")
 
     assert output is None

--- a/tests/jobserver/test_github.py
+++ b/tests/jobserver/test_github.py
@@ -46,8 +46,8 @@ def test_get_branch_sha(mocker):
             "sha": "abc123",
         }
     }
-
     mocker.patch("jobserver.github.get_branch", autospec=True, return_value=data)
+
     output = get_branch_sha("opensafely", "some_repo", "main")
 
     assert output == "abc123"
@@ -55,6 +55,7 @@ def test_get_branch_sha(mocker):
 
 def test_get_branch_sha_with_missing_branch(mocker):
     mocker.patch("jobserver.github.get_branch", autospec=True, return_value=None)
+
     output = get_branch_sha("opensafely", "some_repo", "main")
 
     assert output is None

--- a/tests/jobserver/test_github.py
+++ b/tests/jobserver/test_github.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 import responses
 
@@ -42,22 +40,22 @@ def test_get_branch_with_missing_branch():
     assert output is None
 
 
-def test_get_branch_sha():
+def test_get_branch_sha(mocker):
     data = {
         "commit": {
             "sha": "abc123",
         }
     }
 
-    with patch("jobserver.github.get_branch", lambda *args: data):
-        output = get_branch_sha("opensafely", "some_repo", "main")
+    mocker.patch("jobserver.github.get_branch", lambda *args: data)
+    output = get_branch_sha("opensafely", "some_repo", "main")
 
     assert output == "abc123"
 
 
-def test_get_branch_sha_with_missing_branch():
-    with patch("jobserver.github.get_branch", lambda *args: None):
-        output = get_branch_sha("opensafely", "some_repo", "main")
+def test_get_branch_sha_with_missing_branch(mocker):
+    mocker.patch("jobserver.github.get_branch", lambda *args: None)
+    output = get_branch_sha("opensafely", "some_repo", "main")
 
     assert output is None
 

--- a/tests/jobserver/test_project.py
+++ b/tests/jobserver/test_project.py
@@ -85,16 +85,16 @@ def test_get_actions_success():
 
 
 def test_get_project_no_branch(mocker):
-    mocker.patch("jobserver.project.get_file", lambda *args: None),
-    mocker.patch("jobserver.project.get_branch", lambda *args: None)
+    mocker.patch("jobserver.project.get_file", autospec=True, return_value=None),
+    mocker.patch("jobserver.project.get_branch", autospec=True, return_value=None)
 
     with pytest.raises(Exception, match="Missing branch: 'main'"):
         get_project("opensafely", "test", "main")
 
 
 def test_get_project_no_project_yaml(mocker):
-    mocker.patch("jobserver.project.get_file", lambda *args: None),
-    mocker.patch("jobserver.project.get_branch", lambda *args: True)
+    mocker.patch("jobserver.project.get_file", autospec=True, return_value=None),
+    mocker.patch("jobserver.project.get_branch", autospec=True, return_value=True)
 
     with pytest.raises(Exception, match="Could not find project.yaml"):
         get_project("opensafely", "test", "main")
@@ -105,8 +105,8 @@ def test_get_project_success(mocker):
     actions:
       frobnicate:
     """
-    mocker.patch("jobserver.project.get_file", lambda *args: dummy)
-    mocker.patch("jobserver.project.get_branch", lambda *args: True)
+    mocker.patch("jobserver.project.get_file", autospec=True, return_value=dummy)
+    mocker.patch("jobserver.project.get_branch", autospec=True, return_value=True)
 
     assert get_project("opensafely", "test", "main") == dummy
 

--- a/tests/jobserver/test_project.py
+++ b/tests/jobserver/test_project.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 from furl import furl
 from yaml.scanner import ScannerError
@@ -86,29 +84,31 @@ def test_get_actions_success():
     assert output == expected
 
 
-def test_get_project_no_branch():
-    with patch("jobserver.project.get_file", lambda *args: None), patch(
-        "jobserver.project.get_branch", lambda *args: None
-    ), pytest.raises(Exception, match="Missing branch: 'main'"):
+def test_get_project_no_branch(mocker):
+    mocker.patch("jobserver.project.get_file", lambda *args: None),
+    mocker.patch("jobserver.project.get_branch", lambda *args: None)
+
+    with pytest.raises(Exception, match="Missing branch: 'main'"):
         get_project("opensafely", "test", "main")
 
 
-def test_get_project_no_project_yaml():
-    with patch("jobserver.project.get_file", lambda *args: None), patch(
-        "jobserver.project.get_branch", lambda *args: True
-    ), pytest.raises(Exception, match="Could not find project.yaml"):
+def test_get_project_no_project_yaml(mocker):
+    mocker.patch("jobserver.project.get_file", lambda *args: None),
+    mocker.patch("jobserver.project.get_branch", lambda *args: True)
+
+    with pytest.raises(Exception, match="Could not find project.yaml"):
         get_project("opensafely", "test", "main")
 
 
-def test_get_project_success():
+def test_get_project_success(mocker):
     dummy = """
     actions:
       frobnicate:
     """
-    with patch("jobserver.project.get_file", lambda *args: dummy), patch(
-        "jobserver.project.get_branch", lambda *args: True
-    ):
-        assert get_project("opensafely", "test", "main") == dummy
+    mocker.patch("jobserver.project.get_file", lambda *args: dummy)
+    mocker.patch("jobserver.project.get_branch", lambda *args: True)
+
+    assert get_project("opensafely", "test", "main") == dummy
 
 
 def test_link_run_scripts():

--- a/tests/jobserver/test_roles.py
+++ b/tests/jobserver/test_roles.py
@@ -8,14 +8,14 @@ from ..factories import UserFactory
 
 @pytest.mark.django_db
 def test_can_run_jobs_with_authenticated_user_in_org(user, mocker):
-    mocker.patch("jobserver.roles.is_member_of_org", return_value=True)
+    mocker.patch("jobserver.roles.is_member_of_org", autospec=True, return_value=True)
 
     assert can_run_jobs(user)
 
 
 @pytest.mark.django_db
 def test_can_run_jobs_with_authenticated_user_not_in_gh_org(user, mocker):
-    mocker.patch("jobserver.roles.is_member_of_org", return_value=False)
+    mocker.patch("jobserver.roles.is_member_of_org", autospec=True, return_value=False)
 
     assert not can_run_jobs(user)
 
@@ -27,6 +27,6 @@ def test_can_run_jobs_with_authenticated_user_not_in_os_org():
 
 @pytest.mark.django_db
 def test_can_run_jobs_with_unauthenticated_user(mocker):
-    mocker.patch("jobserver.roles.is_member_of_org", return_value=False)
+    mocker.patch("jobserver.roles.is_member_of_org", autospec=True, return_value=False)
 
     assert not can_run_jobs(AnonymousUser())

--- a/tests/jobserver/test_roles.py
+++ b/tests/jobserver/test_roles.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 from django.contrib.auth.models import AnonymousUser
 
@@ -9,15 +7,17 @@ from ..factories import UserFactory
 
 
 @pytest.mark.django_db
-def test_can_run_jobs_with_authenticated_user_in_org(user):
-    with patch("jobserver.roles.is_member_of_org", return_value=True):
-        assert can_run_jobs(user)
+def test_can_run_jobs_with_authenticated_user_in_org(user, mocker):
+    mocker.patch("jobserver.roles.is_member_of_org", return_value=True)
+
+    assert can_run_jobs(user)
 
 
 @pytest.mark.django_db
-def test_can_run_jobs_with_authenticated_user_not_in_gh_org(user):
-    with patch("jobserver.roles.is_member_of_org", return_value=False):
-        assert not can_run_jobs(user)
+def test_can_run_jobs_with_authenticated_user_not_in_gh_org(user, mocker):
+    mocker.patch("jobserver.roles.is_member_of_org", return_value=False)
+
+    assert not can_run_jobs(user)
 
 
 @pytest.mark.django_db
@@ -26,6 +26,7 @@ def test_can_run_jobs_with_authenticated_user_not_in_os_org():
 
 
 @pytest.mark.django_db
-def test_can_run_jobs_with_unauthenticated_user():
-    with patch("jobserver.roles.is_member_of_org", return_value=False):
-        assert not can_run_jobs(AnonymousUser())
+def test_can_run_jobs_with_unauthenticated_user(mocker):
+    mocker.patch("jobserver.roles.is_member_of_org", return_value=False)
+
+    assert not can_run_jobs(AnonymousUser())

--- a/tests/jobserver/views/test_index.py
+++ b/tests/jobserver/views/test_index.py
@@ -17,7 +17,7 @@ def test_index_success(rf, mocker):
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
 
-    mocker.patch("jobserver.views.index.can_run_jobs", return_value=True, autospec=True)
+    mocker.patch("jobserver.views.index.can_run_jobs", autospec=True, return_value=True)
     response = Index.as_view()(request)
 
     assert response.status_code == 200
@@ -37,7 +37,7 @@ def test_index_with_authenticated_user(rf, mocker):
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
 
-    mocker.patch("jobserver.views.index.can_run_jobs", return_value=True, autospec=True)
+    mocker.patch("jobserver.views.index.can_run_jobs", autospec=True, return_value=True)
     response = Index.as_view()(request)
 
     assert "Add a New Workspace" in response.rendered_content
@@ -56,7 +56,7 @@ def test_index_with_authenticated_but_partially_registered_user(rf, mocker):
     request.user = UserFactory()
 
     mocker.patch(
-        "jobserver.views.index.can_run_jobs", return_value=False, autospec=True
+        "jobserver.views.index.can_run_jobs", autospec=True, return_value=False
     )
     response = Index.as_view()(request)
 

--- a/tests/jobserver/views/test_index.py
+++ b/tests/jobserver/views/test_index.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 from django.contrib.auth.models import AnonymousUser
 
@@ -12,15 +10,15 @@ MEANINGLESS_URL = "/"
 
 
 @pytest.mark.django_db
-def test_index_success(rf):
+def test_index_success(rf, mocker):
     JobRequestFactory(workspace=WorkspaceFactory())
 
     # Build a RequestFactory instance
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
 
-    with patch("jobserver.views.index.can_run_jobs", return_value=True, autospec=True):
-        response = Index.as_view()(request)
+    mocker.patch("jobserver.views.index.can_run_jobs", return_value=True, autospec=True)
+    response = Index.as_view()(request)
 
     assert response.status_code == 200
     assert len(response.context_data["job_requests"]) == 1
@@ -28,7 +26,7 @@ def test_index_success(rf):
 
 
 @pytest.mark.django_db
-def test_index_with_authenticated_user(rf):
+def test_index_with_authenticated_user(rf, mocker):
     """
     Check the Add Workspace button is rendered for authenticated Users on the
     homepage.
@@ -39,14 +37,14 @@ def test_index_with_authenticated_user(rf):
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
 
-    with patch("jobserver.views.index.can_run_jobs", return_value=True, autospec=True):
-        response = Index.as_view()(request)
+    mocker.patch("jobserver.views.index.can_run_jobs", return_value=True, autospec=True)
+    response = Index.as_view()(request)
 
     assert "Add a New Workspace" in response.rendered_content
 
 
 @pytest.mark.django_db
-def test_index_with_authenticated_but_partially_registered_user(rf):
+def test_index_with_authenticated_but_partially_registered_user(rf, mocker):
     """
     Check the Add Workspace button is rendered for authenticated Users on the
     homepage.
@@ -57,8 +55,10 @@ def test_index_with_authenticated_but_partially_registered_user(rf):
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
 
-    with patch("jobserver.views.index.can_run_jobs", return_value=False, autospec=True):
-        response = Index.as_view()(request)
+    mocker.patch(
+        "jobserver.views.index.can_run_jobs", return_value=False, autospec=True
+    )
+    response = Index.as_view()(request)
 
     assert "Add a New Workspace" not in response.rendered_content
 

--- a/tests/jobserver/views/test_index.py
+++ b/tests/jobserver/views/test_index.py
@@ -13,11 +13,11 @@ MEANINGLESS_URL = "/"
 def test_index_success(rf, mocker):
     JobRequestFactory(workspace=WorkspaceFactory())
 
-    # Build a RequestFactory instance
+    mocker.patch("jobserver.views.index.can_run_jobs", autospec=True, return_value=True)
+
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
 
-    mocker.patch("jobserver.views.index.can_run_jobs", autospec=True, return_value=True)
     response = Index.as_view()(request)
 
     assert response.status_code == 200
@@ -33,11 +33,11 @@ def test_index_with_authenticated_user(rf, mocker):
     """
     JobRequestFactory(workspace=WorkspaceFactory())
 
-    # Build a RequestFactory instance
+    mocker.patch("jobserver.views.index.can_run_jobs", autospec=True, return_value=True)
+
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
 
-    mocker.patch("jobserver.views.index.can_run_jobs", autospec=True, return_value=True)
     response = Index.as_view()(request)
 
     assert "Add a New Workspace" in response.rendered_content
@@ -51,13 +51,13 @@ def test_index_with_authenticated_but_partially_registered_user(rf, mocker):
     """
     JobRequestFactory(workspace=WorkspaceFactory())
 
-    # Build a RequestFactory instance
-    request = rf.get(MEANINGLESS_URL)
-    request.user = UserFactory()
-
     mocker.patch(
         "jobserver.views.index.can_run_jobs", autospec=True, return_value=False
     )
+
+    request = rf.get(MEANINGLESS_URL)
+    request.user = UserFactory()
+
     response = Index.as_view()(request)
 
     assert "Add a New Workspace" not in response.rendered_content

--- a/tests/jobserver/views/test_jobs.py
+++ b/tests/jobserver/views/test_jobs.py
@@ -118,7 +118,7 @@ def test_jobdetail_with_authenticated_user(rf, mocker):
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory(is_superuser=False, roles=[])
 
-    mocker.patch("jobserver.views.jobs.can_run_jobs", return_value=True)
+    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=True)
     response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
@@ -131,7 +131,7 @@ def test_jobdetail_with_post_jobrequest_job(rf, mocker):
     # Build a RequestFactory instance
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
-    mocker.patch("jobserver.views.jobs.can_run_jobs", return_value=False)
+    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=False)
     response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
@@ -145,7 +145,7 @@ def test_jobdetail_with_pre_jobrequest_job(rf, mocker):
     # Build a RequestFactory instance
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
-    mocker.patch("jobserver.views.jobs.can_run_jobs", return_value=False)
+    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=False)
     response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
@@ -158,7 +158,7 @@ def test_jobdetail_with_unauthenticated_user(rf, mocker):
     request = rf.get(MEANINGLESS_URL)
     request.user = AnonymousUser()
 
-    mocker.patch("jobserver.views.jobs.can_run_jobs", return_value=False)
+    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=False)
     response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200

--- a/tests/jobserver/views/test_jobs.py
+++ b/tests/jobserver/views/test_jobs.py
@@ -115,10 +115,11 @@ def test_jobcancel_unknown_job(rf, user):
 def test_jobdetail_with_authenticated_user(rf, mocker):
     job = JobFactory()
 
+    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=True)
+
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory(is_superuser=False, roles=[])
 
-    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=True)
     response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
@@ -128,10 +129,11 @@ def test_jobdetail_with_authenticated_user(rf, mocker):
 def test_jobdetail_with_post_jobrequest_job(rf, mocker):
     job = JobFactory()
 
-    # Build a RequestFactory instance
+    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=False)
+
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
-    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=False)
+
     response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
@@ -142,10 +144,11 @@ def test_jobdetail_with_pre_jobrequest_job(rf, mocker):
     job_request = JobRequestFactory(workspace=WorkspaceFactory())
     job = JobFactory(job_request=job_request)
 
-    # Build a RequestFactory instance
+    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=False)
+
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
-    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=False)
+
     response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
@@ -155,10 +158,11 @@ def test_jobdetail_with_pre_jobrequest_job(rf, mocker):
 def test_jobdetail_with_unauthenticated_user(rf, mocker):
     job = JobFactory()
 
+    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=False)
+
     request = rf.get(MEANINGLESS_URL)
     request.user = AnonymousUser()
 
-    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=False)
     response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200

--- a/tests/jobserver/views/test_jobs.py
+++ b/tests/jobserver/views/test_jobs.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 import responses
 from django.conf import settings
@@ -114,54 +112,54 @@ def test_jobcancel_unknown_job(rf, user):
 
 
 @pytest.mark.django_db
-def test_jobdetail_with_authenticated_user(rf):
+def test_jobdetail_with_authenticated_user(rf, mocker):
     job = JobFactory()
 
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory(is_superuser=False, roles=[])
 
-    with patch("jobserver.views.jobs.can_run_jobs", return_value=True):
-        response = JobDetail.as_view()(request, identifier=job.identifier)
+    mocker.patch("jobserver.views.jobs.can_run_jobs", return_value=True)
+    response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-def test_jobdetail_with_post_jobrequest_job(rf):
+def test_jobdetail_with_post_jobrequest_job(rf, mocker):
     job = JobFactory()
 
     # Build a RequestFactory instance
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
-    with patch("jobserver.views.jobs.can_run_jobs", return_value=False):
-        response = JobDetail.as_view()(request, identifier=job.identifier)
+    mocker.patch("jobserver.views.jobs.can_run_jobs", return_value=False)
+    response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-def test_jobdetail_with_pre_jobrequest_job(rf):
+def test_jobdetail_with_pre_jobrequest_job(rf, mocker):
     job_request = JobRequestFactory(workspace=WorkspaceFactory())
     job = JobFactory(job_request=job_request)
 
     # Build a RequestFactory instance
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
-    with patch("jobserver.views.jobs.can_run_jobs", return_value=False):
-        response = JobDetail.as_view()(request, identifier=job.identifier)
+    mocker.patch("jobserver.views.jobs.can_run_jobs", return_value=False)
+    response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-def test_jobdetail_with_unauthenticated_user(rf):
+def test_jobdetail_with_unauthenticated_user(rf, mocker):
     job = JobFactory()
 
     request = rf.get(MEANINGLESS_URL)
     request.user = AnonymousUser()
 
-    with patch("jobserver.views.jobs.can_run_jobs", return_value=False):
-        response = JobDetail.as_view()(request, identifier=job.identifier)
+    mocker.patch("jobserver.views.jobs.can_run_jobs", return_value=False)
+    response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
 

--- a/tests/jobserver/views/test_projects.py
+++ b/tests/jobserver/views/test_projects.py
@@ -419,6 +419,13 @@ def test_projectinvitationcreate_post_with_email_failure(rf, mocker):
         project=project, user=coordinator, roles=[ProjectCoordinator]
     )
 
+    # mock send_project_invite_email to throw an exception
+    mocker.patch(
+        "jobserver.views.projects.send_project_invite_email",
+        autospec=True,
+        side_effect=Exception,
+    )
+
     request = rf.post(
         MEANINGLESS_URL,
         {
@@ -433,12 +440,6 @@ def test_projectinvitationcreate_post_with_email_failure(rf, mocker):
     messages = FallbackStorage(request)
     request._messages = messages
 
-    # mock send_project_invite_email to throw an exception
-    mocker.patch(
-        "jobserver.views.projects.send_project_invite_email",
-        autospec=True,
-        side_effect=Exception,
-    )
     response = ProjectInvitationCreate.as_view()(
         request, org_slug=org.slug, project_slug=project.slug
     )

--- a/tests/jobserver/views/test_workspaces.py
+++ b/tests/jobserver/views/test_workspaces.py
@@ -139,7 +139,9 @@ def test_workspacecreate_get_success(rf, mocker, user):
     responses.add(responses.GET, membership_url, status=204)
 
     mocker.patch(
-        "jobserver.views.workspaces.get_repos_with_branches", new=lambda *args: []
+        "jobserver.views.workspaces.get_repos_with_branches",
+        autospec=True,
+        return_value=[],
     )
     response = WorkspaceCreate.as_view()(request)
 
@@ -167,7 +169,9 @@ def test_workspacecreate_post_success(rf, mocker, user):
 
     repos = [{"name": "Test", "url": "test", "branches": ["test"]}]
     mocker.patch(
-        "jobserver.views.workspaces.get_repos_with_branches", new=lambda *args: repos
+        "jobserver.views.workspaces.get_repos_with_branches",
+        autospec=True,
+        return_value=repos,
     )
     response = WorkspaceCreate.as_view()(request)
 
@@ -248,7 +252,9 @@ def test_workspacedetail_get_success(rf, mocker, user):
     mocker.patch(
         "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
-    mocker.patch("jobserver.views.workspaces.get_project", new=lambda *args: dummy_yaml)
+    mocker.patch(
+        "jobserver.views.workspaces.get_project", autospec=True, return_value=dummy_yaml
+    )
     response = GlobalWorkspaceDetail.as_view()(request, name=workspace.name)
 
     assert response.status_code == 200
@@ -307,9 +313,13 @@ def test_workspacedetail_post_success(rf, mocker, monkeypatch, user):
     mocker.patch(
         "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
-    mocker.patch("jobserver.views.workspaces.get_project", new=lambda *args: dummy_yaml)
     mocker.patch(
-        "jobserver.views.workspaces.get_branch_sha", new=lambda *args: "abc123"
+        "jobserver.views.workspaces.get_project", autospec=True, return_value=dummy_yaml
+    )
+    mocker.patch(
+        "jobserver.views.workspaces.get_branch_sha",
+        autospec=True,
+        return_value="abc123",
     )
     response = GlobalWorkspaceDetail.as_view()(request, name=workspace.name)
 
@@ -350,9 +360,13 @@ def test_workspacedetail_post_with_invalid_backend(rf, mocker, monkeypatch, user
     mocker.patch(
         "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
-    mocker.patch("jobserver.views.workspaces.get_project", new=lambda *args: dummy_yaml)
     mocker.patch(
-        "jobserver.views.workspaces.get_branch_sha", new=lambda *args: "abc123"
+        "jobserver.views.workspaces.get_project", autospec=True, return_value=dummy_yaml
+    )
+    mocker.patch(
+        "jobserver.views.workspaces.get_branch_sha",
+        autospec=True,
+        return_value="abc123",
     )
     response = GlobalWorkspaceDetail.as_view()(request, name=workspace.name)
 
@@ -388,9 +402,13 @@ def test_workspacedetail_post_with_notifications_default(rf, mocker, monkeypatch
     mocker.patch(
         "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
-    mocker.patch("jobserver.views.workspaces.get_project", new=lambda *args: dummy_yaml)
     mocker.patch(
-        "jobserver.views.workspaces.get_branch_sha", new=lambda *args: "abc123"
+        "jobserver.views.workspaces.get_project", autospec=True, return_value=dummy_yaml
+    )
+    mocker.patch(
+        "jobserver.views.workspaces.get_branch_sha",
+        autospec=True,
+        return_value="abc123",
     )
     response = GlobalWorkspaceDetail.as_view()(request, name=workspace.name)
 
@@ -434,9 +452,13 @@ def test_workspacedetail_post_with_notifications_override(
     mocker.patch(
         "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
-    mocker.patch("jobserver.views.workspaces.get_project", new=lambda *args: dummy_yaml)
     mocker.patch(
-        "jobserver.views.workspaces.get_branch_sha", new=lambda *args: "abc123"
+        "jobserver.views.workspaces.get_project", autospec=True, return_value=dummy_yaml
+    )
+    mocker.patch(
+        "jobserver.views.workspaces.get_branch_sha",
+        autospec=True,
+        return_value="abc123",
     )
     response = GlobalWorkspaceDetail.as_view()(request, name=workspace.name)
 

--- a/tests/jobserver/views/test_workspaces.py
+++ b/tests/jobserver/views/test_workspaces.py
@@ -218,12 +218,12 @@ def test_workspacedetail_project_yaml_errors(rf, mocker, user):
     request.user = user
 
     mocker.patch(
-        "jobserver.views.workspaces.can_run_jobs", return_value=True, autospec=True
+        "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
     mocker.patch(
         "jobserver.views.workspaces.get_project",
-        side_effect=Exception("test error"),
         autospec=True,
+        side_effect=Exception("test error"),
     )
     response = GlobalWorkspaceDetail.as_view()(request, name=workspace.name)
 
@@ -246,7 +246,7 @@ def test_workspacedetail_get_success(rf, mocker, user):
       twiddle:
     """
     mocker.patch(
-        "jobserver.views.workspaces.can_run_jobs", return_value=True, autospec=True
+        "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
     mocker.patch("jobserver.views.workspaces.get_project", new=lambda *args: dummy_yaml)
     response = GlobalWorkspaceDetail.as_view()(request, name=workspace.name)
@@ -270,10 +270,10 @@ def test_workspacedetail_post_archived_workspace(rf, mocker):
     request.user = UserFactory()
 
     mocker.patch(
-        "jobserver.views.workspaces.can_run_jobs", return_value=True, autospec=True
+        "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
     mocker.patch(
-        "jobserver.views.workspaces.get_actions", return_value=[], autospec=True
+        "jobserver.views.workspaces.get_actions", autospec=True, return_value=[]
     )
     response = GlobalWorkspaceDetail.as_view()(request, name=workspace.name)
 
@@ -305,7 +305,7 @@ def test_workspacedetail_post_success(rf, mocker, monkeypatch, user):
       twiddle:
     """
     mocker.patch(
-        "jobserver.views.workspaces.can_run_jobs", return_value=True, autospec=True
+        "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
     mocker.patch("jobserver.views.workspaces.get_project", new=lambda *args: dummy_yaml)
     mocker.patch(
@@ -348,7 +348,7 @@ def test_workspacedetail_post_with_invalid_backend(rf, mocker, monkeypatch, user
       twiddle:
     """
     mocker.patch(
-        "jobserver.views.workspaces.can_run_jobs", return_value=True, autospec=True
+        "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
     mocker.patch("jobserver.views.workspaces.get_project", new=lambda *args: dummy_yaml)
     mocker.patch(
@@ -386,7 +386,7 @@ def test_workspacedetail_post_with_notifications_default(rf, mocker, monkeypatch
       twiddle:
     """
     mocker.patch(
-        "jobserver.views.workspaces.can_run_jobs", return_value=True, autospec=True
+        "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
     mocker.patch("jobserver.views.workspaces.get_project", new=lambda *args: dummy_yaml)
     mocker.patch(
@@ -432,7 +432,7 @@ def test_workspacedetail_post_with_notifications_override(
       twiddle:
     """
     mocker.patch(
-        "jobserver.views.workspaces.can_run_jobs", return_value=True, autospec=True
+        "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
     mocker.patch("jobserver.views.workspaces.get_project", new=lambda *args: dummy_yaml)
     mocker.patch(
@@ -523,7 +523,7 @@ def test_workspacelog_search_by_action(rf, mocker):
     request.user = user
 
     mocker.patch(
-        "jobserver.views.workspaces.can_run_jobs", return_value=True, autospec=True
+        "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
     response = WorkspaceLog.as_view()(request, name=workspace.name)
 
@@ -546,7 +546,7 @@ def test_workspacelog_search_by_id(rf, mocker):
     request.user = user
 
     mocker.patch(
-        "jobserver.views.workspaces.can_run_jobs", return_value=True, autospec=True
+        "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
     response = WorkspaceLog.as_view()(request, name=workspace.name)
 
@@ -566,7 +566,7 @@ def test_workspacelog_success(rf, mocker):
     request.user = user
 
     mocker.patch(
-        "jobserver.views.workspaces.can_run_jobs", return_value=True, autospec=True
+        "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
     response = WorkspaceLog.as_view()(request, name=workspace.name)
 
@@ -599,7 +599,7 @@ def test_workspacelog_with_authenticated_user(rf, mocker):
     request.user = UserFactory()
 
     mocker.patch(
-        "jobserver.views.workspaces.can_run_jobs", return_value=True, autospec=True
+        "jobserver.views.workspaces.can_run_jobs", autospec=True, return_value=True
     )
     response = WorkspaceLog.as_view()(request, name=workspace.name)
 


### PR DESCRIPTION
This tidies up how the mocks currently work across all the tests in an effort to standardise them, and more importantly make sure `autospec=True` is always set.  Now that mocks are no longer context managers I've also pulled them away from the request/response construction bits in each test since they feel more akin to factories at this point.

This was pulled out of the bigger chunk of work to move all URLs under Orgs&Projects, which necessitates the combing of the ProjectWorkspaceDetail and GlobalWorkspaceDetail views, which brought up that the mocks could be a little neater/easier to read.