### PR TITLE
Ensure values used for filters exist in the db

### DIFF
--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.decorators import user_passes_test
+from django.core.exceptions import BadRequest
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
@@ -109,8 +110,15 @@ class JobRequestList(FormMixin, ListView):
                 # it then we can look for a job number
                 qs = qs.filter(qwargs | Q(jobs__pk=q))
 
+        def raise_if_not_int(value):
+            try:
+                int(value)
+            except ValueError:
+                raise BadRequest
+
         backend = self.request.GET.get("backend")
         if backend:
+            raise_if_not_int(backend)
             qs = qs.filter(backend_id=backend)
 
         username = self.request.GET.get("username")
@@ -119,6 +127,7 @@ class JobRequestList(FormMixin, ListView):
 
         workspace = self.request.GET.get("workspace")
         if workspace:
+            raise_if_not_int(workspace)
             qs = qs.filter(workspace_id=workspace)
 
         return qs

--- a/tests/jobserver/views/test_job_requests.py
+++ b/tests/jobserver/views/test_job_requests.py
@@ -2,6 +2,7 @@ import pytest
 import responses
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import BadRequest
 from django.http import Http404
 from django.urls import reverse
 
@@ -169,6 +170,15 @@ def test_jobrequestlist_filter_by_backend(rf):
 
 
 @pytest.mark.django_db
+def test_jobrequestlist_filter_by_backend_with_broken_pk(rf):
+    request = rf.get("/?backend=test")
+    request.user = UserFactory()
+
+    with pytest.raises(BadRequest):
+        JobRequestList.as_view()(request)
+
+
+@pytest.mark.django_db
 def test_jobrequestlist_filter_by_status(rf):
     JobFactory(job_request=JobRequestFactory(), status="failed")
 
@@ -258,6 +268,15 @@ def test_jobrequestlist_filter_by_workspace(rf):
     response = JobRequestList.as_view()(request)
 
     assert len(response.context_data["object_list"]) == 1
+
+
+@pytest.mark.django_db
+def test_jobrequestlist_filter_by_workspace_with_broken_pk(rf):
+    request = rf.get("/?workspace=test")
+    request.user = UserFactory()
+
+    with pytest.raises(BadRequest):
+        JobRequestList.as_view()(request)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Django does some automated conversation when we use the ORM so passing
in the string "123" to a filter, eg .filter(pk="123") will find a record
with the integer pk 123.  However if this value can't be converted to an
integer this filter will throw a ValueError.  Since our filter inputs
here are user generated this checks query is using valid values before
adding the filter to the query.

Fixes [this Sentry ticket](https://sentry.io/organizations/ebm-datalab/issues/2424701368/?project=5443358&query=is%3Aunresolved).