### PR TITLE
Add a helper function for the Workspace logs URL

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -904,6 +904,16 @@ class Workspace(models.Model):
             },
         )
 
+    def get_logs_url(self):
+        return reverse(
+            "workspace-logs",
+            kwargs={
+                "org_slug": self.project.org.slug,
+                "project_slug": self.project.slug,
+                "workspace_slug": self.name,
+            },
+        )
+
     def get_notifications_toggle_url(self):
         return reverse(
             "workspace-notifications-toggle",

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -27,9 +27,7 @@
       <h3>{{ workspace.name }}</h3>
 
       <div class="d-flex">
-        <a class="btn btn-primary mr-2" href="{% url 'workspace-logs' org_slug=workspace.project.org.slug project_slug=workspace.project.slug workspace_slug=workspace.name %}">
-          Logs
-        </a>
+        <a class="btn btn-primary mr-2" href="{{ workspace.get_logs_url }}">Logs</a>
         {% if show_details %}
         <a
           class="btn btn-primary"

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -891,6 +891,24 @@ def test_workspace_get_archive_toggle_url():
 
 
 @pytest.mark.django_db
+def test_workspace_get_logs_url():
+    org = OrgFactory()
+    project = ProjectFactory(org=org)
+    workspace = WorkspaceFactory(project=project)
+
+    url = workspace.get_logs_url()
+
+    assert url == reverse(
+        "workspace-logs",
+        kwargs={
+            "org_slug": org.slug,
+            "project_slug": project.slug,
+            "workspace_slug": workspace.name,
+        },
+    )
+
+
+@pytest.mark.django_db
 def test_workspace_get_notifications_toggle_url():
     org = OrgFactory()
     project = ProjectFactory(org=org)

--- a/tests/jobserver/views/test_workspaces.py
+++ b/tests/jobserver/views/test_workspaces.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.http import Http404
-from django.urls import reverse
 
 from jobserver.authorization import ProjectDeveloper
 from jobserver.models import Backend, JobRequest, Workspace
@@ -357,14 +356,7 @@ def test_workspacedetail_post_success(rf, mocker, monkeypatch, user):
     )
 
     assert response.status_code == 302, response.context_data["form"].errors
-    assert response.url == reverse(
-        "workspace-logs",
-        kwargs={
-            "org_slug": workspace.project.org.slug,
-            "project_slug": workspace.project.slug,
-            "workspace_slug": workspace.name,
-        },
-    )
+    assert response.url == workspace.get_logs_url()
 
     job_request = JobRequest.objects.first()
     assert job_request.created_by == user
@@ -467,14 +459,7 @@ def test_workspacedetail_post_with_notifications_default(rf, mocker, monkeypatch
     )
 
     assert response.status_code == 302, response.context_data["form"].errors
-    assert response.url == reverse(
-        "workspace-logs",
-        kwargs={
-            "org_slug": workspace.project.org.slug,
-            "project_slug": workspace.project.slug,
-            "workspace_slug": workspace.name,
-        },
-    )
+    assert response.url == workspace.get_logs_url()
 
     job_request = JobRequest.objects.first()
     assert job_request.created_by == user
@@ -531,14 +516,7 @@ def test_workspacedetail_post_with_notifications_override(
     )
 
     assert response.status_code == 302, response.context_data["form"].errors
-    assert response.url == reverse(
-        "workspace-logs",
-        kwargs={
-            "org_slug": workspace.project.org.slug,
-            "project_slug": workspace.project.slug,
-            "workspace_slug": workspace.name,
-        },
-    )
+    assert response.url == workspace.get_logs_url()
 
     job_request = JobRequest.objects.first()
     assert job_request.created_by == user


### PR DESCRIPTION
This wraps up the workspace-logs URL reversing (and its many kwargs) into a helper function.