### PR TITLE
Remove references to project registration when user is not an Org member

### DIFF
--- a/jobserver/templates/org_detail.html
+++ b/jobserver/templates/org_detail.html
@@ -18,9 +18,11 @@
     <div class="d-flex justify-content-between align-items-center">
       <h2>{{ org.name }}</h2>
 
+      {% if is_member %}
       <div>
         <a class="btn btn-primary" href="{% url 'project-create' org_slug=org.slug %}">Register Project</a>
       </div>
+      {% endif %}
     </div>
 
 
@@ -34,8 +36,11 @@
     </ul>
     {% else %}
     <p class="mt-5">
-      There are no projects for this Organisation yet, click "Register Project"
-      to create one.
+      {% if is_member %}
+      There are no projects for this organisation yet, click "Register Project" to create one.
+      {% else %}
+      There are no projects for this organisation yet.
+      {% endif %}
     </p>
     {% endif %}
 

--- a/jobserver/views/orgs.py
+++ b/jobserver/views/orgs.py
@@ -44,12 +44,14 @@ class OrgDetail(DetailView):
 
             return redirect(workspace)
 
+        is_member = request.user in org.members.all()
         projects = org.projects.order_by("name")
 
         return TemplateResponse(
             request,
             "org_detail.html",
             context={
+                "is_member": is_member,
                 "org": org,
                 "projects": projects,
             },

--- a/tests/jobserver/views/test_orgs.py
+++ b/tests/jobserver/views/test_orgs.py
@@ -4,7 +4,13 @@ from django.http import Http404
 from jobserver.models import Org
 from jobserver.views.orgs import OrgCreate, OrgDetail, OrgList
 
-from ...factories import OrgFactory, ProjectFactory, UserFactory, WorkspaceFactory
+from ...factories import (
+    OrgFactory,
+    OrgMembershipFactory,
+    ProjectFactory,
+    UserFactory,
+    WorkspaceFactory,
+)
 
 
 MEANINGLESS_URL = "/"
@@ -76,6 +82,33 @@ def test_orgdetail_unknown_org_but_known_workspace(rf):
 
     assert response.status_code == 302
     assert response.url == workspace.get_absolute_url()
+
+
+@pytest.mark.django_db
+def test_orgdetail_with_org_member(rf):
+    org = OrgFactory()
+    user = UserFactory()
+    OrgMembershipFactory(org=org, user=user)
+
+    request = rf.get(MEANINGLESS_URL)
+    request.user = user
+
+    response = OrgDetail.as_view()(request, org_slug=org.slug)
+
+    assert response.status_code == 200
+    assert "Register Project" in response.rendered_content
+
+
+@pytest.mark.django_db
+def test_orgdetail_with_non_member_user(rf):
+    org = OrgFactory()
+
+    request = rf.get(MEANINGLESS_URL)
+    request.user = UserFactory()
+    response = OrgDetail.as_view()(request, org_slug=org.slug)
+
+    assert response.status_code == 200
+    assert "Register Project" not in response.rendered_content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This removes the Register Project button, and the text reference to it when there are no Projects, for an Org when the viewing User isn't a member of that Org.