### PR TITLE
Add breadcrumbs to WorkspaceDetail

### DIFF
--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -21,6 +21,28 @@
 </div>
 {% endif %}
 
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+
+    <li class="breadcrumb-item"><a href="/">Home</a></li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ workspace.project.org.get_absolute_url }}">
+        {{ workspace.project.org.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ workspace.project.get_absolute_url }}">
+        {{ workspace.project.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item active" aria-current="page">{{ workspace.name }}</li>
+
+  </ol>
+</nav>
+
 <div class="row">
   <div class="col-lg-8 offset-lg-2">
     <div class="d-flex justify-content-between align-items-center">


### PR DESCRIPTION
This brings the WorkspaceDetail page inline with the other pages by adding some navigation via breadcrumbs.