### PR TITLE
Add ProjectDeveloper role to User who creates a Project

### DIFF
--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -9,7 +9,12 @@ from django.utils.html import escape
 from django.views.generic import CreateView, DetailView, UpdateView, View
 from sentry_sdk import capture_exception
 
-from ..authorization import ProjectCoordinator, has_permission, roles_for
+from ..authorization import (
+    ProjectCoordinator,
+    ProjectDeveloper,
+    has_permission,
+    roles_for,
+)
 from ..authorization.decorators import require_superuser
 from ..emails import send_project_invite_email
 from ..forms import (
@@ -91,7 +96,10 @@ class ProjectCreate(CreateView):
         project.org = self.org
         project.save()
 
-        project.memberships.create(user=self.request.user, roles=[ProjectCoordinator])
+        project.memberships.create(
+            user=self.request.user,
+            roles=[ProjectCoordinator, ProjectDeveloper],
+        )
 
         return redirect(project)
 

--- a/tests/jobserver/views/test_projects.py
+++ b/tests/jobserver/views/test_projects.py
@@ -208,7 +208,7 @@ def test_projectcreate_post_success(rf):
 
     membership = project.memberships.first()
     assert membership.user == user
-    assert membership.roles == [ProjectCoordinator]
+    assert set(membership.roles) == {ProjectCoordinator, ProjectDeveloper}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This adds the `ProjectDeveloper` role to ProjectMembership created when a User creates a Project so said User can run jobs in Workspaces for that Project.