### PR TITLE
Only filter deprecation warnings to know apps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,6 @@ env = [
 ]
 filterwarnings = [
     'ignore:django.conf.urls.url\(\) is deprecated:django.utils.deprecation.RemovedInDjango40Warning:rest_framework|social_django',
-    "ignore::django.utils.deprecation.RemovedInDjango41Warning:django",
+    "ignore:'(debug_toolbar|social_django)':django.utils.deprecation.RemovedInDjango41Warning:django",
     "ignore:A private pytest class or function was used.:pytest.PytestDeprecationWarning:pytest_subtests",
 ]


### PR DESCRIPTION
Rather than filtering any RemovedInDjango41Warning this changes the filter to only target the dependencies which we know it affects.