### PR TITLE
Bring pre-commit python versions inline with other configs (3.9)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,19 +3,19 @@ repos:
     rev: 21.6b0
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.9
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     - id: flake8
-      language_version: python3.8
+      language_version: python3.9
 
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.8.0
     hooks:
     - id: isort
-      language_version: python3.8
+      language_version: python3.9
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
@@ -38,3 +38,4 @@ repos:
     rev: v2.18.3
     hooks:
     - id: pyupgrade
+      language_version: python3.9


### PR DESCRIPTION
This is a small house keeping change to bring the Python versions in our pre-commit config in line with the Python version we use for local dev, CI, prod, etc.