### PR TITLE
Remove backend default when creating JobRequests

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -32,10 +32,9 @@ class JobRequestCreateForm(forms.ModelForm):
             },
         )
 
-        try:
-            initial = backends[0][0]
-        except IndexError:
-            initial = None
+        # only set an initial if there is one backend since the selector will
+        # be hidden on the page
+        initial = backends[0][0] if len(backends) == 1 else None
 
         # bulid the backends field based on the backends passed in
         self.fields["backend"] = forms.ChoiceField(

--- a/tests/jobserver/test_forms.py
+++ b/tests/jobserver/test_forms.py
@@ -7,12 +7,26 @@ from jobserver.models import Backend
 
 
 @pytest.mark.django_db
-def test_jobrequestcreateform_with_backends():
-    choices = backends_to_choices(Backend.objects.all())
-    form = JobRequestCreateForm([], backends=choices)
+def test_jobrequestcreateform_with_single_backend():
+    emis = Backend.objects.get(name="emis")
+    choices = backends_to_choices([emis])
+    form = JobRequestCreateForm({"backend": "emis"}, backends=choices)
 
     assert "backend" in form.fields
     assert form.fields["backend"].choices == choices
+
+    assert form.is_valid, form.errors
+
+
+@pytest.mark.django_db
+def test_jobrequestcreateform_with_multiple_backends():
+    choices = backends_to_choices(Backend.objects.all())
+    form = JobRequestCreateForm({"backend": "tpp"}, backends=choices)
+
+    assert "backend" in form.fields
+    assert form.fields["backend"].choices == choices
+
+    assert form.is_valid, form.errors
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This removes the default option for Backends when the User has access to more than one Backend so the default isn't accidentlly picked.

Fixes #549 