### PR TITLE
Partial job id search

### DIFF
--- a/tests/jobserver/views/test_jobs.py
+++ b/tests/jobserver/views/test_jobs.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 
 from jobserver.views.jobs import JobCancel, JobDetail
 
-from ...factories import JobFactory, JobRequestFactory, UserFactory, WorkspaceFactory
+from ...factories import JobFactory, JobRequestFactory, UserFactory
 
 
 MEANINGLESS_URL = "/"
@@ -123,35 +123,7 @@ def test_jobdetail_with_authenticated_user(rf, mocker):
     response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
-
-
-@pytest.mark.django_db
-def test_jobdetail_with_post_jobrequest_job(rf, mocker):
-    job = JobFactory()
-
-    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=False)
-
-    request = rf.get(MEANINGLESS_URL)
-    request.user = UserFactory()
-
-    response = JobDetail.as_view()(request, identifier=job.identifier)
-
-    assert response.status_code == 200
-
-
-@pytest.mark.django_db
-def test_jobdetail_with_pre_jobrequest_job(rf, mocker):
-    job_request = JobRequestFactory(workspace=WorkspaceFactory())
-    job = JobFactory(job_request=job_request)
-
-    mocker.patch("jobserver.views.jobs.can_run_jobs", autospec=True, return_value=False)
-
-    request = rf.get(MEANINGLESS_URL)
-    request.user = UserFactory()
-
-    response = JobDetail.as_view()(request, identifier=job.identifier)
-
-    assert response.status_code == 200
+    assert "Cancel" in response.rendered_content
 
 
 @pytest.mark.django_db
@@ -166,6 +138,7 @@ def test_jobdetail_with_unauthenticated_user(rf, mocker):
     response = JobDetail.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 200
+    assert "Cancel" not in response.rendered_content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This adds the ability to use a partial identifier to look up a Job when visiting the JobDetail page.  If you use a partial id the view will redirect to itself so the URL becomes the full ID.

I've also reworked the view to use TemplateResponse now that DetailView's `get_object` is no longer a good fit.

Fixes #493 