### PR TITLE
Add help text to the name field of WorkspaceCreateForm

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -134,6 +134,9 @@ class WorkspaceCreateForm(forms.ModelForm):
             "repo",
             "branch",
         ]
+        help_texts = {
+            "name": "Enter a descriptive name which makes this workspace easy to identify.  It will also be the name of the directory in which you will find results after jobs from this workspace are run.",
+        }
         model = Workspace
         widgets = {
             "name": forms.TextInput(),


### PR DESCRIPTION
This adds some help text to the Workspace creation form to explain how it will be used.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/QwuAk60b/7006a2f8-4551-4713-bbe7-39d657b7c9f0.jpg?v=30bf87d5e69bdcbfd6f89198231d0640)

Fixes #472 