### PR TITLE
Improve Backend Filtering of JobRequests API

### DIFF
--- a/jobserver/api.py
+++ b/jobserver/api.py
@@ -269,6 +269,11 @@ class JobRequestAPIList(ListAPIView):
         # filter JobRequests by Backend name
         # Prioritise GET arg then self.backend (from authenticated requests)
         query_arg_backend = self.request.GET.get("backend", None)
+
+        # short term special case
+        if query_arg_backend == "nhsd":
+            query_arg_backend = "databricks"
+
         db_backend = getattr(self.backend, "name", None)
         if backend_name := first([query_arg_backend, db_backend]):
             qs = qs.filter(backend__name=backend_name)

--- a/tests/jobserver/test_api.py
+++ b/tests/jobserver/test_api.py
@@ -481,6 +481,19 @@ def test_jobrequestapilist_filter_by_backend(api_rf):
     assert len(response.data["results"]) == 1
 
 
+@pytest.mark.django_db
+def test_jobrequestapilist_filter_by_databricks(api_rf):
+    job_request = JobRequestFactory(backend=Backend.objects.get(name="databricks"))
+    JobRequestFactory(backend=Backend.objects.get(name="tpp"))
+
+    request = api_rf.get("/?backend=nhsd")
+    response = JobRequestAPIList.as_view()(request)
+
+    assert response.status_code == 200, response.data
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["identifier"] == job_request.identifier
+
+
 def test_jobrequestapilist_get_only(api_rf):
     request = api_rf.post("/", data={}, format="json")
     response = JobRequestAPIList.as_view()(request)


### PR DESCRIPTION
This adds a fix for the databricks job-runner filtering name and creates a warning in Sentry should we see anything similar from any backend to help us track down misconfigurations during intial backend setup.