### PR TITLE
Add Badges to Repo URLs

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -73,6 +73,38 @@ def get_file(org, repo, branch):
     return r.text
 
 
+def get_repo(org, repo):
+    f = furl(BASE_URL)
+    f.path.segments += [
+        "repos",
+        org,
+        repo,
+    ]
+
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": f"token {GITHUB_TOKEN}",
+        "User-Agent": USER_AGENT,
+    }
+    r = requests.get(f.url, headers=headers)
+
+    if r.status_code == 404:
+        return
+
+    r.raise_for_status()
+
+    return r.json()
+
+
+def get_repo_is_private(org, repo):
+    repo = get_repo(org, repo)
+
+    if repo is None:
+        return None
+
+    return repo["private"]
+
+
 def _get_page(session, org, cursor):
     """
     Get a page of Repos (with branches) from the OpenSAFELY Researchers Team

--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -963,6 +963,18 @@ class Workspace(models.Model):
     def repo_name(self):
         """Convert repo URL -> repo name"""
         f = furl(self.repo)
+
         if not f.path:
             raise Exception("Repo URL not in expected format, appears to have no path")
+
         return f.path.segments[-1]
+
+    @property
+    def repo_owner(self):
+        """Convert repo URL -> repo name"""
+        f = furl(self.repo)
+
+        if not f.path:
+            raise Exception("Repo URL not in expected format, appears to have no path")
+
+        return f.path.segments[0]

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -80,11 +80,12 @@
         <div class="mb-4">
           <h5>Repos</h5>
           <ul class="list-unstyled">
-            {% for workspace in workspaces %}
-            <li>
-              <a href="{{ workspace.repo }}">
-                {{ workspace.repo_name }} ({{ workspace.branch }})
-              </a>
+            {% for repo in repos %}
+            <li class="d-flex align-items-center">
+              <a href="{{ repo.url }}">{{ repo.name }}</a>
+              <span class="badge badge-secondary ml-1">
+                {% if repo.is_private %}Private{% else %}Public{% endif %}
+              </span>
             </li>
             {% endfor %}
           </ul>

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -83,6 +83,9 @@
             <strong>Repo:</strong>
             <a href="{{ workspace.repo }}">{{ workspace.repo_name }}</a>
             <span class="text-muted">({{ workspace.branch }})</span>
+            <span class="badge badge-secondary">
+              {% if repo_is_private %}Private{% else %}Public{% endif %}
+            </span>
           </p>
 
           <p><strong>DB:</strong> {{ workspace.db }}</p>

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -15,7 +15,7 @@ from ..forms import (
     WorkspaceCreateForm,
     WorkspaceNotificationsToggleForm,
 )
-from ..github import get_branch_sha, get_repos_with_branches
+from ..github import get_branch_sha, get_repo_is_private, get_repos_with_branches
 from ..models import Backend, JobRequest, Project, Workspace
 from ..project import get_actions, get_project, load_yaml
 from ..roles import can_run_jobs
@@ -157,6 +157,7 @@ class WorkspaceDetail(CreateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["actions"] = self.actions
+        context["repo_is_private"] = self.get_repo_is_private()
         context["latest_job_request"] = self.get_latest_job_request()
         context["show_details"] = self.show_details
         context["user_can_run_jobs"] = self.user_can_run_jobs
@@ -179,6 +180,12 @@ class WorkspaceDetail(CreateView):
         # derive will_notify for the JobRequestCreateForm from the Workspace
         # setting as a default for the form which the user can override.
         return {"will_notify": self.workspace.should_notify}
+
+    def get_repo_is_private(self):
+        return get_repo_is_private(
+            self.workspace.repo_owner,
+            self.workspace.repo_name,
+        )
 
     def get_latest_job_request(self):
         return (

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -1099,6 +1099,20 @@ def test_workspace_repo_name_success():
 
 
 @pytest.mark.django_db
+def test_workspace_repo_owner_no_path():
+    workspace = WorkspaceFactory(repo="http://example.com")
+
+    with pytest.raises(Exception, match="not in expected format"):
+        workspace.repo_owner
+
+
+@pytest.mark.django_db
+def test_workspace_repo_owner_success():
+    workspace = WorkspaceFactory(repo="http://example.com/foo/test")
+    assert workspace.repo_owner == "foo"
+
+
+@pytest.mark.django_db
 def test_workspace_str():
     workspace = WorkspaceFactory(
         name="Corellian Engineering Corporation", repo="Corellia"

--- a/tests/jobserver/views/test_workspaces.py
+++ b/tests/jobserver/views/test_workspaces.py
@@ -32,41 +32,6 @@ MEANINGLESS_URL = "/"
 
 
 @pytest.mark.django_db
-def test_projectworkspacedetail_success(rf, user):
-    org = user.orgs.first()
-    project = ProjectFactory(org=org)
-    workspace = WorkspaceFactory(project=project)
-
-    ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
-
-    request = rf.get(MEANINGLESS_URL)
-    request.user = user
-    response = WorkspaceDetail.as_view()(
-        request,
-        org_slug=org.slug,
-        project_slug=project.slug,
-        workspace_slug=workspace.name,
-    )
-
-    assert response.status_code == 200
-    assert response.context_data["user_can_run_jobs"]
-
-
-@pytest.mark.django_db
-def test_projectworkspacedetail_unknown_workspace(rf):
-    request = rf.get(MEANINGLESS_URL)
-    response = WorkspaceDetail.as_view()(
-        request,
-        org_slug="",
-        project_slug="",
-        workspace_slug="",
-    )
-
-    assert response.status_code == 302
-    assert response.url == "/"
-
-
-@pytest.mark.django_db
 @responses.activate
 def test_workspacearchivetoggle_success(rf, user):
     org = user.orgs.first()
@@ -229,6 +194,11 @@ def test_workspacedetail_project_yaml_errors(rf, mocker, user):
         autospec=True,
         side_effect=Exception("test error"),
     )
+    mocker.patch(
+        "jobserver.views.workspaces.get_repo_is_private",
+        autospec=True,
+        return_value=True,
+    )
 
     request = rf.get(MEANINGLESS_URL)
     request.user = user
@@ -263,6 +233,11 @@ def test_workspacedetail_get_success(rf, mocker, user):
     )
     mocker.patch(
         "jobserver.views.workspaces.get_project", autospec=True, return_value=dummy_yaml
+    )
+    mocker.patch(
+        "jobserver.views.workspaces.get_repo_is_private",
+        autospec=True,
+        return_value=True,
     )
 
     request = rf.get(MEANINGLESS_URL)
@@ -392,6 +367,11 @@ def test_workspacedetail_post_with_invalid_backend(rf, mocker, monkeypatch, user
         "jobserver.views.workspaces.get_branch_sha",
         autospec=True,
         return_value="abc123",
+    )
+    mocker.patch(
+        "jobserver.views.workspaces.get_repo_is_private",
+        autospec=True,
+        return_value=True,
     )
 
     data = {


### PR DESCRIPTION
This adds badges to GitHub repo links showing if they are public or private.  As part of this work I realised we were duplicating repo URLs on the ProjectDetail page so this fixes that too.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/o0uemwPR/86fa8aa0-076f-4855-960a-bd459ccc7ce5.jpg?v=995119b690d9d08d4cb0da5cb7052a0c)

Fixes #442 