### PR TITLE
Fix Sentry Warning Check

### DIFF
--- a/jobserver/api.py
+++ b/jobserver/api.py
@@ -279,7 +279,7 @@ class JobRequestAPIList(ListAPIView):
 
         # send a warning to Sentry if the query arg and token-linked backend
         # names differ
-        if query_arg_backend != db_backend:
+        if query_arg_backend and db_backend and query_arg_backend != db_backend:
             sentry_sdk.set_context(
                 "backend_values",
                 {


### PR DESCRIPTION
This changes the JobRequestAPIList to only compare the query arg and token-linked backend names when they both have a value.

ref: https://github.com/opensafely-core/job-server/pull/581#discussion_r651656478