### PR TITLE
Remove the slice db option

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -130,7 +130,6 @@ class WorkspaceCreateForm(forms.ModelForm):
     class Meta:
         fields = [
             "name",
-            "db",
             "repo",
             "branch",
         ]

--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -882,11 +882,7 @@ class Workspace(models.Model):
     is_archived = models.BooleanField(default=False)
     should_notify = models.BooleanField(default=False)
 
-    DB_OPTIONS = (
-        ("slice", "Cut-down (but real) database"),
-        ("full", "Full database"),
-    )
-    db = models.TextField(choices=DB_OPTIONS)
+    db = models.TextField(choices=[("full", "Full database")])
 
     created_at = models.DateTimeField(default=timezone.now)
 

--- a/tests/jobserver/views/test_workspaces.py
+++ b/tests/jobserver/views/test_workspaces.py
@@ -159,7 +159,6 @@ def test_workspacecreate_post_success(rf, mocker, user):
         "name": "Test",
         "repo": "test",
         "branch": "test",
-        "db": "slice",
     }
     request = rf.post(MEANINGLESS_URL, data)
     request.user = user


### PR DESCRIPTION
This removes the "slice" DB option since it was only available on the TPP backend.