### PR TITLE
Rename "finished" to "completed"

### DIFF
--- a/jobserver/api.py
+++ b/jobserver/api.py
@@ -161,11 +161,11 @@ class JobAPIUpdate(APIView):
                     # false positives.
                     continue
 
-                # check to see if the Job is about to transition to finished
+                # check to see if the Job is about to transition to completed
                 # (failed or succeeded) so we can notify after the update
-                finished = ["failed", "succeeded"]
+                completed = ["failed", "succeeded"]
                 should_notify = (
-                    job.status not in finished and job_data["status"] in finished
+                    job.status not in completed and job_data["status"] in completed
                 )
 
                 # update Job "manually" so we can make the check above for
@@ -179,7 +179,7 @@ class JobAPIUpdate(APIView):
                     continue
 
                 if not should_notify:
-                    # Job didn't move into the finished state (it might have
+                    # Job didn't move into the completed state (it might have
                     # already been there though)
                     continue
 
@@ -188,7 +188,7 @@ class JobAPIUpdate(APIView):
                     job,
                 )
                 log.info(
-                    "Notified requesting user of finished job",
+                    "Notified requesting user of completed job",
                     user_id=job_request.created_by_id,
                 )
 

--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -167,7 +167,7 @@ class Job(models.Model):
         return reverse("job-cancel", kwargs={"identifier": self.identifier})
 
     @property
-    def is_finished(self):
+    def is_completed(self):
         return self.status in ["failed", "succeeded"]
 
     @property
@@ -178,7 +178,7 @@ class Job(models.Model):
         When a Job has yet to finish but we haven't had an update from
         job-runner in >30 minutes we want to show users a warning.
         """
-        if self.is_finished:
+        if self.is_completed:
             # Job has completed, ignore lack of updates
             return False
 
@@ -194,7 +194,7 @@ class Job(models.Model):
 
     @property
     def runtime(self):
-        if not self.is_finished:
+        if not self.is_completed:
             return
 
         if self.started_at is None or self.completed_at is None:
@@ -282,7 +282,7 @@ class JobRequest(models.Model):
         return f.url
 
     @property
-    def is_finished(self):
+    def is_completed(self):
         return self.status in ["failed", "succeeded"]
 
     @property
@@ -306,9 +306,9 @@ class JobRequest(models.Model):
     @property
     def runtime(self):
         """
-        Combined runtime for all finished Jobs of this JobRequest
+        Combined runtime for all completed Jobs of this JobRequest
 
-        Runtime of each finished Job is added together, rather than using the
+        Runtime of each completed Job is added together, rather than using the
         delta of the first start time and last completed time.
         """
         if self.started_at is None:
@@ -320,7 +320,7 @@ class JobRequest(models.Model):
 
             return (job.completed_at - job.started_at).total_seconds()
 
-        # Only look at jobs which have finished
+        # Only look at jobs which have completed
         jobs = self.jobs.filter(Q(status="failed") | Q(status="succeeded"))
         total_runtime = sum(runtime_in_seconds(j) for j in jobs)
 

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -154,7 +154,7 @@
 
       <button
         class="btn btn-block btn-danger"
-        {% if job.is_finished or job.action in job.job_request.cancelled_actions %}
+        {% if job.is_completed or job.action in job.job_request.cancelled_actions %}
         disabled
         {% endif %}
         type="submit">

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -159,7 +159,7 @@
 
       <button
         class="btn btn-block btn-danger"
-        {% if jobrequest.is_finished %}
+        {% if jobrequest.is_completed %}
         disabled
         {% endif %}
         type="submit">

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -36,7 +36,7 @@ class JobRequestCancel(View):
     def post(self, request, *args, **kwargs):
         job_request = get_object_or_404(JobRequest, pk=self.kwargs["pk"])
 
-        if job_request.is_finished:
+        if job_request.is_completed:
             return redirect(job_request)
 
         actions = list(set(job_request.jobs.values_list("action", flat=True)))

--- a/jobserver/views/jobs.py
+++ b/jobserver/views/jobs.py
@@ -15,7 +15,7 @@ class JobCancel(View):
     def post(self, request, *args, **kwargs):
         job = get_object_or_404(Job, identifier=self.kwargs["identifier"])
 
-        if job.is_finished or job.action in job.job_request.cancelled_actions:
+        if job.is_completed or job.action in job.job_request.cancelled_actions:
             return redirect(job)
 
         job.job_request.cancelled_actions.append(job.action)

--- a/tests/jobserver/test_api.py
+++ b/tests/jobserver/test_api.py
@@ -346,7 +346,7 @@ def test_jobapiupdate_mixture(api_rf, freezer):
 
 
 @pytest.mark.django_db
-def test_jobapiupdate_notifications_on_with_move_to_finished(api_rf, mocker):
+def test_jobapiupdate_notifications_on_with_move_to_completed(api_rf, mocker):
     workspace = WorkspaceFactory()
     job_request = JobRequestFactory(workspace=workspace, will_notify=True)
     job = JobFactory(job_request=job_request, status="running")
@@ -383,7 +383,7 @@ def test_jobapiupdate_notifications_on_with_move_to_finished(api_rf, mocker):
 
 
 @pytest.mark.django_db
-def test_jobapiupdate_notifications_on_without_move_to_finished(api_rf, mocker):
+def test_jobapiupdate_notifications_on_without_move_to_completed(api_rf, mocker):
     workspace = WorkspaceFactory()
     job_request = JobRequestFactory(workspace=workspace, will_notify=True)
     job = JobFactory(job_request=job_request, status="succeeded")

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -150,10 +150,10 @@ def test_job_runtime():
 
 
 @pytest.mark.django_db
-def test_job_runtime_not_finished():
+def test_job_runtime_not_completed():
     job = JobFactory(status="running", started_at=timezone.now())
 
-    # an unfinished job has no runtime
+    # an uncompleted job has no runtime
     assert job.runtime is None
 
 
@@ -258,12 +258,12 @@ def test_jobrequest_get_repo_url_success():
 
 
 @pytest.mark.django_db
-def test_jobrequest_is_finished():
+def test_jobrequest_is_completed():
     job_request = JobRequestFactory()
     JobFactory(job_request=job_request, status="failed")
     JobFactory(job_request=job_request, status="succeeded")
 
-    assert job_request.is_finished
+    assert job_request.is_completed
 
 
 @pytest.mark.django_db
@@ -308,7 +308,7 @@ def test_jobrequest_runtime_one_job_missing_completed_at(freezer):
     assert job_request.started_at
     assert not job_request.completed_at
 
-    # combined _finished_ Job runtime is 0 because the failed job has no
+    # combined _completed_ Job runtime is 0 because the failed job has no
     # runtime (it never started)
     assert job_request.runtime
     assert job_request.runtime.hours == 0
@@ -336,7 +336,7 @@ def test_jobrequest_runtime_one_job_missing_started_at(freezer):
     assert job_request.started_at
     assert job_request.completed_at
 
-    # combined _finished_ Job runtime is 2 minutes because the second job
+    # combined _completed_ Job runtime is 2 minutes because the second job
     # failed before it started
     assert job_request.runtime
     assert job_request.runtime.hours == 0
@@ -350,7 +350,7 @@ def test_jobrequest_runtime_no_jobs():
 
 
 @pytest.mark.django_db
-def test_jobrequest_runtime_not_finished(freezer):
+def test_jobrequest_runtime_not_completed(freezer):
     job_request = JobRequestFactory()
 
     JobFactory(
@@ -368,7 +368,7 @@ def test_jobrequest_runtime_not_finished(freezer):
     assert job_request.started_at
     assert not job_request.completed_at
 
-    # combined _finished_ Job runtime is 1 minute
+    # combined _completed_ Job runtime is 1 minute
     assert job_request.runtime
     assert job_request.runtime.hours == 0
     assert job_request.runtime.minutes == 1

--- a/tests/jobserver/views/test_job_requests.py
+++ b/tests/jobserver/views/test_job_requests.py
@@ -27,7 +27,7 @@ MEANINGLESS_URL = "/"
 
 @pytest.mark.django_db
 @responses.activate
-def test_jobrequestcancel_already_finished(rf, user):
+def test_jobrequestcancel_already_completed(rf, user):
     job_request = JobRequestFactory(cancelled_actions=[])
     JobFactory(job_request=job_request, status="succeeded")
     JobFactory(job_request=job_request, status="failed")

--- a/tests/jobserver/views/test_jobs.py
+++ b/tests/jobserver/views/test_jobs.py
@@ -37,9 +37,9 @@ def test_jobcancel_already_cancelled(rf, user):
 
 @pytest.mark.django_db
 @responses.activate
-def test_jobcancel_already_finished(rf, user):
+def test_jobcancel_already_completed(rf, user):
     job_request = JobRequestFactory(cancelled_actions=["another-action"])
-    job = JobFactory(job_request=job_request, action="test", status="finished")
+    job = JobFactory(job_request=job_request, action="test", status="succeeded")
 
     request = rf.post(MEANINGLESS_URL)
     request.user = user

--- a/tests/jobserver/views/test_jobs.py
+++ b/tests/jobserver/views/test_jobs.py
@@ -54,7 +54,7 @@ def test_jobcancel_already_completed(rf, user):
     assert response.url == reverse("job-detail", kwargs={"identifier": job.identifier})
 
     job_request.refresh_from_db()
-    assert job_request.cancelled_actions == ["another-action", "test"]
+    assert job_request.cancelled_actions == ["another-action"]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This selectively does `s/finished/completed/` across the codebase to bring the nomenclature inline with job-runner.  It also fixes an incorrect test discovered along the way.

Fixes #363