### PR TITLE
Remove V2 Section from Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,23 +73,6 @@ bitwarden cli tool installed in order to access passwords.
 A Django development server can be started with `docker-compose up`.
 
 
-### V2
-To test the integration of job-runner and job-server follow these steps:
-
-#### Initial Run
-1. Run job-server locally
-1. Log in
-1. Go to http://localhost:8000/workspaces/new and create a workspace
-1. Create a workspace
-1. Create a `JobRequest` via the actions list on the Workspace page
-1. Configure job-runner to point at your local job-server
-1. Run job-runner with `rm -f workdir/db.sqlite && python -m jobrunner.sync`
-
-#### Subsequent Runs
-1. Run this against the job-server database: `update jobserver_job set status_code = NULL, status_message = '', started = false, started_at = NULL, completed_at = NULL;` (this will wipe all local Job state)
-1. Run job-runner with `rm -f workdir/db.sqlite && python -m jobrunner.sync`
-
-
 ## Add/Updating Static Assets
 We don't currently use any kind of static asset management tool (eg npm, yarn,
 etc) for this project.


### PR DESCRIPTION
This removes a stale section from the docs talking about testing the v2 API.