### PR TITLE
Updates for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__
 htmlcov
 staticfiles
 releases
+.env
+

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,53 +1,70 @@
-# Developer docs
+# Local Development Set Up
+## Native
 
-## Local Development Set Up
-### Native
+### Prerequisites:
+- **Python v3.9.x**
+- **Pip**
+
 Create a virtualenv with your preferred tool and install the dependencies with:
 
-    pip install -r requirements.txt
+    pip install -r requirements.dev.txt
 
+Set up environment (note: you will need the bitwarden cli tool installed in order to access passwords):
+
+    make dev-config
+
+Alternatively, for limited functionality without requiring access to special passwords, copy `dotenv-sample` to `.env`,
+or export the environment variables in `dotenv-sample` with your tool of choice.
 
 Run migrations:
 
     python manage.py migrate
 
-
-Set up the environment variables listed in `dotenv-sample` with your tool of choice.
-
-
 Optionally set up 1 or more administrators by setting `ADMIN_USERS` to a list of strings.
 eg `ADMIN_USERS=ghickman,ingelsp`.
 
-**Note:** this can only contain usernames which exist in the database.
+**Note:** this can only contain usernames which exist in the database.  
+If necessary, you can create the required user(s) first with:
+
+    python manage.py createsuperuser
 
 Then update their User records with:
 
     python manage.py ensure_admins
 
-
 Run the dev server:
 
     python manage.py runserver
 
-### Docker Compose
-Copy `dotenv-sample` to `.env` and run `docker-compose up`.
+Access at http://localhost:8000
+
+## Docker Compose
+
+Set up environment as above:
+
+    make dev-config
+
+Run `docker-compose up`.
 
 *Note:* The dev server inside the container does not currently reload when changes are saved.
 
-## Deployment
+
+# Deployment
 It is currently configured to be deployed Heroku-style, and requires
 the environment variables defined in `dotenv-sample`.
 
-The DataLab job server is deployed to our `dokku2` instance, instructions are in [INSTALL.md](INSTALL.md).
+The DataLab job server is deployed to our `dokku2` instance, instructions are are in [INSTALL.md](INSTALL.md).
 
-## Testing
+# Testing
 
 Run `make dev-config` if you have not already. Note: you will need the
 bitwarden cli tool installed in order to access passwords.
 
-A Django development server can be started with `docker-compose up`.
+Run the tests with:
 
-## Add/Updating Static Assets
+    pytest tests
+
+# Add/Updating Static Assets
 We don't currently use any kind of static asset management tool (eg npm, yarn,
 etc) for this project.
 
@@ -57,17 +74,17 @@ the project with their version number.
 To add or update an asset:
 
 1. Download the asset from its respective site (with `wget` or your favourite tool)
-1. Move the production version to `static/<location>/`
-1. Rename to include the version number (eg `bootstrap.min.css` -> `bootstrap-4.5.0.min.css`)
+2. Move the production version to `static/<location>/`
+3. Rename to include the version number (eg `bootstrap.min.css` -> `bootstrap-4.5.0.min.css`)
 
-## Adding New Backends
+# Adding New Backends
 
-### Steps
+## Steps
 1. Add an empty migration with `python manage.py makemigrations jobserver --empty --name <meaningful name>`.
-1. Create your Backend(s) in a function via RunPython in the new migration file.
-1. Fix the tests (some will check the number of migrations).
+2. Create your Backend(s) in a function via RunPython in the new migration file.
+3. Fix the tests (some will check the number of migrations).
 
-### Why
+## Why
 Backends in this project represent a [job runner](https://github.com/opensafely-core/job-runner) instance somewhere.
 They are a Django model with a unique authentication token attached.
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,13 +1,14 @@
 # Local Development Set Up
 ## Native
 
-### Prerequisites:
+Prerequisites:
 - **Python v3.9.x**
+- **virtualenv**
 - **Pip**
 
 Create a virtualenv with your preferred tool and install the dependencies with:
 
-    pip install -r requirements.dev.txt
+    make setup
 
 Set up environment (note: you will need the bitwarden cli tool installed in order to access passwords):
 
@@ -23,7 +24,7 @@ Run migrations:
 Optionally set up 1 or more administrators by setting `ADMIN_USERS` to a list of strings.
 eg `ADMIN_USERS=ghickman,ingelsp`.
 
-**Note:** this can only contain usernames which exist in the database.  
+**Note:** this can only contain usernames which exist in the database.
 If necessary, you can create the required user(s) first with:
 
     python manage.py createsuperuser
@@ -34,7 +35,7 @@ Then update their User records with:
 
 Run the dev server:
 
-    python manage.py runserver
+    make run
 
 Access at http://localhost:8000
 
@@ -62,7 +63,7 @@ bitwarden cli tool installed in order to access passwords.
 
 Run the tests with:
 
-    pytest tests
+    make test
 
 # Add/Updating Static Assets
 We don't currently use any kind of static asset management tool (eg npm, yarn,

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -21,7 +21,7 @@ from services.sentry import initialise_sentry
 
 
 env = Env()
-
+env.read_env()
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -10,7 +10,9 @@ if ! command -v bw > /dev/null; then
     exit 1
 fi
 
-if test -z "$BW_SESSION"; then
+session_from_env=${BW_SESSION-"not-found"}
+
+if (test $session_from_env = "not-found"); then
     echo "Unlocking bitwarden..."
     BW_SESSION=$(bw unlock --raw)
     export BW_SESSION
@@ -22,9 +24,9 @@ GH_DEV_TOKEN_BW_ID=10242708-234a-4162-982f-ace700ee5c53
 write() {
     local name="$1"
     local value="$2"
-    sed -i "s/$name=.*/$name=$value/" "$target"
+    sed -i"" -e "s/$name=.*/$name=$value/" "$target"
 }
 
-write GITHUB_TOKEN "$(bw get password $GH_DEV_TOKEN_ID)"
+write GITHUB_TOKEN "$(bw get password $GH_DEV_TOKEN_BW_ID)"
 write SOCIAL_AUTH_GITHUB_KEY "$(bw get username $SOCIAL_AUTH_BW_ID)"
 write SOCIAL_AUTH_GITHUB_SECRET "$(bw get password $SOCIAL_AUTH_BW_ID)"


### PR DESCRIPTION
Some updates for getting a local development server running

- added a `read_env()` to settings.py so it'll read env variables from the file if it exists
- updated README to use the dev-env.sh script for native and docker setup
- a couple of updates to the dev-env.sh script to get it working for me (ubuntu 20.04)
- Changed the Testing section to document how to run tests (it was duplicating the docker-compose section)