### PR TITLE
Move Job&JobRequest URLs under Orgs, Projects, & Workspaces

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -75,7 +75,16 @@ class Job(models.Model):
         return reverse("job-detail", kwargs={"identifier": self.identifier})
 
     def get_cancel_url(self):
-        return reverse("job-cancel", kwargs={"identifier": self.identifier})
+        return reverse(
+            "job-cancel",
+            kwargs={
+                "org_slug": self.job_request.workspace.project.org.slug,
+                "project_slug": self.job_request.workspace.project.slug,
+                "workspace_slug": self.job_request.workspace.name,
+                "pk": self.job_request.pk,
+                "identifier": self.identifier,
+            },
+        )
 
     @property
     def is_completed(self):
@@ -169,7 +178,15 @@ class JobRequest(models.Model):
         return last_job.completed_at
 
     def get_cancel_url(self):
-        return reverse("job-request-cancel", kwargs={"pk": self.pk})
+        return reverse(
+            "job-request-cancel",
+            kwargs={
+                "org_slug": self.workspace.project.org.slug,
+                "project_slug": self.workspace.project.slug,
+                "workspace_slug": self.workspace.name,
+                "pk": self.pk,
+            },
+        )
 
     def get_file_url(self, path):
         f = furl(self.workspace.repo)

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -72,7 +72,16 @@ class Job(models.Model):
         return f"{self.action} ({self.pk})"
 
     def get_absolute_url(self):
-        return reverse("job-detail", kwargs={"identifier": self.identifier})
+        return reverse(
+            "job-detail",
+            kwargs={
+                "org_slug": self.job_request.workspace.project.org.slug,
+                "project_slug": self.job_request.workspace.project.slug,
+                "workspace_slug": self.job_request.workspace.name,
+                "pk": self.job_request.pk,
+                "identifier": self.identifier,
+            },
+        )
 
     def get_cancel_url(self):
         return reverse(
@@ -163,7 +172,15 @@ class JobRequest(models.Model):
     created_at = models.DateTimeField(default=timezone.now)
 
     def get_absolute_url(self):
-        return reverse("job-request-detail", kwargs={"pk": self.pk})
+        return reverse(
+            "job-request-detail",
+            kwargs={
+                "org_slug": self.workspace.project.org.slug,
+                "project_slug": self.workspace.project.slug,
+                "workspace_slug": self.workspace.name,
+                "pk": self.pk,
+            },
+        )
 
     @property
     def completed_at(self):

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -19,6 +19,18 @@
     <li class="breadcrumb-item"><a href="/">Home</a></li>
 
     <li class="breadcrumb-item">
+      <a href="{{ job.job_request.workspace.project.org.get_absolute_url }}">
+        {{ job.job_request.workspace.project.org.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ job.job_request.workspace.project.get_absolute_url }}">
+        {{ job.job_request.workspace.project.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
       <a href="{{ job.job_request.workspace.get_absolute_url }}">
         {{ job.job_request.workspace.name }}
       </a>

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -36,7 +36,7 @@
     </li>
 
     <li class="breadcrumb-item active" aria-current="page">
-      Request {{ job.job_request.id }}
+      Request {{ jobrequest.id }}
     </li>
 
   </ol>

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -18,6 +18,18 @@
     <li class="breadcrumb-item"><a href="/">Home</a></li>
 
     <li class="breadcrumb-item">
+      <a href="{{ jobrequest.workspace.project.org.get_absolute_url }}">
+        {{ jobrequest.workspace.project.org.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ jobrequest.workspace.project.get_absolute_url }}">
+        {{ jobrequest.workspace.project.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
       <a href="{{ jobrequest.workspace.get_absolute_url }}">
         {{ jobrequest.workspace.name }}
       </a>

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -25,8 +25,13 @@ from jobserver.api.releases import (
 from .views.admin import ApproveUsers
 from .views.backends import BackendDetail, BackendEdit, BackendList, BackendRotateToken
 from .views.index import Index
-from .views.job_requests import JobRequestCancel, JobRequestDetail, JobRequestList
-from .views.jobs import JobCancel, JobDetail
+from .views.job_requests import (
+    JobRequestCancel,
+    JobRequestDetail,
+    JobRequestDetailRedirect,
+    JobRequestList,
+)
+from .views.jobs import JobCancel, JobDetail, JobDetailRedirect
 from .views.orgs import OrgCreate, OrgDetail, OrgList
 from .views.projects import (
     ProjectAcceptInvite,
@@ -208,6 +213,10 @@ workspace_urls = [
     ),
     path("outputs/", include(outputs_urls)),
     path("releases/", include(releases_urls)),
+    path("<pk>/", JobRequestDetail.as_view(), name="job-request-detail"),
+    path("<pk>/cancel/", JobRequestCancel.as_view(), name="job-request-cancel"),
+    path("<pk>/<identifier>/", JobDetail.as_view(), name="job-detail"),
+    path("<pk>/<identifier>/cancel/", JobCancel.as_view(), name="job-cancel"),
 ]
 
 project_urls = [
@@ -258,18 +267,14 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/v2/", include((api_urls, "api"))),
     path("backends/", include(backend_urls)),
-    path("jobs/", JobRequestList.as_view(), name="job-list"),
-    path("job-requests/", RedirectView.as_view(pattern_name="job-list")),
+    path("event-list/", JobRequestList.as_view(), name="job-list"),
+    path("jobs/", RedirectView.as_view(query_string=True, pattern_name="job-list")),
     path(
-        "job-requests/<int:pk>/", JobRequestDetail.as_view(), name="job-request-detail"
+        "job-requests/<pk>/",
+        JobRequestDetailRedirect.as_view(),
+        name="job-request-detail",
     ),
-    path(
-        "job-requests/<int:pk>/cancel/",
-        JobRequestCancel.as_view(),
-        name="job-request-cancel",
-    ),
-    path("jobs/<identifier>/", JobDetail.as_view(), name="job-detail"),
-    path("jobs/<identifier>/cancel/", JobCancel.as_view(), name="job-cancel"),
+    path("jobs/<identifier>/", JobDetailRedirect.as_view(), name="job-detail"),
     path("logout/", LogoutView.as_view(), name="logout"),
     path("orgs/", include(org_urls)),
     path("settings/", Settings.as_view(), name="settings"),

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -1,9 +1,9 @@
 from django.db.models import Q
 from django.http import Http404
-from django.shortcuts import redirect
+from django.shortcuts import get_object_or_404, redirect
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
-from django.views.generic import DetailView, ListView, View
+from django.views.generic import DetailView, ListView, RedirectView, View
 from django.views.generic.edit import FormMixin
 
 from ..authorization import CoreDeveloper, has_permission, has_role
@@ -78,6 +78,12 @@ class JobRequestDetail(DetailView):
             "project_yaml_url": self.object.get_file_url("project.yaml"),
             "user_can_cancel_jobs": can_cancel_jobs,
         }
+
+
+class JobRequestDetailRedirect(RedirectView):
+    def get_redirect_url(self, *args, **kwargs):
+        job_request = get_object_or_404(JobRequest, pk=self.kwargs["pk"])
+        return job_request.get_absolute_url()
 
 
 class JobRequestList(FormMixin, ListView):

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -51,7 +51,16 @@ def test_job_get_cancel_url():
 
     url = job.get_cancel_url()
 
-    assert url == reverse("job-cancel", kwargs={"identifier": job.identifier})
+    assert url == reverse(
+        "job-cancel",
+        kwargs={
+            "org_slug": job.job_request.workspace.project.org.slug,
+            "project_slug": job.job_request.workspace.project.slug,
+            "workspace_slug": job.job_request.workspace.name,
+            "pk": job.job_request.pk,
+            "identifier": job.identifier,
+        },
+    )
 
 
 @pytest.mark.django_db
@@ -159,8 +168,18 @@ def test_jobrequest_get_absolute_url():
 @pytest.mark.django_db
 def test_jobrequest_get_cancel_url():
     job_request = JobRequestFactory()
+
     url = job_request.get_cancel_url()
-    assert url == reverse("job-request-cancel", kwargs={"pk": job_request.pk})
+
+    assert url == reverse(
+        "job-request-cancel",
+        kwargs={
+            "org_slug": job_request.workspace.project.org.slug,
+            "project_slug": job_request.workspace.project.slug,
+            "workspace_slug": job_request.workspace.name,
+            "pk": job_request.pk,
+        },
+    )
 
 
 @pytest.mark.django_db

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -42,7 +42,16 @@ def test_job_get_absolute_url():
 
     url = job.get_absolute_url()
 
-    assert url == reverse("job-detail", kwargs={"identifier": job.identifier})
+    assert url == reverse(
+        "job-detail",
+        kwargs={
+            "org_slug": job.job_request.workspace.project.org.slug,
+            "project_slug": job.job_request.workspace.project.slug,
+            "workspace_slug": job.job_request.workspace.name,
+            "pk": job.job_request.pk,
+            "identifier": job.identifier,
+        },
+    )
 
 
 @pytest.mark.django_db
@@ -161,8 +170,18 @@ def test_jobrequest_completed_at_while_incomplete():
 @pytest.mark.django_db
 def test_jobrequest_get_absolute_url():
     job_request = JobRequestFactory()
+
     url = job_request.get_absolute_url()
-    assert url == reverse("job-request-detail", kwargs={"pk": job_request.pk})
+
+    assert url == reverse(
+        "job-request-detail",
+        kwargs={
+            "org_slug": job_request.workspace.project.org.slug,
+            "project_slug": job_request.workspace.project.slug,
+            "workspace_slug": job_request.workspace.name,
+            "pk": job_request.pk,
+        },
+    )
 
 
 @pytest.mark.django_db

--- a/tests/jobserver/views/test_job_requests.py
+++ b/tests/jobserver/views/test_job_requests.py
@@ -2,7 +2,6 @@ import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import BadRequest
 from django.http import Http404
-from django.urls import reverse
 
 from jobserver.authorization import ProjectDeveloper
 from jobserver.models import Backend, JobRequest
@@ -43,7 +42,7 @@ def test_jobrequestcancel_already_completed(rf):
     response = JobRequestCancel.as_view()(request, pk=job_request.pk)
 
     assert response.status_code == 302
-    assert response.url == reverse("job-request-detail", kwargs={"pk": job_request.pk})
+    assert response.url == job_request.get_absolute_url()
 
     job_request.refresh_from_db()
     assert job_request.cancelled_actions == []
@@ -67,7 +66,7 @@ def test_jobrequestcancel_success(rf):
     response = JobRequestCancel.as_view()(request, pk=job_request.pk)
 
     assert response.status_code == 302
-    assert response.url == reverse("job-request-detail", kwargs={"pk": job_request.pk})
+    assert response.url == job_request.get_absolute_url()
 
     job_request.refresh_from_db()
     assert "test1" in job_request.cancelled_actions
@@ -87,7 +86,7 @@ def test_jobrequestcancel_with_job_request_creator(rf):
     response = JobRequestCancel.as_view()(request, pk=job_request.pk)
 
     assert response.status_code == 302
-    assert response.url == reverse("job-request-detail", kwargs={"pk": job_request.pk})
+    assert response.url == job_request.get_absolute_url()
 
     job_request.refresh_from_db()
     assert "test1" in job_request.cancelled_actions

--- a/tests/jobserver/views/test_job_requests.py
+++ b/tests/jobserver/views/test_job_requests.py
@@ -9,6 +9,7 @@ from jobserver.models import Backend, JobRequest
 from jobserver.views.job_requests import (
     JobRequestCancel,
     JobRequestDetail,
+    JobRequestDetailRedirect,
     JobRequestList,
 )
 
@@ -168,6 +169,26 @@ def test_jobrequestdetail_with_unprivileged_user(rf):
 
     assert response.status_code == 200
     assert "Cancel" not in response.rendered_content
+
+
+@pytest.mark.django_db
+def test_jobrequestdetailredirect_success(rf):
+    job_request = JobRequestFactory()
+
+    request = rf.get(MEANINGLESS_URL)
+
+    response = JobRequestDetailRedirect.as_view()(request, pk=job_request.pk)
+
+    assert response.status_code == 302
+    assert response.url == job_request.get_absolute_url()
+
+
+@pytest.mark.django_db
+def test_jobrequestdetailredirect_with_unknown_job(rf):
+    request = rf.get(MEANINGLESS_URL)
+
+    with pytest.raises(Http404):
+        JobRequestDetailRedirect.as_view()(request, pk=0)
 
 
 @pytest.mark.django_db

--- a/tests/jobserver/views/test_jobs.py
+++ b/tests/jobserver/views/test_jobs.py
@@ -1,7 +1,6 @@
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404
-from django.urls import reverse
 
 from jobserver.authorization import ProjectDeveloper
 from jobserver.views.jobs import JobCancel, JobDetail, JobDetailRedirect
@@ -32,7 +31,7 @@ def test_jobcancel_already_cancelled(rf, user):
     response = JobCancel.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 302
-    assert response.url == reverse("job-detail", kwargs={"identifier": job.identifier})
+    assert response.url == job.get_absolute_url()
 
     job_request.refresh_from_db()
     assert job_request.cancelled_actions == ["another-action", "test"]
@@ -53,7 +52,7 @@ def test_jobcancel_already_completed(rf, user):
     response = JobCancel.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 302
-    assert response.url == reverse("job-detail", kwargs={"identifier": job.identifier})
+    assert response.url == job.get_absolute_url()
 
     job_request.refresh_from_db()
     assert job_request.cancelled_actions == ["another-action"]
@@ -75,7 +74,7 @@ def test_jobcancel_success(rf):
     response = JobCancel.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 302
-    assert response.url == reverse("job-detail", kwargs={"identifier": job.identifier})
+    assert response.url == job.get_absolute_url()
 
     job_request.refresh_from_db()
     assert job_request.cancelled_actions == ["test"]
@@ -93,7 +92,7 @@ def test_jobcancel_with_job_creator(rf):
     response = JobCancel.as_view()(request, identifier=job.identifier)
 
     assert response.status_code == 302
-    assert response.url == reverse("job-detail", kwargs={"identifier": job.identifier})
+    assert response.url == job.get_absolute_url()
 
     job_request.refresh_from_db()
     assert job_request.cancelled_actions == ["test"]

--- a/tests/jobserver/views/test_jobs.py
+++ b/tests/jobserver/views/test_jobs.py
@@ -4,7 +4,7 @@ from django.http import Http404
 from django.urls import reverse
 
 from jobserver.authorization import ProjectDeveloper
-from jobserver.views.jobs import JobCancel, JobDetail
+from jobserver.views.jobs import JobCancel, JobDetail, JobDetailRedirect
 
 from ...factories import (
     JobFactory,
@@ -131,7 +131,14 @@ def test_jobdetail_with_authenticated_user(rf):
     request = rf.get(MEANINGLESS_URL)
     request.user = user
 
-    response = JobDetail.as_view()(request, identifier=job.identifier)
+    response = JobDetail.as_view()(
+        request,
+        org_slug=job.job_request.workspace.project.org.slug,
+        project_slug=job.job_request.workspace.project.slug,
+        workspace_slug=job.job_request.workspace.name,
+        pk=job.job_request.pk,
+        identifier=job.identifier,
+    )
 
     assert response.status_code == 200
     assert "Cancel" in response.rendered_content
@@ -146,22 +153,37 @@ def test_jobdetail_with_job_creator(rf):
     request = rf.get(MEANINGLESS_URL)
     request.user = user
 
-    response = JobDetail.as_view()(request, identifier=job.identifier)
+    response = JobDetail.as_view()(
+        request,
+        org_slug=job.job_request.workspace.project.org.slug,
+        project_slug=job.job_request.workspace.project.slug,
+        workspace_slug=job.job_request.workspace.name,
+        pk=job.job_request.pk,
+        identifier=job.identifier,
+    )
 
     assert response.status_code == 200
     assert "Cancel" in response.rendered_content
 
 
 @pytest.mark.django_db
-def test_jobdetail_with_partial_identifier_failure(rf):
-    JobFactory(identifier="123abc")
-    JobFactory(identifier="123def")
+def test_jobdetail_with_partial_identifier_failure(rf, mocker):
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, identifier="123abc")
+    JobFactory(job_request=job_request, identifier="123def")
 
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
 
     with pytest.raises(Http404):
-        JobDetail.as_view()(request, identifier="123")
+        JobDetail.as_view()(
+            request,
+            org_slug=job_request.workspace.project.org.slug,
+            project_slug=job_request.workspace.project.slug,
+            workspace_slug=job_request.workspace.name,
+            pk=job_request.pk,
+            identifier="123",
+        )
 
 
 @pytest.mark.django_db
@@ -171,7 +193,14 @@ def test_jobdetail_with_partial_identifier_success(rf):
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
 
-    response = JobDetail.as_view()(request, identifier=job.identifier[:4])
+    response = JobDetail.as_view()(
+        request,
+        org_slug=job.job_request.workspace.project.org.slug,
+        project_slug=job.job_request.workspace.project.slug,
+        workspace_slug=job.job_request.workspace.name,
+        pk=job.job_request.pk,
+        identifier=job.identifier[:4],
+    )
 
     assert response.status_code == 302
     assert response.url == job.get_absolute_url()
@@ -184,7 +213,14 @@ def test_jobdetail_with_unpriviliged_user(rf):
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
 
-    response = JobDetail.as_view()(request, identifier=job.identifier)
+    response = JobDetail.as_view()(
+        request,
+        org_slug=job.job_request.workspace.project.org.slug,
+        project_slug=job.job_request.workspace.project.slug,
+        workspace_slug=job.job_request.workspace.name,
+        pk=job.job_request.pk,
+        identifier=job.identifier,
+    )
 
     assert response.status_code == 200
     assert "Cancel" not in response.rendered_content
@@ -197,7 +233,14 @@ def test_jobdetail_with_unauthenticated_user(rf):
     request = rf.get(MEANINGLESS_URL)
     request.user = AnonymousUser()
 
-    response = JobDetail.as_view()(request, identifier=job.identifier)
+    response = JobDetail.as_view()(
+        request,
+        org_slug=job.job_request.workspace.project.org.slug,
+        project_slug=job.job_request.workspace.project.slug,
+        workspace_slug=job.job_request.workspace.name,
+        pk=job.job_request.pk,
+        identifier=job.identifier,
+    )
 
     assert response.status_code == 200
     assert "Cancel" not in response.rendered_content
@@ -205,7 +248,36 @@ def test_jobdetail_with_unauthenticated_user(rf):
 
 @pytest.mark.django_db
 def test_jobdetail_with_unknown_job(rf):
+    job_request = JobRequestFactory()
+
     request = rf.get(MEANINGLESS_URL)
 
     with pytest.raises(Http404):
-        JobDetail.as_view()(request, identifier="test")
+        JobDetail.as_view()(
+            request,
+            org_slug=job_request.workspace.project.org.slug,
+            project_slug=job_request.workspace.project.slug,
+            workspace_slug=job_request.workspace.name,
+            pk=job_request.pk,
+            identifier="test",
+        )
+
+
+@pytest.mark.django_db
+def test_jobdetailredirect_success(rf):
+    job = JobFactory()
+
+    request = rf.get(MEANINGLESS_URL)
+
+    response = JobDetailRedirect.as_view()(request, identifier=job.identifier)
+
+    assert response.status_code == 302
+    assert response.url == job.get_absolute_url()
+
+
+@pytest.mark.django_db
+def test_jobdetailredirect_with_unknown_job(rf):
+    request = rf.get(MEANINGLESS_URL)
+
+    with pytest.raises(Http404):
+        JobDetailRedirect.as_view()(request, identifier="test")


### PR DESCRIPTION
This moves the `/jobs/*` and `/job-requests/*` URLs under the main URL hiearchy of Org -> Project -> Workspace, and does some related housekeeping.

`/jobs/` has been moved to `/event-log/` to match the menu item.

Redirect views have been added for the old URLs.