### PR TITLE
Add basic releases skeleton page

### DIFF
--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -113,7 +113,24 @@
           </ul>
         </div>
 
+        {% if releases %}
+        <div class="mb-4">
+          <h5>Releases</h5>
+
+          <a class="btn btn-primary btn-sm" href="{% url 'project-releases' org_slug=project.org.slug project_slug=project.slug %}">
+            View
+          </a>
+          {# <ul class="list-unstyled"> #}
+          {#   {% for release in releases %} #}
+          {#   <li>{{ release }}</li> #}
+          {#   {% endfor %} #}
+          {# </ul> #}
+        </div>
+        {% endif %}
+
       </div>
+
+    </div>
 
   </div>
 </div>

--- a/jobserver/templates/project_releases.html
+++ b/jobserver/templates/project_releases.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+
+    <li class="breadcrumb-item"><a href="/">Home</a></li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ project.org.get_absolute_url }}">
+        {{ project.org.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ project.get_absolute_url }}">
+        {{ project.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item active" aria-current="page">Releases</li>
+
+  </ol>
+</nav>
+
+<div>
+</div>
+{% endblock %}

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -45,6 +45,7 @@ from .views.projects import (
     ProjectOnboardingCreate,
     ProjectSettings,
 )
+from .views.releases import Releases
 from .views.status import Status
 from .views.users import Settings, UserDetail, UserList
 from .views.workspaces import (
@@ -132,6 +133,7 @@ project_urls = [
         name="project-membership-remove",
     ),
     path("new-workspace/", WorkspaceCreate.as_view(), name="workspace-create"),
+    path("releases/", Releases.as_view(), name="project-releases"),
     path("settings/", ProjectSettings.as_view(), name="project-settings"),
     path("<workspace_slug>/", include(workspace_urls)),
 ]

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -182,12 +182,15 @@ class ProjectDetail(DetailView):
 
         repos = sorted(set(workspaces.values_list("repo", flat=True)))
 
-        context = super().get_context_data(**kwargs)
-        context["can_manage_workspaces"] = can_manage_workspaces
-        context["can_manage_members"] = can_manage_members
-        context["repos"] = list(self.get_repos(repos))
-        context["workspaces"] = workspaces
-        return context
+        releases = ["derp", "foo"]
+
+        return super().get_context_data(**kwargs) | {
+            "can_manage_workspaces": can_manage_workspaces,
+            "can_manage_members": can_manage_members,
+            "releases": releases,
+            "repos": list(self.get_repos(repos)),
+            "workspaces": workspaces,
+        }
 
     def get_repos(self, repo_urls):
         for url in repo_urls:

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -1,0 +1,25 @@
+from django.shortcuts import get_object_or_404
+from django.template.response import TemplateResponse
+from django.views.generic import View
+
+from ..models import Project
+
+
+class Releases(View):
+    def get(self, request, *args, **kwargs):
+        project = get_object_or_404(
+            Project,
+            slug=self.kwargs["project_slug"],
+            org__slug=self.kwargs["org_slug"],
+        )
+
+        # TODO: check ACL and build signed URLs here
+
+        context = {
+            "project": project,
+        }
+        return TemplateResponse(
+            request,
+            "project_releases.html",
+            context=context,
+        )

--- a/tests/jobserver/views/test_releases.py
+++ b/tests/jobserver/views/test_releases.py
@@ -1,0 +1,28 @@
+import pytest
+from django.http import Http404
+
+from jobserver.views.releases import Releases
+
+from ...factories import OrgFactory, ProjectFactory
+
+
+@pytest.mark.django_db
+def test_releases_success(rf):
+    project = ProjectFactory()
+
+    request = rf.get("/")
+
+    response = Releases.as_view()(
+        request, org_slug=project.org.slug, project_slug=project.slug
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_releases_unknown_project(rf):
+    org = OrgFactory()
+
+    request = rf.get("/")
+    with pytest.raises(Http404):
+        Releases.as_view()(request, org_slug=org.slug, project_slug="")


### PR DESCRIPTION
This adds a new page at `/<org>/<project>/releases` for us to build the output publishing flow under.  We'll likely change the URL (and view name) as we flesh out the MVP but this allows for developement of the SPA in the meantime.