### PR TITLE
Split Up Models

### DIFF
--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -22,7 +22,7 @@ class CoreDeveloper:
         "Internal user who develops and deploys the OpenSAFELY core framework."
     )
     models = [
-        "jobserver.models.User",
+        "jobserver.models.core.User",
     ]
     permissions = [
         cancel_job,
@@ -46,7 +46,7 @@ class DataInvestigator:
     display_name = "Data Investigator"
     description = ""
     models = [
-        "jobserver.models.User",
+        "jobserver.models.core.User",
     ]
     permissions = []
 
@@ -60,7 +60,7 @@ class GovernanceReviewer:
     display_name = "Governance Reviewer"
     description = ""
     models = [
-        "jobserver.models.User",
+        "jobserver.models.core.User",
     ]
     permissions = []
 
@@ -76,7 +76,7 @@ class OnboardingAgent:
     display_name = "Onboarding Agent"
     description = ""
     models = [
-        "jobserver.models.User",
+        "jobserver.models.core.User",
     ]
     permissions = []
 
@@ -89,7 +89,7 @@ class OrgCoordinator:
     display_name = "Organisation Coordinator"
     description = ""
     models = [
-        "jobserver.models.OrgMembership",
+        "jobserver.models.core.OrgMembership",
     ]
     permissions = []
 
@@ -102,7 +102,7 @@ class OutputChecker:
     display_name = "Output Checker"
     description = ""
     models = [
-        "jobserver.models.User",
+        "jobserver.models.core.User",
     ]
     permissions = [
         check_output,
@@ -118,7 +118,7 @@ class OutputPublisher:
     display_name = "Output Publisher"
     description = ""
     models = [
-        "jobserver.models.User",
+        "jobserver.models.core.User",
     ]
     permissions = [
         publish_output,
@@ -133,8 +133,8 @@ class ProjectCollaborator:
     display_name = "Project Collaborator"
     description = ""
     models = [
-        "jobserver.models.ProjectInvitation",
-        "jobserver.models.ProjectMembership",
+        "jobserver.models.core.ProjectInvitation",
+        "jobserver.models.core.ProjectMembership",
     ]
     permissions = [
         "",
@@ -156,8 +156,8 @@ class ProjectCoordinator:
     display_name = "Project Coordinator"
     description = "An administrator for the Project."
     models = [
-        "jobserver.models.ProjectInvitation",
-        "jobserver.models.ProjectMembership",
+        "jobserver.models.core.ProjectInvitation",
+        "jobserver.models.core.ProjectMembership",
     ]
     permissions = [
         invite_project_members,
@@ -176,8 +176,8 @@ class ProjectDeveloper:
     display_name = "Project Developer"
     description = "An external user who is developing and executing code to analyse data in OpenSAFELY; they will likely want to review (and flag for release) their own outputs."
     models = [
-        "jobserver.models.ProjectInvitation",
-        "jobserver.models.ProjectMembership",
+        "jobserver.models.core.ProjectInvitation",
+        "jobserver.models.core.ProjectMembership",
     ]
     permissions = [
         cancel_job,
@@ -197,7 +197,7 @@ class SuperUser:
     display_name = "Super User"
     description = ""
     models = [
-        "jobserver.models.User",
+        "jobserver.models.core.User",
     ]
     permissions = []
 
@@ -211,7 +211,7 @@ class TechnicalReviewer:
     display_name = "Technical Reviewer"
     description = ""
     models = [
-        "jobserver.models.User",
+        "jobserver.models.core.User",
     ]
     permissions = [
         review_project,

--- a/jobserver/migrations/0001_initial.py
+++ b/jobserver/migrations/0001_initial.py
@@ -154,7 +154,7 @@ class Migration(migrations.Migration):
                 ("parent_directory", models.TextField(default="")),
                 (
                     "auth_token",
-                    models.TextField(default=jobserver.models.generate_token),
+                    models.TextField(default=jobserver.models.backends.generate_token),
                 ),
                 ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
                 ("updated_at", models.DateTimeField(auto_now=True)),
@@ -228,7 +228,7 @@ class Migration(migrations.Migration):
                 ("sha", models.TextField()),
                 (
                     "identifier",
-                    models.TextField(default=jobserver.models.new_id, unique=True),
+                    models.TextField(default=jobserver.models.core.new_id, unique=True),
                 ),
                 ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
                 (

--- a/jobserver/models/__init__.py
+++ b/jobserver/models/__init__.py
@@ -1,0 +1,33 @@
+from .backends import Backend, BackendMembership
+from .core import (
+    Job,
+    JobRequest,
+    Org,
+    OrgMembership,
+    Project,
+    ProjectInvitation,
+    ProjectMembership,
+    User,
+    Workspace,
+)
+from .onboarding import ResearcherRegistration
+from .outputs import Release
+from .stats import Stats
+
+
+__all__ = [
+    "Backend",
+    "BackendMembership",
+    "Job",
+    "JobRequest",
+    "Org",
+    "OrgMembership",
+    "Project",
+    "ProjectInvitation",
+    "ProjectMembership",
+    "Release",
+    "ResearcherRegistration",
+    "Stats",
+    "User",
+    "Workspace",
+]

--- a/jobserver/models/backends.py
+++ b/jobserver/models/backends.py
@@ -1,0 +1,95 @@
+import binascii
+import os
+
+from django.db import models
+from django.urls import reverse
+from django.utils import timezone
+
+from ..backends import get_configured_backends
+
+
+def generate_token():
+    """Generate a random token string."""
+    return binascii.hexlify(os.urandom(20)).decode()
+
+
+class BackendManager(models.Manager):
+    def get_queryset(self):
+        """
+        Override default QuerySet to limit backends to those configured
+
+        We want to limit the available backends from the database to those
+        configured in the environment without changing the backed in model
+        validation. Each Backend is created via a migration.  This function
+        limits which backends can be looked up via the ORM to the set listed in
+        the env.
+        """
+        # lookup configured backends on demand to make testing easier
+        configured_backends = get_configured_backends()
+
+        qs = super().get_queryset()
+
+        if not configured_backends:
+            # if no backends are configured, make all available
+            return qs
+
+        return qs.filter(name__in=configured_backends)
+
+
+class Backend(models.Model):
+    """A job-runner instance"""
+
+    name = models.TextField(unique=True)
+    display_name = models.TextField()
+
+    parent_directory = models.TextField(default="")
+    is_active = models.BooleanField(default=False)
+
+    auth_token = models.TextField(default=generate_token)
+
+    created_at = models.DateTimeField(default=timezone.now)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    objects = BackendManager()
+
+    def __str__(self):
+        return self.name
+
+    def get_absolute_url(self):
+        return reverse("backend-detail", kwargs={"pk": self.pk})
+
+    def get_rotate_url(self):
+        return reverse("backend-rotate-token", kwargs={"pk": self.pk})
+
+    def rotate_token(self):
+        self.auth_token = generate_token()
+        self.save()
+
+
+class BackendMembership(models.Model):
+    """Models the ability for a User to run jobs against a Backend."""
+
+    created_by = models.ForeignKey(
+        "User",
+        on_delete=models.SET_NULL,
+        related_name="created_backend_memberships",
+        null=True,
+    )
+    backend = models.ForeignKey(
+        "Backend",
+        on_delete=models.CASCADE,
+        related_name="memberships",
+    )
+    user = models.ForeignKey(
+        "User",
+        on_delete=models.CASCADE,
+        related_name="backend_memberships",
+    )
+
+    created_at = models.DateTimeField(default=timezone.now)
+
+    class Meta:
+        unique_together = ["backend", "user"]
+
+    def __str__(self):
+        return f"{self.user.username} | {self.backend.display_name}"

--- a/jobserver/models/onboarding.py
+++ b/jobserver/models/onboarding.py
@@ -1,0 +1,29 @@
+from django.db import models
+from django.utils import timezone
+
+
+class ResearcherRegistration(models.Model):
+    """
+    The Registration of a Researcher for a Project
+
+    When registering a new Project 0-N researchers might be named as part of
+    the Project.  Instead of requiring they sign up to the service during the
+    registration process this model holds their details, and can be attached to
+    a User instance if the Project proceeds past registration.
+    """
+
+    user = models.ForeignKey(
+        "User",
+        null=True,
+        on_delete=models.SET_NULL,
+        related_name="researcher_registrations",
+    )
+
+    name = models.TextField()
+    passed_researcher_training_at = models.DateTimeField()
+    is_ons_accredited_researcher = models.BooleanField(default=False)
+
+    created_at = models.DateTimeField(default=timezone.now)
+
+    def __str__(self):
+        return self.name

--- a/jobserver/models/outputs.py
+++ b/jobserver/models/outputs.py
@@ -1,0 +1,56 @@
+import json
+
+from django.conf import settings
+from django.db import models
+from django.urls import reverse
+from django.utils import timezone
+
+
+class Release(models.Model):
+    """Reviewed and redacted outputs from a Workspace"""
+
+    # No value in the default Autoid as we are using a content-addressable hash
+    # as it. Additionaly it avoids enumeration attacks.
+    id = models.TextField(primary_key=True)
+    # TODO: link this formally via backend_username once we have a mapping
+    # between User and their backend username
+    publishing_user = models.ForeignKey(
+        "User",
+        on_delete=models.PROTECT,
+        null=True,
+        related_name="+",
+    )
+    workspace = models.ForeignKey(
+        "Workspace",
+        on_delete=models.PROTECT,
+        related_name="releases",
+    )
+    backend = models.ForeignKey(
+        "Backend",
+        on_delete=models.PROTECT,
+        related_name="+",
+    )
+    published_at = models.DateTimeField(default=timezone.now)
+    upload_dir = models.TextField()
+    # list of files in the release upload
+    files = models.JSONField()
+    # store local TPP/EMIS username for audit
+    backend_user = models.TextField()
+
+    def get_absolute_url(self):
+        return reverse(
+            "workspace-release",
+            kwargs={
+                "org_slug": self.workspace.project.org.slug,
+                "project_slug": self.workspace.project.slug,
+                "workspace_slug": self.workspace.name,
+                "release": self.id,
+            },
+        )
+
+    def file_path(self, filename):
+        return settings.RELEASE_STORAGE / self.upload_dir / filename
+
+    @property
+    def manifest(self):
+        return json.loads(self.file_path("metadata/manifest.json").read_text())

--- a/jobserver/models/stats.py
+++ b/jobserver/models/stats.py
@@ -1,0 +1,24 @@
+from django.db import models
+
+
+class Stats(models.Model):
+    """This holds per-Backend, per-URL API statistics."""
+
+    backend = models.ForeignKey(
+        "Backend", on_delete=models.PROTECT, related_name="stats"
+    )
+
+    api_last_seen = models.DateTimeField(null=True, blank=True)
+    url = models.TextField()
+
+    class Meta:
+        unique_together = ["backend", "url"]
+
+    def __str__(self):
+        backend = self.backend.name
+        last_seen = (
+            self.api_last_seen.strftime("%Y-%m-%d %H:%M:%S")
+            if self.api_last_seen
+            else "never"
+        )
+        return f"{backend} | {last_seen} | {self.url}"

--- a/tests/jobserver/authorization/test_utils.py
+++ b/tests/jobserver/authorization/test_utils.py
@@ -101,7 +101,10 @@ def test_roles_for_success():
 
 
 def test_strings_to_roles_success():
-    roles = strings_to_roles(["ProjectDeveloper"], "jobserver.models.ProjectMembership")
+    roles = strings_to_roles(
+        ["ProjectDeveloper"],
+        "jobserver.models.core.ProjectMembership",
+    )
 
     assert len(roles) == 1
     assert roles[0] == ProjectDeveloper
@@ -115,8 +118,6 @@ def test_strings_to_roles_with_no_available_roles():
 
 
 def test_strings_to_roles_with_unknown_roles():
-    msg = (
-        "Unknown Roles:\n - DummyRole\nAvailable Roles for jobserver.models.User are:.*"
-    )
+    msg = "Unknown Roles:\n - DummyRole\nAvailable Roles for jobserver.models.core.User are:.*"
     with pytest.raises(Exception, match=msg):
-        strings_to_roles(["DummyRole"], "jobserver.models.User")
+        strings_to_roles(["DummyRole"], "jobserver.models.core.User")

--- a/tests/jobserver/models/test_backends.py
+++ b/tests/jobserver/models/test_backends.py
@@ -1,0 +1,66 @@
+import pytest
+from django.urls import reverse
+
+from jobserver.models import Backend
+
+from ...factories import BackendFactory, BackendMembershipFactory, UserFactory
+
+
+@pytest.mark.django_db
+def test_backend_no_configured_backends(monkeypatch):
+    monkeypatch.setenv("BACKENDS", "")
+
+    # backends are created by migrations
+    assert Backend.objects.count() == 6
+
+
+@pytest.mark.django_db
+def test_backend_one_configured_backend(monkeypatch):
+    monkeypatch.setenv("BACKENDS", "tpp")
+
+    # backends are created by migrations
+    assert Backend.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_backend_get_absolute_url():
+    backend = BackendFactory(auth_token="test")
+
+    url = backend.get_absolute_url()
+
+    assert url == reverse("backend-detail", kwargs={"pk": backend.pk})
+
+
+@pytest.mark.django_db
+def test_backend_get_rotate_url():
+    backend = BackendFactory(auth_token="test")
+
+    url = backend.get_rotate_url()
+
+    assert url == reverse("backend-rotate-token", kwargs={"pk": backend.pk})
+
+
+@pytest.mark.django_db
+def test_backend_rotate_token():
+    backend = BackendFactory(auth_token="test")
+    assert backend.auth_token == "test"
+
+    backend.rotate_token()
+    assert backend.auth_token != "test"
+
+
+@pytest.mark.django_db
+def test_backend_str():
+    backend = BackendFactory(name="Test Backend")
+
+    assert str(backend) == "Test Backend"
+
+
+@pytest.mark.django_db
+def test_backendmembership_str():
+    backend = BackendFactory(display_name="Test Backend")
+    user = UserFactory(username="ben")
+
+    membership = BackendMembershipFactory(backend=backend, user=user)
+
+    assert str(membership) == "ben | Test Backend"

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -1,0 +1,1048 @@
+from datetime import timedelta
+
+import pytest
+from django.core import signing
+from django.urls import reverse
+from django.utils import timezone
+
+from jobserver.authorization.roles import (
+    CoreDeveloper,
+    DataInvestigator,
+    OrgCoordinator,
+    ProjectCollaborator,
+    ProjectDeveloper,
+)
+from jobserver.models import Backend, JobRequest, ProjectInvitation, ProjectMembership
+
+from ...factories import (
+    JobFactory,
+    JobRequestFactory,
+    OrgFactory,
+    OrgMembershipFactory,
+    ProjectFactory,
+    ProjectInvitationFactory,
+    ProjectMembershipFactory,
+    UserFactory,
+    WorkspaceFactory,
+)
+
+
+@pytest.mark.django_db
+def test_job_get_absolute_url():
+    job = JobFactory()
+
+    url = job.get_absolute_url()
+
+    assert url == reverse("job-detail", kwargs={"identifier": job.identifier})
+
+
+@pytest.mark.django_db
+def test_job_get_cancel_url():
+    job = JobFactory()
+
+    url = job.get_cancel_url()
+
+    assert url == reverse("job-cancel", kwargs={"identifier": job.identifier})
+
+
+@pytest.mark.django_db
+def test_job_is_missing_updates_above_threshold():
+    last_update = timezone.now() - timedelta(minutes=50)
+    job = JobFactory(completed_at=None, updated_at=last_update)
+
+    assert job.is_missing_updates
+
+
+@pytest.mark.django_db
+def test_job_is_missing_updates_below_threshold():
+    last_update = timezone.now() - timedelta(minutes=29)
+    job = JobFactory(completed_at=None, updated_at=last_update)
+
+    assert not job.is_missing_updates
+
+
+@pytest.mark.django_db
+def test_job_is_missing_updates_missing_updated_at():
+    assert not JobFactory(status="pending", updated_at=None).is_missing_updates
+
+
+@pytest.mark.django_db
+def test_job_is_missing_updates_completed():
+    assert not JobFactory(status="failed").is_missing_updates
+
+
+@pytest.mark.django_db
+def test_job_runtime():
+    duration = timedelta(hours=1, minutes=2, seconds=3)
+    started_at = timezone.now() - duration
+    job = JobFactory(
+        status="succeeded", started_at=started_at, completed_at=timezone.now()
+    )
+
+    assert job.runtime.hours == 1
+    assert job.runtime.minutes == 2
+    assert job.runtime.seconds == 3
+
+
+@pytest.mark.django_db
+def test_job_runtime_not_completed():
+    job = JobFactory(status="running", started_at=timezone.now())
+
+    # an uncompleted job has no runtime
+    assert job.runtime is None
+
+
+@pytest.mark.django_db
+def test_job_runtime_not_started():
+    job = JobFactory(status="pending")
+
+    # an unstarted job has no runtime
+    assert job.runtime is None
+
+
+@pytest.mark.django_db
+def test_job_runtime_without_timestamps():
+    job = JobFactory(status="succeeded", started_at=None, completed_at=None)
+
+    assert job.runtime is None
+
+
+@pytest.mark.django_db
+def test_job_str():
+    job = JobFactory(action="Run")
+
+    assert str(job) == f"Run ({job.pk})"
+
+
+@pytest.mark.django_db
+def test_jobrequest_completed_at_no_jobs():
+    assert not JobRequestFactory().completed_at
+
+
+@pytest.mark.django_db
+def test_jobrequest_completed_at_success():
+    job_request = JobRequestFactory()
+
+    job1, job2 = JobFactory.create_batch(2, job_request=job_request, status="succeeded")
+
+    jr = JobRequest.objects.prefetch_related("jobs").get(pk=job_request.pk)
+    assert jr.completed_at == job2.completed_at
+
+
+@pytest.mark.django_db
+def test_jobrequest_completed_at_while_incomplete():
+    job_request = JobRequestFactory()
+
+    JobFactory(job_request=job_request, completed_at=timezone.now())
+    JobFactory(job_request=job_request)
+
+    jr = JobRequest.objects.prefetch_related("jobs").get(pk=job_request.pk)
+    assert not jr.completed_at
+
+
+@pytest.mark.django_db
+def test_jobrequest_get_absolute_url():
+    job_request = JobRequestFactory()
+    url = job_request.get_absolute_url()
+    assert url == reverse("job-request-detail", kwargs={"pk": job_request.pk})
+
+
+@pytest.mark.django_db
+def test_jobrequest_get_cancel_url():
+    job_request = JobRequestFactory()
+    url = job_request.get_cancel_url()
+    assert url == reverse("job-request-cancel", kwargs={"pk": job_request.pk})
+
+
+@pytest.mark.django_db
+def test_jobrequest_get_project_yaml_url_no_sha():
+    workspace = WorkspaceFactory(repo="http://example.com/opensafely/some_repo")
+    job_request = JobRequestFactory(workspace=workspace)
+
+    url = job_request.get_file_url("test-blah.foo")
+
+    assert url == "http://example.com/opensafely/some_repo"
+
+
+@pytest.mark.django_db
+def test_jobrequest_get_project_yaml_url_success():
+    workspace = WorkspaceFactory(repo="http://example.com/opensafely/some_repo")
+    job_request = JobRequestFactory(workspace=workspace, sha="abc123")
+
+    url = job_request.get_file_url("test-blah.foo")
+
+    assert url == "http://example.com/opensafely/some_repo/blob/abc123/test-blah.foo"
+
+
+@pytest.mark.django_db
+def test_jobrequest_get_repo_url_no_sha():
+    workspace = WorkspaceFactory(repo="http://example.com/opensafely/some_repo")
+    job_request = JobRequestFactory(workspace=workspace)
+
+    url = job_request.get_repo_url()
+
+    assert url == "http://example.com/opensafely/some_repo"
+
+
+@pytest.mark.django_db
+def test_jobrequest_get_repo_url_success():
+    workspace = WorkspaceFactory(repo="http://example.com/opensafely/some_repo")
+    job_request = JobRequestFactory(workspace=workspace, sha="abc123")
+
+    url = job_request.get_repo_url()
+
+    assert url == "http://example.com/opensafely/some_repo/tree/abc123"
+
+
+@pytest.mark.django_db
+def test_jobrequest_is_completed():
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, status="failed")
+    JobFactory(job_request=job_request, status="succeeded")
+
+    jr = JobRequest.objects.prefetch_related("jobs").get(pk=job_request.pk)
+    assert jr.is_completed
+
+
+@pytest.mark.django_db
+def test_jobrequest_is_invalid():
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, action="__error__")
+
+    assert job_request.is_invalid
+
+
+@pytest.mark.django_db
+def test_jobrequest_num_completed_no_jobs():
+    assert JobRequestFactory().num_completed == 0
+
+
+@pytest.mark.django_db
+def test_job_request_num_completed_success():
+    job_request = JobRequestFactory()
+
+    job1, job2 = JobFactory.create_batch(2, job_request=job_request, status="succeeded")
+
+    assert job_request.num_completed == 2
+
+
+@pytest.mark.django_db
+def test_jobrequest_runtime_one_job_missing_completed_at(freezer):
+    job_request = JobRequestFactory()
+
+    JobFactory(
+        job_request=job_request,
+        status="succeeded",
+        started_at=timezone.now() - timedelta(minutes=3),
+        completed_at=timezone.now() - timedelta(minutes=2),
+    )
+    JobFactory(
+        job_request=job_request,
+        status="running",
+        started_at=timezone.now() - timedelta(minutes=1),
+        completed_at=None,
+    )
+
+    jr = JobRequest.objects.prefetch_related("jobs").get(pk=job_request.pk)
+    assert jr.started_at
+    assert not jr.completed_at
+
+    # combined _completed_ Job runtime is 0 because the failed job has no
+    # runtime (it never started)
+    assert jr.runtime
+    assert jr.runtime.hours == 0
+    assert jr.runtime.minutes == 1
+    assert jr.runtime.seconds == 0
+
+
+@pytest.mark.django_db
+def test_jobrequest_runtime_one_job_missing_started_at(freezer):
+    job_request = JobRequestFactory()
+
+    JobFactory(
+        job_request=job_request,
+        status="failed",
+        started_at=timezone.now() - timedelta(minutes=5),
+        completed_at=timezone.now() - timedelta(minutes=3),
+    )
+    JobFactory(
+        job_request=job_request,
+        status="failed",
+        started_at=None,
+        completed_at=timezone.now(),
+    )
+
+    jr = JobRequest.objects.prefetch_related("jobs").get(pk=job_request.pk)
+    assert jr.started_at
+    assert jr.completed_at
+
+    # combined _completed_ Job runtime is 2 minutes because the second job
+    # failed before it started
+    assert jr.runtime
+    assert jr.runtime.hours == 0
+    assert jr.runtime.minutes == 2
+    assert jr.runtime.seconds == 0
+
+
+@pytest.mark.django_db
+def test_jobrequest_runtime_no_jobs():
+    assert not JobRequestFactory().runtime
+
+
+@pytest.mark.django_db
+def test_jobrequest_runtime_not_completed(freezer):
+    job_request = JobRequestFactory()
+
+    JobFactory(
+        job_request=job_request,
+        status="succeeded",
+        started_at=timezone.now() - timedelta(minutes=2),
+        completed_at=timezone.now() - timedelta(minutes=1),
+    )
+    JobFactory(
+        job_request=job_request,
+        status="running",
+        started_at=timezone.now() - timedelta(seconds=30),
+    )
+
+    jr = JobRequest.objects.prefetch_related("jobs").get(pk=job_request.pk)
+    assert jr.started_at
+    assert not jr.completed_at
+
+    # combined _completed_ Job runtime is 1 minute
+    assert jr.runtime
+    assert jr.runtime.hours == 0
+    assert jr.runtime.minutes == 1
+    assert jr.runtime.seconds == 0
+
+
+@pytest.mark.django_db
+def test_jobrequest_runtime_not_started():
+    job_request = JobRequestFactory()
+
+    JobFactory(job_request=job_request, status="running")
+    JobFactory(job_request=job_request, status="pending")
+
+    assert not job_request.runtime
+
+
+@pytest.mark.django_db
+def test_jobrequest_runtime_success():
+    job_request = JobRequestFactory()
+
+    start = timezone.now() - timedelta(hours=1)
+
+    JobFactory(
+        job_request=job_request,
+        status="succeeded",
+        started_at=start,
+        completed_at=start + timedelta(minutes=1),
+    )
+    JobFactory(
+        job_request=job_request,
+        status="failed",
+        started_at=start + timedelta(minutes=2),
+        completed_at=start + timedelta(minutes=3),
+    )
+
+    assert job_request.runtime
+    assert job_request.runtime.hours == 0
+    assert job_request.runtime.minutes == 2
+    assert job_request.runtime.seconds == 0
+
+
+@pytest.mark.django_db
+def test_jobrequest_started_at_no_jobs():
+    assert not JobRequestFactory().started_at
+
+
+@pytest.mark.django_db
+def test_jobrequest_started_at_success():
+    job_request = JobRequestFactory()
+
+    JobFactory(job_request=job_request, started_at=timezone.now())
+    JobFactory(job_request=job_request, started_at=timezone.now())
+
+    assert job_request.started_at
+
+
+@pytest.mark.django_db
+def test_jobrequest_status_all_jobs_the_same(subtests):
+    status_groups = [
+        ["failed", "failed", "failed", "failed"],
+        ["pending", "pending", "pending", "pending"],
+        ["running", "running", "running", "running"],
+        ["succeeded", "succeeded", "succeeded", "succeeded"],
+    ]
+    for statuses in status_groups:
+        with subtests.test(statuses=statuses):
+            job_request = JobRequestFactory()
+            for status in statuses:
+                JobFactory(job_request=job_request, status=status)
+
+            jr = JobRequest.objects.prefetch_related("jobs").get(pk=job_request.pk)
+            assert jr.status == statuses[0]
+
+
+@pytest.mark.django_db
+def test_jobrequest_status_running_in_job_statuses():
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, status="pending")
+    JobFactory(job_request=job_request, status="running")
+    JobFactory(job_request=job_request, status="failed")
+    JobFactory(job_request=job_request, status="succeeded")
+
+    jr = JobRequest.objects.prefetch_related("jobs").get(pk=job_request.pk)
+    assert jr.status == "running"
+
+
+@pytest.mark.django_db
+def test_jobrequest_status_running_not_in_job_statues():
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, status="pending")
+    JobFactory(job_request=job_request, status="pending")
+    JobFactory(job_request=job_request, status="failed")
+    JobFactory(job_request=job_request, status="succeeded")
+
+    jr = JobRequest.objects.prefetch_related("jobs").get(pk=job_request.pk)
+    assert jr.status == "running"
+
+
+@pytest.mark.django_db
+def test_jobrequest_status_failed():
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, status="failed")
+    JobFactory(job_request=job_request, status="succeeded")
+    JobFactory(job_request=job_request, status="failed")
+    JobFactory(job_request=job_request, status="succeeded")
+
+    jr = JobRequest.objects.prefetch_related("jobs").get(pk=job_request.pk)
+    assert jr.status == "failed"
+
+
+@pytest.mark.django_db
+def test_jobrequest_status_unknown():
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, status="foo")
+    JobFactory(job_request=job_request, status="bar")
+
+    jr = JobRequest.objects.prefetch_related("jobs").get(pk=job_request.pk)
+    assert jr.status == "unknown"
+
+
+@pytest.mark.django_db
+def test_jobrequest_status_uses_prefetch_cache(django_assert_num_queries):
+    for i in range(5):
+        jr = JobRequestFactory()
+        JobFactory.create_batch(5, job_request=jr)
+
+    with django_assert_num_queries(2):
+        # 1. select JobRequests
+        # 2. select Jobs for those JobRequests
+        [jr.status for jr in JobRequest.objects.prefetch_related("jobs")]
+
+
+@pytest.mark.django_db
+def test_jobrequest_status_without_prefetching_jobs(django_assert_num_queries):
+    job_request = JobRequestFactory()
+    JobFactory.create_batch(5, job_request=job_request)
+
+    with pytest.raises(Exception, match="JobRequest queries must prefetch jobs."):
+        job_request.status
+
+
+@pytest.mark.django_db
+def test_org_get_absolute_url():
+    org = OrgFactory()
+    url = org.get_absolute_url()
+    assert url == reverse("org-detail", kwargs={"org_slug": org.slug})
+
+
+@pytest.mark.django_db
+def test_org_populates_slug():
+    assert OrgFactory(name="Test Org", slug="").slug == "test-org"
+
+
+@pytest.mark.django_db
+def test_org_str():
+    assert str(OrgFactory(name="Test Org")) == "Test Org"
+
+
+@pytest.mark.django_db
+def test_orgmembership_str():
+    org = OrgFactory(name="EBMDataLab")
+    user = UserFactory(username="ben")
+
+    membership = OrgMembershipFactory(org=org, user=user)
+
+    assert str(membership) == "ben | EBMDataLab"
+
+
+@pytest.mark.django_db
+def test_project_get_absolute_url():
+    org = OrgFactory(name="test-org")
+    project = ProjectFactory(org=org)
+    url = project.get_absolute_url()
+    assert url == reverse(
+        "project-detail", kwargs={"org_slug": org.slug, "project_slug": project.slug}
+    )
+
+
+@pytest.mark.django_db
+def test_projectmembership_get_edit_url():
+    org = OrgFactory(name="test-org")
+    project = ProjectFactory(org=org)
+    user = UserFactory()
+
+    membership = ProjectMembershipFactory(project=project, user=user)
+
+    url = membership.get_edit_url()
+    assert url == reverse(
+        "project-membership-edit",
+        kwargs={
+            "org_slug": org.slug,
+            "project_slug": project.slug,
+            "pk": membership.pk,
+        },
+    )
+
+
+@pytest.mark.django_db
+def test_projectmembership_get_remove_url():
+    org = OrgFactory(name="test-org")
+    project = ProjectFactory(org=org)
+    user = UserFactory()
+
+    membership = ProjectMembershipFactory(project=project, user=user)
+
+    url = membership.get_remove_url()
+    assert url == reverse(
+        "project-membership-remove",
+        kwargs={
+            "org_slug": org.slug,
+            "project_slug": project.slug,
+            "pk": membership.pk,
+        },
+    )
+
+
+@pytest.mark.django_db
+def test_project_get_invitation_url():
+    org = OrgFactory(name="test-org")
+    project = ProjectFactory(org=org)
+    url = project.get_invitation_url()
+    assert url == reverse(
+        "project-invitation-create",
+        kwargs={"org_slug": org.slug, "project_slug": project.slug},
+    )
+
+
+@pytest.mark.django_db
+def test_project_get_settings_url():
+    org = OrgFactory(name="test-org")
+    project = ProjectFactory(org=org)
+    url = project.get_settings_url()
+    assert url == reverse(
+        "project-settings", kwargs={"org_slug": org.slug, "project_slug": project.slug}
+    )
+
+
+@pytest.mark.django_db
+def test_project_populates_slug():
+    assert ProjectFactory(name="Test Project", slug="").slug == "test-project"
+
+
+@pytest.mark.django_db
+def test_project_str():
+    project = ProjectFactory(
+        org=OrgFactory(name="test-org"),
+        name="Very Good Project",
+    )
+    assert str(project) == "test-org | Very Good Project"
+
+
+@pytest.mark.django_db
+def test_projectinvitation_create_membership():
+    invite = ProjectInvitationFactory(accepted_at=None, membership=None)
+
+    assert not ProjectMembership.objects.exists()
+
+    invite.create_membership()
+
+    assert ProjectMembership.objects.exists()
+
+    membership = ProjectMembership.objects.first()
+    assert membership.project == invite.project
+    assert membership.user == invite.user
+
+    assert invite.accepted_at is not None
+    assert invite.membership == membership
+
+
+@pytest.mark.django_db
+def test_projectinvitation_get_cancel_url():
+    org = OrgFactory()
+    project = ProjectFactory(org=org)
+    invite = ProjectInvitationFactory(project=project)
+    url = invite.get_cancel_url()
+
+    assert url == reverse(
+        "project-cancel-invite",
+        kwargs={
+            "org_slug": org.slug,
+            "project_slug": project.slug,
+        },
+    )
+
+
+@pytest.mark.django_db
+def test_projectinvitation_get_from_signed_pk_success():
+    invite_a = ProjectInvitationFactory()
+
+    invite_b = ProjectInvitation.get_from_signed_pk(invite_a.signed_pk)
+
+    assert invite_b == invite_a
+
+
+def test_projectinvitation_get_from_signed_pk_with_bad_value():
+    with pytest.raises(signing.BadSignature):
+        ProjectInvitation.get_from_signed_pk("test")
+
+
+@pytest.mark.django_db
+def test_projectinvitation_get_from_signed_pk_with_unknown_pk():
+    signed_pk = ProjectInvitation.signer().sign(0)
+
+    with pytest.raises(ProjectInvitation.DoesNotExist):
+        ProjectInvitation.get_from_signed_pk(signed_pk)
+
+
+@pytest.mark.django_db
+def test_projectinvitation_get_invitation_url():
+    org = OrgFactory()
+    project = ProjectFactory(org=org)
+    invite = ProjectInvitationFactory(project=project)
+    url = invite.get_invitation_url()
+
+    assert url == reverse(
+        "project-accept-invite",
+        kwargs={
+            "org_slug": org.slug,
+            "project_slug": project.slug,
+            "signed_pk": invite.signed_pk,
+        },
+    )
+
+
+@pytest.mark.django_db
+def test_projectinvitation_signed_pk():
+    invite = ProjectInvitationFactory()
+
+    assert ProjectInvitation.signer().sign(invite.pk) == invite.signed_pk
+
+
+def test_projectinvitation_signer():
+    signer = ProjectInvitation.signer()
+
+    # check the salt for this model is set up correctly
+    assert signer.salt == "project-invitation"
+
+
+@pytest.mark.django_db
+def test_projectinvitation_str():
+    project = ProjectFactory(name="DataLab")
+    user = UserFactory(username="ben")
+
+    invitation = ProjectInvitationFactory(project=project, user=user)
+
+    assert str(invitation) == "ben | DataLab"
+
+
+@pytest.mark.django_db
+def test_projectmembership_str():
+    project = ProjectFactory(name="DataLab")
+    user = UserFactory(username="ben")
+
+    membership = ProjectMembershipFactory(project=project, user=user)
+
+    assert str(membership) == "ben | DataLab"
+
+
+@pytest.mark.django_db
+def test_user_name_with_first_and_last_name():
+    user = UserFactory(first_name="first", last_name="last")
+
+    assert user.name == "first last"
+
+
+@pytest.mark.django_db
+def test_user_name_without_first_and_last_name():
+    user = UserFactory()
+    assert user.name == user.username
+
+
+@pytest.mark.django_db
+def test_user_get_absolute_url():
+    user = UserFactory()
+
+    url = user.get_absolute_url()
+
+    assert url == reverse(
+        "user-detail",
+        kwargs={
+            "username": user.username,
+        },
+    )
+
+
+@pytest.mark.django_db
+def test_user_get_all_permissions():
+    org = OrgFactory()
+    project = ProjectFactory(org=org)
+    user = UserFactory(roles=[CoreDeveloper])
+
+    OrgMembershipFactory(org=org, user=user, roles=[OrgCoordinator])
+    ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
+
+    output = user.get_all_permissions()
+    expected = {
+        "global": [
+            "cancel_job",
+            "invite_project_members",
+            "manage_backends",
+            "manage_project_members",
+            "manage_project_workspaces",
+            "manage_users",
+            "run_job",
+        ],
+        "orgs": [{"slug": org.slug, "permissions": []}],
+        "projects": [
+            {
+                "slug": project.slug,
+                "permissions": ["cancel_job", "check_output", "run_job"],
+            }
+        ],
+    }
+
+    assert output == expected
+
+
+@pytest.mark.django_db
+def test_user_get_all_permissions_empty():
+    user = UserFactory()
+
+    output = user.get_all_permissions()
+
+    expected = {
+        "global": [],
+        "projects": [],
+        "orgs": [],
+    }
+    assert output == expected
+
+
+@pytest.mark.django_db
+def test_user_get_all_roles():
+    project = ProjectFactory()
+    user = UserFactory(roles=[DataInvestigator])
+
+    ProjectMembershipFactory(project=project, user=user, roles=[ProjectCollaborator])
+
+    output = user.get_all_roles()
+    expected = {
+        "global": ["DataInvestigator"],
+        "orgs": [],
+        "projects": [
+            {
+                "slug": project.slug,
+                "roles": ["ProjectCollaborator"],
+            }
+        ],
+    }
+
+    assert output == expected
+
+
+@pytest.mark.django_db
+def test_user_get_all_roles_empty():
+    user = UserFactory()
+
+    output = user.get_all_roles()
+
+    expected = {
+        "global": [],
+        "projects": [],
+        "orgs": [],
+    }
+    assert output == expected
+
+
+@pytest.mark.django_db
+def test_user_is_unapproved_by_default():
+    assert not UserFactory().is_approved
+
+
+@pytest.mark.django_db
+def test_workspace_get_absolute_url():
+    org = OrgFactory()
+    project = ProjectFactory(org=org)
+    workspace = WorkspaceFactory(project=project)
+
+    url = workspace.get_absolute_url()
+
+    assert url == reverse(
+        "workspace-detail",
+        kwargs={
+            "org_slug": org.slug,
+            "project_slug": project.slug,
+            "workspace_slug": workspace.name,
+        },
+    )
+
+
+@pytest.mark.django_db
+def test_workspace_get_archive_toggle_url():
+    org = OrgFactory()
+    project = ProjectFactory(org=org)
+    workspace = WorkspaceFactory(project=project)
+
+    url = workspace.get_archive_toggle_url()
+
+    assert url == reverse(
+        "workspace-archive-toggle",
+        kwargs={
+            "org_slug": org.slug,
+            "project_slug": project.slug,
+            "workspace_slug": workspace.name,
+        },
+    )
+
+
+@pytest.mark.django_db
+def test_workspace_get_logs_url():
+    org = OrgFactory()
+    project = ProjectFactory(org=org)
+    workspace = WorkspaceFactory(project=project)
+
+    url = workspace.get_logs_url()
+
+    assert url == reverse(
+        "workspace-logs",
+        kwargs={
+            "org_slug": org.slug,
+            "project_slug": project.slug,
+            "workspace_slug": workspace.name,
+        },
+    )
+
+
+@pytest.mark.django_db
+def test_workspace_get_notifications_toggle_url():
+    org = OrgFactory()
+    project = ProjectFactory(org=org)
+    workspace = WorkspaceFactory(project=project)
+
+    url = workspace.get_notifications_toggle_url()
+
+    assert url == reverse(
+        "workspace-notifications-toggle",
+        kwargs={
+            "org_slug": org.slug,
+            "project_slug": project.slug,
+            "workspace_slug": workspace.name,
+        },
+    )
+
+
+@pytest.mark.django_db
+def test_workspace_get_statuses_url():
+    workspace = WorkspaceFactory()
+    url = workspace.get_statuses_url()
+    assert url == reverse("workspace-statuses", kwargs={"name": workspace.name})
+
+
+@pytest.mark.django_db
+def test_workspace_get_action_status_lut_no_jobs():
+    assert WorkspaceFactory().get_action_status_lut() == {}
+
+
+@pytest.mark.django_db
+def test_workspace_get_action_status_lut_with_backend():
+    emis = Backend.objects.get(name="emis")
+    tpp = Backend.objects.get(name="tpp")
+    workspace1 = WorkspaceFactory()
+    job_request = JobRequestFactory(backend=emis, workspace=workspace1)
+    JobFactory(job_request=job_request, action="action1", status="pending")
+
+    workspace2 = WorkspaceFactory()
+
+    job_request1 = JobRequestFactory(backend=tpp, workspace=workspace2)
+    # action1 (succeeded) & action2 (failure)
+    JobFactory(
+        job_request=job_request1,
+        action="action1",
+        status="succeeded",
+        created_at=timezone.now() - timedelta(minutes=7),
+    )
+    JobFactory(
+        job_request=job_request1,
+        action="action2",
+        status="failed",
+        created_at=timezone.now() - timedelta(minutes=6),
+    )
+
+    job_request2 = JobRequestFactory(backend=tpp, workspace=workspace2)
+    # action2 (succeeded) & action3 (failed)
+    JobFactory(
+        job_request=job_request2,
+        action="action2",
+        status="succeeded",
+        created_at=timezone.now() - timedelta(minutes=5),
+    )
+    JobFactory(
+        job_request=job_request2,
+        action="action3",
+        status="failed",
+        created_at=timezone.now() - timedelta(minutes=4),
+    )
+
+    job_request3 = JobRequestFactory(backend=tpp, workspace=workspace2)
+    # action2 (failed)
+    JobFactory(
+        job_request=job_request3,
+        action="action2",
+        status="failed",
+        created_at=timezone.now() - timedelta(minutes=2),
+    )
+
+    job_request4 = JobRequestFactory(backend=tpp, workspace=workspace2)
+    # action3 (succeeded) & action4 (failed)
+    JobFactory(
+        job_request=job_request4,
+        action="action3",
+        status="succeeded",
+        created_at=timezone.now() - timedelta(minutes=2),
+    )
+    JobFactory(
+        job_request=job_request4,
+        action="action4",
+        status="failed",
+        created_at=timezone.now() - timedelta(minutes=1),
+    )
+
+    output = workspace2.get_action_status_lut(backend="tpp")
+    expected = {
+        "action1": "succeeded",
+        "action2": "failed",
+        "action3": "succeeded",
+        "action4": "failed",
+    }
+    assert output == expected
+
+
+@pytest.mark.django_db
+def test_workspace_get_action_status_lut_without_backend():
+    workspace1 = WorkspaceFactory()
+    job_request = JobRequestFactory(workspace=workspace1)
+    JobFactory(job_request=job_request, action="action1", status="pending")
+
+    workspace2 = WorkspaceFactory()
+
+    job_request1 = JobRequestFactory(workspace=workspace2)
+    # action1 (succeeded) & action2 (failure)
+    JobFactory(
+        job_request=job_request1,
+        action="action1",
+        status="succeeded",
+        created_at=timezone.now() - timedelta(minutes=7),
+    )
+    JobFactory(
+        job_request=job_request1,
+        action="action2",
+        status="failed",
+        created_at=timezone.now() - timedelta(minutes=6),
+    )
+
+    job_request2 = JobRequestFactory(workspace=workspace2)
+    # action2 (succeeded) & action3 (failed)
+    JobFactory(
+        job_request=job_request2,
+        action="action2",
+        status="succeeded",
+        created_at=timezone.now() - timedelta(minutes=5),
+    )
+    JobFactory(
+        job_request=job_request2,
+        action="action3",
+        status="failed",
+        created_at=timezone.now() - timedelta(minutes=4),
+    )
+
+    job_request3 = JobRequestFactory(workspace=workspace2)
+    # action2 (failed)
+    JobFactory(
+        job_request=job_request3,
+        action="action2",
+        status="failed",
+        created_at=timezone.now() - timedelta(minutes=2),
+    )
+
+    job_request4 = JobRequestFactory(workspace=workspace2)
+    # action3 (succeeded) & action4 (failed)
+    JobFactory(
+        job_request=job_request4,
+        action="action3",
+        status="succeeded",
+        created_at=timezone.now() - timedelta(minutes=2),
+    )
+    JobFactory(
+        job_request=job_request4,
+        action="action4",
+        status="failed",
+        created_at=timezone.now() - timedelta(minutes=1),
+    )
+
+    output = workspace2.get_action_status_lut()
+    expected = {
+        "action1": "succeeded",
+        "action2": "failed",
+        "action3": "succeeded",
+        "action4": "failed",
+    }
+    assert output == expected
+
+
+@pytest.mark.django_db
+def test_workspace_repo_name_no_path():
+    workspace = WorkspaceFactory(repo="http://example.com")
+
+    with pytest.raises(Exception, match="not in expected format"):
+        workspace.repo_name
+
+
+@pytest.mark.django_db
+def test_workspace_repo_name_success():
+    workspace = WorkspaceFactory(repo="http://example.com/foo/test")
+    assert workspace.repo_name == "test"
+
+
+@pytest.mark.django_db
+def test_workspace_repo_owner_no_path():
+    workspace = WorkspaceFactory(repo="http://example.com")
+
+    with pytest.raises(Exception, match="not in expected format"):
+        workspace.repo_owner
+
+
+@pytest.mark.django_db
+def test_workspace_repo_owner_success():
+    workspace = WorkspaceFactory(repo="http://example.com/foo/test")
+    assert workspace.repo_owner == "foo"
+
+
+@pytest.mark.django_db
+def test_workspace_str():
+    workspace = WorkspaceFactory(
+        name="Corellian Engineering Corporation", repo="Corellia"
+    )
+    assert str(workspace) == "Corellian Engineering Corporation (Corellia)"

--- a/tests/jobserver/models/test_onboarding.py
+++ b/tests/jobserver/models/test_onboarding.py
@@ -1,0 +1,13 @@
+import pytest
+from django.utils import timezone
+
+from ...factories import ResearcherRegistrationFactory
+
+
+@pytest.mark.django_db
+def test_researcher_registration_str():
+    researcher = ResearcherRegistrationFactory(
+        name="Terry",
+        passed_researcher_training_at=timezone.now(),
+    )
+    assert str(researcher) == "Terry"

--- a/tests/jobserver/models/test_outputs.py
+++ b/tests/jobserver/models/test_outputs.py
@@ -1,0 +1,31 @@
+import pytest
+from django.urls import reverse
+
+from ...factories import OrgFactory, ProjectFactory, ReleaseFactory, WorkspaceFactory
+
+
+@pytest.mark.django_db
+def test_release_creation():
+    release = ReleaseFactory(files=["file.txt"], upload_dir="workspace/release")
+
+    assert str(release.file_path("file.txt")) == "releases/workspace/release/file.txt"
+
+
+@pytest.mark.django_db
+def test_release_get_absolute_url():
+    org = OrgFactory()
+    project = ProjectFactory(org=org)
+    workspace = WorkspaceFactory(project=project)
+    release = ReleaseFactory(workspace=workspace)
+
+    url = release.get_absolute_url()
+
+    assert url == reverse(
+        "workspace-release",
+        kwargs={
+            "org_slug": org.slug,
+            "project_slug": project.slug,
+            "workspace_slug": workspace.name,
+            "release": release.id,
+        },
+    )

--- a/tests/jobserver/models/test_stats.py
+++ b/tests/jobserver/models/test_stats.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+import pytest
+from django.utils import timezone
+
+from jobserver.models import Backend
+
+from ...factories import StatsFactory
+
+
+@pytest.mark.django_db
+def test_stats_str_with_last_seen(freezer):
+    tpp = Backend.objects.get(name="tpp")
+
+    last_seen = datetime(2020, 12, 25, 10, 11, 12, tzinfo=timezone.utc)
+    stats = StatsFactory(backend=tpp, api_last_seen=last_seen, url="/foo")
+
+    assert str(stats) == "tpp | 2020-12-25 10:11:12 | /foo"
+
+
+@pytest.mark.django_db
+def test_stats_str_without_last_seen(freezer):
+    tpp = Backend.objects.get(name="tpp")
+
+    stats = StatsFactory(backend=tpp, api_last_seen=None, url="")
+
+    assert str(stats) == "tpp | never | "


### PR DESCRIPTION
This breaks models module into a package since it's grown fairly large.  The new modules are a little arbitrary but here is my reasoning:

* `onboarding` because the spike into an onboarding flow showed we likely needed more than just `ResearcherRegistration` to preserve state of in-flight sign ups.
* `stats` because it didn't have a better home.
* `backends` because they're sort of a (core?) sub-system unto themselves.
* `outputs` because the project outputs voyage is adding more models around this.

No new migrations are required because of the importing in `jobserver/models/__init__.py` but unfortuately the Roles definitions needed updating.