### PR TITLE
Remove extra queries from URL construction on index page

### DIFF
--- a/jobserver/views/index.py
+++ b/jobserver/views/index.py
@@ -11,7 +11,11 @@ class Index(TemplateView):
         job_requests = JobRequest.objects.prefetch_related("jobs").order_by(
             "-created_at"
         )[:5]
-        workspaces = Workspace.objects.filter(is_archived=False).order_by("name")
+        workspaces = (
+            Workspace.objects.filter(is_archived=False)
+            .select_related("project", "project__org")
+            .order_by("name")
+        )
 
         context = super().get_context_data(**kwargs)
         context["job_requests"] = job_requests


### PR DESCRIPTION
This removes the extra queries spawned by Workspace.get_absolute_url calls for the list of Workspaces after moving Workspaces under Org and Project.
