### PR TITLE
Ignore Accepted Invitations

### DIFF
--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -44,6 +44,9 @@ class ProjectAcceptInvite(View):
             )
             return redirect("/")
 
+        if invite.membership:
+            return redirect(invite.project)
+
         invite.create_membership()
 
         return redirect(invite.project)


### PR DESCRIPTION
This stops a User clicking the accept invitation link for the second time getting a 500.