### PR TITLE
Remove Use of SuperUser Role

### DIFF
--- a/jobserver/authorization/admins.py
+++ b/jobserver/authorization/admins.py
@@ -2,7 +2,7 @@ from django.db import transaction
 from environs import Env
 
 from ..models import User
-from .roles import SuperUser
+from .roles import CoreDeveloper
 
 
 env = Env()
@@ -23,11 +23,12 @@ def get_admins():
 @transaction.atomic()
 def ensure_admins(usernames):
     """
-    Given an iterable of username strings, ensure they have the SuperUser role
+    Given an iterable of username strings, ensure they have the CoreDeveloper
+    role which we to denote administrators.
     """
     for user in User.objects.all():
         try:
-            user.roles.remove(SuperUser)
+            user.roles.remove(CoreDeveloper)
         except ValueError:
             pass
         user.save()
@@ -40,5 +41,5 @@ def ensure_admins(usernames):
         raise Exception(f"Unknown admin usernames: {', '.join(sorted_missing)}")
 
     for admin in admins_to_be:
-        admin.roles.append(SuperUser)
+        admin.roles.append(CoreDeveloper)
         admin.save()

--- a/jobserver/authorization/decorators.py
+++ b/jobserver/authorization/decorators.py
@@ -3,7 +3,6 @@ from functools import wraps
 from django.http import HttpResponseForbidden
 
 from .permissions import manage_backends
-from .roles import SuperUser
 from .utils import has_permission, has_role
 
 
@@ -44,4 +43,3 @@ def require_role(role):
 
 
 require_manage_backends = require_permission(manage_backends)
-require_superuser = require_role(SuperUser)

--- a/jobserver/authorization/permissions.py
+++ b/jobserver/authorization/permissions.py
@@ -1,5 +1,6 @@
 cancel_job = "cancel_job"
 check_output = "check_output"
+create_org = "create_org"
 invite_org_members = "invite_org_members"
 invite_project_members = "invite_project_members"
 manage_backends = "manage_backends"

--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -1,6 +1,7 @@
 from .permissions import (
     cancel_job,
     check_output,
+    create_org,
     invite_project_members,
     manage_backends,
     manage_project_members,
@@ -26,6 +27,7 @@ class CoreDeveloper:
     ]
     permissions = [
         cancel_job,
+        create_org,
         invite_project_members,
         manage_backends,
         manage_project_members,

--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -130,6 +130,10 @@ class SettingsForm(forms.ModelForm):
 
 
 class UserForm(RolesForm):
+    is_superuser = forms.TypedChoiceField(
+        coerce=bool, empty_value=False, required=False
+    )
+
     def __init__(self, *, available_backends, **kwargs):
         super().__init__(**kwargs)
 

--- a/jobserver/templates/user_detail.html
+++ b/jobserver/templates/user_detail.html
@@ -146,6 +146,28 @@
 
       </div>
 
+      <div class="form-group mb-5">
+        <h4>Django Admin Access</h4>
+
+        <div class="custom-control custom-checkbox">
+          <input
+            type="checkbox"
+            class="custom-control-input"
+            id="id_is_superuser"
+            name="is_superuser"
+            value="{{ form.is_superuser.value }}"
+            {% if form.is_superuser.value %}
+            checked
+            {% endif %}
+            />
+          <label class="custom-control-label" for="id_is_superuser">
+            <span class="d-block">
+              Should <strong>{{ user.username }}</strong> have access to the Django Admin?
+            </span>
+          </label>
+        </div>
+      </div>
+
       <div class="form-group">
         <button class="btn btn-primary" type="submit">Save</button>
       </div>

--- a/jobserver/views/admin.py
+++ b/jobserver/views/admin.py
@@ -1,12 +1,12 @@
 from django import forms
 from django.contrib import messages
+from django.contrib.auth.decorators import user_passes_test
 from django.db import transaction
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.generic import FormView
 
-from ..authorization.decorators import require_superuser
 from ..models import Backend, BackendMembership, Org, OrgMembership, User
 
 
@@ -19,7 +19,7 @@ class ApprovalForm(forms.Form):
         self.fields["orgs"] = forms.ModelMultipleChoiceField(queryset=orgs)
 
 
-@method_decorator(require_superuser, name="dispatch")
+@method_decorator(user_passes_test(lambda u: u.is_superuser), name="dispatch")
 class ApproveUsers(FormView):
     form_class = ApprovalForm
     success_url = reverse_lazy("admin:jobserver_user_changelist")

--- a/jobserver/views/orgs.py
+++ b/jobserver/views/orgs.py
@@ -4,12 +4,12 @@ from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import CreateView, DetailView, ListView
 
-from ..authorization.decorators import require_superuser
+from ..authorization.decorators import require_permission
 from ..forms import OrgCreateForm
 from ..models import Org, Workspace
 
 
-@method_decorator(require_superuser, name="dispatch")
+@method_decorator(require_permission("create_org"), name="dispatch")
 class OrgCreate(CreateView):
     form_class = OrgCreateForm
     model = Org

--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -48,6 +48,7 @@ class UserDetail(UpdateView):
         for backend in form.cleaned_data["backends"]:
             backend.memberships.create(user=self.object, created_by=self.request.user)
 
+        self.object.is_superuser = form.cleaned_data["is_superuser"]
         self.object.roles = form.cleaned_data["roles"]
         self.object.save()
 
@@ -77,6 +78,7 @@ class UserDetail(UpdateView):
     def get_initial(self):
         return super().get_initial() | {
             "backends": self.object.backends.values_list("name", flat=True),
+            "is_superuser": self.object.is_superuser,
             "roles": self.object.roles,
         }
 

--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -4,6 +4,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.db.models import Q
+from django.db.models.functions import Lower
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.generic import ListView, UpdateView
@@ -85,7 +86,7 @@ class UserDetail(UpdateView):
 
 @method_decorator(require_permission("manage_users"), name="dispatch")
 class UserList(ListView):
-    queryset = User.objects.order_by("username")
+    queryset = User.objects.order_by(Lower("username"))
     template_name = "user_list.html"
 
     def get_context_data(self, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import structlog
 from django.conf import settings
 from structlog.testing import LogCapture
 
-from jobserver.authorization.roles import CoreDeveloper, SuperUser
+from jobserver.authorization.roles import CoreDeveloper
 
 from .factories import OrgFactory, OrgMembershipFactory, UserFactory
 
@@ -33,11 +33,6 @@ def fixture_configure_structlog(log_output):
 @pytest.fixture(autouse=True)
 def set_release_storage(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "RELEASE_STORAGE", tmp_path / "releases")
-
-
-@pytest.fixture
-def superuser():
-    return UserFactory(roles=[SuperUser])
 
 
 @pytest.fixture

--- a/tests/jobserver/api/test_jobs.py
+++ b/tests/jobserver/api/test_jobs.py
@@ -582,6 +582,7 @@ def test_userapidetail_success(api_rf):
     permissions = response.data["permissions"]
     assert permissions["global"] == [
         "cancel_job",
+        "create_org",
         "invite_project_members",
         "manage_backends",
         "manage_project_members",

--- a/tests/jobserver/authorization/test_admins.py
+++ b/tests/jobserver/authorization/test_admins.py
@@ -1,7 +1,7 @@
 import pytest
 
 from jobserver.authorization.admins import ensure_admins, get_admins
-from jobserver.authorization.roles import SuperUser
+from jobserver.authorization.roles import CoreDeveloper
 from jobserver.models import User
 
 from ...factories import UserFactory
@@ -9,41 +9,41 @@ from ...factories import UserFactory
 
 @pytest.mark.django_db
 def test_ensure_admins_remove_user():
-    # is superuser now, and will be afterwards
-    UserFactory(username="aaa", roles=[SuperUser])
+    # is CoreDeveloper now, and will be afterwards
+    UserFactory(username="aaa", roles=[CoreDeveloper])
 
-    # is superuser now, and won't be afterwards
-    UserFactory(username="bbb", roles=[SuperUser])
+    # is CoreDeveloper now, and won't be afterwards
+    UserFactory(username="bbb", roles=[CoreDeveloper])
 
-    # isn't superuser now, and will be afterwards
+    # isn't CoreDeveloper now, and will be afterwards
     UserFactory(username="ccc")
 
-    # isn't superuser now, and won't be afterwards
+    # isn't CoreDeveloper now, and won't be afterwards
     UserFactory(username="ddd")
 
     ensure_admins(["aaa", "ccc"])
 
-    assert SuperUser in User.objects.get(username="aaa").roles
-    assert SuperUser not in User.objects.get(username="bbb").roles
-    assert SuperUser in User.objects.get(username="ccc").roles
-    assert SuperUser not in User.objects.get(username="ddd").roles
+    assert CoreDeveloper in User.objects.get(username="aaa").roles
+    assert CoreDeveloper not in User.objects.get(username="bbb").roles
+    assert CoreDeveloper in User.objects.get(username="ccc").roles
+    assert CoreDeveloper not in User.objects.get(username="ddd").roles
 
 
 @pytest.mark.django_db
 def test_ensure_admins_success():
     user = UserFactory(username="ghickman")
-    assert SuperUser not in user.roles
+    assert CoreDeveloper not in user.roles
 
     ensure_admins(["ghickman"])
 
     user.refresh_from_db()
-    assert SuperUser in user.roles
+    assert CoreDeveloper in user.roles
 
 
 @pytest.mark.django_db
 def test_ensure_admins_unknown_user():
     user = UserFactory(username="ghickman")
-    assert SuperUser not in user.roles
+    assert CoreDeveloper not in user.roles
 
     with pytest.raises(Exception, match="Unknown admin usernames: test"):
         ensure_admins(["ghickman", "test"])
@@ -52,7 +52,7 @@ def test_ensure_admins_unknown_user():
 @pytest.mark.django_db
 def test_ensure_admins_unknown_users():
     user = UserFactory(username="ghickman")
-    assert SuperUser not in user.roles
+    assert CoreDeveloper not in user.roles
 
     with pytest.raises(Exception, match="Unknown admin usernames: foo, test"):
         ensure_admins(["ghickman", "foo", "test"])

--- a/tests/jobserver/authorization/test_decorators.py
+++ b/tests/jobserver/authorization/test_decorators.py
@@ -1,9 +1,7 @@
 import pytest
 
-from jobserver.authorization.decorators import (
-    require_manage_backends,
-    require_superuser,
-)
+from jobserver.authorization import CoreDeveloper
+from jobserver.authorization.decorators import require_manage_backends, require_role
 
 from ...factories import UserFactory
 
@@ -33,24 +31,23 @@ def test_require_manage_backends_without_core_dev_role(rf):
 
 
 @pytest.mark.django_db
-def test_require_superuser_with_core_dev_role(rf, superuser):
+def test_require_role_success(rf):
     request = rf.get("/")
-    request.user = superuser
+    request.user = UserFactory(roles=[CoreDeveloper])
 
     def dispatch(request):
         return request
 
-    returned_request = require_superuser(dispatch)(request)
+    returned_request = require_role(CoreDeveloper)(dispatch)(request)
 
-    # check the request is passed through the decorator
     assert returned_request == request
 
 
 @pytest.mark.django_db
-def test_require_superuser_without_core_dev_role(rf):
+def test_require_role_without_role(rf):
     request = rf.get("/")
     request.user = UserFactory(roles=[])
 
-    response = require_superuser(None)(request)
+    response = require_role(CoreDeveloper)(None)(request)
 
     assert response.status_code == 403

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -716,6 +716,7 @@ def test_user_get_all_permissions():
     expected = {
         "global": [
             "cancel_job",
+            "create_org",
             "invite_project_members",
             "manage_backends",
             "manage_project_members",

--- a/tests/jobserver/test_admin.py
+++ b/tests/jobserver/test_admin.py
@@ -9,7 +9,7 @@ from ..factories import UserFactory
 
 
 @pytest.mark.django_db
-def test_useradmin_approve_users(rf, superuser):
+def test_useradmin_approve_users(rf):
     UserFactory.create_batch(5)
 
     # only work with a subset of created users to ensure we don't somehow
@@ -19,7 +19,7 @@ def test_useradmin_approve_users(rf, superuser):
     user_admin = UserAdmin(model=User, admin_site=AdminSite())
 
     request = rf.get("/")
-    request.user = superuser
+    request.user = UserFactory(is_superuser=True)
 
     response = user_admin.approve_users(request, users)
 

--- a/tests/jobserver/views/test_admin.py
+++ b/tests/jobserver/views/test_admin.py
@@ -15,23 +15,25 @@ def test_approveusers_as_non_superuser(rf):
 
     response = ApproveUsers.as_view()(request)
 
-    assert response.status_code == 403
+    assert response.status_code == 302
+    assert response.url == "/login/github/?next=/"
 
 
 @pytest.mark.django_db
-def test_approveusers_get_success(rf, superuser):
-    request = rf.get(f"/?user={superuser.pk}")
-    request.user = superuser
+def test_approveusers_get_success(rf):
+    user = UserFactory(is_superuser=True)
+    request = rf.get(f"/?user={user.pk}")
+    request.user = user
 
     response = ApproveUsers.as_view()(request)
 
     assert response.status_code == 200
 
-    assert list(response.context_data["users"]) == [superuser]
+    assert list(response.context_data["users"]) == [user]
 
 
 @pytest.mark.django_db
-def test_approveusers_post_success(rf, superuser):
+def test_approveusers_post_success(rf):
     user1 = UserFactory()
     user2 = UserFactory()
 
@@ -49,7 +51,7 @@ def test_approveusers_post_success(rf, superuser):
         "orgs": [org1.pk],
     }
     request = rf.post(f"/?user={user1.pk}&user={user2.pk}", data)
-    request.user = superuser
+    request.user = UserFactory(is_superuser=True)
 
     # set up messages framework
     request.session = "session"
@@ -70,9 +72,11 @@ def test_approveusers_post_success(rf, superuser):
 
 
 @pytest.mark.django_db
-def test_approveusers_with_invalid_form(rf, superuser):
-    request = rf.post(f"/?user={superuser.pk}")
-    request.user = superuser
+def test_approveusers_with_invalid_form(rf):
+    user = UserFactory(is_superuser=True)
+
+    request = rf.post(f"/?user={user.pk}")
+    request.user = user
 
     response = ApproveUsers.as_view()(request)
 
@@ -81,9 +85,11 @@ def test_approveusers_with_invalid_form(rf, superuser):
 
 
 @pytest.mark.django_db
-def test_approveusers_with_no_users(rf, superuser):
+def test_approveusers_with_no_users(rf):
+    user = UserFactory(is_superuser=True)
+
     request = rf.get("/")
-    request.user = superuser
+    request.user = user
 
     # set up messages framework
     request.session = "session"

--- a/tests/jobserver/views/test_orgs.py
+++ b/tests/jobserver/views/test_orgs.py
@@ -17,12 +17,12 @@ MEANINGLESS_URL = "/"
 
 
 @pytest.mark.django_db
-def test_orgcreate_get_success(rf, superuser):
+def test_orgcreate_get_success(rf, core_developer):
     oxford = OrgFactory(name="University of Oxford")
     ebmdatalab = OrgFactory(name="EBMDataLab")
 
     request = rf.get(MEANINGLESS_URL)
-    request.user = superuser
+    request.user = core_developer
     response = OrgCreate.as_view()(request)
 
     assert response.status_code == 200
@@ -34,9 +34,9 @@ def test_orgcreate_get_success(rf, superuser):
 
 
 @pytest.mark.django_db
-def test_orgcreate_post_success(rf, superuser):
+def test_orgcreate_post_success(rf, core_developer):
     request = rf.post(MEANINGLESS_URL, {"name": "A New Org"})
-    request.user = superuser
+    request.user = core_developer
     response = OrgCreate.as_view()(request)
 
     assert response.status_code == 302

--- a/tests/jobserver/views/test_projects.py
+++ b/tests/jobserver/views/test_projects.py
@@ -611,27 +611,28 @@ def test_projectmembershipremove_without_permission(rf):
 
 
 @pytest.mark.django_db
-def test_projectonboardingcreate_get_success(rf, superuser):
+def test_projectonboardingcreate_get_success(rf):
     org = OrgFactory()
 
     request = rf.get(MEANINGLESS_URL)
-    request.user = superuser
+    request.user = UserFactory()
+
     response = ProjectOnboardingCreate.as_view()(request, org_slug=org.slug)
 
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-def test_projectonboardingcreate_get_unknown_org(rf, superuser):
+def test_projectonboardingcreate_get_unknown_org(rf):
     request = rf.get(MEANINGLESS_URL)
-    request.user = superuser
+    request.user = UserFactory()
 
     with pytest.raises(Http404):
         ProjectOnboardingCreate.as_view()(request, org_slug="")
 
 
 @pytest.mark.django_db
-def test_projectonboardingcreate_post_invalid_data(rf, superuser):
+def test_projectonboardingcreate_post_invalid_data(rf):
     org = OrgFactory()
 
     data = {
@@ -645,7 +646,7 @@ def test_projectonboardingcreate_post_invalid_data(rf, superuser):
     }
 
     request = rf.post(MEANINGLESS_URL, data)
-    request.user = superuser
+    request.user = UserFactory()
     response = ProjectOnboardingCreate.as_view()(request, org_slug=org.slug)
 
     assert response.status_code == 200
@@ -653,7 +654,7 @@ def test_projectonboardingcreate_post_invalid_data(rf, superuser):
 
 
 @pytest.mark.django_db
-def test_projectonboardingcreate_post_success(rf, superuser):
+def test_projectonboardingcreate_post_success(rf):
     org = OrgFactory()
 
     data = {
@@ -670,7 +671,7 @@ def test_projectonboardingcreate_post_success(rf, superuser):
     }
 
     request = rf.post(MEANINGLESS_URL, data)
-    request.user = superuser
+    request.user = UserFactory()
     response = ProjectOnboardingCreate.as_view()(request, org_slug=org.slug)
 
     assert response.status_code == 302
@@ -687,9 +688,9 @@ def test_projectonboardingcreate_post_success(rf, superuser):
 
 
 @pytest.mark.django_db
-def test_projectonboardingcreate_post_unknown_org(rf, superuser):
+def test_projectonboardingcreate_post_unknown_org(rf):
     request = rf.post(MEANINGLESS_URL)
-    request.user = superuser
+    request.user = UserFactory()
 
     with pytest.raises(Http404):
         ProjectOnboardingCreate.as_view()(request, org_slug="")


### PR DESCRIPTION
This removes our use of the SuperUser Role from all parts of the code base, opting to either add an appropriate new permission or fallback to `User.is_superuser`.

The Role itself can be removed when all Users no longer have it assigned.