### PR TITLE
Refactor Release testing machinery

### DIFF
--- a/jobserver/models/outputs.py
+++ b/jobserver/models/outputs.py
@@ -48,8 +48,13 @@ class Release(models.Model):
             },
         )
 
-    def file_path(self, filename):
-        return settings.RELEASE_STORAGE / self.upload_dir / filename
+    def file_path(self, filepath):
+        if filepath not in self.files:
+            return None
+        abs_path = settings.RELEASE_STORAGE / self.upload_dir / filepath
+        if not abs_path.exists():
+            return None
+        return abs_path
 
     @property
     def manifest(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 import structlog
+from django.conf import settings
 from structlog.testing import LogCapture
 
 from jobserver.authorization.roles import CoreDeveloper, SuperUser
@@ -27,6 +28,11 @@ def fixture_log_output():
 @pytest.fixture(autouse=True)
 def fixture_configure_structlog(log_output):
     structlog.configure(processors=[log_output])
+
+
+@pytest.fixture(autouse=True)
+def set_release_storage(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "RELEASE_STORAGE", tmp_path / "releases")
 
 
 @pytest.fixture

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,4 +1,9 @@
+import io
+import json
 from datetime import datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from zipfile import ZipFile
 
 import factory
 import factory.fuzzy
@@ -6,6 +11,7 @@ from django.utils import timezone
 from pytz import utc
 from social_django.models import UserSocialAuth
 
+from jobserver import releases
 from jobserver.models import (
     Backend,
     BackendMembership,
@@ -110,15 +116,83 @@ class ProjectMembershipFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory("tests.factories.UserFactory")
 
 
-class ReleaseFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = Release
+DEFAULT_MANIFEST = {"workspace": "workspace", "repo": "repo"}
+DEFAULT_FILES = {"file.txt": "test"}
 
-    backend = factory.SubFactory("tests.factories.BackendFactory")
-    workspace = factory.SubFactory("tests.factories.WorkspaceFactory")
 
-    id = factory.Sequence(lambda n: f"release-{n}")
-    files = []
+class ReleaseUploadFactory:
+    """A zip bytestream with valid hash."""
+
+    def __init__(
+        self, files=DEFAULT_FILES, manifest=DEFAULT_MANIFEST, raw_manifest=None
+    ):
+        self.zip = io.BytesIO()
+        with TemporaryDirectory() as d:
+            tmp = Path(d)
+
+            for path, contents in files.items():
+                (tmp / path).write_text(contents)
+
+            # raw_manifest allows us to write bad json for testing
+            # setting manifest=None means we do not write a manifest
+            if raw_manifest is None and manifest:
+                raw_manifest = json.dumps(manifest)
+
+            if raw_manifest:
+                path = tmp / "metadata" / "manifest.json"
+                path.parent.mkdir()
+                path.write_text(raw_manifest)
+
+            self.hash, self.files = releases.hash_files(tmp)
+
+            with ZipFile(self.zip, "w") as zf:
+                for f in self.files:
+                    zf.write(tmp / f, arcname=str(f))
+
+        self.zip.seek(0)
+
+
+def ReleaseFactory(**kwargs):
+    """Factory for Release objects.
+
+    Release has attributes that depend on its file contents, namely id,
+    upload_dir and files. It also requires the associated filesystem state to
+    exist.
+
+    This makes it difficult to fit into how DjangoModelFactory works, so we
+    implement our own Factory, that quacks like a DjangoModelFactory.
+
+    It returns a Release object, but we create it manually.
+    """
+
+    files = kwargs.pop("files", DEFAULT_FILES)
+
+    # files can be a list of files or a dict.
+    # If it is a list, we default the file contents to be the name of the file.
+    # If it is a dict, we use the values as content.
+    if isinstance(files, list):
+        files = {f: f for f in files}  # pragma: no cover
+
+    manifest = kwargs.pop("manifest", DEFAULT_MANIFEST)
+    raw_manifest = kwargs.pop("raw_manifest", None)
+
+    # create these if needed
+    kwargs.setdefault("workspace", WorkspaceFactory())
+    kwargs.setdefault("backend", BackendFactory())
+
+    # create an upload, so we know the release_hash ahead of time.
+    upload = ReleaseUploadFactory(files, manifest, raw_manifest)
+    upload_dir = f"{kwargs['workspace'].name}/{upload.hash}"
+
+    # write the actual files to disk
+    releases.extract_upload(upload_dir, ZipFile(upload.zip))
+
+    return Release.objects.create(
+        id=upload.hash,
+        upload_dir=upload_dir,
+        files=upload.files,
+        **kwargs,
+    )
 
 
 class ResearcherRegistrationFactory(factory.django.DjangoModelFactory):

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -24,7 +24,6 @@ from ..factories import (
     ProjectFactory,
     ProjectInvitationFactory,
     ProjectMembershipFactory,
-    ReleaseFactory,
     ResearcherRegistrationFactory,
     StatsFactory,
     UserFactory,
@@ -731,33 +730,6 @@ def test_projectmembership_str():
     membership = ProjectMembershipFactory(project=project, user=user)
 
     assert str(membership) == "ben | DataLab"
-
-
-@pytest.mark.django_db
-def test_release_creation():
-    release = ReleaseFactory(files=["file.txt"], upload_dir="workspace/release")
-
-    assert str(release.file_path("file.txt")) == "releases/workspace/release/file.txt"
-
-
-@pytest.mark.django_db
-def test_release_get_absolute_url():
-    org = OrgFactory()
-    project = ProjectFactory(org=org)
-    workspace = WorkspaceFactory(project=project)
-    release = ReleaseFactory(workspace=workspace)
-
-    url = release.get_absolute_url()
-
-    assert url == reverse(
-        "workspace-release",
-        kwargs={
-            "org_slug": org.slug,
-            "project_slug": project.slug,
-            "workspace_slug": workspace.name,
-            "release": release.id,
-        },
-    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
1. New ReleaseUploadFactory to setup a zip stream and valid hash for
   testing upload handling

2. Re-implementend ReleaseFactory in order to handle the fact that it
   needs filesystem state set up first before we create the ORM object,
   and that some of its attribute depend on the hash of the uploaded
   content.

3. Add autouse fixture to ensure every tests uses a clean
   RELEASE_STORAGE dir

4. Refactored some of handle_release workflow to share more things in
   common with the testing setup