### PR TITLE
Add releases read API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ sort:
 .PHONY: test
 test:
 	python manage.py collectstatic --no-input && \
-	pytest --cov=jobserver --cov=services --cov=tests
+	pytest --cov=jobserver --cov=services --cov=tests --cov-report term-missing
 
 
 .PHONY: dev-config

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -1,7 +1,9 @@
 import structlog
+from django.conf import settings
+from django.http import FileResponse
 from django.urls import reverse
 from rest_framework import serializers
-from rest_framework.exceptions import NotAuthenticated, ValidationError
+from rest_framework.exceptions import NotAuthenticated, NotFound, ValidationError
 from rest_framework.generics import CreateAPIView
 from rest_framework.parsers import FileUploadParser
 from rest_framework.response import Response
@@ -9,7 +11,7 @@ from rest_framework.views import APIView
 from slack_sdk.errors import SlackApiError
 
 from jobserver.api import get_backend_from_token
-from jobserver.models import Workspace
+from jobserver.models import Release, Workspace
 from jobserver.releases import handle_release
 from services.slack import client as slack_client
 
@@ -78,4 +80,50 @@ class ReleaseUploadAPI(APIView):
             )
         )
         response["Release-Id"] = release.id
+        return response
+
+
+def validate_release_access(request, release_hash):
+    try:
+        release = Release.objects.get(id=release_hash)
+    except Release.DoesNotExist:
+        raise NotFound(f"Release {release_hash} does not exist")
+
+    # TODO: check if release is published
+    if request.user.is_anonymous:
+        raise NotAuthenticated("Invalid user or token")
+    else:
+        project = release.workspace.project
+        if not project.members.filter(username=request.user.username).exists():
+            raise NotAuthenticated(f"Invalid user or token for release {release_hash}")
+
+    return release
+
+
+class ReleaseIndexAPI(APIView):
+    def get(self, request, release_hash):
+        release = validate_release_access(request, release_hash)
+        return Response(release.files)
+
+
+class ReleaseFileAPI(APIView):
+    def get(self, request, release_hash, filepath):
+        release = validate_release_access(request, release_hash)
+        handle = release.file_path(filepath)
+
+        if handle is None:
+            raise NotFound(f"File {filepath} not found in release {release_hash}")
+
+        internal_redirect = request.headers.get("Releases-Redirect")
+        if internal_redirect:
+            # we're behind nginx, so use X-Accel-Redirect to serve the file from nginx
+            relative_path = handle.relative_to(settings.RELEASE_STORAGE)
+            redirect_path = f"{internal_redirect}/{relative_path}"
+            response = Response()
+            response.headers["X-Accel-Redirect"] = redirect_path
+        else:
+            # serve directly from django in dev
+            # use regular django response to bypass DRFs renderer framework and just serve bytes
+            response = FileResponse(handle.open("rb"))
+
         return response

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -26,7 +26,12 @@ from jobserver.api.jobs import (
     UserAPIDetail,
     WorkspaceStatusesAPI,
 )
-from jobserver.api.releases import ReleaseNotificationAPICreate, ReleaseUploadAPI
+from jobserver.api.releases import (
+    ReleaseFileAPI,
+    ReleaseIndexAPI,
+    ReleaseNotificationAPICreate,
+    ReleaseUploadAPI,
+)
 
 from .views.admin import ApproveUsers
 from .views.backends import BackendDetail, BackendList, BackendRotateToken
@@ -72,6 +77,16 @@ api_urls = [
         "workspaces/<workspace_name>/releases/<release_hash>",
         ReleaseUploadAPI.as_view(),
         name="workspace-upload-release",
+    ),
+    path(
+        "releases/<release_hash>",
+        ReleaseIndexAPI.as_view(),
+        name="release-index",
+    ),
+    path(
+        "releases/<release_hash>/<filepath>",
+        ReleaseFileAPI.as_view(),
+        name="release-file",
     ),
 ]
 


### PR DESCRIPTION
One to list the files in release, another to get the file contents.

Download api supports a production optimisation for using nginx.

Drive by fix to report missing coverage lines by default.

Fixes #627