### PR TITLE
Require Configured GitHub Orgs to Login

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     command: /app/manage.py runserver 0.0.0.0:8000
     environment:
       - ADMIN_USERS
+      - AUTHORIZATION_ORGS
       - DATABASE_URL
       - DEBUG
       - GITHUB_TOKEN

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,6 +1,10 @@
 # Set this to your GitHub username
 ADMIN_USERS=dummy
 
+# Set this to a comma-delimited list of GitHub Organisations you want to have
+# access to the platform
+AUTHORIZATION_ORGS=opensafely
+
 # Turn on debug
 DEBUG=1
 

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -158,7 +158,7 @@ LOGGING = logging_config_dict
 
 # Auth
 AUTHENTICATION_BACKENDS = [
-    "social_core.backends.github.GithubOAuth2",
+    "jobserver.github.GithubOrganizationOAuth2",
     "django.contrib.auth.backends.ModelBackend",
 ]
 AUTH_USER_MODEL = "jobserver.User"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ use_parentheses = true
 addopts = "--disable-network"
 DJANGO_SETTINGS_MODULE = "jobserver.settings"
 env = [
+  "AUTHORIZATION_ORGS=opensafely",
   "GITHUB_TOKEN=empty",
   "SECRET_KEY=12345",
   "SOCIAL_AUTH_GITHUB_KEY=test",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from structlog.testing import LogCapture
 
 from jobserver.authorization.roles import CoreDeveloper
+from jobserver.github import GithubOrganizationOAuth2
 
 from .factories import OrgFactory, OrgMembershipFactory, UserFactory
 
@@ -18,6 +19,23 @@ def api_rf():
 @pytest.fixture
 def core_developer():
     return UserFactory(roles=[CoreDeveloper])
+
+
+@pytest.fixture
+def dummy_backend():
+    """
+    Create a DummyBackend instance
+
+    Our GithubOrganizationOAuth2 backend will be instantiated in practice.
+    This allows us to test instances of it with _user_data() set (as it would
+    be in practice).
+    """
+
+    class DummyBackend(GithubOrganizationOAuth2):
+        def _user_data(self, *args, **kwargs):
+            return {"email": "test-email", "login": "test-username"}
+
+    return DummyBackend()
 
 
 @pytest.fixture(name="log_output")

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -48,6 +48,9 @@ def test_login_pipeline(client):
         ]
         rsps.add(responses.GET, emails_url, json=emails_data, status=200)
 
+        membership_url = "https://api.github.com/orgs/opensafely/members/dummy-user"
+        rsps.add(responses.GET, membership_url, status=204)
+
         # set a dummy state value in the test Client's session to match the
         # value in redirect_url below
         session = client.session

--- a/tests/jobserver/test_github.py
+++ b/tests/jobserver/test_github.py
@@ -1,6 +1,8 @@
 import pytest
 import responses
+from social_core.exceptions import AuthFailed
 
+from jobserver import github
 from jobserver.github import (
     get_branch,
     get_branch_sha,
@@ -255,6 +257,48 @@ def test_get_repos_with_branches_200_error():
 
     with pytest.raises(RuntimeError):
         list(get_repos_with_branches("opensafely"))
+
+
+@responses.activate
+def test_githuborganizationoauth2_user_data_204(monkeypatch, dummy_backend):
+    monkeypatch.setattr(github, "AUTHORIZATION_ORGS", ["opensafely"])
+
+    expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
+    responses.add(responses.GET, url=expected_url, status=204)
+
+    dummy_backend.user_data("access-token")
+
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_githuborganizationoauth2_user_data_302(monkeypatch, dummy_backend):
+    monkeypatch.setattr(github, "AUTHORIZATION_ORGS", ["opensafely"])
+
+    expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
+    responses.add(responses.GET, url=expected_url, status=302)
+
+    match = (
+        '"test-username" is not part of the OpenSAFELY GitHub Organization. '
+        '<a href="https://opensafely.org/contact/">Contact us</a> to request access.'
+    )
+    with pytest.raises(AuthFailed, match=match):
+        dummy_backend.user_data("access-token")
+
+
+@responses.activate
+def test_githuborganizationoauth2_user_data_404(monkeypatch, dummy_backend):
+    monkeypatch.setattr(github, "AUTHORIZATION_ORGS", ["opensafely"])
+
+    expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
+    responses.add(responses.GET, url=expected_url, status=404)
+
+    match = (
+        '"test-username" is not part of the OpenSAFELY GitHub Organization. '
+        '<a href="https://opensafely.org/contact/">Contact us</a> to request access.'
+    )
+    with pytest.raises(AuthFailed, match=match):
+        dummy_backend.user_data("access-token")
 
 
 @responses.activate


### PR DESCRIPTION
This is a near full revert of 5c3313c, except the auth backend now handles multiple GitHub Orgs, provided via configuration.

This continues to a separate check to our permissions framework, but will enable us to get rid of `can_run_jobs` as per #642 

Fixes #644 