### PR TITLE
List Releases for Workspaces and Projects

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -784,6 +784,16 @@ class Workspace(models.Model):
             },
         )
 
+    def get_releases_url(self):
+        return reverse(
+            "workspace-release-list",
+            kwargs={
+                "org_slug": self.project.org.slug,
+                "project_slug": self.project.slug,
+                "workspace_slug": self.name,
+            },
+        )
+
     def get_statuses_url(self):
         return reverse("workspace-statuses", kwargs={"name": self.name})
 

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -432,6 +432,12 @@ class Project(models.Model):
             kwargs={"org_slug": self.org.slug, "project_slug": self.slug},
         )
 
+    def get_releases_url(self):
+        return reverse(
+            "project-release-list",
+            kwargs={"org_slug": self.org.slug, "project_slug": self.slug},
+        )
+
     def get_settings_url(self):
         return reverse(
             "project-settings",

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -810,6 +810,21 @@ class Workspace(models.Model):
 
         return action_status_lut
 
+    def latest_files(self):
+        """
+        Gets the latest version of each file for this Workspace
+
+        We use Python to find the latest version of each file because SQLite
+        doesn't support DISTINCT ON so we can't use
+        `.distinct("release__created_at")`.
+        """
+        seen = {}
+        files = self.files.order_by("-release__created_at")
+        for file in files:
+            if file.name not in seen:
+                seen[file.name] = file
+        return list(seen.values())
+
     @property
     def repo_name(self):
         """Convert repo URL -> repo name"""

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -113,20 +113,16 @@
           </ul>
         </div>
 
-        {% if releases %}
         <div class="mb-4">
-          <h5>Releases</h5>
+          <h5>
+            Releases
+            <small>({{ releases_count }} files)</small>
+          </h5>
 
-          <a class="btn btn-primary btn-sm" href="{% url 'project-releases' org_slug=project.org.slug project_slug=project.slug %}">
+          <a class="btn btn-primary btn-sm" href="{{ project.get_releases_url }}">
             View
           </a>
-          {# <ul class="list-unstyled"> #}
-          {#   {% for release in releases %} #}
-          {#   <li>{{ release }}</li> #}
-          {#   {% endfor %} #}
-          {# </ul> #}
         </div>
-        {% endif %}
 
       </div>
 

--- a/jobserver/templates/project_release_list.html
+++ b/jobserver/templates/project_release_list.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+
+{% load humanize %}
+
+{% block content %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+
+    <li class="breadcrumb-item"><a href="/">Home</a></li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ project.org.get_absolute_url }}">
+        {{ project.org.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ project.get_absolute_url }}">
+        {{ project.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item active" aria-current="page">Releases</li>
+
+  </ol>
+</nav>
+
+
+<div class="row">
+  <div class="col-lg-8 offset-lg-2">
+
+    <p>
+      Below are all released files for the {{ project.name }} project across
+      all of its workspaces.
+    </p>
+    {% for release in object_list %}
+    <div class="border rounded p-2 pl-3 mb-3">
+
+      <div class="d-flex justify-content-between">
+        <span>
+          Files released by {{ release.created_by.name }} in the
+          <a href="{{ release.workspace.get_absolute_url }}">{{ release.workspace.name }}</a>
+          workspace {{ release.created_at|naturaltime }}
+        </span>
+
+        <button
+          class="btn btn-sm btn-primary"
+          type="button"
+          data-toggle="collapse"
+          data-target="#release-{{ release.id }}-files"
+          aria-expanded="false"
+          aria-controls="release-{{ release.id }}-files">
+          Files
+        </button>
+      </div>
+
+      <div class="collapse" id="release-{{ release.id }}-files">
+        <div class="card card-body border-0 mt-2 p-0 px-2">
+          <ul class="list-unstyled mb-0">
+            {% for file in release.files.all %}
+            <li><code>{{ file.name }}</code></li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+
+    </div>
+    {% endfor %}
+
+  </div>
+
+</div>
+{% endblock %}

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -49,6 +49,7 @@
       <h3>{{ workspace.name }}</h3>
 
       <div class="d-flex">
+        <a class="btn btn-primary mr-2" href="{{ workspace.get_releases_url }}">Releases</a>
         <a class="btn btn-primary mr-2" href="{{ workspace.get_logs_url }}">Logs</a>
         {% if show_details %}
         <a

--- a/jobserver/templates/workspace_release_list.html
+++ b/jobserver/templates/workspace_release_list.html
@@ -1,0 +1,92 @@
+{% extends "base.html" %}
+
+{% load humanize %}
+
+{% block content %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+
+    <li class="breadcrumb-item"><a href="/">Home</a></li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ workspace.project.org.get_absolute_url }}">
+        {{ workspace.project.org.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ workspace.project.get_absolute_url }}">
+        {{ workspace.project.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ workspace.get_absolute_url }}">
+        {{ workspace.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item active" aria-current="page">Releases</li>
+
+  </ol>
+</nav>
+
+
+<div class="row">
+  <div class="col-lg-8 offset-lg-2">
+
+    <div class="mb-4">
+      <h4>Workspace Files</h4>
+      <p>
+        These are the latest versions of all files that have been released so
+        far for this workspace.
+      </p>
+
+      <ul>
+        {% for file in files %}
+        <li>
+          {{ file.name }}
+          <small class="text-muted">({{ file.release.id }})</small>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+
+    <h4>All Releases</h4>
+    {% for release in object_list %}
+    <div class="border rounded p-2 pl-3 mb-3">
+
+      <div class="d-flex justify-content-between">
+        <span>
+          Files released by {{ release.created_by.name }} {{ release.created_at|naturaltime }}
+        </span>
+
+        <button
+          class="btn btn-primary"
+          type="button"
+          data-toggle="collapse"
+          data-target="#release-{{ release.id }}-files"
+          aria-expanded="false"
+          aria-controls="release-{{ release.id }}-files">
+          Files
+        </button>
+      </div>
+
+      <div class="collapse" id="release-{{ release.id }}-files">
+        <div class="card card-body border-0 mt-2 p-0 px-2">
+          <ul class="list-unstyled mb-0">
+            {% for file in release.files.all %}
+            <li><code>{{ file.name }}</code></li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+
+    </div>
+    {% endfor %}
+
+  </div>
+
+</div>
+{% endblock %}

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -50,7 +50,7 @@ from .views.projects import (
     ProjectOnboardingCreate,
     ProjectSettings,
 )
-from .views.releases import Releases, WorkspaceReleaseList
+from .views.releases import ProjectReleaseList, Releases, WorkspaceReleaseList
 from .views.status import Status
 from .views.users import Settings, UserDetail, UserList
 from .views.workspaces import (
@@ -153,7 +153,8 @@ project_urls = [
         name="project-membership-remove",
     ),
     path("new-workspace/", WorkspaceCreate.as_view(), name="workspace-create"),
-    path("releases/", Releases.as_view(), name="project-releases"),
+    path("releases/", ProjectReleaseList.as_view(), name="project-release-list"),
+    path("releases/spa/", Releases.as_view(), name="project-releases"),
     path("settings/", ProjectSettings.as_view(), name="project-settings"),
     path("<workspace_slug>/", include(workspace_urls)),
 ]

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -50,7 +50,7 @@ from .views.projects import (
     ProjectOnboardingCreate,
     ProjectSettings,
 )
-from .views.releases import Releases
+from .views.releases import Releases, WorkspaceReleaseList
 from .views.status import Status
 from .views.users import Settings, UserDetail, UserList
 from .views.workspaces import (
@@ -116,6 +116,11 @@ workspace_urls = [
         "notifications-toggle/",
         WorkspaceNotificationsToggle.as_view(),
         name="workspace-notifications-toggle",
+    ),
+    path(
+        "releases/",
+        WorkspaceReleaseList.as_view(),
+        name="workspace-release-list",
     ),
     path(
         "releases/<release>",

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -24,7 +24,7 @@ from ..forms import (
     ResearcherFormSet,
 )
 from ..github import get_repo_is_private
-from ..models import Org, Project, ProjectInvitation, ProjectMembership, User
+from ..models import Org, Project, ProjectInvitation, ProjectMembership, Release, User
 
 
 @method_decorator(login_required, name="dispatch")
@@ -185,12 +185,12 @@ class ProjectDetail(DetailView):
 
         repos = sorted(set(workspaces.values_list("repo", flat=True)))
 
-        releases = ["derp", "foo"]
+        releases_count = Release.objects.filter(workspace__project=self.object).count()
 
         return super().get_context_data(**kwargs) | {
             "can_manage_workspaces": can_manage_workspaces,
             "can_manage_members": can_manage_members,
-            "releases": releases,
+            "releases_count": releases_count,
             "repos": list(self.get_repos(repos)),
             "workspaces": workspaces,
         }

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -2,7 +2,7 @@ from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.views.generic import ListView, View
 
-from ..models import Project, Workspace
+from ..models import Project, Release, Workspace
 
 
 class Releases(View):
@@ -22,6 +22,31 @@ class Releases(View):
             request,
             "project_releases.html",
             context=context,
+        )
+
+
+class ProjectReleaseList(ListView):
+    template_name = "project_release_list.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        self.project = get_object_or_404(
+            Project,
+            org__slug=self.kwargs["org_slug"],
+            slug=self.kwargs["project_slug"],
+        )
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(**kwargs) | {
+            "project": self.project,
+        }
+
+    def get_queryset(self):
+        return (
+            Release.objects.filter(workspace__project=self.project)
+            .order_by("-created_at")
+            .select_related("workspace")
         )
 
 

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -1,8 +1,8 @@
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
-from django.views.generic import View
+from django.views.generic import ListView, View
 
-from ..models import Project
+from ..models import Project, Workspace
 
 
 class Releases(View):
@@ -23,3 +23,28 @@ class Releases(View):
             "project_releases.html",
             context=context,
         )
+
+
+class WorkspaceReleaseList(ListView):
+    template_name = "workspace_release_list.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        self.workspace = get_object_or_404(
+            Workspace,
+            project__org__slug=self.kwargs["org_slug"],
+            project__slug=self.kwargs["project_slug"],
+            name=self.kwargs["workspace_slug"],
+        )
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        files = sorted(self.workspace.latest_files(), key=lambda file: file.name)
+
+        return super().get_context_data(**kwargs) | {
+            "files": files,
+            "workspace": self.workspace,
+        }
+
+    def get_queryset(self):
+        return self.workspace.releases.order_by("-created_at")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -158,6 +158,7 @@ def ReleaseFactory(
     workspace=None,
     backend=None,
     backend_user="user",
+    created_at=None,
 ):
     """Factory for Release objects.
 
@@ -190,6 +191,11 @@ def ReleaseFactory(
     release, _ = releases.handle_release(
         workspace, backend, backend_user, upload.hash, upload.zip
     )
+
+    if created_at is not None:
+        release.created_at = created_at
+        release.save()
+
     return release
 
 

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -547,6 +547,21 @@ def test_project_get_invitation_url():
 
 
 @pytest.mark.django_db
+def test_project_get_releases_url():
+    project = ProjectFactory()
+
+    url = project.get_releases_url()
+
+    assert url == reverse(
+        "project-release-list",
+        kwargs={
+            "org_slug": project.org.slug,
+            "project_slug": project.slug,
+        },
+    )
+
+
+@pytest.mark.django_db
 def test_project_get_settings_url():
     org = OrgFactory(name="test-org")
     project = ProjectFactory(org=org)

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -884,6 +884,22 @@ def test_workspace_get_notifications_toggle_url():
 
 
 @pytest.mark.django_db
+def test_workspace_get_releases_url():
+    workspace = WorkspaceFactory()
+
+    url = workspace.get_releases_url()
+
+    assert url == reverse(
+        "workspace-release-list",
+        kwargs={
+            "org_slug": workspace.project.org.slug,
+            "project_slug": workspace.project.slug,
+            "workspace_slug": workspace.name,
+        },
+    )
+
+
+@pytest.mark.django_db
 def test_workspace_get_statuses_url():
     workspace = WorkspaceFactory()
     url = workspace.get_statuses_url()

--- a/tests/jobserver/views/test_releases.py
+++ b/tests/jobserver/views/test_releases.py
@@ -1,9 +1,12 @@
+from datetime import timedelta
+
 import pytest
 from django.http import Http404
+from django.utils import timezone
 
-from jobserver.views.releases import Releases
+from jobserver.views.releases import Releases, WorkspaceReleaseList
 
-from ...factories import OrgFactory, ProjectFactory
+from ...factories import OrgFactory, ProjectFactory, ReleaseFactory, WorkspaceFactory
 
 
 @pytest.mark.django_db
@@ -26,3 +29,60 @@ def test_releases_unknown_project(rf):
     request = rf.get("/")
     with pytest.raises(Http404):
         Releases.as_view()(request, org_slug=org.slug, project_slug="")
+
+
+@pytest.mark.django_db
+def test_workspacereleaselist_success(rf, freezer):
+    workspace = WorkspaceFactory()
+    release1 = ReleaseFactory(
+        workspace=workspace,
+        files=["test1", "test2"],
+        created_at=timezone.now() - timedelta(minutes=3),
+    )
+    release2 = ReleaseFactory(
+        workspace=workspace,
+        files=["test2", "test3"],
+        created_at=timezone.now() - timedelta(minutes=2),
+    )
+    release3 = ReleaseFactory(
+        workspace=workspace,
+        files=["test3", "test4"],
+        created_at=timezone.now() - timedelta(minutes=1),
+    )
+
+    request = rf.get("/")
+
+    response = WorkspaceReleaseList.as_view()(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+
+    assert response.context_data["workspace"] == workspace
+
+    assert response.context_data["files"][0].name == "test1"
+    assert response.context_data["files"][0].release == release1
+    assert response.context_data["files"][1].name == "test2"
+    assert response.context_data["files"][1].release == release2
+    assert response.context_data["files"][2].name == "test3"
+    assert response.context_data["files"][2].release == release3
+    assert response.context_data["files"][3].name == "test4"
+    assert response.context_data["files"][3].release == release3
+
+
+@pytest.mark.django_db
+def test_workspacereleaselist_unknown_workspace(rf):
+    project = ProjectFactory()
+
+    request = rf.get("/")
+
+    with pytest.raises(Http404):
+        WorkspaceReleaseList.as_view()(
+            request,
+            org_slug=project.org.slug,
+            project_slug=project.slug,
+            workspace_slug="",
+        )


### PR DESCRIPTION
This adds two new views listing Releases in their Workspace or Project contexts.  It includes a a function to get the latest version of each file, akin to a current working directory view for a Workspace, however the implementation of this is expected to potentially change as the current voyage proceeds.

**Workspace Files**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/p9uAY8QJ/5af32d31-d03a-4417-801c-a3b062f4d120.jpg?v=ed684793ba1d60cee344ae741cd24d78)

**Project Files**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/geug14OR/61694884-ac87-4d02-b60d-b2dbd6015849.jpg?v=2cc8a3cfef6e93e5fe7ee3f5dc05f6d2)

Fixes #654 