### PR TITLE
Add a Feature Flag for Release Pages

### DIFF
--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -113,6 +113,7 @@
           </ul>
         </div>
 
+        {% if can_use_releases %}
         <div class="mb-4">
           <h5>
             Releases
@@ -123,6 +124,7 @@
             View
           </a>
         </div>
+        {% endif %}
 
       </div>
 

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -49,7 +49,9 @@
       <h3>{{ workspace.name }}</h3>
 
       <div class="d-flex">
+        {% if can_use_releases %}
         <a class="btn btn-primary mr-2" href="{{ workspace.get_releases_url }}">Releases</a>
+        {% endif %}
         <a class="btn btn-primary mr-2" href="{{ workspace.get_logs_url }}">Logs</a>
         {% if show_details %}
         <a

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -11,9 +11,11 @@ from furl import furl
 from sentry_sdk import capture_exception
 
 from ..authorization import (
+    CoreDeveloper,
     ProjectCoordinator,
     ProjectDeveloper,
     has_permission,
+    has_role,
     roles_for,
 )
 from ..emails import send_project_invite_email
@@ -180,6 +182,7 @@ class ProjectDetail(DetailView):
             "manage_project_members",
             project=self.object,
         )
+        can_use_releases = has_role(self.request.user, CoreDeveloper)
 
         workspaces = self.object.workspaces.order_by("name")
 
@@ -190,6 +193,7 @@ class ProjectDetail(DetailView):
         return super().get_context_data(**kwargs) | {
             "can_manage_workspaces": can_manage_workspaces,
             "can_manage_members": can_manage_members,
+            "can_use_releases": can_use_releases,
             "releases_count": releases_count,
             "repos": list(self.get_repos(repos)),
             "workspaces": workspaces,

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -7,6 +7,7 @@ from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import CreateView, ListView, View
 
+from ..authorization import CoreDeveloper, has_role
 from ..backends import backends_to_choices
 from ..forms import (
     JobRequestCreateForm,
@@ -152,8 +153,11 @@ class WorkspaceDetail(CreateView):
         )
 
     def get_context_data(self, **kwargs):
+        can_use_releases = has_role(self.request.user, CoreDeveloper)
+
         context = super().get_context_data(**kwargs)
         context["actions"] = self.actions
+        context["can_use_releases"] = can_use_releases
         context["repo_is_private"] = self.get_repo_is_private()
         context["latest_job_request"] = self.get_latest_job_request()
         context["show_details"] = self.show_details


### PR DESCRIPTION
Releases are still being developed but we don't want to run a staging site or have a long running branch while developing them so this adds logic to remove links to them from the relevant pages.