### PR TITLE
Add a release management command for local dev:

### DIFF
--- a/jobserver/management/commands/release.py
+++ b/jobserver/management/commands/release.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+
+from jobserver.models import Backend, Workspace
+from jobserver.releases import create_upload_zip, handle_release
+
+
+class Command(BaseCommand):
+    help = "Configure admins to "
+
+    def add_arguments(self, parser):
+        parser.add_argument("workspace_name", help="worksapace name to release to")
+        parser.add_argument("backend_name", help="backend to release from")
+        parser.add_argument("directory", help="directory of files to release")
+
+    def handle(self, workspace_name, backend_name, directory, *args, **options):
+        try:
+            workspace = Workspace.objects.get(name=workspace_name)
+            backend = Backend.objects.get(name=backend_name)
+            release_hash, zipstream = create_upload_zip(Path(directory))
+            handle_release(workspace, backend, "local user", release_hash, zipstream)
+        except Exception as e:
+            print(str(e), file=sys.stderr)
+            sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ branch = true
 omit = [
   "jobserver/asgi.py",
   "jobserver/management/commands/ensure_admins.py",
+  "jobserver/management/commands/release.py",
   "jobserver/migrations/*",
   "jobserver/settings.py",
   "jobserver/wsgi.py",

--- a/tests/jobserver/test_releases.py
+++ b/tests/jobserver/test_releases.py
@@ -146,6 +146,7 @@ def test_hash_files(tmp_path):
         "foo.txt": "foo",
         "dir/bar.txt": "bar",
         "outputs/data.csv": "data",
+        "metadata/manifest.json": '{"foo":"bar"}',
     }
 
     for name, contents in files.items():
@@ -153,5 +154,6 @@ def test_hash_files(tmp_path):
         path.parent.mkdir(exist_ok=True, parents=True)
         path.write_text(contents)
 
-    release_hash, _ = hash_files(dirpath)
+    release_hash, release_files = hash_files(dirpath)
+    assert "metadata/manifest.json" not in release_files
     assert release_hash == "6c52ca16d696574e6ab5ece283eb3f3d"


### PR DESCRIPTION
Usage:

    python manage.py release <workspace> <backend> directory/

Involved a refactor of the ReleaseUploadFactory code to extract the zip-construction logic, including automatically generating a manifest.

Also, found and fixed a bug in the exclusion of MANIFEST_PATH from the release hash.