### PR TITLE
Add Outputs Page

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -790,6 +790,16 @@ class Workspace(models.Model):
             },
         )
 
+    def get_outputs_url(self):
+        return reverse(
+            "workspace-output-list",
+            kwargs={
+                "org_slug": self.project.org.slug,
+                "project_slug": self.project.slug,
+                "workspace_slug": self.name,
+            },
+        )
+
     def get_releases_url(self):
         return reverse(
             "workspace-release-list",

--- a/jobserver/models/outputs.py
+++ b/jobserver/models/outputs.py
@@ -89,7 +89,7 @@ class ReleaseFile(models.Model):
 
     def get_absolute_url(self):
         return reverse(
-            "release-detail-with-path",
+            "release-detail",
             kwargs={
                 "org_slug": self.release.workspace.project.org.slug,
                 "project_slug": self.release.workspace.project.slug,

--- a/jobserver/templates/outputs-spa.html
+++ b/jobserver/templates/outputs-spa.html
@@ -1,0 +1,4 @@
+<div>
+
+  <pre>Path: {{ path }}</pre>
+</div>

--- a/jobserver/templates/release_detail.html
+++ b/jobserver/templates/release_detail.html
@@ -36,8 +36,6 @@
   </ol>
 </nav>
 
-<div>
+{% include "outputs-spa.html" %}
 
-  <pre>Path: {{ path }}</pre>
-</div>
 {% endblock %}

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -50,6 +50,7 @@
 
       <div class="d-flex">
         {% if can_use_releases %}
+        <a class="btn btn-primary mr-2" href="{{ workspace.get_outputs_url }}">Outputs</a>
         <a class="btn btn-primary mr-2" href="{{ workspace.get_releases_url }}">Release History</a>
         {% endif %}
         <a class="btn btn-primary mr-2" href="{{ workspace.get_logs_url }}">Logs</a>

--- a/jobserver/templates/workspace_output_list.html
+++ b/jobserver/templates/workspace_output_list.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+
+    <li class="breadcrumb-item"><a href="/">Home</a></li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ workspace.project.org.get_absolute_url }}">
+        {{ workspace.project.org.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ workspace.project.get_absolute_url }}">
+        {{ workspace.project.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ workspace.get_absolute_url }}">
+        {{ workspace.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item active" aria-current="page">Outputs</li>
+
+  </ol>
+</nav>
+
+{% include "outputs-spa.html" %}
+
+{% endblock %}

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -60,6 +60,7 @@ from .views.workspaces import (
     WorkspaceDetail,
     WorkspaceLog,
     WorkspaceNotificationsToggle,
+    WorkspaceOutputList,
 )
 
 
@@ -121,6 +122,12 @@ workspace_urls = [
         "notifications-toggle/",
         WorkspaceNotificationsToggle.as_view(),
         name="workspace-notifications-toggle",
+    ),
+    path("outputs/", WorkspaceOutputList.as_view(), name="workspace-output-list"),
+    path(
+        "outputs/<path:path>",
+        WorkspaceOutputList.as_view(),
+        name="workspace-output-list",
     ),
     path(
         "releases/",

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -135,11 +135,7 @@ workspace_urls = [
         name="workspace-release-list",
     ),
     path("releases/<pk>/", ReleaseDetail.as_view(), name="release-detail"),
-    path(
-        "releases/<pk>/<path:path>",
-        ReleaseDetail.as_view(),
-        name="release-detail-with-path",
-    ),
+    path("releases/<pk>/<path:path>", ReleaseDetail.as_view(), name="release-detail"),
 ]
 
 project_urls = [

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -269,3 +269,32 @@ class WorkspaceNotificationsToggle(View):
         workspace.save()
 
         return redirect(workspace)
+
+
+class WorkspaceOutputList(View):
+    def get(self, request, *args, **kwargs):
+        """
+        Orchestrate viewing of a Release in the SPA
+
+        We consume two URLs with one view, because we want to both do
+        permissions checks on the Release but also load the SPA for any given
+        path under a Release.
+        """
+        workspace = get_object_or_404(
+            Workspace,
+            project__org__slug=self.kwargs["org_slug"],
+            project__slug=self.kwargs["project_slug"],
+            name=self.kwargs["workspace_slug"],
+        )
+
+        # TODO: check permissions here
+
+        context = {
+            "api_url": workspace.get_api_index_url(),
+            "workspace": workspace,
+        }
+        return TemplateResponse(
+            request,
+            "release_detail.html",
+            context=context,
+        )

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -295,6 +295,6 @@ class WorkspaceOutputList(View):
         }
         return TemplateResponse(
             request,
-            "release_detail.html",
+            "workspace_output_list.html",
             context=context,
         )

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -906,6 +906,22 @@ def test_workspace_get_notifications_toggle_url():
 
 
 @pytest.mark.django_db
+def test_workspace_get_outputs_url():
+    workspace = WorkspaceFactory()
+
+    url = workspace.get_outputs_url()
+
+    assert url == reverse(
+        "workspace-output-list",
+        kwargs={
+            "org_slug": workspace.project.org.slug,
+            "project_slug": workspace.project.slug,
+            "workspace_slug": workspace.name,
+        },
+    )
+
+
+@pytest.mark.django_db
 def test_workspace_get_releases_url():
     workspace = WorkspaceFactory()
 

--- a/tests/jobserver/models/test_outputs.py
+++ b/tests/jobserver/models/test_outputs.py
@@ -60,7 +60,7 @@ def test_releasefile_get_absolute_url():
     url = file.get_absolute_url()
 
     assert url == reverse(
-        "release-detail-with-path",
+        "release-detail",
         kwargs={
             "org_slug": release.workspace.project.org.slug,
             "project_slug": release.workspace.project.slug,

--- a/tests/jobserver/views/test_workspaces.py
+++ b/tests/jobserver/views/test_workspaces.py
@@ -13,6 +13,7 @@ from jobserver.views.workspaces import (
     WorkspaceDetail,
     WorkspaceLog,
     WorkspaceNotificationsToggle,
+    WorkspaceOutputList,
 )
 
 from ...factories import (
@@ -770,4 +771,35 @@ def test_workspacenotificationstoggle_unknown_workspace(rf, user):
     with pytest.raises(Http404):
         WorkspaceNotificationsToggle.as_view()(
             request, org_slug=org.slug, project_slug=project.slug, workspace_slug="test"
+        )
+
+
+@pytest.mark.django_db
+def test_workspaceoutputlist_success(rf):
+    workspace = WorkspaceFactory()
+
+    request = rf.get("/")
+
+    response = WorkspaceOutputList.as_view()(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_workspaceoutputs_unknown_workspace(rf):
+    project = ProjectFactory()
+
+    request = rf.get("/")
+
+    with pytest.raises(Http404):
+        WorkspaceOutputList.as_view()(
+            request,
+            org_slug=project.org.slug,
+            project_slug=project.slug,
+            workspace_slug="",
         )


### PR DESCRIPTION
This adds a new entrypoint to the SPA, the "outputs" page, our meta view showing the latest version of each file across all releases.

I've pulled the SPA template out into an include so we can use it in two different contexts and not complicate the breadcrumb construction.

Fixes #663 