### PR TITLE
Namespace API URLs

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -811,10 +811,13 @@ class Workspace(models.Model):
         )
 
     def get_api_index_url(self):
-        return reverse("workspace-release-index", kwargs={"workspace_name": self.name})
+        return reverse(
+            "api:workspace-release-index",
+            kwargs={"workspace_name": self.name},
+        )
 
     def get_statuses_url(self):
-        return reverse("workspace-statuses", kwargs={"name": self.name})
+        return reverse("api:workspace-statuses", kwargs={"name": self.name})
 
     def get_action_status_lut(self, backend=None):
         """

--- a/jobserver/models/outputs.py
+++ b/jobserver/models/outputs.py
@@ -54,7 +54,7 @@ class Release(models.Model):
         )
 
     def get_api_index_url(self):
-        return reverse("release-index", kwargs={"release_hash": self.id})
+        return reverse("api:release-index", kwargs={"release_hash": self.id})
 
     @property
     def manifest(self):
@@ -102,7 +102,7 @@ class ReleaseFile(models.Model):
     def get_api_url(self):
         """The API url that will serve up this file."""
         return reverse(
-            "release-file",
+            "api:release-file",
             kwargs={
                 "release_hash": self.release.id,
                 "filename": self.name,

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -168,7 +168,7 @@ urlpatterns = [
     path("favicon.ico", RedirectView.as_view(url=settings.STATIC_URL + "favicon.ico")),
     path("admin/approve-users", ApproveUsers.as_view(), name="approve-users"),
     path("admin/", admin.site.urls),
-    path("api/v2/", include(api_urls)),
+    path("api/v2/", include((api_urls, "api"))),
     path("backends/", include(backend_urls)),
     path("jobs/", JobRequestList.as_view(), name="job-list"),
     path("job-requests/", RedirectView.as_view(pattern_name="job-list")),

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -1,18 +1,3 @@
-"""jobserver URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/3.0/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
 import debug_toolbar
 from django.conf import settings
 from django.contrib import admin

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -51,7 +51,9 @@ class ReleaseDetail(View):
         # TODO: check permissions here
 
         context = {
-            "api_url": reverse("release-index", kwargs={"release_hash": release.id}),
+            "api_url": reverse(
+                "api:release-index", kwargs={"release_hash": release.id}
+            ),
             "release": release,
         }
         return TemplateResponse(

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -941,7 +941,7 @@ def test_workspace_get_releases_url():
 def test_workspace_get_statuses_url():
     workspace = WorkspaceFactory()
     url = workspace.get_statuses_url()
-    assert url == reverse("workspace-statuses", kwargs={"name": workspace.name})
+    assert url == reverse("api:workspace-statuses", kwargs={"name": workspace.name})
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This puts the API URL names under the `api` namespace.

Fixes #664 