### PR TITLE
Add <time>_ago Helper Functions

### DIFF
--- a/tests/jobserver/api/test_jobs.py
+++ b/tests/jobserver/api/test_jobs.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 import pytest
 from django.utils import timezone
 from rest_framework.exceptions import NotAuthenticated
@@ -26,7 +24,7 @@ from tests.factories import (
     UserFactory,
     WorkspaceFactory,
 )
-from tests.utils import minutes_ago
+from tests.utils import minutes_ago, seconds_ago
 
 
 def test_token_backend_empty_token():
@@ -115,7 +113,7 @@ def test_jobapiupdate_all_existing(api_rf, freezer):
             "created_at": minutes_ago(now, 2),
             "started_at": minutes_ago(now, 1),
             "updated_at": now,
-            "completed_at": now - timedelta(seconds=30),
+            "completed_at": seconds_ago(now, 30),
         },
         {
             "identifier": "job2",
@@ -161,7 +159,7 @@ def test_jobapiupdate_all_existing(api_rf, freezer):
     assert job1.identifier == "job1"
     assert job1.started_at == minutes_ago(now, 1)
     assert job1.updated_at == now
-    assert job1.completed_at == now - timedelta(seconds=30)
+    assert job1.completed_at == seconds_ago(now, 30)
 
     # running
     assert job2.identifier == "job2"
@@ -299,7 +297,7 @@ def test_jobapiupdate_mixture(api_rf, freezer):
             "created_at": minutes_ago(now, 2),
             "started_at": minutes_ago(now, 1),
             "updated_at": now,
-            "completed_at": now - timedelta(seconds=30),
+            "completed_at": seconds_ago(now, 30),
         },
         {
             "identifier": "job3",
@@ -334,7 +332,7 @@ def test_jobapiupdate_mixture(api_rf, freezer):
     assert job2.identifier == "job2"
     assert job2.started_at == minutes_ago(now, 1)
     assert job2.updated_at == now
-    assert job2.completed_at == now - timedelta(seconds=30)
+    assert job2.completed_at == seconds_ago(now, 30)
 
     # running
     assert job3.pk != job1.pk
@@ -368,7 +366,7 @@ def test_jobapiupdate_notifications_on_with_move_to_completed(api_rf, mocker):
             "created_at": minutes_ago(now, 2),
             "started_at": minutes_ago(now, 1),
             "updated_at": now,
-            "completed_at": now - timedelta(seconds=30),
+            "completed_at": seconds_ago(now, 30),
         },
     ]
     request = api_rf.post(
@@ -407,7 +405,7 @@ def test_jobapiupdate_notifications_on_without_move_to_completed(api_rf, mocker)
             "created_at": minutes_ago(now, 2),
             "started_at": minutes_ago(now, 1),
             "updated_at": now,
-            "completed_at": now - timedelta(seconds=30),
+            "completed_at": seconds_ago(now, 30),
         },
     ]
     request = api_rf.post(

--- a/tests/jobserver/api/test_jobs.py
+++ b/tests/jobserver/api/test_jobs.py
@@ -26,6 +26,7 @@ from tests.factories import (
     UserFactory,
     WorkspaceFactory,
 )
+from tests.utils import minutes_ago
 
 
 def test_token_backend_empty_token():
@@ -82,6 +83,8 @@ def test_jobapiupdate_all_existing(api_rf, freezer):
     backend = BackendFactory()
     job_request = JobRequestFactory()
 
+    now = timezone.now()
+
     # 3 pending jobs already exist
     job1, job2, job3, = JobFactory.create_batch(
         3,
@@ -109,10 +112,10 @@ def test_jobapiupdate_all_existing(api_rf, freezer):
             "status": "succeeded",
             "status_code": "",
             "status_message": "",
-            "created_at": timezone.now() - timedelta(minutes=2),
-            "started_at": timezone.now() - timedelta(minutes=1),
-            "updated_at": timezone.now(),
-            "completed_at": timezone.now() - timedelta(seconds=30),
+            "created_at": minutes_ago(now, 2),
+            "started_at": minutes_ago(now, 1),
+            "updated_at": now,
+            "completed_at": now - timedelta(seconds=30),
         },
         {
             "identifier": "job2",
@@ -121,9 +124,9 @@ def test_jobapiupdate_all_existing(api_rf, freezer):
             "status": "running",
             "status_code": "",
             "status_message": "",
-            "created_at": timezone.now() - timedelta(minutes=2),
-            "started_at": timezone.now() - timedelta(minutes=1),
-            "updated_at": timezone.now(),
+            "created_at": minutes_ago(now, 2),
+            "started_at": minutes_ago(now, 1),
+            "updated_at": now,
             "completed_at": None,
         },
         {
@@ -133,9 +136,9 @@ def test_jobapiupdate_all_existing(api_rf, freezer):
             "status": "pending",
             "status_code": "",
             "status_message": "",
-            "created_at": timezone.now() - timedelta(minutes=2),
+            "created_at": minutes_ago(now, 2),
             "started_at": None,
-            "updated_at": timezone.now(),
+            "updated_at": now,
             "completed_at": None,
         },
     ]
@@ -156,20 +159,20 @@ def test_jobapiupdate_all_existing(api_rf, freezer):
 
     # succeeded
     assert job1.identifier == "job1"
-    assert job1.started_at == timezone.now() - timedelta(minutes=1)
-    assert job1.updated_at == timezone.now()
-    assert job1.completed_at == timezone.now() - timedelta(seconds=30)
+    assert job1.started_at == minutes_ago(now, 1)
+    assert job1.updated_at == now
+    assert job1.completed_at == now - timedelta(seconds=30)
 
     # running
     assert job2.identifier == "job2"
-    assert job2.started_at == timezone.now() - timedelta(minutes=1)
-    assert job2.updated_at == timezone.now()
+    assert job2.started_at == minutes_ago(now, 1)
+    assert job2.updated_at == now
     assert job2.completed_at is None
 
     # pending
     assert job3.identifier == "job3"
     assert job3.started_at is None
-    assert job3.updated_at == timezone.now()
+    assert job3.updated_at == now
     assert job3.completed_at is None
 
 
@@ -177,6 +180,8 @@ def test_jobapiupdate_all_existing(api_rf, freezer):
 def test_jobapiupdate_all_new(api_rf):
     backend = BackendFactory()
     job_request = JobRequestFactory()
+
+    now = timezone.now()
 
     assert Job.objects.count() == 0
 
@@ -188,9 +193,9 @@ def test_jobapiupdate_all_new(api_rf):
             "status": "running",
             "status_code": "",
             "status_message": "",
-            "created_at": timezone.now() - timedelta(minutes=2),
-            "started_at": timezone.now() - timedelta(minutes=1),
-            "updated_at": timezone.now(),
+            "created_at": minutes_ago(now, 2),
+            "started_at": minutes_ago(now, 1),
+            "updated_at": now,
             "completed_at": None,
         },
         {
@@ -200,8 +205,8 @@ def test_jobapiupdate_all_new(api_rf):
             "status": "pending",
             "status_code": "",
             "status_message": "",
-            "created_at": timezone.now() - timedelta(minutes=2),
-            "updated_at": timezone.now(),
+            "created_at": minutes_ago(now, 2),
+            "updated_at": now,
             "started_at": None,
             "completed_at": None,
         },
@@ -212,9 +217,9 @@ def test_jobapiupdate_all_new(api_rf):
             "status": "running",
             "status_code": "",
             "status_message": "",
-            "created_at": timezone.now() - timedelta(minutes=2),
+            "created_at": minutes_ago(now, 2),
             "started_at": None,
-            "updated_at": timezone.now(),
+            "updated_at": now,
             "completed_at": None,
         },
     ]
@@ -262,6 +267,8 @@ def test_jobapiupdate_mixture(api_rf, freezer):
     backend = BackendFactory()
     job_request = JobRequestFactory()
 
+    now = timezone.now()
+
     # pending
     job1 = JobFactory(
         job_request=job_request,
@@ -289,10 +296,10 @@ def test_jobapiupdate_mixture(api_rf, freezer):
             "status": "succeeded",
             "status_code": "",
             "status_message": "",
-            "created_at": timezone.now() - timedelta(minutes=2),
-            "started_at": timezone.now() - timedelta(minutes=1),
-            "updated_at": timezone.now(),
-            "completed_at": timezone.now() - timedelta(seconds=30),
+            "created_at": minutes_ago(now, 2),
+            "started_at": minutes_ago(now, 1),
+            "updated_at": now,
+            "completed_at": now - timedelta(seconds=30),
         },
         {
             "identifier": "job3",
@@ -301,9 +308,9 @@ def test_jobapiupdate_mixture(api_rf, freezer):
             "status": "running",
             "status_code": "",
             "status_message": "",
-            "created_at": timezone.now() - timedelta(minutes=2),
-            "started_at": timezone.now() - timedelta(minutes=1),
-            "updated_at": timezone.now(),
+            "created_at": minutes_ago(now, 2),
+            "started_at": minutes_ago(now, 1),
+            "updated_at": now,
             "completed_at": None,
         },
     ]
@@ -325,16 +332,16 @@ def test_jobapiupdate_mixture(api_rf, freezer):
     # succeeded
     assert job2.pk == job2.pk
     assert job2.identifier == "job2"
-    assert job2.started_at == timezone.now() - timedelta(minutes=1)
-    assert job2.updated_at == timezone.now()
-    assert job2.completed_at == timezone.now() - timedelta(seconds=30)
+    assert job2.started_at == minutes_ago(now, 1)
+    assert job2.updated_at == now
+    assert job2.completed_at == now - timedelta(seconds=30)
 
     # running
     assert job3.pk != job1.pk
     assert job3.pk != job2.pk
     assert job3.identifier == "job3"
-    assert job3.started_at == timezone.now() - timedelta(minutes=1)
-    assert job3.updated_at == timezone.now()
+    assert job3.started_at == minutes_ago(now, 1)
+    assert job3.updated_at == now
     assert job3.completed_at is None
 
 
@@ -343,6 +350,8 @@ def test_jobapiupdate_notifications_on_with_move_to_completed(api_rf, mocker):
     workspace = WorkspaceFactory()
     job_request = JobRequestFactory(workspace=workspace, will_notify=True)
     job = JobFactory(job_request=job_request, status="running")
+
+    now = timezone.now()
 
     mocked_send = mocker.patch(
         "jobserver.api.jobs.send_finished_notification", autospec=True
@@ -356,10 +365,10 @@ def test_jobapiupdate_notifications_on_with_move_to_completed(api_rf, mocker):
             "status": "succeeded",
             "status_code": "",
             "status_message": "",
-            "created_at": timezone.now() - timedelta(minutes=2),
-            "started_at": timezone.now() - timedelta(minutes=1),
-            "updated_at": timezone.now(),
-            "completed_at": timezone.now() - timedelta(seconds=30),
+            "created_at": minutes_ago(now, 2),
+            "started_at": minutes_ago(now, 1),
+            "updated_at": now,
+            "completed_at": now - timedelta(seconds=30),
         },
     ]
     request = api_rf.post(
@@ -381,6 +390,8 @@ def test_jobapiupdate_notifications_on_without_move_to_completed(api_rf, mocker)
     job_request = JobRequestFactory(workspace=workspace, will_notify=True)
     job = JobFactory(job_request=job_request, status="succeeded")
 
+    now = timezone.now()
+
     mocked_send = mocker.patch(
         "jobserver.api.jobs.send_finished_notification", autospec=True
     )
@@ -393,10 +404,10 @@ def test_jobapiupdate_notifications_on_without_move_to_completed(api_rf, mocker)
             "status": "succeeded",
             "status_code": "",
             "status_message": "",
-            "created_at": timezone.now() - timedelta(minutes=2),
-            "started_at": timezone.now() - timedelta(minutes=1),
-            "updated_at": timezone.now(),
-            "completed_at": timezone.now() - timedelta(seconds=30),
+            "created_at": minutes_ago(now, 2),
+            "started_at": minutes_ago(now, 1),
+            "updated_at": now,
+            "completed_at": now - timedelta(seconds=30),
         },
     ]
     request = api_rf.post(
@@ -438,6 +449,8 @@ def test_jobapiupdate_unknown_job_request(api_rf):
     backend = BackendFactory()
     JobRequestFactory()
 
+    now = timezone.now()
+
     data = [
         {
             "identifier": "job1",
@@ -446,9 +459,9 @@ def test_jobapiupdate_unknown_job_request(api_rf):
             "status": "running",
             "status_code": "",
             "status_message": "",
-            "created_at": timezone.now() - timedelta(minutes=2),
-            "started_at": timezone.now() - timedelta(minutes=1),
-            "updated_at": timezone.now(),
+            "created_at": minutes_ago(now, 2),
+            "started_at": minutes_ago(now, 1),
+            "updated_at": now,
             "completed_at": None,
         }
     ]

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -33,7 +33,7 @@ from ...factories import (
     UserFactory,
     WorkspaceFactory,
 )
-from ...utils import minutes_ago
+from ...utils import minutes_ago, seconds_ago
 
 
 @pytest.mark.django_db
@@ -317,7 +317,7 @@ def test_jobrequest_runtime_not_completed(freezer):
     JobFactory(
         job_request=job_request,
         status="running",
-        started_at=now - timedelta(seconds=30),
+        started_at=seconds_ago(now, 30),
     )
 
     jr = JobRequest.objects.prefetch_related("jobs").get(pk=job_request.pk)

--- a/tests/jobserver/test_backends.py
+++ b/tests/jobserver/test_backends.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 import pytest
 from django.utils import timezone
 
@@ -10,6 +8,7 @@ from jobserver.backends import (
 )
 
 from ..factories import BackendFactory
+from ..utils import minutes_ago
 
 
 @pytest.mark.django_db
@@ -56,15 +55,15 @@ def test_show_warning_last_seen_is_none():
 
 
 def test_show_warning_last_seen_equal_threhold(freezer):
-    last_seen = timezone.now() - timedelta(minutes=3)
+    last_seen = minutes_ago(timezone.now(), 3)
     assert show_warning(last_seen, minutes=3) is True
 
 
 def test_show_warning_last_seen_less_than_threhold(freezer):
-    last_seen = timezone.now() - timedelta(minutes=2)
+    last_seen = minutes_ago(timezone.now(), 2)
     assert show_warning(last_seen, minutes=3) is False
 
 
 def test_show_warning_success(freezer):
-    last_seen = timezone.now() - timedelta(minutes=6)
+    last_seen = minutes_ago(timezone.now(), 6)
     assert show_warning(last_seen) is True

--- a/tests/jobserver/test_context_processors.py
+++ b/tests/jobserver/test_context_processors.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 import pytest
 from django.urls import reverse
 from django.utils import timezone
@@ -8,6 +6,7 @@ from jobserver.context_processors import backend_warnings, nav, scripts_attrs
 from jobserver.models import Backend
 
 from ..factories import JobRequestFactory, StatsFactory, UserFactory
+from ..utils import minutes_ago
 
 
 @pytest.mark.django_db
@@ -19,7 +18,7 @@ def test_backend_warnings_with_debug_on(rf, settings):
 
     JobRequestFactory(backend=tpp)
 
-    last_seen = timezone.now() - timedelta(minutes=10)
+    last_seen = minutes_ago(timezone.now(), 10)
     StatsFactory(backend=tpp, api_last_seen=last_seen)
 
     request = rf.get("/")
@@ -32,7 +31,7 @@ def test_backend_warnings_with_debug_on(rf, settings):
 def test_backend_warnings_with_no_warnings(rf):
     tpp = Backend.objects.get(name="tpp")
 
-    last_seen = timezone.now() - timedelta(minutes=1)
+    last_seen = minutes_ago(timezone.now(), 1)
     StatsFactory(backend=tpp, api_last_seen=last_seen)
 
     request = rf.get("/")
@@ -47,7 +46,7 @@ def test_backend_warnings_with_warnings(rf):
 
     JobRequestFactory(backend=tpp)
 
-    last_seen = timezone.now() - timedelta(minutes=10)
+    last_seen = minutes_ago(timezone.now(), 10)
     StatsFactory(backend=tpp, api_last_seen=last_seen)
 
     request = rf.get("/")

--- a/tests/jobserver/test_releases.py
+++ b/tests/jobserver/test_releases.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 import pytest
 from django.conf import settings
 from django.db import DatabaseError
@@ -14,6 +12,7 @@ from ..factories import (
     ReleaseUploadFactory,
     WorkspaceFactory,
 )
+from ..utils import minutes_ago
 
 
 def raise_error(**kwargs):
@@ -194,45 +193,42 @@ def test_workspace_files_many_releases(freezer):
     backend2 = BackendFactory(name="backend2")
     workspace = WorkspaceFactory()
 
-    def minutes_ago(minutes):
-        return now - timedelta(minutes=minutes)
-
     ReleaseFactory(
         workspace=workspace,
         backend=backend1,
         files=["test1", "test2", "test3"],
-        created_at=minutes_ago(10),
+        created_at=minutes_ago(now, 10),
     )
     ReleaseFactory(
         workspace=workspace,
         backend=backend1,
         files=["test2", "test3"],
-        created_at=minutes_ago(8),
+        created_at=minutes_ago(now, 8),
     )
     release3 = ReleaseFactory(
         workspace=workspace,
         backend=backend1,
         files=["test2"],
-        created_at=minutes_ago(6),
+        created_at=minutes_ago(now, 6),
     )
     release4 = ReleaseFactory(
         workspace=workspace,
         backend=backend1,
         files=["test1", "test3"],
-        created_at=minutes_ago(4),
+        created_at=minutes_ago(now, 4),
     )
     release5 = ReleaseFactory(
         workspace=workspace,
         backend=backend1,
         files=["test1"],
-        created_at=minutes_ago(2),
+        created_at=minutes_ago(now, 2),
     )
     # different backend, same file name, more recent
     release6 = ReleaseFactory(
         workspace=workspace,
         backend=backend2,
         files={"test1": "content"},
-        created_at=minutes_ago(1),
+        created_at=minutes_ago(now, 1),
     )
 
     output = workspace_files(workspace)

--- a/tests/jobserver/views/test_status.py
+++ b/tests/jobserver/views/test_status.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 import pytest
 from django.utils import timezone
 from first import first
@@ -8,6 +6,7 @@ from jobserver.models import Backend
 from jobserver.views.status import Status
 
 from ...factories import JobFactory, JobRequestFactory, StatsFactory
+from ...utils import minutes_ago
 
 
 MEANINGLESS_URL = "/"
@@ -20,7 +19,7 @@ def test_status_healthy(rf):
     # acked, because JobFactory will implicitly create JobRequests
     JobFactory.create_batch(3, job_request__backend=tpp)
 
-    last_seen = timezone.now() - timedelta(minutes=1)
+    last_seen = minutes_ago(timezone.now(), 1)
     StatsFactory(backend=tpp, api_last_seen=last_seen)
 
     request = rf.get(MEANINGLESS_URL)
@@ -53,7 +52,7 @@ def test_status_no_last_seen(rf):
 def test_status_unacked_jobs_but_recent_api_contact(rf):
     tpp = Backend.objects.get(name="tpp")
 
-    last_seen = timezone.now() - timedelta(minutes=1)
+    last_seen = minutes_ago(timezone.now(), 1)
     StatsFactory(backend=tpp, api_last_seen=last_seen)
 
     request = rf.get(MEANINGLESS_URL)
@@ -78,7 +77,7 @@ def test_status_unhealthy(rf):
     # unacked, because it has no Jobs
     JobRequestFactory(backend=tpp)
 
-    last_seen = timezone.now() - timedelta(minutes=10)
+    last_seen = minutes_ago(timezone.now(), 10)
     StatsFactory(backend=tpp, api_last_seen=last_seen, url="foo")
 
     request = rf.get(MEANINGLESS_URL)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,3 +3,7 @@ from datetime import timedelta
 
 def minutes_ago(now, minutes):
     return now - timedelta(minutes=minutes)
+
+
+def seconds_ago(now, seconds):
+    return now - timedelta(seconds=seconds)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,5 @@
+from datetime import timedelta
+
+
+def minutes_ago(now, minutes):
+    return now - timedelta(minutes=minutes)


### PR DESCRIPTION
This pulls the `minutes_ago` function out of a test function and into a utils module, applying it everywhere we can.  It also adds `seconds_ago` since we were also doing that in various places.

Fixes #669 