### PR TITLE
Fix User Detail Form

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -130,9 +130,7 @@ class SettingsForm(forms.ModelForm):
 
 
 class UserForm(RolesForm):
-    is_superuser = forms.TypedChoiceField(
-        coerce=bool, empty_value=False, required=False
-    )
+    is_superuser = forms.BooleanField(required=False)
 
     def __init__(self, *, available_backends, **kwargs):
         super().__init__(**kwargs)

--- a/jobserver/templates/user_detail.html
+++ b/jobserver/templates/user_detail.html
@@ -155,7 +155,6 @@
             class="custom-control-input"
             id="id_is_superuser"
             name="is_superuser"
-            value="{{ form.is_superuser.value }}"
             {% if form.is_superuser.value %}
             checked
             {% endif %}

--- a/jobserver/templates/user_detail.html
+++ b/jobserver/templates/user_detail.html
@@ -165,6 +165,15 @@
               Should <strong>{{ user.username }}</strong> have access to the Django Admin?
             </span>
           </label>
+
+          {% if form.is_superuser.errors %}
+          <ul class="pl-3 mb-1">
+            {% for error in form.is_superuser.errors %}
+            <li class="text-danger">{{ error }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+
         </div>
       </div>
 

--- a/tests/jobserver/test_forms.py
+++ b/tests/jobserver/test_forms.py
@@ -35,6 +35,7 @@ def test_userform_success():
 
     data = {
         "backends": ["emis", "tpp"],
+        "is_superuser": ["on"],
         "roles": [],
     }
 
@@ -52,6 +53,8 @@ def test_userform_success():
     )
     assert output == expected
 
+    assert form.cleaned_data["is_superuser"]
+
 
 @pytest.mark.django_db
 def test_userform_with_no_backends():
@@ -59,6 +62,7 @@ def test_userform_with_no_backends():
 
     data = {
         "backends": [],
+        "is_superuser": ["on"],
         "roles": [],
     }
 
@@ -78,6 +82,7 @@ def test_userform_with_unknown_backend():
 
     data = {
         "backends": ["emis", "tpp", "unknown"],
+        "is_superuser": [""],
         "roles": [],
     }
 

--- a/tests/jobserver/views/test_users.py
+++ b/tests/jobserver/views/test_users.py
@@ -112,6 +112,7 @@ def test_userdetail_post_success(rf, core_developer):
 
     data = {
         "backends": ["test"],
+        "is_superuser": ["on"],
         "roles": ["jobserver.authorization.roles.OutputPublisher"],
     }
     request = rf.post("/", data)
@@ -123,8 +124,9 @@ def test_userdetail_post_success(rf, core_developer):
     assert response.url == user.get_absolute_url()
 
     user.refresh_from_db()
-    assert user.roles == [OutputPublisher]
     assert list(user.backends.values_list("name", flat=True)) == ["test"]
+    assert user.roles == [OutputPublisher]
+    assert user.is_superuser
 
 
 @pytest.mark.django_db
@@ -147,6 +149,7 @@ def test_userdetail_post_with_unknown_backend(rf, core_developer):
 
     data = {
         "backends": ["not-a-real-backend"],
+        "is_superuser": [""],
         "roles": ["jobserver.authorization.roles.OutputPublisher"],
     }
     request = rf.post("/", data)
@@ -192,6 +195,7 @@ def test_userdetail_post_with_unknown_role(rf, core_developer):
 
     data = {
         "backends": ["test", "tpp"],
+        "is_superuser": ["on"],
         "roles": ["not-a-real-role"],
     }
     request = rf.post("/", data)


### PR DESCRIPTION
This fixes the form on the UserDetail page by 1) tell us there was a problem by rendering the error and 2) use an appropriate form field for a boolean.