### PR TITLE
List Outputs on Project page

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -96,6 +96,24 @@ def validate_release_access(request, workspace):
         raise NotAuthenticated(f"Invalid user or token for workspace {workspace.name}")
 
 
+def validate_snapshot_access(request, snapshot):
+    """
+    Validate this request can access this snapshot.
+
+    This validation uses Django's regular User auth.
+    """
+    if snapshot.published_at:
+        return
+
+    if request.user.is_anonymous:
+        raise NotAuthenticated("Invalid user or token")
+
+    if not has_permission(
+        request.user, "view_release_file", project=snapshot.workspace.project
+    ):
+        raise NotAuthenticated(f"Invalid user or token for snapshot pk={snapshot.pk}")
+
+
 def generate_index(files):
     """Generate a JSON list of files as expected by the SPA."""
 
@@ -226,7 +244,7 @@ class SnapshotAPI(APIView):
             pk=self.kwargs["snapshot_id"],
         )
 
-        validate_release_access(request, snapshot.workspace)
+        validate_snapshot_access(request, snapshot)
         files = {f.name: f for f in snapshot.files.all()}
 
         return Response(generate_index(files))

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -115,14 +115,17 @@
 
         {% if can_use_releases %}
         <div class="mb-4">
-          <h5>
-            Releases
-            <small>({{ releases_count }} files)</small>
-          </h5>
+          <h5>Outputs</h5>
 
-          <a class="btn btn-primary btn-sm" href="{{ project.get_releases_url }}">
-            View
-          </a>
+          <ul class="list-unstyled">
+            {% for snapshot in outputs %}
+            <li>
+              <a class="mr-3" href="{{ snapshot.get_absolute_url }}">
+                Published on {{ snapshot.created_at|date:"Y-m-d" }}
+              </a>
+            </li>
+            {% endfor %}
+          </ul>
         </div>
         {% endif %}
 

--- a/jobserver/templates/workspace_output_list.html
+++ b/jobserver/templates/workspace_output_list.html
@@ -56,7 +56,7 @@
         <div>
           <a class="mr-3" href="{{ snapshot.get_absolute_url }}">
             {% if user_can_view_all_files %}Created{% else %}Published{% endif %}
-            on {{ snapshot.created_at|date:"D-m-d" }} by {{ snapshot.created_by.name }}
+            on {{ snapshot.created_at|date:"Y-m-d" }} by {{ snapshot.created_by.name }}
           </a>
           {% if user_can_view_all_files %}
           <span class="badge badge-secondary">

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -73,9 +73,11 @@ class SnapshotDetail(View):
             pk=self.kwargs["pk"],
         )
 
-        if not has_permission(
+        has_permission_to_view = has_permission(
             request.user, "view_release_file", project=snapshot.workspace.project
-        ):
+        )
+        is_published = snapshot.published_at is not None
+        if not (is_published or has_permission_to_view):
             raise Http404
 
         context = {


### PR DESCRIPTION
This adds a list of outputs to the ProjectDetail page.  It only takes the most recent published version from each Workspace.  Each output links to the same entry point used on the Workspace's Outputs page.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/2NuqOB5l/28aa08ca-7b6e-40c0-90df-4a27661b132a.jpg?v=e2f06b21c55b7d763b6ac0069382bbf7)

Fixes #702 