### PR TITLE
Open Published Snapshots to the Public

### DIFF
--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -110,9 +110,11 @@ class SnapshotDetail(View):
             pk=self.kwargs["pk"],
         )
 
-        if not has_permission(
+        has_permission_to_view = has_permission(
             request.user, "view_release_file", project=snapshot.workspace.project
-        ):
+        )
+        is_published = snapshot.published_at is not None
+        if not (is_published or has_permission_to_view):
             raise Http404
 
         context = {

--- a/tests/jobserver/api/test_releases.py
+++ b/tests/jobserver/api/test_releases.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from django.utils import timezone
 from rest_framework.test import APIClient
 from slack_sdk.errors import SlackApiError
 
@@ -596,8 +597,46 @@ def test_release_file_api_file_deleted():
 
 
 @pytest.mark.django_db
-def test_snapshot_api_anonymous():
-    snapshot = SnapshotFactory()
+def test_snapshot_api_published_anonymous(freezer):
+    snapshot = SnapshotFactory(published_at=timezone.now())
+
+    client = APIClient()
+    response = client.get(f"/api/v2/releases/snapshot/{snapshot.pk}")
+
+    assert response.status_code == 200
+    assert response.data == {"files": []}
+
+
+@pytest.mark.django_db
+def test_snapshot_api_published_no_permission():
+    snapshot = SnapshotFactory(published_at=timezone.now())
+
+    client = APIClient()
+    # logged in, but no permission
+    client.force_authenticate(user=UserFactory())
+
+    response = client.get(f"/api/v2/releases/snapshot/{snapshot.pk}")
+
+    assert response.status_code == 200
+    assert response.data == {"files": []}
+
+
+@pytest.mark.django_db
+def test_snapshot_api_published_with_permission():
+    snapshot = SnapshotFactory(published_at=timezone.now())
+
+    client = APIClient()
+    client.force_authenticate(user=UserFactory(roles=[ProjectCollaborator]))
+
+    response = client.get(f"/api/v2/releases/snapshot/{snapshot.pk}")
+
+    assert response.status_code == 200
+    assert response.data == {"files": []}
+
+
+@pytest.mark.django_db
+def test_snapshot_api_unpublished_anonymous():
+    snapshot = SnapshotFactory(published_at=None)
 
     client = APIClient()
     response = client.get(f"/api/v2/releases/snapshot/{snapshot.pk}")
@@ -606,8 +645,8 @@ def test_snapshot_api_anonymous():
 
 
 @pytest.mark.django_db
-def test_snapshot_api_no_permission():
-    snapshot = SnapshotFactory()
+def test_snapshot_api_unpublished_no_permission():
+    snapshot = SnapshotFactory(published_at=None)
 
     client = APIClient()
     # logged in, but no permission
@@ -619,13 +658,12 @@ def test_snapshot_api_no_permission():
 
 
 @pytest.mark.django_db
-def test_snapshot_api_success():
-    snapshot = SnapshotFactory()
+def test_snapshot_api_unpublished_with_permission():
+    snapshot = SnapshotFactory(published_at=None)
 
     client = APIClient()
     client.force_authenticate(user=UserFactory(roles=[ProjectCollaborator]))
 
     response = client.get(f"/api/v2/releases/snapshot/{snapshot.pk}")
-
     assert response.status_code == 200
     assert response.data == {"files": []}

--- a/tests/jobserver/views/test_releases.py
+++ b/tests/jobserver/views/test_releases.py
@@ -1,6 +1,8 @@
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.http import Http404
+from django.utils import timezone
 
 from jobserver.authorization import OutputPublisher, ProjectCollaborator
 from jobserver.views.releases import (
@@ -249,8 +251,26 @@ def test_snapshotcreate_without_permission(rf):
 
 
 @pytest.mark.django_db
-def test_snapshotdetail_success(rf):
-    snapshot = SnapshotFactory()
+def test_snapshotdetail_published_logged_out(rf):
+    snapshot = SnapshotFactory(published_at=timezone.now())
+
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    response = SnapshotDetail.as_view()(
+        request,
+        org_slug=snapshot.workspace.project.org.slug,
+        project_slug=snapshot.workspace.project.slug,
+        workspace_slug=snapshot.workspace.name,
+        pk=snapshot.pk,
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_snapshotdetail_published_with_permission(rf):
+    snapshot = SnapshotFactory(published_at=timezone.now())
 
     request = rf.get("/")
     request.user = UserFactory(roles=[ProjectCollaborator])
@@ -267,8 +287,44 @@ def test_snapshotdetail_success(rf):
 
 
 @pytest.mark.django_db
-def test_snapshotdetail_without_permission(rf):
-    snapshot = SnapshotFactory()
+def test_snapshotdetail_published_without_permission(rf):
+    snapshot = SnapshotFactory(published_at=timezone.now())
+
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    response = SnapshotDetail.as_view()(
+        request,
+        org_slug=snapshot.workspace.project.org.slug,
+        project_slug=snapshot.workspace.project.slug,
+        workspace_slug=snapshot.workspace.name,
+        pk=snapshot.pk,
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_snapshotdetail_unpublished_with_permission(rf):
+    snapshot = SnapshotFactory(published_at=None)
+
+    request = rf.get("/")
+    request.user = UserFactory(roles=[ProjectCollaborator])
+
+    response = SnapshotDetail.as_view()(
+        request,
+        org_slug=snapshot.workspace.project.org.slug,
+        project_slug=snapshot.workspace.project.slug,
+        workspace_slug=snapshot.workspace.name,
+        pk=snapshot.pk,
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_snapshotdetail_unpublished_without_permission(rf):
+    snapshot = SnapshotFactory(published_at=None)
 
     request = rf.get("/")
     request.user = UserFactory()


### PR DESCRIPTION
This allows the general public to view published Snapshots (eg on the project or workspace pages) without any permissions, or even being logged in.

I've duplicated the `validate_release_access` function for this because the current one doesn't quite fit with this paradigm, but I'd like to see if we can combine them in #699.

Ref #702 
Ref #689 