### PR TITLE
Move Publish Outputs into SPA

### DIFF
--- a/assets/src/scripts/outputs-viewer/App.jsx
+++ b/assets/src/scripts/outputs-viewer/App.jsx
@@ -14,7 +14,7 @@ const queryClient = new QueryClient({
   },
 });
 
-function App({ apiUrl }) {
+function App({ filesUrl }) {
   const [listVisible, setListVisible] = useState(false);
   const [file, setFile] = useState({ name: "", url: "" });
 
@@ -30,7 +30,7 @@ function App({ apiUrl }) {
             {listVisible ? "Hide" : "Show"} file list
           </button>
           <FileList
-            apiUrl={apiUrl}
+            apiUrl={filesUrl}
             listVisible={listVisible}
             setFile={setFile}
             setListVisible={setListVisible}
@@ -48,5 +48,5 @@ function App({ apiUrl }) {
 export default App;
 
 App.propTypes = {
-  apiUrl: PropTypes.string.isRequired,
+  filesUrl: PropTypes.string.isRequired,
 };

--- a/assets/src/scripts/outputs-viewer/App.jsx
+++ b/assets/src/scripts/outputs-viewer/App.jsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import FileList from "./components/FileList/FileList";
+import PrepareButton from "./components/PrepareButton/PrepareButton";
 import Viewer from "./components/Viewer/Viewer";
 
 const queryClient = new QueryClient({
@@ -14,12 +15,23 @@ const queryClient = new QueryClient({
   },
 });
 
-function App({ filesUrl }) {
+function App({ csrfToken, filesUrl, prepareUrl }) {
   const [listVisible, setListVisible] = useState(false);
   const [file, setFile] = useState({ name: "", url: "" });
 
   return (
     <QueryClientProvider client={queryClient}>
+      {prepareUrl && (
+        <div className="row">
+          <div className="col">
+            <PrepareButton
+              csrfToken={csrfToken}
+              filesUrl={filesUrl}
+              prepareUrl={prepareUrl}
+            />
+          </div>
+        </div>
+      )}
       <div className="row">
         <div className="col-lg-3">
           <button
@@ -48,5 +60,12 @@ function App({ filesUrl }) {
 export default App;
 
 App.propTypes = {
+  csrfToken: PropTypes.string,
   filesUrl: PropTypes.string.isRequired,
+  prepareUrl: PropTypes.string,
+};
+
+App.defaultProps = {
+  csrfToken: null,
+  prepareUrl: null,
 };

--- a/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
@@ -1,8 +1,7 @@
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
-import { useQuery } from "react-query";
+import useFileList from "../../hooks/use-file-list";
 import useWindowSize from "../../hooks/useWindowSize";
-import handleErrors from "../../utils/fetch-handle-errors";
 import classes from "./FileList.module.scss";
 
 function ListWrapper({ listHeight, children, listVisible }) {
@@ -22,11 +21,7 @@ function FileList({ apiUrl, listVisible, setFile, setListVisible }) {
   const windowSize = useWindowSize();
   const [listHeight, setListHeight] = useState(0);
 
-  const { isLoading, isError, data, error } = useQuery("FILE_LIST", async () =>
-    fetch(apiUrl)
-      .then(handleErrors)
-      .then(async (response) => response.json())
-  );
+  const { isLoading, isError, data, error } = useFileList({ apiUrl });
 
   useEffect(() => {
     if (window.innerWidth > 991) {

--- a/assets/src/scripts/outputs-viewer/components/PrepareButton/PrepareButton.jsx
+++ b/assets/src/scripts/outputs-viewer/components/PrepareButton/PrepareButton.jsx
@@ -1,0 +1,62 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { useMutation } from "react-query";
+import useFileList from "../../hooks/use-file-list";
+import handleErrors from "../../utils/fetch-handle-errors";
+
+function PrepareButton({ csrfToken, filesUrl, prepareUrl }) {
+  const { data: fileList } = useFileList({ apiUrl: filesUrl });
+
+  const mutation = useMutation(
+    ({ fileIds }) =>
+      fetch(prepareUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRFToken": csrfToken,
+        },
+        body: JSON.stringify({ file_ids: fileIds }),
+      })
+        .then(handleErrors)
+        .then((response) => response.json()),
+    {
+      mutationKey: "PUBLISH_RELEASE",
+      onSuccess: (data) => {
+        // redirect to URL returned from the API
+        window.location.href = data.url;
+      },
+      onError: (error) => {
+        // eslint-disable-next-line no-console
+        console.error("Error", { error });
+      },
+    }
+  );
+
+  const onPublish = ({ e, fileIds }) => {
+    e.preventDefault();
+    mutation.mutate({ fileIds });
+  };
+
+  if (!fileList) return null;
+
+  const fileIds = fileList.files.map((f) => f.id);
+
+  return (
+    <button
+      className={`btn btn-${mutation.isLoading ? "secondary" : "primary"}`}
+      disabled={mutation.isLoading}
+      onClick={(e) => onPublish({ e, fileIds })}
+      type="button"
+    >
+      {mutation.isLoading ? "Publishing…" : "Publish"}
+    </button>
+  );
+}
+
+PrepareButton.propTypes = {
+  csrfToken: PropTypes.string.isRequired,
+  filesUrl: PropTypes.string.isRequired,
+  prepareUrl: PropTypes.string.isRequired,
+};
+
+export default PrepareButton;

--- a/assets/src/scripts/outputs-viewer/hooks/use-file-list.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file-list.js
@@ -1,0 +1,9 @@
+import { useQuery } from "react-query";
+import handleErrors from "../utils/fetch-handle-errors";
+
+export default ({ apiUrl }) =>
+  useQuery("FILE_LIST", async () =>
+    fetch(apiUrl)
+      .then(handleErrors)
+      .then(async (response) => response.json())
+  );

--- a/assets/src/scripts/outputs-viewer/index.jsx
+++ b/assets/src/scripts/outputs-viewer/index.jsx
@@ -6,7 +6,7 @@ const element = document.getElementById("outputsSPA");
 
 ReactDOM.render(
   <React.StrictMode>
-    <App apiUrl={element.dataset.apiUrl} />
+    <App filesUrl={element.dataset.filesUrl} />
   </React.StrictMode>,
   element
 );

--- a/assets/src/scripts/outputs-viewer/index.jsx
+++ b/assets/src/scripts/outputs-viewer/index.jsx
@@ -6,7 +6,11 @@ const element = document.getElementById("outputsSPA");
 
 ReactDOM.render(
   <React.StrictMode>
-    <App filesUrl={element.dataset.filesUrl} />
+    <App
+      csrfToken={element.dataset.csrfToken}
+      filesUrl={element.dataset.filesUrl}
+      prepareUrl={element.dataset.prepareUrl}
+    />
   </React.StrictMode>,
   element
 );

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -210,9 +210,13 @@ class ReleaseFileAPI(APIView):
 
 
 class SnapshotAPI(APIView):
-    def get(self, request, snapshot_id):
+    def get(self, request, *args, **kwargs):
         """A list of files for this Snapshot."""
-        snapshot = get_object_or_404(Snapshot, pk=snapshot_id)
+        snapshot = get_object_or_404(
+            Snapshot,
+            workspace__name=self.kwargs["workspace_id"],
+            pk=self.kwargs["snapshot_id"],
+        )
 
         validate_release_access(request, snapshot.workspace)
         files = {f.name: f for f in snapshot.files.all()}

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -101,6 +101,7 @@ def generate_index(files):
         files=[
             dict(
                 name=name,
+                id=rfile.pk,
                 url=rfile.get_api_url(),
                 user=rfile.created_by.username,
                 date=rfile.created_at.isoformat(),

--- a/jobserver/authorization/permissions.py
+++ b/jobserver/authorization/permissions.py
@@ -1,6 +1,7 @@
 cancel_job = "cancel_job"
 check_output = "check_output"
 create_org = "create_org"
+create_snapshot = "create_snapshot"
 invite_org_members = "invite_org_members"
 invite_project_members = "invite_project_members"
 manage_backends = "manage_backends"

--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -2,6 +2,7 @@ from .permissions import (
     cancel_job,
     check_output,
     create_org,
+    create_snapshot,
     invite_project_members,
     manage_backends,
     manage_project_members,
@@ -187,6 +188,7 @@ class ProjectDeveloper:
     permissions = [
         cancel_job,
         check_output,
+        create_snapshot,
         run_job,
     ]
 

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -770,6 +770,9 @@ class Workspace(models.Model):
             },
         )
 
+    def get_create_snapshot_api_url(self):
+        return reverse("api:snapshot-create", kwargs={"workspace_id": self.name})
+
     def get_current_outputs_url(self):
         return reverse(
             "workspace-current-outputs-detail",
@@ -803,16 +806,6 @@ class Workspace(models.Model):
     def get_outputs_url(self):
         return reverse(
             "workspace-output-list",
-            kwargs={
-                "org_slug": self.project.org.slug,
-                "project_slug": self.project.slug,
-                "workspace_slug": self.name,
-            },
-        )
-
-    def get_publish_url(self):
-        return reverse(
-            "workspace-publish",
             kwargs={
                 "org_slug": self.project.org.slug,
                 "project_slug": self.project.slug,

--- a/jobserver/models/outputs.py
+++ b/jobserver/models/outputs.py
@@ -165,4 +165,10 @@ class Snapshot(models.Model):
         )
 
     def get_api_url(self):
-        return reverse("api:snapshot", kwargs={"snapshot_id": self.pk})
+        return reverse(
+            "api:snapshot",
+            kwargs={
+                "workspace_id": self.workspace.name,
+                "snapshot_id": self.pk,
+            },
+        )

--- a/jobserver/templates/outputs-spa.html
+++ b/jobserver/templates/outputs-spa.html
@@ -1,6 +1,11 @@
 {% load django_vite %}
 
-<div data-files-url="{{ files_url }}" id="outputsSPA"></div>
+<div
+  data-csrf-token="{{ csrf_token }}"
+  data-files-url="{{ files_url }}"
+  data-prepare-url="{{ prepare_url }}"
+  id="outputsSPA">
+</div>
 
 {% block extra_js %}
   {% vite_asset 'assets/src/scripts/outputs-viewer/index.jsx' %}

--- a/jobserver/templates/outputs-spa.html
+++ b/jobserver/templates/outputs-spa.html
@@ -1,6 +1,6 @@
 {% load django_vite %}
 
-<div data-api-url="{{ api_url }}" id="outputsSPA"></div>
+<div data-files-url="{{ files_url }}" id="outputsSPA"></div>
 
 {% block extra_js %}
   {% vite_asset 'assets/src/scripts/outputs-viewer/index.jsx' %}

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -83,16 +83,9 @@
           Current Outputs
         </a>
         <a class="btn btn-primary mr-2" href="{{ workspace.get_outputs_url }}">Outputs</a>
-        {% endif %}
-
-        {% if user_can_run_jobs %}
-        <form method="POST" action="{{ workspace.get_publish_url }}">
-          {% csrf_token %}
-
-          <button class="btn btn-primary mr-2" type="submit">
-            Publish
-          </button>
-        </form>
+        <a class="btn btn-primary mr-2" href="{{ workspace.get_current_outputs_url }}">
+          Publish
+        </a>
         {% endif %}
 
         <a class="btn btn-primary mr-2" href="{{ workspace.get_releases_url }}">Release History</a>

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -17,6 +17,7 @@ from jobserver.api.releases import (
     ReleaseNotificationAPICreate,
     ReleaseWorkspaceAPI,
     SnapshotAPI,
+    SnapshotCreateAPI,
 )
 
 from .views.admin import ApproveUsers
@@ -39,7 +40,6 @@ from .views.projects import (
 from .views.releases import (
     ProjectReleaseList,
     ReleaseDetail,
-    SnapshotCreate,
     SnapshotDetail,
     WorkspaceReleaseList,
 )
@@ -67,6 +67,11 @@ api_urls = [
         name="workspace-statuses",
     ),
     # releasing outputs API
+    path(
+        "workspaces/<workspace_id>/snapshots",
+        SnapshotCreateAPI.as_view(),
+        name="snapshot-create",
+    ),
     path(
         "workspaces/<workspace_id>/snapshots/<snapshot_id>",
         SnapshotAPI.as_view(),
@@ -141,11 +146,6 @@ workspace_urls = [
         name="workspace-notifications-toggle",
     ),
     path("outputs/", include(outputs_urls)),
-    path(
-        "publish/",
-        SnapshotCreate.as_view(),
-        name="workspace-publish",
-    ),
     path(
         "releases/",
         WorkspaceReleaseList.as_view(),

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -68,6 +68,11 @@ api_urls = [
     ),
     # releasing outputs API
     path(
+        "workspaces/<workspace_id>/snapshots/<snapshot_id>",
+        SnapshotAPI.as_view(),
+        name="snapshot",
+    ),
+    path(
         "releases/workspace/<workspace_name>",
         ReleaseWorkspaceAPI.as_view(),
         name="release-workspace",
@@ -81,11 +86,6 @@ api_urls = [
         "releases/file/<file_id>",
         ReleaseFileAPI.as_view(),
         name="release-file",
-    ),
-    path(
-        "releases/snapshot/<snapshot_id>",
-        SnapshotAPI.as_view(),
-        name="snapshot",
     ),
 ]
 

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -56,7 +56,7 @@ class ReleaseDetail(View):
         # TODO: check permissions here
 
         context = {
-            "api_url": reverse("api:release", kwargs={"release_id": release.id}),
+            "files_url": reverse("api:release", kwargs={"release_id": release.id}),
             "release": release,
         }
         return TemplateResponse(
@@ -116,7 +116,7 @@ class SnapshotDetail(View):
             raise Http404
 
         context = {
-            "api_url": snapshot.get_api_url(),
+            "files_url": snapshot.get_api_url(),
             "snapshot": snapshot,
         }
         return TemplateResponse(

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -1,14 +1,11 @@
-from django.contrib import messages
 from django.http import Http404
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.views.generic import ListView, View
 
 from ..authorization import has_permission
 from ..models import Project, Release, Snapshot, Workspace
-from ..releases import workspace_files
-from ..utils import set_from_qs
 
 
 class ProjectReleaseList(ListView):
@@ -64,40 +61,6 @@ class ReleaseDetail(View):
             "release_detail.html",
             context=context,
         )
-
-
-class SnapshotCreate(View):
-    def post(self, request, *args, **kwargs):
-        workspace = get_object_or_404(
-            Workspace,
-            project__org__slug=self.kwargs["org_slug"],
-            project__slug=self.kwargs["project_slug"],
-            name=self.kwargs["workspace_slug"],
-        )
-
-        if not has_permission(request.user, "publish_output"):
-            raise Http404
-
-        if not workspace.files.exists():
-            messages.error(
-                request,
-                "There are no outputs to publish for this workspace.",
-            )
-            return redirect(workspace)
-
-        file_ids = {f.pk for f in workspace_files(workspace).values()}
-        snapshot_ids = [set_from_qs(pr.files.all()) for pr in workspace.snapshots.all()]
-        if file_ids in snapshot_ids:
-            messages.error(
-                request,
-                "A release with the current files already exists, please use that one.",
-            )
-            return redirect(workspace)
-
-        snapshot = workspace.snapshots.create(created_by=request.user)
-        snapshot.files.set(workspace.files.all())
-
-        return redirect(workspace)
 
 
 class SnapshotDetail(View):

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -310,6 +310,7 @@ class WorkspaceCurrentOutputsDetail(View):
 
         context = {
             "files_url": workspace.get_releases_api_url(),
+            "prepare_url": workspace.get_create_snapshot_api_url(),
             "workspace": workspace,
         }
         return TemplateResponse(

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -309,7 +309,7 @@ class WorkspaceCurrentOutputsDetail(View):
             raise Http404
 
         context = {
-            "api_url": workspace.get_releases_api_url(),
+            "files_url": workspace.get_releases_api_url(),
             "workspace": workspace,
         }
         return TemplateResponse(

--- a/tests/jobserver/api/test_jobs.py
+++ b/tests/jobserver/api/test_jobs.py
@@ -609,7 +609,10 @@ def test_userapidetail_success(api_rf):
         },
     ]
     assert permissions["projects"] == [
-        {"slug": project.slug, "permissions": ["cancel_job", "check_output", "run_job"]}
+        {
+            "slug": project.slug,
+            "permissions": ["cancel_job", "check_output", "create_snapshot", "run_job"],
+        }
     ]
 
     # roles

--- a/tests/jobserver/api/test_releases.py
+++ b/tests/jobserver/api/test_releases.py
@@ -287,6 +287,7 @@ def test_workspace_index_api_have_permission():
         "files": [
             {
                 "name": "backend2/file1.txt",
+                "id": release2.files.first().pk,
                 "url": f"/api/v2/releases/file/{release2.files.first().id}",
                 "user": user.username,
                 "date": release2.files.first().created_at.isoformat(),
@@ -295,6 +296,7 @@ def test_workspace_index_api_have_permission():
             },
             {
                 "name": "backend1/file1.txt",
+                "id": release1.files.first().pk,
                 "url": f"/api/v2/releases/file/{release1.files.first().id}",
                 "user": user.username,
                 "date": release1.files.first().created_at.isoformat(),
@@ -355,6 +357,7 @@ def test_release_index_api_have_permission():
         "files": [
             {
                 "name": "file.txt",
+                "id": rfile.pk,
                 "url": f"/api/v2/releases/file/{rfile.id}",
                 "user": rfile.created_by.username,
                 "date": rfile.created_at.isoformat(),

--- a/tests/jobserver/api/test_releases.py
+++ b/tests/jobserver/api/test_releases.py
@@ -622,7 +622,9 @@ def test_snapshot_api_anonymous():
     snapshot = SnapshotFactory()
 
     client = APIClient()
-    response = client.get(f"/api/v2/releases/snapshot/{snapshot.pk}")
+    response = client.get(
+        f"/api/v2/workspaces/{snapshot.workspace.name}/snapshots/{snapshot.pk}"
+    )
 
     assert response.status_code == 403
 
@@ -635,7 +637,9 @@ def test_snapshot_api_no_permission():
     # logged in, but no permission
     client.force_authenticate(user=UserFactory())
 
-    response = client.get(f"/api/v2/releases/snapshot/{snapshot.pk}")
+    response = client.get(
+        f"/api/v2/workspaces/{snapshot.workspace.name}/snapshots/{snapshot.pk}"
+    )
 
     assert response.status_code == 403
 
@@ -647,7 +651,9 @@ def test_snapshot_api_success():
     client = APIClient()
     client.force_authenticate(user=UserFactory(roles=[ProjectCollaborator]))
 
-    response = client.get(f"/api/v2/releases/snapshot/{snapshot.pk}")
+    response = client.get(
+        f"/api/v2/workspaces/{snapshot.workspace.name}/snapshots/{snapshot.pk}"
+    )
 
     assert response.status_code == 200
     assert response.data == {"files": []}

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -750,7 +750,12 @@ def test_user_get_all_permissions():
         "projects": [
             {
                 "slug": project.slug,
-                "permissions": ["cancel_job", "check_output", "run_job"],
+                "permissions": [
+                    "cancel_job",
+                    "check_output",
+                    "create_snapshot",
+                    "run_job",
+                ],
             }
         ],
     }

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -951,22 +951,6 @@ def test_workspace_get_outputs_url():
 
 
 @pytest.mark.django_db
-def test_workspace_get_publish_url():
-    workspace = WorkspaceFactory()
-
-    url = workspace.get_publish_url()
-
-    assert url == reverse(
-        "workspace-publish",
-        kwargs={
-            "org_slug": workspace.project.org.slug,
-            "project_slug": workspace.project.slug,
-            "workspace_slug": workspace.name,
-        },
-    )
-
-
-@pytest.mark.django_db
 def test_workspace_get_releases_url():
     workspace = WorkspaceFactory()
 

--- a/tests/jobserver/models/test_outputs.py
+++ b/tests/jobserver/models/test_outputs.py
@@ -117,4 +117,10 @@ def test_snapshot_get_api_url():
 
     url = snapshot.get_api_url()
 
-    assert url == reverse("api:snapshot", kwargs={"snapshot_id": snapshot.pk})
+    assert url == reverse(
+        "api:snapshot",
+        kwargs={
+            "workspace_id": snapshot.workspace.name,
+            "snapshot_id": snapshot.pk,
+        },
+    )

--- a/tests/jobserver/test_utils.py
+++ b/tests/jobserver/test_utils.py
@@ -1,6 +1,26 @@
+import pytest
+
 from jobserver.authorization import OutputChecker
-from jobserver.utils import dotted_path
+from jobserver.models import Job
+from jobserver.utils import dotted_path, set_from_qs
+
+from ..factories import JobFactory
 
 
 def test_dotted_path():
     assert dotted_path(OutputChecker) == "jobserver.authorization.roles.OutputChecker"
+
+
+@pytest.mark.django_db
+def test_set_from_qs():
+    job1 = JobFactory(status="test")
+    job2 = JobFactory(status="success")
+    job3 = JobFactory(status="success")
+
+    # check using the default field of pk
+    output = set_from_qs(Job.objects.all())
+    assert output == {job1.pk, job2.pk, job3.pk}
+
+    # check using the field kwarg
+    output = set_from_qs(Job.objects.all(), field="status")
+    assert output == {"test", "success"}

--- a/tests/jobserver/views/test_releases.py
+++ b/tests/jobserver/views/test_releases.py
@@ -1,12 +1,10 @@
 import pytest
-from django.contrib.messages.storage.fallback import FallbackStorage
 from django.http import Http404
 
-from jobserver.authorization import OutputPublisher, ProjectCollaborator
+from jobserver.authorization import ProjectCollaborator
 from jobserver.views.releases import (
     ProjectReleaseList,
     ReleaseDetail,
-    SnapshotCreate,
     SnapshotDetail,
     WorkspaceReleaseList,
 )
@@ -114,138 +112,6 @@ def test_releasedetail_with_path_success(rf):
     )
 
     assert response.status_code == 200
-
-
-@pytest.mark.django_db
-def test_snapshotcreate_success(rf):
-    workspace = WorkspaceFactory()
-    ReleaseFactory(ReleaseUploadsFactory(["file1", "file2"]), workspace=workspace)
-
-    assert workspace.snapshots.count() == 0
-
-    request = rf.post("/")
-    request.user = UserFactory(roles=[OutputPublisher])
-
-    response = SnapshotCreate.as_view()(
-        request,
-        org_slug=workspace.project.org.slug,
-        project_slug=workspace.project.slug,
-        workspace_slug=workspace.name,
-    )
-
-    assert response.status_code == 302
-    assert response.url == workspace.get_absolute_url()
-
-    workspace.refresh_from_db()
-    assert workspace.snapshots.count() == 1
-
-    # confirm the snapshot's files match the current workspace files
-    output = set(workspace.snapshots.first().files.values_list("pk", flat=True))
-    expected = set(workspace.files.values_list("pk", flat=True))
-    assert output == expected
-
-
-@pytest.mark.django_db
-def test_snapshotcreate_unknown_workspace(rf):
-    project = ProjectFactory()
-
-    request = rf.post("/")
-    request.user = UserFactory(roles=[OutputPublisher])
-
-    with pytest.raises(Http404):
-        SnapshotCreate.as_view()(
-            request,
-            org_slug=project.org.slug,
-            project_slug=project.slug,
-            workspace_slug="",
-        )
-
-
-@pytest.mark.django_db
-def test_snapshotcreate_with_duplicate_snapshot(rf):
-    workspace = WorkspaceFactory()
-    ReleaseFactory(ReleaseUploadsFactory(["file1", "file2"]), workspace=workspace)
-
-    # create a Snapshot of the Workspace in its current state
-    snapshot = SnapshotFactory(workspace=workspace)
-    snapshot.files.set(workspace.files.all())
-    assert workspace.snapshots.count() == 1
-    assert workspace.snapshots.first() == snapshot
-
-    request = rf.post("/")
-    request.user = UserFactory(roles=[OutputPublisher])
-
-    # set up messages framework
-    request.session = "session"
-    messages = FallbackStorage(request)
-    request._messages = messages
-
-    response = SnapshotCreate.as_view()(
-        request,
-        org_slug=workspace.project.org.slug,
-        project_slug=workspace.project.slug,
-        workspace_slug=workspace.name,
-    )
-
-    assert response.status_code == 302
-    assert response.url == workspace.get_absolute_url()
-
-    workspace.refresh_from_db()
-
-    # check the snapshot is still the one we created above
-    assert workspace.snapshots.count() == 1
-    assert workspace.snapshots.first() == snapshot
-
-    # check we have a message for the user
-    messages = list(messages)
-    assert len(messages) == 1
-    expected = "A release with the current files already exists, please use that one."
-    assert str(messages[0]) == expected
-
-
-@pytest.mark.django_db
-def test_snapshotcreate_with_no_outputs(rf):
-    workspace = WorkspaceFactory()
-
-    request = rf.post("/")
-    request.user = UserFactory(roles=[OutputPublisher])
-
-    # set up messages framework
-    request.session = "session"
-    messages = FallbackStorage(request)
-    request._messages = messages
-
-    response = SnapshotCreate.as_view()(
-        request,
-        org_slug=workspace.project.org.slug,
-        project_slug=workspace.project.slug,
-        workspace_slug=workspace.name,
-    )
-
-    assert response.status_code == 302
-    assert response.url == workspace.get_absolute_url()
-
-    # check we have a message for the user
-    messages = list(messages)
-    assert len(messages) == 1
-    expected = "There are no outputs to publish for this workspace."
-    assert str(messages[0]) == expected
-
-
-@pytest.mark.django_db
-def test_snapshotcreate_without_permission(rf):
-    workspace = WorkspaceFactory()
-
-    request = rf.post("/")
-    request.user = UserFactory()
-
-    with pytest.raises(Http404):
-        SnapshotCreate.as_view()(
-            request,
-            org_slug=workspace.project.org.slug,
-            project_slug=workspace.project.slug,
-            workspace_slug=workspace.name,
-        )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This teaches the outputs SPA about the snapshot preparation URL, showing a "Publish" button if it's instantiated with one:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/OAuQAeYg/8ff0c2b7-3a83-46eb-89d7-226581ce3d67.jpg?v=1a9c277c3b8acd3bc799c2189e343d23)

Since a User must already be privileged to view the current ReleaseFile for a Workspace we don't need to do any further permission checks.

The SPA will use the prepare URL to post a list of ReleaseFile IDs to the API, which creates a draft Snapshot, and returns the direct URL for an SPA.

I've not taken much (any) time to style the button because there's a confirmation flow to add on top of it, where I'll deal with that.

Refs #675