### PR TITLE
Fixes for IE11 and file list height on small screens

### DIFF
--- a/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
@@ -32,6 +32,7 @@ function FileList({ apiUrl, listVisible, setFile, setListVisible }) {
           30
       );
     }
+    setListHeight(0);
   }, [windowSize, setListVisible, listVisible]);
 
   if (isLoading) {

--- a/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
@@ -31,8 +31,9 @@ function FileList({ apiUrl, listVisible, setFile, setListVisible }) {
           document.querySelector("#outputsSPA").getBoundingClientRect().top -
           30
       );
+    } else {
+      setListHeight(0);
     }
-    setListHeight(0);
   }, [windowSize, setListVisible, listVisible]);
 
   if (isLoading) {

--- a/jobserver/templates/outputs-spa.html
+++ b/jobserver/templates/outputs-spa.html
@@ -9,5 +9,7 @@
 
 {% block extra_js %}
   {% vite_asset 'assets/src/scripts/outputs-viewer/index.jsx' %}
+
+  {% vite_asset 'vite/legacy-polyfills' scripts_attrs=scripts_attrs %}
   {% vite_asset 'assets/src/scripts/outputs-viewer/index-legacy.jsx' scripts_attrs=scripts_attrs %}
 {% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "version": "1.0.0",
       "dependencies": {
+        "bluebird": "^3.7.2",
         "bootstrap": "^4.5.2",
         "convert-csv-to-json": "^1.3.1",
         "jquery": "^3.5.1",
@@ -18,7 +19,8 @@
         "react-dom": "^17.0.2",
         "react-papaparse": "^3.16.1",
         "react-query": "^3.19.0",
-        "select2": "^4.0.13"
+        "select2": "^4.0.13",
+        "whatwg-fetch": "^3.6.2"
       },
       "devDependencies": {
         "@preact/preset-vite": "^2.1.0",
@@ -1151,6 +1153,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -5448,6 +5455,11 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6392,6 +6404,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "boolbase": {
       "version": "1.0.0",
@@ -9569,6 +9586,11 @@
           }
         }
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "vite": "^2.4.3"
   },
   "dependencies": {
+    "bluebird": "^3.7.2",
     "bootstrap": "^4.5.2",
     "convert-csv-to-json": "^1.3.1",
     "jquery": "^3.5.1",
@@ -41,7 +42,8 @@
     "react-dom": "^17.0.2",
     "react-papaparse": "^3.16.1",
     "react-query": "^3.19.0",
-    "select2": "^4.0.13"
+    "select2": "^4.0.13",
+    "whatwg-fetch": "^3.6.2"
   },
   "eslintConfig": {
     "extends": [

--- a/vite.config.js
+++ b/vite.config.js
@@ -34,7 +34,12 @@ const config = {
   plugins: [
     preact(),
     legacy({
-      additionalLegacyPolyfills: ["regenerator-runtime/runtime"],
+      additionalLegacyPolyfills: [
+        "regenerator-runtime/runtime",
+        "bluebird",
+        "whatwg-fetch",
+      ],
+      targets: ["ie >= 11"],
     }),
     copy({
       targets: [


### PR DESCRIPTION
- Add polyfills for Fetch and Promise
- Tell Vite Legacy to specifically target IE11
- Fix File List height depending on screen size