### PR TITLE
Pull Branch Name into a Section

### DIFF
--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -98,11 +98,12 @@
           <p>
             <strong>Repo:</strong>
             <a href="{{ workspace.repo }}">{{ workspace.repo_name }}</a>
-            <span class="text-muted">({{ workspace.branch }})</span>
             <span class="badge badge-secondary">
               {% if repo_is_private %}Private{% else %}Public{% endif %}
             </span>
           </p>
+
+          <p><strong>Branch:</strong> {{ workspace.branch }}</p>
 
           <p><strong>DB:</strong> {{ workspace.db }}</p>
 


### PR DESCRIPTION
This pulls the branch name from a muted string at the end of the repo name (where we all missed it!) into its own section.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/NQuo8pQ6/215ecb01-4164-4ba4-ba1d-87cfd3988f6c.jpg?v=7a67206aa1149a8fa6cca21744ac1cd8)

Fixes #715 