### PR TITLE
Enforce Permissions for Workspace Creation

### DIFF
--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -168,7 +168,6 @@ class ProjectCoordinator:
     permissions = [
         invite_project_members,
         manage_project_members,
-        manage_project_workspaces,
     ]
 
 
@@ -189,6 +188,7 @@ class ProjectDeveloper:
         cancel_job,
         check_output,
         create_snapshot,
+        manage_project_workspaces,
         run_job,
     ]
 

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -57,6 +57,14 @@ class WorkspaceCreate(CreateView):
             get_repos_with_branches(gh_org), key=lambda r: r["name"].lower()
         )
 
+        can_manage_workspaces = has_permission(
+            self.request.user,
+            "manage_project_workspaces",
+            project=self.project,
+        )
+        if not can_manage_workspaces:
+            raise Http404
+
         return super().dispatch(request, *args, **kwargs)
 
     def form_valid(self, form):

--- a/tests/jobserver/api/test_jobs.py
+++ b/tests/jobserver/api/test_jobs.py
@@ -611,7 +611,13 @@ def test_userapidetail_success(api_rf):
     assert permissions["projects"] == [
         {
             "slug": project.slug,
-            "permissions": ["cancel_job", "check_output", "create_snapshot", "run_job"],
+            "permissions": [
+                "cancel_job",
+                "check_output",
+                "create_snapshot",
+                "manage_project_workspaces",
+                "run_job",
+            ],
         }
     ]
 

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -754,6 +754,7 @@ def test_user_get_all_permissions():
                     "cancel_job",
                     "check_output",
                     "create_snapshot",
+                    "manage_project_workspaces",
                     "run_job",
                 ],
             }

--- a/tests/jobserver/views/test_workspaces.py
+++ b/tests/jobserver/views/test_workspaces.py
@@ -6,11 +6,7 @@ from django.contrib.messages.storage.fallback import FallbackStorage
 from django.http import Http404
 from django.utils import timezone
 
-from jobserver.authorization import (
-    ProjectCollaborator,
-    ProjectCoordinator,
-    ProjectDeveloper,
-)
+from jobserver.authorization import ProjectCollaborator, ProjectDeveloper
 from jobserver.models import Backend, JobRequest, Workspace
 from jobserver.views.workspaces import (
     WorkspaceArchiveToggle,
@@ -92,7 +88,7 @@ def test_workspacearchivetoggle_unauthorized(rf, user):
 def test_workspacecreate_get_success(rf, mocker, user):
     org = user.orgs.first()
     project = ProjectFactory(org=org)
-    ProjectMembershipFactory(project=project, user=user, roles=[ProjectCoordinator])
+    ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
 
     gh_org = user.orgs.first().github_orgs[0]
     membership_url = f"https://api.github.com/orgs/{gh_org}/members/{user.username}"
@@ -142,7 +138,7 @@ def test_workspacecreate_get_without_permission(rf, mocker, user):
 def test_workspacecreate_post_success(rf, mocker, user):
     org = user.orgs.first()
     project = ProjectFactory(org=org)
-    ProjectMembershipFactory(project=project, user=user, roles=[ProjectCoordinator])
+    ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
 
     gh_org = user.orgs.first().github_orgs[0]
     membership_url = f"https://api.github.com/orgs/{gh_org}/members/{user.username}"


### PR DESCRIPTION
This double checks a User has the `manage_project_workspaces` permission in the WorkspaceCreate view itself.  It also moves this permission onto the `ProjectDeveloper` role so researchers can create workspaces.