### PR TITLE
Reparse content-disposition header to get full filename

### DIFF
--- a/tests/jobserver/api/test_releases.py
+++ b/tests/jobserver/api/test_releases.py
@@ -438,7 +438,7 @@ def test_release_api_upload_no_files():
 @pytest.mark.django_db
 def test_release_api_upload_bad_backend():
     user = UserFactory()
-    uploads = ReleaseUploadsFactory(["file.txt"])
+    uploads = ReleaseUploadsFactory(["output/file.txt"])
     release = ReleaseFactory(uploads, uploaded=False)
     bad_backend = BackendFactory()
 


### PR DESCRIPTION
DRF helpfully strips of leading paths.
