### PR TITLE
Remove Some Uses of can_run_jobs

### DIFF
--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -146,7 +146,7 @@
 
   <div class="col-md-3 col-lg-2">
 
-    {% if user_can_run_jobs %}
+    {% if user_can_cancel_jobs %}
     <h3 class="text-center">Tools</h3>
 
     <form class="mb-3" method="POST" action="{{ job.get_cancel_url }}">

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -168,7 +168,7 @@
       </a>
     </div>
 
-    {% if user_can_run_jobs %}
+    {% if user_can_cancel_jobs %}
     <form class="mb-2" method="POST" action="{{ jobrequest.get_cancel_url }}">
       {% csrf_token %}
 

--- a/jobserver/views/jobs.py
+++ b/jobserver/views/jobs.py
@@ -1,19 +1,22 @@
-from django.contrib.auth.decorators import user_passes_test
 from django.core.exceptions import MultipleObjectsReturned
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
-from django.utils.decorators import method_decorator
 from django.views.generic import View
 
+from ..authorization import has_permission
 from ..models import Job
-from ..roles import can_run_jobs
 
 
-@method_decorator(user_passes_test(can_run_jobs), name="dispatch")
 class JobCancel(View):
     def post(self, request, *args, **kwargs):
         job = get_object_or_404(Job, identifier=self.kwargs["identifier"])
+
+        can_cancel_job = job.job_request.created_by == request.user or has_permission(
+            request.user, "cancel_job", project=job.job_request.workspace.project
+        )
+        if not can_cancel_job:
+            raise Http404
 
         if job.is_completed or job.action in job.job_request.cancelled_actions:
             return redirect(job)
@@ -36,10 +39,14 @@ class JobDetail(View):
             # redirect to the full URL if a partial identifier was used
             return redirect(job)
 
+        can_cancel_jobs = job.job_request.created_by == request.user or has_permission(
+            request.user, "cancel_job", project=job.job_request.workspace.project
+        )
+
         context = {
             "job": job,
             "object": job,
-            "user_can_run_jobs": can_run_jobs(self.request.user),
+            "user_can_cancel_jobs": can_cancel_jobs,
             "view": self,
         }
 


### PR DESCRIPTION
This switches cancelling jobs on either the Job or JobRequest detail pages to use the `cancel_job` permission instead of relying on `can_run_jobs()`.  This refines who can cancel jobs, to only those with either the CoreDeveloper role or the ProjectDeveloper role, the latter of which is tied to the Project any given Job[Request] is owned by.

Ref #642 