### PR TITLE
Update Vite legacy dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@sentry/react": "^6.10.0",
-        "bluebird": "^3.7.2",
         "bootstrap": "^4.5.2",
         "convert-csv-to-json": "^1.3.1",
         "jquery": "^3.5.1",
@@ -1249,11 +1248,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -6590,11 +6584,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "boolbase": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@preact/preset-vite": "^2.1.0",
-        "@vitejs/plugin-legacy": "^1.5.0",
+        "@vitejs/plugin-legacy": "^1.5.1",
         "autoprefixer": "^10.2.6",
         "cssnano": "^5.0.7",
         "eslint": "^7.31.0",
@@ -460,9 +460,9 @@
       }
     },
     "node_modules/@babel/standalone": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.14.8.tgz",
-      "integrity": "sha512-5Aa1Bhis4oZD23iLJE5CDYHEs1zSC3ejppHE5aim0OWjGCWTa9Oq1PwopK4u1++ao6B6POW/PqNZjOCZNTSx0Q==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.14.9.tgz",
+      "integrity": "sha512-EEAwahkk3VW8WOlEAd3xtKN4tVDcgbSiDCc50qD4IgjyMowI2mvLnIZbRpZU5G/yZBGZsEPg7FssT/+yLFBlQQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -970,13 +970,13 @@
       }
     },
     "node_modules/@vitejs/plugin-legacy": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-1.5.0.tgz",
-      "integrity": "sha512-q3F6/AEn6LNvK0ERkn0t8gzXTwPdexW4FtsIeIsCxopj02EQLtKi3XfWukU9+kjU599QouyRihvr+C2qO+0Xeg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-1.5.1.tgz",
+      "integrity": "sha512-g+0iy0X3NJRUSKZK+OCeSxNWnCuuE/6lsmr2WLWPOEt1vp6LdfHuNCYRooCm6s0ccTZ/SiumVk8vt9DWSYs+8A==",
       "dev": true,
       "dependencies": {
-        "@babel/standalone": "^7.14.8",
-        "core-js": "^3.15.2",
+        "@babel/standalone": "^7.14.9",
+        "core-js": "^3.16.0",
         "magic-string": "^0.25.7",
         "regenerator-runtime": "^0.13.9",
         "systemjs": "^6.10.2"
@@ -1499,9 +1499,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
-      "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.0.tgz",
+      "integrity": "sha512-5+5VxRFmSf97nM8Jr2wzOwLqRo6zphH2aX+7KsAUONObyzakDNq2G/bgbhinxB4PoV9L3aXQYhiDKyIKWd2c8g==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -6010,9 +6010,9 @@
       }
     },
     "@babel/standalone": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.14.8.tgz",
-      "integrity": "sha512-5Aa1Bhis4oZD23iLJE5CDYHEs1zSC3ejppHE5aim0OWjGCWTa9Oq1PwopK4u1++ao6B6POW/PqNZjOCZNTSx0Q==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.14.9.tgz",
+      "integrity": "sha512-EEAwahkk3VW8WOlEAd3xtKN4tVDcgbSiDCc50qD4IgjyMowI2mvLnIZbRpZU5G/yZBGZsEPg7FssT/+yLFBlQQ==",
       "dev": true
     },
     "@babel/template": {
@@ -6395,13 +6395,13 @@
       }
     },
     "@vitejs/plugin-legacy": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-1.5.0.tgz",
-      "integrity": "sha512-q3F6/AEn6LNvK0ERkn0t8gzXTwPdexW4FtsIeIsCxopj02EQLtKi3XfWukU9+kjU599QouyRihvr+C2qO+0Xeg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-1.5.1.tgz",
+      "integrity": "sha512-g+0iy0X3NJRUSKZK+OCeSxNWnCuuE/6lsmr2WLWPOEt1vp6LdfHuNCYRooCm6s0ccTZ/SiumVk8vt9DWSYs+8A==",
       "dev": true,
       "requires": {
-        "@babel/standalone": "^7.14.8",
-        "core-js": "^3.15.2",
+        "@babel/standalone": "^7.14.9",
+        "core-js": "^3.16.0",
         "magic-string": "^0.25.7",
         "regenerator-runtime": "^0.13.9",
         "systemjs": "^6.10.2"
@@ -6790,9 +6790,9 @@
       }
     },
     "core-js": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
-      "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.0.tgz",
+      "integrity": "sha512-5+5VxRFmSf97nM8Jr2wzOwLqRo6zphH2aX+7KsAUONObyzakDNq2G/bgbhinxB4PoV9L3aXQYhiDKyIKWd2c8g==",
       "dev": true
     },
     "core-js-pure": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@sentry/react": "^6.10.0",
-    "bluebird": "^3.7.2",
     "bootstrap": "^4.5.2",
     "convert-csv-to-json": "^1.3.1",
     "jquery": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.1.0",
-    "@vitejs/plugin-legacy": "^1.5.0",
+    "@vitejs/plugin-legacy": "^1.5.1",
     "autoprefixer": "^10.2.6",
     "cssnano": "^5.0.7",
     "eslint": "^7.31.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,7 +36,6 @@ const config = {
     legacy({
       additionalLegacyPolyfills: [
         "regenerator-runtime/runtime",
-        "bluebird",
         "whatwg-fetch",
       ],
       targets: ["ie >= 11"],


### PR DESCRIPTION
- Update @vitejs/plugin-legacy to 1.5.1
- Remove Bluebird as Promises has a polyfill ([source](https://github.com/vitejs/vite/blob/365e3ad224e83e99811e61edd8a6aab7b2280cce/packages/plugin-legacy/CHANGELOG.md#151-2021-08-03))