### PR TITLE
Better Outputs Buttons

### DIFF
--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -79,13 +79,7 @@
       <div class="d-flex">
         {% if can_use_releases %}
         {% if user_can_view_outputs %}
-        <a class="btn btn-primary mr-2" href="{{ workspace.get_current_outputs_url }}">
-          Current Outputs
-        </a>
         <a class="btn btn-primary mr-2" href="{{ workspace.get_outputs_url }}">Outputs</a>
-        <a class="btn btn-primary mr-2" href="{{ workspace.get_current_outputs_url }}">
-          Publish
-        </a>
         {% endif %}
 
         {% if user_can_view_files %}

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -83,7 +83,9 @@
         <a class="btn btn-primary mr-2" href="{{ workspace.get_files_url }}">Level 4 Outputs</a>
         {% endif %}
 
+        {% if user_can_view_releases %}
         <a class="btn btn-primary mr-2" href="{{ workspace.get_releases_url }}">Released Outputs</a>
+        {% endif %}
 
         {% if user_can_view_outputs %}
         <a class="btn btn-primary mr-2" href="{{ workspace.get_outputs_url }}">Published Outputs</a>

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -78,15 +78,17 @@
 
       <div class="d-flex">
         {% if can_use_releases %}
-        {% if user_can_view_outputs %}
-        <a class="btn btn-primary mr-2" href="{{ workspace.get_outputs_url }}">Outputs</a>
-        {% endif %}
 
         {% if user_can_view_files %}
-        <a class="btn btn-primary mr-2" href="{{ workspace.get_files_url }}">Backend Files</a>
+        <a class="btn btn-primary mr-2" href="{{ workspace.get_files_url }}">Level 4 Outputs</a>
         {% endif %}
 
-        <a class="btn btn-primary mr-2" href="{{ workspace.get_releases_url }}">Release History</a>
+        <a class="btn btn-primary mr-2" href="{{ workspace.get_releases_url }}">Released Outputs</a>
+
+        {% if user_can_view_outputs %}
+        <a class="btn btn-primary mr-2" href="{{ workspace.get_outputs_url }}">Published Outputs</a>
+        {% endif %}
+
         {% endif %}
       </div>
 

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -237,7 +237,9 @@ class WorkspaceDetail(CreateView):
         has_published_snapshots = self.workspace.snapshots.exclude(
             published_at=None
         ).exists()
-        can_view_outputs = is_privileged_user or has_published_snapshots
+        can_view_outputs = has_published_snapshots or (
+            is_privileged_user and can_view_releases
+        )
 
         return super().get_context_data(**kwargs) | {
             "actions": self.actions,

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -228,6 +228,9 @@ class WorkspaceDetail(CreateView):
         has_backends = self.request.user.backends.exclude(level_4_url="").exists()
         can_view_files = is_privileged_user and has_backends
 
+        # are there any releases to show for the workspace?
+        can_view_releases = self.workspace.releases.exists()
+
         # unprivileged users can only see published snapshots, but privileged
         # users can see snapshots if there are any releases since they can also
         # prepare and publish them from the same views.
@@ -245,6 +248,7 @@ class WorkspaceDetail(CreateView):
             "user_can_run_jobs": self.user_can_run_jobs,
             "user_can_view_files": can_view_files,
             "user_can_view_outputs": can_view_outputs,
+            "user_can_view_releases": can_view_releases,
             "workspace": self.workspace,
         }
 


### PR DESCRIPTION
This tidies up the outputs buttons on a WorkspaceDetail page so they're in the order one gains access to them, and improve the logic around when they're added.

I've also removed the two buttons (with different names!) pointing to the "current" outputs (latest version of every file released in a workspace) since that's available via the Released Outputs and it felt confusing in the UI.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/wbub1doQ/44f95b25-813a-49bb-8207-198f60c656da.jpg?v=5e0fafd3965a737a18538fe17cc37f2f)