### PR TITLE
Denote Published Outputs

### DIFF
--- a/jobserver/templates/snapshot_detail.html
+++ b/jobserver/templates/snapshot_detail.html
@@ -37,9 +37,11 @@
 </nav>
 
 <h1 class="h3">
-  Outputs for {{ snapshot.workspace.name }}
   {% if snapshot.is_draft %}
+  Outputs for {{ snapshot.workspace.name }}
   <span class="badge badge-secondary">Draft</span>
+  {% else %}
+  Published outputs for {{ snapshot.workspace.name }}
   {% endif %}
 </h1>
 


### PR DESCRIPTION
We mark draft versions of published outputs, so this marks published ones explicitly too.

Fixes #757 