### PR TITLE
Check Perms for Publish Button

### DIFF
--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -83,7 +83,9 @@
         <a class="btn btn-primary mr-2" href="{{ workspace.get_files_url }}">Level 4 Outputs</a>
         {% endif %}
 
+        {% if user_can_view_releases %}
         <a class="btn btn-primary mr-2" href="{{ workspace.get_releases_url }}">Released Outputs</a>
+        {% endif %}
 
         {% if user_can_view_outputs %}
         <a class="btn btn-primary mr-2" href="{{ workspace.get_outputs_url }}">Published Outputs</a>

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -83,9 +83,7 @@
         <a class="btn btn-primary mr-2" href="{{ workspace.get_files_url }}">Level 4 Outputs</a>
         {% endif %}
 
-        {% if user_can_view_releases %}
         <a class="btn btn-primary mr-2" href="{{ workspace.get_releases_url }}">Released Outputs</a>
-        {% endif %}
 
         {% if user_can_view_outputs %}
         <a class="btn btn-primary mr-2" href="{{ workspace.get_outputs_url }}">Published Outputs</a>

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -414,9 +414,16 @@ class WorkspaceCurrentOutputsDetail(View):
         ):
             raise Http404
 
+        # only show the publish button if the user has permission to publish
+        # ouputs
+        can_publish = has_permission(
+            request.user, "create_snapshot", project=workspace.project
+        )
+        prepare_url = workspace.get_create_snapshot_api_url() if can_publish else ""
+
         context = {
             "files_url": workspace.get_releases_api_url(),
-            "prepare_url": workspace.get_create_snapshot_api_url(),
+            "prepare_url": prepare_url,
             "workspace": workspace,
         }
         return TemplateResponse(

--- a/tests/jobserver/views/test_workspaces.py
+++ b/tests/jobserver/views/test_workspaces.py
@@ -319,6 +319,45 @@ def test_workspacecreate_unauthorized(rf, user):
 
 @pytest.mark.django_db
 def test_workspacecurrentoutputsdetail_success(rf):
+    user = UserFactory(roles=[ProjectCollaborator])
+    workspace = WorkspaceFactory()
+
+    ProjectMembershipFactory(
+        project=workspace.project, user=user, roles=[ProjectDeveloper]
+    )
+
+    request = rf.get("/")
+    request.user = user
+
+    response = WorkspaceCurrentOutputsDetail.as_view()(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+    assert response.context_data["prepare_url"]
+
+
+@pytest.mark.django_db
+def test_workspacecurrentoutputsdetail_without_file_permission(rf):
+    workspace = WorkspaceFactory()
+
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    with pytest.raises(Http404):
+        WorkspaceCurrentOutputsDetail.as_view()(
+            request,
+            org_slug=workspace.project.org.slug,
+            project_slug=workspace.project.slug,
+            workspace_slug=workspace.name,
+        )
+
+
+@pytest.mark.django_db
+def test_workspacecurrentoutputsdetail_without_publish_permission(rf):
     workspace = WorkspaceFactory()
 
     request = rf.get("/")
@@ -332,22 +371,7 @@ def test_workspacecurrentoutputsdetail_success(rf):
     )
 
     assert response.status_code == 200
-
-
-@pytest.mark.django_db
-def test_workspacecurrentoutputsdetail_without_permission(rf):
-    workspace = WorkspaceFactory()
-
-    request = rf.get("/")
-    request.user = UserFactory()
-
-    with pytest.raises(Http404):
-        WorkspaceCurrentOutputsDetail.as_view()(
-            request,
-            org_slug=workspace.project.org.slug,
-            project_slug=workspace.project.slug,
-            workspace_slug=workspace.name,
-        )
+    assert not response.context_data["prepare_url"]
 
 
 @pytest.mark.django_db

--- a/tests/jobserver/views/test_workspaces.py
+++ b/tests/jobserver/views/test_workspaces.py
@@ -318,6 +318,54 @@ def test_workspacecreate_unauthorized(rf, user):
 
 
 @pytest.mark.django_db
+def test_workspacecurrentoutputsdetail_success(rf):
+    workspace = WorkspaceFactory()
+
+    request = rf.get("/")
+    request.user = UserFactory(roles=[ProjectCollaborator])
+
+    response = WorkspaceCurrentOutputsDetail.as_view()(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_workspacecurrentoutputsdetail_without_permission(rf):
+    workspace = WorkspaceFactory()
+
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    with pytest.raises(Http404):
+        WorkspaceCurrentOutputsDetail.as_view()(
+            request,
+            org_slug=workspace.project.org.slug,
+            project_slug=workspace.project.slug,
+            workspace_slug=workspace.name,
+        )
+
+
+@pytest.mark.django_db
+def test_workspacecurrentoutputsdetail_unknown_workspace(rf):
+    project = ProjectFactory()
+
+    request = rf.get("/")
+
+    with pytest.raises(Http404):
+        WorkspaceCurrentOutputsDetail.as_view()(
+            request,
+            org_slug=project.org.slug,
+            project_slug=project.slug,
+            workspace_slug="",
+        )
+
+
+@pytest.mark.django_db
 def test_workspacedetail_logged_out(rf):
     org = OrgFactory()
     project = ProjectFactory(org=org)
@@ -1132,54 +1180,6 @@ def test_workspacenotificationstoggle_unknown_workspace(rf, user):
     with pytest.raises(Http404):
         WorkspaceNotificationsToggle.as_view()(
             request, org_slug=org.slug, project_slug=project.slug, workspace_slug="test"
-        )
-
-
-@pytest.mark.django_db
-def test_workspacecurrentoutputsdetail_success(rf):
-    workspace = WorkspaceFactory()
-
-    request = rf.get("/")
-    request.user = UserFactory(roles=[ProjectCollaborator])
-
-    response = WorkspaceCurrentOutputsDetail.as_view()(
-        request,
-        org_slug=workspace.project.org.slug,
-        project_slug=workspace.project.slug,
-        workspace_slug=workspace.name,
-    )
-
-    assert response.status_code == 200
-
-
-@pytest.mark.django_db
-def test_workspacecurrentoutputsdetail_without_permission(rf):
-    workspace = WorkspaceFactory()
-
-    request = rf.get("/")
-    request.user = UserFactory()
-
-    with pytest.raises(Http404):
-        WorkspaceCurrentOutputsDetail.as_view()(
-            request,
-            org_slug=workspace.project.org.slug,
-            project_slug=workspace.project.slug,
-            workspace_slug=workspace.name,
-        )
-
-
-@pytest.mark.django_db
-def test_workspacecurrentoutputsdetail_unknown_workspace(rf):
-    project = ProjectFactory()
-
-    request = rf.get("/")
-
-    with pytest.raises(Http404):
-        WorkspaceCurrentOutputsDetail.as_view()(
-            request,
-            org_slug=project.org.slug,
-            project_slug=project.slug,
-            workspace_slug="",
         )
 
 


### PR DESCRIPTION
This checks that the current user has the `create_snapshot` permission to gate showing the Publish button.

Fixes #756 