### PR TITLE
Disable Viewing Files when Release is Empty

### DIFF
--- a/jobserver/templates/workspace_release_list.html
+++ b/jobserver/templates/workspace_release_list.html
@@ -42,7 +42,12 @@
 
       <div class="d-flex justify-content-between">
         <span>
-          Files released by {{ release.created_by.name }} {{ release.created_at|naturaltime }}
+          {% if release.files.exist %}
+          Files released
+          {% else %}
+          Release
+          {% endif %}
+          by {{ release.created_by.name }} {{ release.created_at|naturaltime }}
         </span>
 
         <div>

--- a/jobserver/templates/workspace_release_list.html
+++ b/jobserver/templates/workspace_release_list.html
@@ -46,10 +46,15 @@
         </span>
 
         <div>
-          <a class="btn btn-sm btn-primary" href="{{ release.get_absolute_url }}">View</a>
+          <a
+            class="btn btn-sm btn-primary {% if not release.files.exists %}disabled{% endif %}"
+            href="{{ release.get_absolute_url }}">View</a>
           <button
             class="btn btn-sm btn-primary"
             type="button"
+            {% if not release.files.exists %}
+            disabled
+            {% endif %}
             data-toggle="collapse"
             data-target="#release-{{ release.id }}-files"
             aria-expanded="false"

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -50,6 +50,9 @@ class ReleaseDetail(View):
             pk=self.kwargs["pk"],
         )
 
+        if not release.files.exists():
+            raise Http404
+
         # TODO: check permissions here
 
         context = {

--- a/tests/jobserver/views/test_releases.py
+++ b/tests/jobserver/views/test_releases.py
@@ -117,6 +117,22 @@ def test_releasedetail_with_path_success(rf):
 
 
 @pytest.mark.django_db
+def test_releasedetail_without_files(rf):
+    release = ReleaseFactory(uploads=[], uploaded=False)
+
+    request = rf.get("/")
+
+    with pytest.raises(Http404):
+        ReleaseDetail.as_view()(
+            request,
+            org_slug=release.workspace.project.org.slug,
+            project_slug=release.workspace.project.slug,
+            workspace_slug=release.workspace.name,
+            pk=release.id,
+        )
+
+
+@pytest.mark.django_db
 def test_snapshotdetail_published_logged_out(rf):
     snapshot = SnapshotFactory(published_at=timezone.now())
 


### PR DESCRIPTION
This disables the view and files buttons on the ReleaseList page when a Release has no files to view (eg from a broken upload) and returns a 404 on the ReleaseDetail page if there are no files for a Release.

Fixes #751 