### PR TITLE
File size fixes for the Outputs SPA

### DIFF
--- a/assets/src/scripts/outputs-viewer/components/FileList/List.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/List.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import useFileList from "../../hooks/use-file-list";
 import useStore from "../../stores/use-store";
+import prettyFileSize from "../../utils/pretty-file-size";
 
 function List() {
   const { data, error, isError, isLoading } = useFileList();
@@ -25,7 +26,11 @@ function List() {
     <>
       {data.map((item) => (
         <li key={item.url}>
-          <a href={item.url} onClick={(e) => selectFile({ e, item })}>
+          <a
+            href={item.url}
+            onClick={(e) => selectFile({ e, item })}
+            title={`File size: ${prettyFileSize(item.size)}`}
+          >
             {item.shortName}
           </a>
         </li>

--- a/assets/src/scripts/outputs-viewer/components/Metadata/Metadata.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Metadata/Metadata.jsx
@@ -1,14 +1,12 @@
-import prettyBytes from "pretty-bytes";
 import React from "react";
 import useStore from "../../stores/use-store";
+import prettyFileSize from "../../utils/pretty-file-size";
 import classes from "./Metadata.module.scss";
 
 function Metadata() {
   const { file } = useStore();
 
-  const fileSize = file.size
-    ? prettyBytes(file.size, { locale: "en-gb" })
-    : "unknown";
+  const fileSize = prettyFileSize(file.size);
   const date = new Date(file.date);
   const fileDateAbs = date.toISOString();
   const fileDate = new Intl.DateTimeFormat("en-GB", {

--- a/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
@@ -2,6 +2,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { readString } from "react-papaparse";
+import useStore from "../../stores/use-store";
 
 const TableCell = ({ cell }) => <td>{cell}</td>;
 
@@ -14,10 +15,25 @@ const TableRow = ({ row }) => (
 );
 
 function Table({ data }) {
+  const { file } = useStore();
+
   const jsonData = readString(data, {
     chunk: true,
     complete: (results) => results,
   }).data;
+
+  if (jsonData.length > 1000) {
+    return (
+      <>
+        <p>We cannot show a preview of this file.</p>
+        <p className="mb-0">
+          <a href={file.url} rel="noreferrer noopener" target="_blank">
+            Open file in a new tab &#8599;
+          </a>
+        </p>
+      </>
+    );
+  }
 
   return (
     <div className="table-responsive">

--- a/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
@@ -15,6 +15,7 @@ const TableRow = ({ row }) => (
 
 function Table({ data }) {
   const jsonData = readString(data, {
+    chunk: true,
     complete: (results) => results,
   }).data;
 

--- a/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-array-index-key */
 import PropTypes from "prop-types";
 import React from "react";
 import { readString } from "react-papaparse";
@@ -6,8 +7,8 @@ const TableCell = ({ cell }) => <td>{cell}</td>;
 
 const TableRow = ({ row }) => (
   <tr>
-    {row.map((cell) => (
-      <TableCell key={row + cell} cell={cell} />
+    {row.map((cell, i) => (
+      <TableCell key={i} cell={cell} />
     ))}
   </tr>
 );
@@ -21,8 +22,8 @@ function Table({ data }) {
     <div className="table-responsive">
       <table className="table table-striped">
         <tbody>
-          {jsonData.map((row) => (
-            <TableRow key={row.join(",")} row={row} />
+          {jsonData.map((row, i) => (
+            <TableRow key={i} row={row} />
           ))}
         </tbody>
       </table>

--- a/assets/src/scripts/outputs-viewer/hooks/use-file.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file.js
@@ -1,16 +1,21 @@
 import { useQuery } from "react-query";
 import useStore from "../stores/use-store";
 import handleErrors from "../utils/fetch-handle-errors";
-import { canDisplay } from "../utils/file-type-match";
+import { canDisplay, isCsv } from "../utils/file-type-match";
 
 function useFile(file) {
   const { authToken } = useStore();
 
   return useQuery(["FILE", file.url], async () => {
     // If we can't display the file type
-    // or the file size is too large
+    // or the file size is too large (>20mb)
     // don't try to return the data
     if (!canDisplay(file) || file.size > 20000000) return {};
+
+    // If the file is a CSV
+    // and the file size is too large (>5mb)
+    // don't try to return the data
+    if (isCsv(file) && file.size > 5000000) return {};
 
     return fetch(file.url, {
       headers: new Headers({

--- a/assets/src/scripts/outputs-viewer/utils/pretty-file-size.js
+++ b/assets/src/scripts/outputs-viewer/utils/pretty-file-size.js
@@ -1,0 +1,7 @@
+import prettyBytes from "pretty-bytes";
+
+function prettyFileSize(fileSize) {
+  return fileSize ? prettyBytes(fileSize, { locale: "en-gb" }) : "unknown";
+}
+
+export default prettyFileSize;


### PR DESCRIPTION
- Show file size as `title` in the file list
- Improve performance when rendering CSVs
- Stop large CSVs from being previewed