### PR TITLE
Download Releases

### DIFF
--- a/jobserver/models/outputs.py
+++ b/jobserver/models/outputs.py
@@ -64,6 +64,17 @@ class Release(models.Model):
     def get_api_url(self):
         return reverse("api:release", kwargs={"release_id": self.id})
 
+    def get_download_url(self):
+        return reverse(
+            "release-download",
+            kwargs={
+                "org_slug": self.workspace.project.org.slug,
+                "project_slug": self.workspace.project.slug,
+                "workspace_slug": self.workspace.name,
+                "pk": self.id,
+            },
+        )
+
 
 class ReleaseFile(models.Model):
     """Individual files in a Release.

--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -1,4 +1,6 @@
 import hashlib
+import io
+import zipfile
 from datetime import timedelta
 from pathlib import Path
 
@@ -33,6 +35,22 @@ def build_hatch_token_and_url(*, backend, workspace, user, expiry=None):
     token = builder.sign(key=backend.auth_token, salt="hatch")
 
     return token, f.url
+
+
+def build_outputs_zip(release_files):
+    # create an in memory stream so we don't need to write the file to disk
+    in_memory_zf = io.BytesIO()
+
+    # add each ReleaseFile to the zip using their name as the name in the
+    # archive
+    with zipfile.ZipFile(in_memory_zf, "w") as zip_obj:
+        for rfile in release_files:
+            zip_obj.write(rfile.absolute_path(), arcname=rfile.name)
+
+    # rewind the file stream to the start
+    in_memory_zf.seek(0)
+
+    return in_memory_zf
 
 
 def check_not_already_uploaded(filename, filehash, backend):

--- a/jobserver/templates/release_detail.html
+++ b/jobserver/templates/release_detail.html
@@ -36,7 +36,13 @@
   </ol>
 </nav>
 
-<h1 class="h3">Release from {{ release.workspace.name }}</h1>
+<div class="d-flex justify-content-between align-items-center">
+  <h1 class="h3">Release from {{ release.workspace.name }}</h1>
+
+  <a class="btn btn-sm btn-primary" href="{{ release.get_download_url }}">
+    Download
+  </a>
+</div>
 
 <p class="mb-2 text-muted">
   Released by {{ release.created_by.name }} on

--- a/jobserver/templates/workspace_release_list.html
+++ b/jobserver/templates/workspace_release_list.html
@@ -53,6 +53,9 @@
         <div>
           <a
             class="btn btn-sm btn-primary {% if not release.files.exists %}disabled{% endif %}"
+            href="{{ release.get_download_url }}">Download</a>
+          <a
+            class="btn btn-sm btn-primary {% if not release.files.exists %}disabled{% endif %}"
             href="{{ release.get_absolute_url }}">View</a>
           <button
             class="btn btn-sm btn-primary"

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -43,6 +43,7 @@ from .views.projects import (
 from .views.releases import (
     ProjectReleaseList,
     ReleaseDetail,
+    ReleaseDownload,
     SnapshotDetail,
     WorkspaceReleaseList,
 )
@@ -183,6 +184,7 @@ workspace_urls = [
         name="workspace-release-list",
     ),
     path("releases/<pk>/", ReleaseDetail.as_view(), name="release-detail"),
+    path("releases/<pk>/download/", ReleaseDownload.as_view(), name="release-download"),
     path("releases/<pk>/<path:path>", ReleaseDetail.as_view(), name="release-detail"),
 ]
 

--- a/tests/jobserver/models/test_outputs.py
+++ b/tests/jobserver/models/test_outputs.py
@@ -35,6 +35,23 @@ def test_release_get_api_url():
 
 
 @pytest.mark.django_db
+def test_release_get_download_url():
+    release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
+
+    url = release.get_download_url()
+
+    assert url == reverse(
+        "release-download",
+        kwargs={
+            "org_slug": release.workspace.project.org.slug,
+            "project_slug": release.workspace.project.slug,
+            "workspace_slug": release.workspace.name,
+            "pk": release.id,
+        },
+    )
+
+
+@pytest.mark.django_db
 def test_release_ulid():
     release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
     assert release.ulid.timestamp


### PR DESCRIPTION
This adds the ability for privileged users (those with ProjectCollaborator role/`view_release_file` permission) to download a zip of a Release.

**Downlad from Release list page**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/lluomBn1/3ba45c4d-350e-4322-a3fd-7abde0964943.jpg?v=7286550ce88e6052569f21ee0413bfae)

**Download from ReleaseDetail page** 
![](https://p198.p4.n0.cdn.getcloudapp.com/items/JruxAdqo/c59137d4-2033-4807-81b1-300bb7d84682.jpg?v=f8b2418c0ac1ecbdc8a216aa084524a4)

Fixes #766 