### PR TITLE
Download Snapshots

### DIFF
--- a/jobserver/models/outputs.py
+++ b/jobserver/models/outputs.py
@@ -190,6 +190,17 @@ class Snapshot(models.Model):
             },
         )
 
+    def get_download_url(self):
+        return reverse(
+            "workspace-snapshot-download",
+            kwargs={
+                "org_slug": self.workspace.project.org.slug,
+                "project_slug": self.workspace.project.slug,
+                "workspace_slug": self.workspace.name,
+                "pk": self.pk,
+            },
+        )
+
     def get_publish_api_url(self):
         return reverse(
             "api:snapshot-publish",

--- a/jobserver/templates/snapshot_detail.html
+++ b/jobserver/templates/snapshot_detail.html
@@ -36,14 +36,20 @@
   </ol>
 </nav>
 
-<h1 class="h3">
-  {% if snapshot.is_draft %}
-  Outputs for {{ snapshot.workspace.name }}
-  <span class="badge badge-secondary">Draft</span>
-  {% else %}
-  Published outputs for {{ snapshot.workspace.name }}
-  {% endif %}
-</h1>
+<div class="d-flex justify-content-between align-items-center">
+  <h1 class="h3">
+    {% if snapshot.is_draft %}
+    Outputs for {{ snapshot.workspace.name }}
+    <span class="badge badge-secondary">Draft</span>
+    {% else %}
+    Published outputs for {{ snapshot.workspace.name }}
+    {% endif %}
+  </h1>
+
+  <a class="btn btn-sm btn-primary" href="{{ snapshot.get_download_url }}">
+    Download
+  </a>
+</div>
 
 {% include "outputs-spa.html" %}
 

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -45,6 +45,7 @@ from .views.releases import (
     ReleaseDetail,
     ReleaseDownload,
     SnapshotDetail,
+    SnapshotDownload,
     WorkspaceReleaseList,
 )
 from .views.status import Status
@@ -157,6 +158,11 @@ outputs_urls = [
         "<pk>/",
         SnapshotDetail.as_view(),
         name="workspace-snapshot-detail",
+    ),
+    path(
+        "<pk>/download/",
+        SnapshotDownload.as_view(),
+        name="workspace-snapshot-download",
     ),
     path(
         "<pk>/<path:path>",

--- a/tests/jobserver/models/test_outputs.py
+++ b/tests/jobserver/models/test_outputs.py
@@ -144,6 +144,23 @@ def test_snapshot_get_api_url():
 
 
 @pytest.mark.django_db
+def test_snapshot_get_download_url():
+    snapshot = SnapshotFactory()
+
+    url = snapshot.get_download_url()
+
+    assert url == reverse(
+        "workspace-snapshot-download",
+        kwargs={
+            "org_slug": snapshot.workspace.project.org.slug,
+            "project_slug": snapshot.workspace.project.slug,
+            "workspace_slug": snapshot.workspace.name,
+            "pk": snapshot.pk,
+        },
+    )
+
+
+@pytest.mark.django_db
 def test_snapshot_get_publish_api_url():
     snapshot = SnapshotFactory()
 


### PR DESCRIPTION
This lets users download the files in a Snapshot (published outputs) as a zip.  Users must be a ProjectCollaborator to download the files in a draft Snapshot.

Fixes #767 