### PR TITLE
Fixes for outputs file viewer SPA

### DIFF
--- a/assets/src/scripts/outputs-viewer/components/FileList/Filter.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/Filter.jsx
@@ -1,11 +1,10 @@
 import PropTypes from "prop-types";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import useFileList from "../../hooks/use-file-list";
 
 function Filter({ setFiles }) {
   const { data } = useFileList();
   const [filter, setFilter] = useState("");
-  const inputRef = useRef(null);
 
   useEffect(() => {
     if (filter) {
@@ -31,7 +30,6 @@ function Filter({ setFiles }) {
     <label className="w-100" htmlFor="filterFiles">
       <span className="sr-only">Find a file…</span>
       <input
-        ref={inputRef}
         autoCapitalize="off"
         autoComplete="off"
         autoCorrect="off"

--- a/assets/src/scripts/outputs-viewer/components/FileList/Filter.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/Filter.jsx
@@ -13,7 +13,7 @@ function Filter({ setFiles }) {
         () =>
           setFiles(
             data.filter((state) =>
-              state.name.toLowerCase().includes(filter.toLowerCase())
+              state.shortName.toLowerCase().includes(filter.toLowerCase())
             )
           ),
         350

--- a/assets/src/scripts/outputs-viewer/components/FileList/Filter.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/Filter.jsx
@@ -1,17 +1,28 @@
 import PropTypes from "prop-types";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import useFileList from "../../hooks/use-file-list";
 
 function Filter({ setFiles }) {
   const { data } = useFileList();
   const [filter, setFilter] = useState("");
+  const inputRef = useRef(null);
 
   useEffect(() => {
-    if (data) {
-      return filter
-        ? setFiles(data.filter((item) => item.shortName.includes(filter)))
-        : setFiles(data);
+    if (filter) {
+      const timer = setTimeout(
+        () =>
+          setFiles(
+            data.filter((state) =>
+              state.name.toLowerCase().includes(filter.toLowerCase())
+            )
+          ),
+        350
+      );
+
+      return () => clearTimeout(timer);
     }
+
+    if (data) return setFiles(data);
 
     return setFiles([]);
   }, [data, filter, setFiles]);
@@ -20,6 +31,7 @@ function Filter({ setFiles }) {
     <label className="w-100" htmlFor="filterFiles">
       <span className="sr-only">Find a file…</span>
       <input
+        ref={inputRef}
         autoCapitalize="off"
         autoComplete="off"
         autoCorrect="off"

--- a/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
@@ -22,7 +22,7 @@ function Table({ data }) {
     complete: (results) => results,
   }).data;
 
-  if (jsonData.length > 1000) {
+  if (jsonData.length > 5000) {
     return (
       <>
         <p>We cannot show a preview of this file.</p>
@@ -31,6 +31,25 @@ function Table({ data }) {
             Open file in a new tab &#8599;
           </a>
         </p>
+      </>
+    );
+  }
+
+  if (jsonData.length > 1000) {
+    return (
+      <>
+        <p>
+          <strong>This is a preview of the first 1000 lines</strong>
+        </p>
+        <div className="table-responsive">
+          <table className="table table-striped">
+            <tbody>
+              {jsonData.slice(0, 999).map((row, i) => (
+                <TableRow key={i} row={row} />
+              ))}
+            </tbody>
+          </table>
+        </div>
       </>
     );
   }

--- a/assets/src/scripts/outputs-viewer/components/Viewer/Viewer.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Viewer/Viewer.jsx
@@ -7,6 +7,7 @@ import {
   isCsv,
   isHtml,
   isImg,
+  isJson,
   isTxt,
 } from "../../utils/file-type-match";
 import Iframe from "../Iframe/Iframe";
@@ -79,7 +80,7 @@ function Viewer() {
       {isCsv(file) ? <Table data={data} /> : null}
       {isHtml(file) ? <Iframe data={data} /> : null}
       {isImg(file) ? <Image /> : null}
-      {isTxt(file) ? <Text data={data} /> : null}
+      {isTxt(file) || isJson(file) ? <Text data={data} /> : null}
     </Wrapper>
   );
 }

--- a/assets/src/scripts/outputs-viewer/utils/file-type-match.js
+++ b/assets/src/scripts/outputs-viewer/utils/file-type-match.js
@@ -1,13 +1,13 @@
-export const isCsv = (file) => file.name.match(/.*\.(?:csv)$/i);
+export const isCsv = (file) => file.name.toLowerCase().match(/.*\.(?:csv)$/i);
 
-export const isHtml = (file) => file.name.match(/.*\.(?:html)$/i);
+export const isHtml = (file) => file.name.toLowerCase().match(/.*\.(?:html)$/i);
 
 export const isImg = (file) =>
-  file.name.match(/.*\.(?:gif|jpg|jpeg|png|svg)$/i);
+  file.name.toLowerCase().match(/.*\.(?:gif|jpg|jpeg|png|svg)$/i);
 
-export const isTxt = (file) => file.name.match(/.*\.(?:txt)$/i);
+export const isTxt = (file) => file.name.toLowerCase().match(/.*\.(?:txt)$/i);
 
-export const isJson = (file) => file.name.match(/.*\.(?:json)$/i);
+export const isJson = (file) => file.name.toLowerCase().match(/.*\.(?:json)$/i);
 
 export const canDisplay = (file) =>
   isCsv(file) || isHtml(file) || isImg(file) || isTxt(file) || isJson(file);

--- a/assets/src/scripts/outputs-viewer/utils/file-type-match.js
+++ b/assets/src/scripts/outputs-viewer/utils/file-type-match.js
@@ -7,5 +7,7 @@ export const isImg = (file) =>
 
 export const isTxt = (file) => file.name.match(/.*\.(?:txt)$/i);
 
+export const isJson = (file) => file.name.match(/.*\.(?:json)$/i);
+
 export const canDisplay = (file) =>
-  isCsv(file) || isHtml(file) || isImg(file) || isTxt(file);
+  isCsv(file) || isHtml(file) || isImg(file) || isTxt(file) || isJson(file);


### PR DESCRIPTION
- Debounce the file filter functions to improve performance
- JSON files can now be previewed
- Do not preview CSV files over 500 lines
- Preview first 1000 lines of CSV files between 1000-5000 lines long