### PR TITLE
Render FileList using a virtualisation library

### DIFF
--- a/assets/src/scripts/outputs-viewer/App.jsx
+++ b/assets/src/scripts/outputs-viewer/App.jsx
@@ -25,7 +25,7 @@ function App() {
     <BrowserRouter basename={basePath}>
       <QueryClientProvider client={queryClient}>
         {hasButtons && (
-          <div className="row">
+          <div className="row mb-2">
             <div className="col">
               {prepareUrl && <PrepareButton />}
               {publishUrl && <PublishButton />}

--- a/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
@@ -90,7 +90,7 @@ function FileList() {
   };
 
   return (
-    <>
+    <div className={classes.sidebar}>
       <Filter
         className={`${listVisible ? "d-block" : "d-none"}`}
         listRef={listRef}
@@ -118,7 +118,7 @@ function FileList() {
           </li>
         )}
       </FixedSizeList>
-    </>
+    </div>
   );
 }
 

--- a/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
@@ -27,12 +27,17 @@ function FileList() {
     const hasScrollbarX =
       listEl.current?.clientWidth < listEl.current?.scrollWidth;
 
-    // Viewport size, minus the list height, minus 30px for spacing
-    // If there are horizontal scrollbars, minus 17px for the scrollbar
     const fileListHeight =
+      // Viewport size height
       window.innerHeight -
+      // if the list exists
+      // minus the height from the top of the list
+      // else minus zero
       (listEl.current?.getBoundingClientRect().top || 0) -
+      // minus 30px for spacing at the bottom
       30 -
+      // if there are horizontal scrollbars
+      // minus 17px for the scrollbar (magic number)
       (hasScrollbarX ? 17 : 0);
 
     if (largeViewport) {

--- a/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { createRef, useEffect, useRef, useState } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import { FixedSizeList } from "react-window";
 import useFileList from "../../hooks/use-file-list";
@@ -20,6 +20,7 @@ function FileList() {
   const windowSize = useWindowSize();
 
   const listEl = useRef(null);
+  const listRef = createRef();
 
   useEffect(() => {
     const largeViewport = window.innerWidth > 991;
@@ -39,7 +40,6 @@ function FileList() {
       return setListHeight(fileListHeight);
     }
 
-    console.log({ fileListHeight });
     return setListHeight(fileListHeight);
   }, [files, windowSize]);
 
@@ -91,8 +91,13 @@ function FileList() {
 
   return (
     <>
-      <Filter setFiles={setFiles} />
+      <Filter
+        className={`${listVisible ? "d-block" : "d-none"}`}
+        listRef={listRef}
+        setFiles={setFiles}
+      />
       <FixedSizeList
+        ref={listRef}
         className={`${classes.list} card ${listVisible ? "d-block" : "d-none"}`}
         height={listHeight}
         innerElementType="ul"

--- a/assets/src/scripts/outputs-viewer/components/FileList/FileList.module.scss
+++ b/assets/src/scripts/outputs-viewer/components/FileList/FileList.module.scss
@@ -1,16 +1,22 @@
-.list {
-  ul {
-  font-size: 0.9rem;
-  list-style-type: none;
-  margin: 1rem;
-  padding: 0;
+.sidebar {
   position: sticky;
   top: 1rem;
-  white-space: pre-line;
-  width: calc(100% - 1rem) !important;
+}
 
-  li a {
-    padding-right: 0.5rem;
-    white-space: nowrap;
+.list {
+  ul {
+    font-size: 0.9rem;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+
+    li {
+      padding: 1rem;
+
+      a {
+        padding-right: 0.5rem;
+        white-space: nowrap;
+      }
+    }
   }
-}}
+}

--- a/assets/src/scripts/outputs-viewer/components/FileList/FileList.module.scss
+++ b/assets/src/scripts/outputs-viewer/components/FileList/FileList.module.scss
@@ -1,13 +1,16 @@
 .list {
+  ul {
   font-size: 0.9rem;
-  margin: 0;
-  overflow: auto;
-  padding: 1rem;
+  list-style-type: none;
+  margin: 1rem;
+  padding: 0;
   position: sticky;
   top: 1rem;
   white-space: pre-line;
+  width: calc(100% - 1rem) !important;
 
   li a {
+    padding-right: 0.5rem;
     white-space: nowrap;
   }
-}
+}}

--- a/assets/src/scripts/outputs-viewer/components/FileList/Filter.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/Filter.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import useFileList from "../../hooks/use-file-list";
 
-function Filter({ setFiles }) {
+function Filter({ className, listRef, setFiles }) {
   const { data } = useFileList();
   const [filter, setFilter] = useState("");
 
@@ -26,8 +26,13 @@ function Filter({ setFiles }) {
     return setFiles([]);
   }, [data, filter, setFiles]);
 
+  function filterOnChange(e) {
+    listRef?.current?.scrollToItem(0);
+    setFilter(e.target.value);
+  }
+
   return (
-    <label className="w-100" htmlFor="filterFiles">
+    <label className={`w-100 ${className}`} htmlFor="filterFiles">
       <span className="sr-only">Find a file…</span>
       <input
         autoCapitalize="off"
@@ -35,7 +40,7 @@ function Filter({ setFiles }) {
         autoCorrect="off"
         className="form-control mb-0"
         id="filterFiles"
-        onChange={(e) => setFilter(e.target.value)}
+        onChange={(e) => filterOnChange(e)}
         placeholder="Find a file…"
         spellCheck="false"
         type="search"
@@ -48,5 +53,14 @@ function Filter({ setFiles }) {
 export default Filter;
 
 Filter.propTypes = {
+  className: PropTypes.string,
+  listRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]).isRequired,
   setFiles: PropTypes.func.isRequired,
+};
+
+Filter.defaultProps = {
+  className: "",
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-papaparse": "^3.17.1",
         "react-query": "^3.19.2",
         "react-router-dom": "^5.2.0",
+        "react-window": "^1.8.6",
         "select2": "^4.0.13",
         "whatwg-fetch": "^3.6.2",
         "zustand": "^3.5.7"
@@ -3006,6 +3007,11 @@
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
       "dev": true
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4205,6 +4211,22 @@
       },
       "peerDependencies": {
         "react": ">=15"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
+      "integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/read-pkg": {
@@ -7492,6 +7514,11 @@
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
       "dev": true
     },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -8321,6 +8348,15 @@
         "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-window": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
+      "integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-papaparse": "^3.17.1",
     "react-query": "^3.19.2",
     "react-router-dom": "^5.2.0",
+    "react-window": "^1.8.6",
     "select2": "^4.0.13",
     "whatwg-fetch": "^3.6.2",
     "zustand": "^3.5.7"


### PR DESCRIPTION
[React window](https://github.com/bvaughn/react-window) works by only rendering part of a large data set (just enough to fill the viewport). This helps address some common performance bottlenecks:

- It reduces the amount of work (and time) required to render the initial view and to process updates.
- It reduces the memory footprint by avoiding over-allocation of DOM nodes.

We can use this library for the FileList to help alleviate performance issues.

---

Closes #802 