### PR TITLE
Fix Release List Permissions

### DIFF
--- a/jobserver/templates/_release_list.html
+++ b/jobserver/templates/_release_list.html
@@ -6,18 +6,18 @@
     <span>{{ r.title }}</span>
 
     <div>
-      <a class="btn btn-sm btn-primary {% if not r.files %}disabled{% endif %}"
+      <a class="btn btn-sm btn-primary {% if not r.can_view_files %}disabled{% endif %}"
          href="{{ r.download_url }}">
         Download
       </a>
-      <a class="btn btn-sm btn-primary {% if not r.files %}disabled{% endif %}"
+      <a class="btn btn-sm btn-primary {% if not r.can_view_files %}disabled{% endif %}"
          href="{{ r.view_url }}">
         View
       </a>
       <button
         class="btn btn-sm btn-primary"
         type="button"
-        {% if not r.files %}
+        {% if not r.can_view_files %}
         disabled
         {% endif %}
         data-toggle="collapse"
@@ -29,6 +29,7 @@
     </div>
   </div>
 
+  {% if r.can_view_files %}
   <div class="collapse" id="release-{{ r.id }}-files">
     <div class="card card-body border-0 mt-2 p-0 px-2">
       <table class="table table-striped">
@@ -72,5 +73,6 @@
       </table>
     </div>
   </div>
+  {% endif %}
 
 </div>

--- a/jobserver/templates/workspace_release_list.html
+++ b/jobserver/templates/workspace_release_list.html
@@ -38,7 +38,7 @@
 
     <h4>Releases for the {{ workspace.name }} workspace</h4>
 
-    {% if user_can_view_all_files %}
+    {% if latest_files.can_view_files %}
     {% include "_release_list.html" with r=latest_files %}
     {% endif %}
 

--- a/tests/jobserver/views/test_releases.py
+++ b/tests/jobserver/views/test_releases.py
@@ -101,7 +101,7 @@ def test_projectreleaselist_with_delete_permission(rf):
     )
 
     request = rf.get("/")
-    request.user = UserFactory(roles=[OutputChecker])
+    request.user = UserFactory(roles=[OutputChecker, ProjectCollaborator])
 
     response = ProjectReleaseList.as_view()(
         request,
@@ -624,7 +624,7 @@ def test_workspacereleaselist_authenticated_to_view_not_delete(rf):
     assert response.context_data["workspace"] == workspace
     assert len(response.context_data["releases"]) == 1
 
-    assert response.context_data["user_can_view_all_files"]
+    assert all(r["can_view_files"] for r in response.context_data["releases"])
     assert "Latest outputs" in response.rendered_content
 
     assert not response.context_data["user_can_delete_files"]
@@ -649,7 +649,7 @@ def test_workspacereleaselist_authenticated_to_view_and_delete(rf):
     assert response.status_code == 200
     assert len(response.context_data["releases"]) == 1
 
-    assert response.context_data["user_can_view_all_files"]
+    assert all(r["can_view_files"] for r in response.context_data["releases"])
     assert "Latest outputs" in response.rendered_content
 
     assert response.context_data["user_can_delete_files"]


### PR DESCRIPTION
We don't want to disclose ReleaseFile names when a User doesn't have permission to view files, so this combines the two checks of "does this Release[-like-object] have files" and "can the user view them" into a boolean on those objects letting us hide the files list when it's not true.

It also uses that boolean to disable the controls for viewing and downloading the files.

This permission is already checked in the relevant views the controls link to, but this makes the UI less confusing for a User without the relevant permission.

Ref #721 