### PR TITLE
Fix error when no data passed to preview components

### DIFF
--- a/assets/src/scripts/outputs-viewer/components/Iframe/Iframe.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Iframe/Iframe.jsx
@@ -1,10 +1,11 @@
-import PropTypes from "prop-types";
 import React, { useLayoutEffect, useState } from "react";
+import useFile from "../../hooks/use-file";
 import useWindowSize from "../../hooks/use-window-size";
 import useStore from "../../stores/use-store";
 
-function Iframe({ data }) {
+function Iframe() {
   const { file } = useStore();
+  const { data } = useFile(file);
   const windowSize = useWindowSize();
   const [frameHeight, setFrameHeight] = useState(0);
   const id = encodeURIComponent(file.url).replace(/\W/g, "");
@@ -36,9 +37,5 @@ function Iframe({ data }) {
     />
   );
 }
-
-Iframe.propTypes = {
-  data: PropTypes.string.isRequired,
-};
 
 export default Iframe;

--- a/assets/src/scripts/outputs-viewer/components/Image/Image.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Image/Image.jsx
@@ -1,13 +1,12 @@
-import PropTypes from "prop-types";
 import React from "react";
+import useFile from "../../hooks/use-file";
+import useStore from "../../stores/use-store";
 import classes from "./Image.module.scss";
 
-function Image({ data }) {
+function Image() {
+  const { file } = useStore();
+  const { data } = useFile(file);
   return <img alt="" className={classes.img} src={data} />;
 }
 
 export default Image;
-
-Image.propTypes = {
-  data: PropTypes.string.isRequired,
-};

--- a/assets/src/scripts/outputs-viewer/components/NoPreview/NoPreview.jsx
+++ b/assets/src/scripts/outputs-viewer/components/NoPreview/NoPreview.jsx
@@ -1,0 +1,29 @@
+import PropTypes from "prop-types";
+import React from "react";
+import useStore from "../../stores/use-store";
+
+function NoPreview({ error }) {
+  const { file } = useStore();
+
+  return (
+    <>
+      {error ? <p>Error: {error}</p> : null}
+      <p>We cannot show a preview of this file.</p>
+      <p className="mb-0">
+        <a href={file.url} rel="noreferrer noopener" target="_blank">
+          Open file in a new tab &#8599;
+        </a>
+      </p>
+    </>
+  );
+}
+
+export default NoPreview;
+
+NoPreview.propTypes = {
+  error: PropTypes.string,
+};
+
+NoPreview.defaultProps = {
+  error: null,
+};

--- a/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
@@ -2,38 +2,34 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { readString } from "react-papaparse";
+import useFile from "../../hooks/use-file";
 import useStore from "../../stores/use-store";
+import NoPreview from "../NoPreview/NoPreview";
 
-const TableCell = ({ cell }) => <td>{cell}</td>;
+function TableCell({ cell }) {
+  return <td>{cell}</td>;
+}
 
-const TableRow = ({ row }) => (
-  <tr>
-    {row.map((cell, i) => (
-      <TableCell key={i} cell={cell} />
-    ))}
-  </tr>
-);
+function TableRow({ row }) {
+  return (
+    <tr>
+      {row.map((cell, i) => (
+        <TableCell key={i} cell={cell} />
+      ))}
+    </tr>
+  );
+}
 
-function Table({ data }) {
+function Table() {
   const { file } = useStore();
+  const { data } = useFile(file);
 
   const jsonData = readString(data, {
     chunk: true,
     complete: (results) => results,
   }).data;
 
-  if (jsonData.length > 5000) {
-    return (
-      <>
-        <p>We cannot show a preview of this file.</p>
-        <p className="mb-0">
-          <a href={file.url} rel="noreferrer noopener" target="_blank">
-            Open file in a new tab &#8599;
-          </a>
-        </p>
-      </>
-    );
-  }
+  if (jsonData.length > 5000) return <NoPreview />;
 
   if (jsonData.length > 1000) {
     return (
@@ -73,10 +69,6 @@ TableCell.propTypes = {
 
 TableRow.propTypes = {
   row: PropTypes.arrayOf(PropTypes.string).isRequired,
-};
-
-Table.propTypes = {
-  data: PropTypes.string.isRequired,
 };
 
 export default Table;

--- a/assets/src/scripts/outputs-viewer/components/Text/Text.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Text/Text.jsx
@@ -1,13 +1,12 @@
-import PropTypes from "prop-types";
 import React from "react";
+import useFile from "../../hooks/use-file";
+import useStore from "../../stores/use-store";
 import classes from "./Text.module.scss";
 
-function Text({ data }) {
+function Text() {
+  const { file } = useStore();
+  const { data } = useFile(file);
   return <pre className={classes.txt}>{data}</pre>;
 }
-
-Text.propTypes = {
-  data: PropTypes.string.isRequired,
-};
 
 export default Text;

--- a/assets/src/scripts/outputs-viewer/components/Viewer/Viewer.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Viewer/Viewer.jsx
@@ -13,6 +13,7 @@ import {
 import Iframe from "../Iframe/Iframe";
 import Image from "../Image/Image";
 import Metadata from "../Metadata/Metadata";
+import NoPreview from "../NoPreview/NoPreview";
 import Table from "../Table/Table";
 import Text from "../Text/Text";
 
@@ -45,15 +46,10 @@ function Viewer() {
     );
   }
 
-  if (isError) {
+  if (isError || !data) {
     return (
       <Wrapper>
-        <p>Error: {error}</p>
-        <p className="mb-0">
-          <a href={file.url} rel="noreferrer noopener" target="_blank">
-            Open file in a new tab &#8599;
-          </a>
-        </p>
+        <NoPreview error={error} />
       </Wrapper>
     );
   }
@@ -65,12 +61,7 @@ function Viewer() {
   if (incompatibleFileType || emptyData) {
     return (
       <Wrapper>
-        <p>We cannot show a preview of this file.</p>
-        <p className="mb-0">
-          <a href={file.url} rel="noreferrer noopener" target="_blank">
-            Open file in a new tab &#8599;
-          </a>
-        </p>
+        <NoPreview error={error} />
       </Wrapper>
     );
   }

--- a/assets/src/scripts/outputs-viewer/components/Viewer/Viewer.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Viewer/Viewer.jsx
@@ -68,10 +68,10 @@ function Viewer() {
 
   return (
     <Wrapper>
-      {isCsv(file) ? <Table data={data} /> : null}
-      {isHtml(file) ? <Iframe data={data} /> : null}
-      {isImg(file) ? <Image data={data} /> : null}
-      {isTxt(file) || isJson(file) ? <Text data={data} /> : null}
+      {isCsv(file) ? <Table /> : null}
+      {isHtml(file) ? <Iframe /> : null}
+      {isImg(file) ? <Image /> : null}
+      {isTxt(file) || isJson(file) ? <Text /> : null}
     </Wrapper>
   );
 }


### PR DESCRIPTION
Error in `react-papaparse`: `Cannot read property 'readable' of undefined`

- Do not show preview components if data returned is not defined
- Replace `data` prop with query in each preview component
- Define a `<NoPreview />` component to be used when preview is failing