### PR TITLE
Fix word break for long file names

### DIFF
--- a/assets/src/scripts/outputs-viewer/components/Toast/Toast.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Toast/Toast.jsx
@@ -20,6 +20,14 @@ function Toast() {
       toastOptions={{
         duration: Infinity,
 
+        style: {
+          whiteSpace: "pre-line",
+          overflowWrap: "break-word",
+          wordWrap: "break-word",
+          wordBreak: "break-word",
+          hyphens: "auto",
+        },
+
         error: {
           style: {
             color: "#721c24",


### PR DESCRIPTION
## Before

![before](https://user-images.githubusercontent.com/24863179/129554957-8017186c-e18d-4bb1-a46d-9c86f7927b5b.png)

## After

![after](https://user-images.githubusercontent.com/24863179/129554953-7feb8492-e25a-4fad-8eea-6d4473685e57.png)

