### PR TITLE
Check Users have Access to Backends to Run Jobs

### DIFF
--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -14,7 +14,6 @@ from ..forms import JobRequestCreateForm, JobRequestSearchForm
 from ..github import get_branch_sha
 from ..models import Backend, JobRequest, User, Workspace
 from ..project import get_actions, get_project, load_yaml, render_definition
-from ..roles import can_run_jobs
 from ..utils import raise_if_not_int
 
 
@@ -84,8 +83,7 @@ class JobRequestCreate(CreateView):
             messages.error(request, msg)
             return redirect(self.workspace)
 
-        self.user_can_run_jobs = can_run_jobs(request.user)
-        if not self.user_can_run_jobs:
+        if not has_permission(request.user, "run_job", project=self.workspace.project):
             raise Http404
 
         action_status_lut = self.workspace.get_action_status_lut()

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -75,6 +75,9 @@ class JobRequestCreate(CreateView):
         except Workspace.DoesNotExist:
             return redirect("/")
 
+        if not has_permission(request.user, "run_job", project=self.workspace.project):
+            raise Http404
+
         if self.workspace.is_archived:
             msg = (
                 "You cannot create Jobs for an archived Workspace."
@@ -82,9 +85,6 @@ class JobRequestCreate(CreateView):
             )
             messages.error(request, msg)
             return redirect(self.workspace)
-
-        if not has_permission(request.user, "run_job", project=self.workspace.project):
-            raise Http404
 
         action_status_lut = self.workspace.get_action_status_lut()
 

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -86,6 +86,11 @@ class JobRequestCreate(CreateView):
             messages.error(request, msg)
             return redirect(self.workspace)
 
+        # jobs need to be run on a backend so the user needs to have access to
+        # at least one
+        if not request.user.backends.exists():
+            raise Http404
+
         action_status_lut = self.workspace.get_action_status_lut()
 
         # build actions as list or render the exception to the page

--- a/tests/jobserver/views/test_job_requests.py
+++ b/tests/jobserver/views/test_job_requests.py
@@ -454,12 +454,17 @@ def test_jobrequestcreate_unknown_workspace(rf, user):
 
 @pytest.mark.django_db
 def test_jobrequestcreate_with_archived_workspace(rf):
+    user = UserFactory()
     workspace = WorkspaceFactory(is_archived=True)
+
+    ProjectMembershipFactory(
+        project=workspace.project, user=user, roles=[ProjectDeveloper]
+    )
 
     request = rf.get("/")
     request.session = "session"
     request._messages = FallbackStorage(request)
-    request.user = UserFactory()
+    request.user = user
 
     response = JobRequestCreate.as_view()(
         request,

--- a/tests/jobserver/views/test_job_requests.py
+++ b/tests/jobserver/views/test_job_requests.py
@@ -121,6 +121,7 @@ def test_jobrequestcancel_unknown_job_request(rf):
 def test_jobrequestcreate_get_with_project_yaml_errors(rf, mocker, user):
     workspace = WorkspaceFactory()
 
+    BackendMembershipFactory(backend=Backend.objects.get(slug="tpp"), user=user)
     ProjectMembershipFactory(
         project=workspace.project, user=user, roles=[ProjectDeveloper]
     )
@@ -151,6 +152,7 @@ def test_jobrequestcreate_get_with_project_yaml_errors(rf, mocker, user):
 def test_jobrequestcreate_get_success(rf, mocker, user):
     workspace = WorkspaceFactory()
 
+    BackendMembershipFactory(backend=Backend.objects.get(slug="tpp"), user=user)
     ProjectMembershipFactory(
         project=workspace.project, user=user, roles=[ProjectDeveloper]
     )
@@ -188,6 +190,7 @@ def test_jobrequestcreate_get_success(rf, mocker, user):
 def test_jobrequestcreate_get_with_permission(rf, mocker, user):
     workspace = WorkspaceFactory()
 
+    BackendMembershipFactory(backend=Backend.objects.get(slug="tpp"), user=user)
     ProjectMembershipFactory(
         project=workspace.project, user=user, roles=[ProjectDeveloper]
     )
@@ -475,6 +478,27 @@ def test_jobrequestcreate_with_archived_workspace(rf):
 
     assert response.status_code == 302
     assert response.url == workspace.get_absolute_url()
+
+
+@pytest.mark.django_db
+def test_jobrequestcreate_with_no_backends(rf):
+    user = UserFactory()
+    workspace = WorkspaceFactory()
+
+    ProjectMembershipFactory(
+        project=workspace.project, user=user, roles=[ProjectDeveloper]
+    )
+
+    request = rf.get("/")
+    request.user = user
+
+    with pytest.raises(Http404):
+        JobRequestCreate.as_view()(
+            request,
+            org_slug=workspace.project.org.slug,
+            project_slug=workspace.project.slug,
+            workspace_slug=workspace.name,
+        )
 
 
 @pytest.mark.django_db

--- a/tests/jobserver/views/test_job_requests.py
+++ b/tests/jobserver/views/test_job_requests.py
@@ -119,15 +119,12 @@ def test_jobrequestcancel_unknown_job_request(rf):
 
 @pytest.mark.django_db
 def test_jobrequestcreate_get_with_project_yaml_errors(rf, mocker, user):
-    org = user.orgs.first()
-    project = ProjectFactory(org=org)
-    workspace = WorkspaceFactory(project=project)
+    workspace = WorkspaceFactory()
 
-    ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
-
-    mocker.patch(
-        "jobserver.views.job_requests.can_run_jobs", autospec=True, return_value=True
+    ProjectMembershipFactory(
+        project=workspace.project, user=user, roles=[ProjectDeveloper]
     )
+
     mocker.patch(
         "jobserver.views.job_requests.get_project",
         autospec=True,
@@ -139,8 +136,8 @@ def test_jobrequestcreate_get_with_project_yaml_errors(rf, mocker, user):
 
     response = JobRequestCreate.as_view()(
         request,
-        org_slug=org.slug,
-        project_slug=project.slug,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
         workspace_slug=workspace.name,
     )
 
@@ -151,36 +148,17 @@ def test_jobrequestcreate_get_with_project_yaml_errors(rf, mocker, user):
 
 
 @pytest.mark.django_db
-def test_jobrequestcreate_get_logged_out(rf):
+def test_jobrequestcreate_get_success(rf, mocker, user):
     workspace = WorkspaceFactory()
 
-    request = rf.get("/")
-    request.user = AnonymousUser()
-
-    with pytest.raises(Http404):
-        JobRequestCreate.as_view()(
-            request,
-            org_slug=workspace.project.org.slug,
-            project_slug=workspace.project.slug,
-            workspace_slug=workspace.name,
-        )
-
-
-@pytest.mark.django_db
-def test_jobrequestcreate_get_success(rf, mocker, user):
-    org = user.orgs.first()
-    project = ProjectFactory(org=org)
-    workspace = WorkspaceFactory(project=project)
-
-    ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
+    ProjectMembershipFactory(
+        project=workspace.project, user=user, roles=[ProjectDeveloper]
+    )
 
     dummy_yaml = """
     actions:
       twiddle:
     """
-    mocker.patch(
-        "jobserver.views.job_requests.can_run_jobs", autospec=True, return_value=True
-    )
     mocker.patch(
         "jobserver.views.job_requests.get_project",
         autospec=True,
@@ -192,8 +170,8 @@ def test_jobrequestcreate_get_success(rf, mocker, user):
 
     response = JobRequestCreate.as_view()(
         request,
-        org_slug=org.slug,
-        project_slug=project.slug,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
         workspace_slug=workspace.name,
     )
 
@@ -208,19 +186,16 @@ def test_jobrequestcreate_get_success(rf, mocker, user):
 
 @pytest.mark.django_db
 def test_jobrequestcreate_get_with_permission(rf, mocker, user):
-    org = user.orgs.first()
-    project = ProjectFactory(org=org)
-    workspace = WorkspaceFactory(project=project)
+    workspace = WorkspaceFactory()
 
-    ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
+    ProjectMembershipFactory(
+        project=workspace.project, user=user, roles=[ProjectDeveloper]
+    )
 
     dummy_yaml = """
     actions:
       twiddle:
     """
-    mocker.patch(
-        "jobserver.views.job_requests.can_run_jobs", autospec=True, return_value=True
-    )
     mocker.patch(
         "jobserver.views.job_requests.get_project",
         autospec=True,
@@ -232,8 +207,8 @@ def test_jobrequestcreate_get_with_permission(rf, mocker, user):
 
     response = JobRequestCreate.as_view()(
         request,
-        org_slug=org.slug,
-        project_slug=project.slug,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
         workspace_slug=workspace.name,
     )
 
@@ -250,20 +225,17 @@ def test_jobrequestcreate_get_with_permission(rf, mocker, user):
 def test_jobrequestcreate_post_success(rf, mocker, monkeypatch, user):
     monkeypatch.setenv("BACKENDS", "tpp")
 
-    org = user.orgs.first()
-    project = ProjectFactory(org=org)
-    workspace = WorkspaceFactory(project=project)
+    workspace = WorkspaceFactory()
 
     BackendMembershipFactory(backend=Backend.objects.get(slug="tpp"), user=user)
-    ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
+    ProjectMembershipFactory(
+        project=workspace.project, user=user, roles=[ProjectDeveloper]
+    )
 
     dummy_yaml = """
     actions:
       twiddle:
     """
-    mocker.patch(
-        "jobserver.views.job_requests.can_run_jobs", autospec=True, return_value=True
-    )
     mocker.patch(
         "jobserver.views.job_requests.get_project",
         autospec=True,
@@ -285,8 +257,8 @@ def test_jobrequestcreate_post_success(rf, mocker, monkeypatch, user):
 
     response = JobRequestCreate.as_view()(
         request,
-        org_slug=org.slug,
-        project_slug=project.slug,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
         workspace_slug=workspace.name,
     )
 
@@ -306,20 +278,17 @@ def test_jobrequestcreate_post_success(rf, mocker, monkeypatch, user):
 def test_jobrequestcreate_post_with_invalid_backend(rf, mocker, monkeypatch, user):
     monkeypatch.setenv("BACKENDS", "tpp,emis")
 
-    org = user.orgs.first()
-    project = ProjectFactory(org=org)
-    workspace = WorkspaceFactory(project=project)
+    workspace = WorkspaceFactory()
 
     BackendMembershipFactory(backend=Backend.objects.get(slug="tpp"), user=user)
-    ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
+    ProjectMembershipFactory(
+        project=workspace.project, user=user, roles=[ProjectDeveloper]
+    )
 
     dummy_yaml = """
     actions:
       twiddle:
     """
-    mocker.patch(
-        "jobserver.views.job_requests.can_run_jobs", autospec=True, return_value=True
-    )
     mocker.patch(
         "jobserver.views.job_requests.get_project",
         autospec=True,
@@ -341,8 +310,8 @@ def test_jobrequestcreate_post_with_invalid_backend(rf, mocker, monkeypatch, use
 
     response = JobRequestCreate.as_view()(
         request,
-        org_slug=org.slug,
-        project_slug=project.slug,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
         workspace_slug=workspace.name,
     )
 
@@ -358,20 +327,17 @@ def test_jobrequestcreate_post_with_notifications_default(
 ):
     monkeypatch.setenv("BACKENDS", "tpp")
 
-    org = user.orgs.first()
-    project = ProjectFactory(org=org)
-    workspace = WorkspaceFactory(project=project, should_notify=True)
+    workspace = WorkspaceFactory(should_notify=True)
 
     BackendMembershipFactory(backend=Backend.objects.get(slug="tpp"), user=user)
-    ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
+    ProjectMembershipFactory(
+        project=workspace.project, user=user, roles=[ProjectDeveloper]
+    )
 
     dummy_yaml = """
     actions:
       twiddle:
     """
-    mocker.patch(
-        "jobserver.views.job_requests.can_run_jobs", autospec=True, return_value=True
-    )
     mocker.patch(
         "jobserver.views.job_requests.get_project",
         autospec=True,
@@ -394,8 +360,8 @@ def test_jobrequestcreate_post_with_notifications_default(
 
     response = JobRequestCreate.as_view()(
         request,
-        org_slug=org.slug,
-        project_slug=project.slug,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
         workspace_slug=workspace.name,
     )
 
@@ -417,20 +383,17 @@ def test_jobrequestcreate_post_with_notifications_override(
 ):
     monkeypatch.setenv("BACKENDS", "tpp")
 
-    org = user.orgs.first()
-    project = ProjectFactory(org=org)
-    workspace = WorkspaceFactory(project=project, should_notify=True)
+    workspace = WorkspaceFactory(should_notify=True)
 
     BackendMembershipFactory(backend=Backend.objects.get(slug="tpp"), user=user)
-    ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
+    ProjectMembershipFactory(
+        project=workspace.project, user=user, roles=[ProjectDeveloper]
+    )
 
     dummy_yaml = """
     actions:
       twiddle:
     """
-    mocker.patch(
-        "jobserver.views.job_requests.can_run_jobs", autospec=True, return_value=True
-    )
     mocker.patch(
         "jobserver.views.job_requests.get_project",
         autospec=True,
@@ -453,8 +416,8 @@ def test_jobrequestcreate_post_with_notifications_override(
 
     response = JobRequestCreate.as_view()(
         request,
-        org_slug=org.slug,
-        project_slug=project.slug,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
         workspace_slug=workspace.name,
     )
 
@@ -869,6 +832,5 @@ def test_jobrequestlist_with_unauthenticated_user(rf):
     request = rf.get(MEANINGLESS_URL)
     request.user = AnonymousUser()
     response = JobRequestList.as_view()(request)
-
     assert response.status_code == 200
     assert "Look up JobRequest by Identifier" not in response.rendered_content


### PR DESCRIPTION
This ensures only users with access to one or more Backends can access the page to run jobs.

It also tidies up the JobRequestCreate tests on top of the work done in #814 

Fixes #653 