### PR TITLE
Add Timezone to Timings Hovers

### DIFF
--- a/jobserver/templates/_job_requests.html
+++ b/jobserver/templates/_job_requests.html
@@ -29,7 +29,7 @@
       <div class="d-none d-md-block action text-truncate" title="{{ group.requested_actions|join:"," }}">
         {{ group.requested_actions|join:"," }}
       </div>
-      <div class="started-at">{{ group.started_at|date:"Y-m-d H:i:s"|default:"-" }}</div>
+      <div class="started-at">{{ group.started_at|date:"Y-m-d H:i:sO"|default:"-" }}</div>
       <div class="mx-2">
         <button
           class="btn btn-sm btn-primary"

--- a/jobserver/templates/_release_list.html
+++ b/jobserver/templates/_release_list.html
@@ -45,7 +45,7 @@
 
                 {% if file.is_deleted %}
                 <small class="text-muted">
-                  (Deleted by {{ file.deleted_by.name }} at {{ file.deleted_at|date:"Y-m-d H:i:s" }})
+                  (Deleted by {{ file.deleted_by.name }} at {{ file.deleted_at|date:"Y-m-d H:i:sO" }})
                 </small>
                 {% endif %}
 

--- a/jobserver/templates/index.html
+++ b/jobserver/templates/index.html
@@ -103,7 +103,7 @@
         <div class="d-flex align-items-center py-2">
           <div class="status status-icon {{ job_request.status }} mx-3"></div>
           <div class="flex-grow-1">{{ job_request.workspace.name }}</div>
-          <div class="started-at">{{ job_request.started_at|date:"Y-m-d H:i:s"|default:"-" }}</div>
+          <div class="started-at">{{ job_request.started_at|date:"Y-m-d H:i:sO"|default:"-" }}</div>
           <div class="mx-2">
             <a class="btn btn-sm btn-primary" href="{{ job_request.get_absolute_url }}">View</a>
           </div>

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -113,21 +113,21 @@
 
       <div>
         <strong>Created:</strong>
-        <span title="{{ job.created_at|date:"Y-m-d H:i:s" }}">
+        <span title="{{ job.created_at|date:"Y-m-d H:i:sO" }}">
           {{ job.created_at|naturaltime }}
         </span>
       </div>
 
       <div>
         <strong>Started:</strong>
-        <span title="{{ job.started_at|date:"Y-m-d H:i:s"|default_if_none:"" }}">
+        <span title="{{ job.started_at|date:"Y-m-d H:i:sO"|default_if_none:"" }}">
           {{ job.started_at|naturaltime|default_if_none:"-" }}
         </span>
       </div>
 
       <div>
         <strong>Finished:</strong>
-        <span title="{{ job.completed_at|date:"Y-m-d H:i:s"|default_if_none:"" }}">
+        <span title="{{ job.completed_at|date:"Y-m-d H:i:sO"|default_if_none:"" }}">
           {{ job.completed_at|naturaltime|default_if_none:"-"}}
         </span>
       </div>
@@ -138,7 +138,7 @@
 
       <div>
         <strong>Last Updated by Runner:</strong>
-        <span title="{{ job.updated_at|date:"Y-m-d H:i:s"|default_if_none:"" }}">
+        <span title="{{ job.updated_at|date:"Y-m-d H:i:sO"|default_if_none:"" }}">
           {{ job.updated_at|naturaltime|default_if_none:"-" }}
         </span>
 

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -111,6 +111,10 @@
     <div class="mb-4">
       <h3>Timings</h3>
 
+      <p>
+        The timestamps below are generated and stored using the UTC timezone.
+      </p>
+
       <div>
         <strong>Created:</strong>
         <span title="{{ job.created_at|date:"Y-m-d H:i:sO" }}">

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -126,6 +126,10 @@
     <div class="mb-4">
       <h3>Timings</h3>
 
+      <p>
+        The timestamps below are generated and stored using the UTC timezone.
+      </p>
+
       <div>
         <strong>Created:</strong>
         <span title="{{ jobrequest.created_at|date:"Y-m-d H:i:sO" }}">

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -128,7 +128,7 @@
 
       <div>
         <strong>Created:</strong>
-        <span title="{{ jobrequest.created_at|date:"Y-m-d H:i:s" }}">
+        <span title="{{ jobrequest.created_at|date:"Y-m-d H:i:sO" }}">
           {{ jobrequest.created_at|naturaltime }}
         </span>
       </div>

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -101,7 +101,7 @@
 
         <div class="mb-4">
           <h5>Created</h5>
-          <span title="{{ project.created_at|date:"Y-m-d H:i:s" }}">
+          <span title="{{ project.created_at|date:"Y-m-d H:i:sO" }}">
             {{ project.created_at|naturaltime }}
           </span>
 

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -104,7 +104,7 @@
 
            <p>
              <strong>Created:</strong>
-             <span title="{{ workspace.created_at|date:"Y-m-d H:i:s" }}">
+             <span title="{{ workspace.created_at|date:"Y-m-d H:i:sO" }}">
                {{ workspace.created_at|naturaltime }}
              </span>
            </p>


### PR DESCRIPTION
This adds the timezone, in the format +0000, to all timestamp hovers across the site (where we use the `title` attribute) and a short explainer to why timestamps are all in UTC.

We can't reliably get the local timezone for a User without asking them to set it on their account which currently felt overkill.

Fixes #451 