### PR TITLE
Various fixes for the Outputs SPA

### DIFF
--- a/assets/src/scripts/outputs-viewer/components/Button/PrepareButton.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Button/PrepareButton.jsx
@@ -48,7 +48,7 @@ function PrepareButton() {
     }
   );
 
-  if (!fileList) return null;
+  if (!fileList?.length) return null;
 
   const fileIds = fileList.map((f) => f.id);
 

--- a/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
@@ -84,13 +84,17 @@ function FileList() {
     e.preventDefault();
 
     const itemName = `/${item.name}`;
-    // Only push a state change if clicking on a new file
-    if (itemName !== location.pathname) {
-      history.push(itemName);
-      return useStore.setState({ file: { ...item } });
+
+    // Don't push a state change if clicking on a new file
+    if (
+      itemName === location.pathname ||
+      itemName === location?.location?.pathname
+    ) {
+      return null;
     }
 
-    return null;
+    history.push(itemName);
+    return useStore.setState({ file: { ...item } });
   };
 
   return (

--- a/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
@@ -12,7 +12,7 @@ function FileList() {
   const [files, setFiles] = useState([]);
   const [listHeight, setListHeight] = useState(0);
 
-  const { isError, isLoading } = useFileList();
+  const { data, isError, isLoading } = useFileList();
   const { listVisible } = useStore();
   const history = useHistory();
   const location = useLocation();
@@ -93,7 +93,7 @@ function FileList() {
 
   return (
     <div className={`${classes.sidebar} ${listVisible ? "d-block" : "d-none"}`}>
-      <Filter listRef={listRef} setFiles={setFiles} />
+      <Filter files={data} listRef={listRef} setFiles={setFiles} />{" "}
       <div className="card pt-2">
         <FixedSizeList
           ref={listRef}

--- a/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
@@ -28,8 +28,10 @@ function FileList() {
       listEl.current?.clientWidth < listEl.current?.scrollWidth;
 
     const fileListHeight =
-      // Viewport size height
-      window.innerHeight -
+      // If the viewport height is taller than 600px
+      // Use the viewport height
+      // Otherwise use 600px
+      (window.innerHeight > 600 ? window.innerHeight : 600) -
       // if the list exists
       // minus the height from the top of the list
       // else minus zero

--- a/assets/src/scripts/outputs-viewer/components/FileList/Filter.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/Filter.jsx
@@ -1,9 +1,7 @@
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
-import useFileList from "../../hooks/use-file-list";
 
-function Filter({ listRef, setFiles }) {
-  const { data } = useFileList();
+function Filter({ files, listRef, setFiles }) {
   const [filter, setFilter] = useState("");
 
   useEffect(() => {
@@ -11,7 +9,7 @@ function Filter({ listRef, setFiles }) {
       const timer = setTimeout(
         () =>
           setFiles(
-            data.filter((state) =>
+            files.filter((state) =>
               state.shortName.toLowerCase().includes(filter.toLowerCase())
             )
           ),
@@ -21,10 +19,10 @@ function Filter({ listRef, setFiles }) {
       return () => clearTimeout(timer);
     }
 
-    if (data) return setFiles(data);
+    if (files) return setFiles(files);
 
     return setFiles([]);
-  }, [data, filter, setFiles]);
+  }, [files, filter, setFiles]);
 
   function filterOnChange(e) {
     listRef?.current?.scrollToItem(0);
@@ -53,6 +51,7 @@ function Filter({ listRef, setFiles }) {
 export default Filter;
 
 Filter.propTypes = {
+  files: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   listRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(Element) }),

--- a/assets/src/scripts/outputs-viewer/components/Iframe/Iframe.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Iframe/Iframe.jsx
@@ -1,11 +1,10 @@
+import PropTypes from "prop-types";
 import React, { useLayoutEffect, useState } from "react";
-import useFile from "../../hooks/use-file";
 import useWindowSize from "../../hooks/use-window-size";
 import useStore from "../../stores/use-store";
 
-function Iframe() {
+function Iframe({ data }) {
   const { file } = useStore();
-  const { data } = useFile(file);
   const windowSize = useWindowSize();
   const [frameHeight, setFrameHeight] = useState(0);
   const id = encodeURIComponent(file.url).replace(/\W/g, "");
@@ -39,3 +38,7 @@ function Iframe() {
 }
 
 export default Iframe;
+
+Iframe.propTypes = {
+  data: PropTypes.string.isRequired,
+};

--- a/assets/src/scripts/outputs-viewer/components/Iframe/Iframe.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Iframe/Iframe.jsx
@@ -10,17 +10,19 @@ function Iframe({ data }) {
   const id = encodeURIComponent(file.url).replace(/\W/g, "");
 
   useLayoutEffect(() => {
-    if (window.innerWidth > 991) {
-      setFrameHeight(
-        Math.round(
-          window.innerHeight -
-            document.getElementById(id).getBoundingClientRect().top -
-            17 - // Magic number for scroll bar height
-            40 // 2rem
-        )
-      );
-    } else {
-      setFrameHeight(1000);
+    if (document.getElementById(id)) {
+      if (window.innerWidth > 991) {
+        setFrameHeight(
+          Math.round(
+            window.innerHeight -
+              document.getElementById(id).getBoundingClientRect().top -
+              17 - // Magic number for scroll bar height
+              40 // 2rem
+          )
+        );
+      } else {
+        setFrameHeight(1000);
+      }
     }
   }, [windowSize, id]);
 

--- a/assets/src/scripts/outputs-viewer/components/Image/Image.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Image/Image.jsx
@@ -1,12 +1,13 @@
+import PropTypes from "prop-types";
 import React from "react";
-import useFile from "../../hooks/use-file";
-import useStore from "../../stores/use-store";
 import classes from "./Image.module.scss";
 
-function Image() {
-  const { file } = useStore();
-  const { data } = useFile(file);
+function Image({ data }) {
   return <img alt="" className={classes.img} src={data} />;
 }
 
 export default Image;
+
+Image.propTypes = {
+  data: PropTypes.string.isRequired,
+};

--- a/assets/src/scripts/outputs-viewer/components/Metadata/Metadata.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Metadata/Metadata.jsx
@@ -1,11 +1,9 @@
+import PropTypes from "prop-types";
 import React from "react";
-import useStore from "../../stores/use-store";
 import prettyFileSize from "../../utils/pretty-file-size";
 import classes from "./Metadata.module.scss";
 
-function Metadata() {
-  const { file } = useStore();
-
+function Metadata({ file }) {
   const fileSize = prettyFileSize(file.size);
   const date = new Date(file.date);
   const fileDateAbs = date.toISOString();
@@ -43,3 +41,12 @@ function Metadata() {
 }
 
 export default Metadata;
+
+Metadata.propTypes = {
+  file: PropTypes.shape({
+    date: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    size: PropTypes.number.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
@@ -2,8 +2,6 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { readString } from "react-papaparse";
-import useFile from "../../hooks/use-file";
-import useStore from "../../stores/use-store";
 import NoPreview from "../NoPreview/NoPreview";
 
 function TableCell({ cell }) {
@@ -20,10 +18,7 @@ function TableRow({ row }) {
   );
 }
 
-function Table() {
-  const { file } = useStore();
-  const { data } = useFile(file);
-
+function Table({ data }) {
   const jsonData = readString(data, {
     chunk: true,
     complete: (results) => results,
@@ -63,6 +58,8 @@ function Table() {
   );
 }
 
+export default Table;
+
 TableCell.propTypes = {
   cell: PropTypes.string.isRequired,
 };
@@ -71,4 +68,6 @@ TableRow.propTypes = {
   row: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
-export default Table;
+Table.propTypes = {
+  data: PropTypes.string.isRequired,
+};

--- a/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
@@ -24,18 +24,18 @@ function Table({ data }) {
     complete: (results) => results,
   }).data;
 
-  if (jsonData.length > 5000) return <NoPreview />;
+  if (jsonData.length >= 5000) return <NoPreview />;
 
-  if (jsonData.length > 1000) {
+  if (jsonData.length >= 1000) {
     return (
       <>
-        <p>
-          <strong>This is a preview of the first 1000 lines</strong>
+        <p role="alert">
+          <strong>This is a preview of the first 1000 rows</strong>
         </p>
         <div className="table-responsive">
           <table className="table table-striped">
             <tbody>
-              {jsonData.slice(0, 999).map((row, i) => (
+              {jsonData.slice(0, 1000).map((row, i) => (
                 <TableRow key={i} row={row} />
               ))}
             </tbody>

--- a/assets/src/scripts/outputs-viewer/components/Text/Text.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Text/Text.jsx
@@ -1,12 +1,13 @@
+import PropTypes from "prop-types";
 import React from "react";
-import useFile from "../../hooks/use-file";
-import useStore from "../../stores/use-store";
 import classes from "./Text.module.scss";
 
-function Text() {
-  const { file } = useStore();
-  const { data } = useFile(file);
+function Text({ data }) {
   return <pre className={classes.txt}>{data}</pre>;
 }
 
 export default Text;
+
+Text.propTypes = {
+  data: PropTypes.string.isRequired,
+};

--- a/assets/src/scripts/outputs-viewer/components/Viewer/Viewer.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Viewer/Viewer.jsx
@@ -54,10 +54,11 @@ function Viewer() {
 
   return (
     <Wrapper>
-      {isCsv(file) ? <Table /> : null}
-      {isHtml(file) ? <Iframe /> : null}
-      {isImg(file) ? <Image /> : null}
-      {isTxt(file) || isJson(file) ? <Text /> : null}
+      {isCsv(file) ? <Table data={data} /> : null}
+      {isHtml(file) ? <Iframe data={data} /> : null}
+      {isImg(file) ? <Image data={data} /> : null}
+      {isTxt(file) ? <Text data={data} /> : null}
+      {isJson(file) ? <Text data={JSON.stringify(data)} /> : null}
     </Wrapper>
   );
 }

--- a/assets/src/scripts/outputs-viewer/components/Viewer/Viewer.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Viewer/Viewer.jsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import React from "react";
 import useFile from "../../hooks/use-file";
 import useStore from "../../stores/use-store";
@@ -12,23 +11,10 @@ import {
 } from "../../utils/file-type-match";
 import Iframe from "../Iframe/Iframe";
 import Image from "../Image/Image";
-import Metadata from "../Metadata/Metadata";
 import NoPreview from "../NoPreview/NoPreview";
 import Table from "../Table/Table";
 import Text from "../Text/Text";
-
-function Wrapper({ children }) {
-  return (
-    <>
-      <div className="card">
-        <div className="card-header">
-          <Metadata />
-        </div>
-        <div className="card-body">{children}</div>
-      </div>
-    </>
-  );
-}
+import Wrapper from "./Wrapper";
 
 function Viewer() {
   const { file } = useStore();
@@ -75,9 +61,5 @@ function Viewer() {
     </Wrapper>
   );
 }
-
-Wrapper.propTypes = {
-  children: PropTypes.node.isRequired,
-};
 
 export default Viewer;

--- a/assets/src/scripts/outputs-viewer/components/Viewer/Wrapper.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Viewer/Wrapper.jsx
@@ -1,0 +1,25 @@
+import PropTypes from "prop-types";
+import React from "react";
+import useStore from "../../stores/use-store";
+import Metadata from "../Metadata/Metadata";
+
+function Wrapper({ children }) {
+  const { file } = useStore();
+
+  return (
+    <>
+      <div className="card">
+        <div className="card-header">
+          <Metadata file={file} />
+        </div>
+        <div className="card-body">{children}</div>
+      </div>
+    </>
+  );
+}
+
+export default Wrapper;
+
+Wrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/assets/src/scripts/outputs-viewer/hooks/use-file-list.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file-list.js
@@ -3,7 +3,7 @@ import { useQuery } from "react-query";
 import useStore from "../stores/use-store";
 import { toastError } from "../utils/toast";
 
-function longestStartingSubstr(array) {
+export function longestStartingSubstr(array) {
   const A = array.concat().sort();
   const a1 = A[0];
   const a2 = A[A.length - 1];
@@ -13,7 +13,7 @@ function longestStartingSubstr(array) {
   return a1.substring(0, i);
 }
 
-function sortedFiles(files) {
+export function sortedFiles(files) {
   const fileNameArr = [...files].map((file) => file.name);
   const prefix = longestStartingSubstr(fileNameArr);
 

--- a/assets/src/scripts/outputs-viewer/hooks/use-file-list.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file-list.js
@@ -45,7 +45,7 @@ function useFileList() {
         })
         .then((response) => response.data)
         .catch((error) => {
-          throw error?.response?.data?.detail || error;
+          throw error?.response?.data?.detail || error.toJSON().message;
         }),
     {
       select: (data) => sortedFiles(data.files),

--- a/assets/src/scripts/outputs-viewer/hooks/use-file.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file.js
@@ -44,7 +44,7 @@ function useFile(file) {
           .then((response) => response.data)
           .then((blob) => convertBlobToBase64(blob))
           .catch((error) => {
-            throw error?.response?.data?.detail || error;
+            throw error?.response?.data?.detail || error.toJSON().message;
           });
 
       return axios
@@ -55,7 +55,7 @@ function useFile(file) {
         })
         .then((response) => response.data)
         .catch((error) => {
-          throw error?.response?.data?.detail || error;
+          throw error?.response?.data?.detail || error.toJSON().message;
         });
     },
     {


### PR DESCRIPTION
Whilst adding tests (https://github.com/opensafely-core/job-server/issues/711) - various issues with the code have been identified. This PR covers fixes to the Outputs SPA as the first part of adding tests.

---

One issues identified was added in https://github.com/opensafely-core/job-server/pull/821:

> Replace `data` prop with query in each preview component

This meant that each child component of the `<Viewer />` required knowledge of the state of the query. This overcomplicates each child component, and therefore has been reverted to pass `data` as a prop to the child components.