### PR TITLE
Fix SPA errors in Firefox

### DIFF
--- a/assets/src/scripts/outputs-viewer/hooks/use-file-list.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file-list.js
@@ -45,7 +45,7 @@ function useFileList() {
         })
         .then((response) => response.data)
         .catch((error) => {
-          throw error?.response?.data?.detail || error.toJSON().message;
+          throw error?.response?.data?.detail || error.message;
         }),
     {
       select: (data) => sortedFiles(data.files),

--- a/assets/src/scripts/outputs-viewer/hooks/use-file.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file.js
@@ -44,7 +44,7 @@ function useFile(file) {
           .then((response) => response.data)
           .then((blob) => convertBlobToBase64(blob))
           .catch((error) => {
-            throw error?.response?.data?.detail || error.toJSON().message;
+            throw error?.response?.data?.detail || error?.message;
           });
 
       return axios
@@ -55,7 +55,7 @@ function useFile(file) {
         })
         .then((response) => response.data)
         .catch((error) => {
-          throw error?.response?.data?.detail || error.toJSON().message;
+          throw error?.response?.data?.detail || error?.message;
         });
     },
     {

--- a/assets/src/scripts/outputs-viewer/hooks/use-file.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file.js
@@ -36,9 +36,9 @@ function useFile(file) {
       if (isImg(file))
         return axios
           .get(file.url, {
-            headers: new Headers({
+            headers: {
               Authorization: authToken,
-            }),
+            },
             responseType: "blob",
           })
           .then((response) => response.data)
@@ -49,9 +49,9 @@ function useFile(file) {
 
       return axios
         .get(file.url, {
-          headers: new Headers({
+          headers: {
             Authorization: authToken,
-          }),
+          },
         })
         .then((response) => response.data)
         .catch((error) => {


### PR DESCRIPTION
- `Headers()` constructor is broken with Axios in Firefox
- `.toJSON()` is not required for retrieving the error message