### PR TITLE
Fix Homepage for Unauthenticated Users

### DIFF
--- a/jobserver/templates/index.html
+++ b/jobserver/templates/index.html
@@ -56,6 +56,7 @@
       {% endfor %}
     </div>
 
+    {% if request.user.is_authenticated %}
     <div class="text-center">
       <p><strong>OR</strong></p>
 
@@ -76,6 +77,7 @@
       </div>
 
     </div>
+    {% endif %}
 
   </div>
 </div>

--- a/tests/jobserver/views/test_index.py
+++ b/tests/jobserver/views/test_index.py
@@ -65,9 +65,13 @@ def test_index_with_unauthenticated_user(rf):
     Check the Add Workspace button is not rendered for unauthenticated Users on
     the homepage.
     """
+    WorkspaceFactory()
+
     request = rf.get(MEANINGLESS_URL)
     request.user = AnonymousUser()
 
     response = Index.as_view()(request)
+
+    assert response.status_code == 200
 
     assert "Add a New Workspace" not in response.rendered_content


### PR DESCRIPTION
This fixes the test for checking the page without users by making sure there is a Workspace so that whole section of the template loads, and fixes the actual bug by only showing the button block when the user is authenticated.

The broken version didn't deploy thanks to the deploy checks at least.