### PR TITLE
Better Timing Labels

### DIFF
--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -117,8 +117,10 @@
       <h3>Timings</h3>
 
       <p>
-        The timestamps below are generated and stored using the UTC timezone on
-        the secure backend which created this job, {{ job.job_request.backend.name }}.
+        The timestamps below are generated and stored using the
+        <a href="https://en.wikipedia.org/wiki/Coordinated_Universal_Time">UTC</a>
+        timezone on the secure backend which created this job,
+        {{ job.job_request.backend.name }}.
       </p>
 
       <div class="mb-2">

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -117,39 +117,61 @@
       <h3>Timings</h3>
 
       <p>
-        The timestamps below are generated and stored using the UTC timezone.
+        The timestamps below are generated and stored using the UTC timezone on
+        the secure backend which created this job, {{ job.job_request.backend.name }}.
       </p>
 
-      <div>
+      <div class="mb-2">
         <strong>Created:</strong>
         <span title="{{ job.created_at|date:"Y-m-d H:i:sO" }}">
           {{ job.created_at|naturaltime }}
         </span>
+        <br />
+        <small class="text-muted">When the job was created by the secure backend.</small>
       </div>
 
-      <div>
-        <strong>Started:</strong>
+      <div class="mb-2">
+        <strong>Acknowledged:</strong>
         <span title="{{ job.started_at|date:"Y-m-d H:i:sO"|default_if_none:"" }}">
           {{ job.started_at|naturaltime|default_if_none:"-" }}
         </span>
+        <br />
+        <small class="text-muted">
+          When the job moved to the pending or running state on the secure backend.
+        </small>
       </div>
 
-      <div>
+      <div class="mb-2">
         <strong>Finished:</strong>
         <span title="{{ job.completed_at|date:"Y-m-d H:i:sO"|default_if_none:"" }}">
           {{ job.completed_at|naturaltime|default_if_none:"-"}}
         </span>
+        <br />
+        <small class="text-muted">
+          When the job finished running on the secure backend.
+        </small>
       </div>
 
-      <div>
-        <strong>Runtime:</strong> <span>{% runtime job.runtime %}</span>
+      <div class="mb-2">
+        <strong>Duration:</strong> <span>{% runtime job.runtime %}</span>
+        <br />
+        <small class="text-muted">
+          How long the job ran for on the secure backend, this includes time
+          spent copying files, and waiting to be checked by the backend.
+        </small>
       </div>
 
-      <div>
-        <strong>Last Updated by Runner:</strong>
+      <div class="mb-2">
+        <strong>Last Updated by Backend:</strong>
         <span title="{{ job.updated_at|date:"Y-m-d H:i:sO"|default_if_none:"" }}">
           {{ job.updated_at|naturaltime|default_if_none:"-" }}
         </span>
+
+        <br />
+        <small class="text-muted">
+          How long ago did the secure backend update the website about this
+          job.
+        </small>
 
         {% if job.is_missing_updates %}
         <div>

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -56,6 +56,11 @@
       ID: {{ job.identifier }}
     </p>
 
+    <p>
+      This page describes a "job", an action ({{ job.action }}) requested by the
+      user, and run on a secure backend ({{ job.job_request.backend.name }}).
+    </p>
+
     <div class="mb-4">
       <h3>State</h3>
 


### PR DESCRIPTION
This adds explanations for what users are seeing on a jobs page, particularly around the timings of jobs.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/z8urYKej/2f4a7e64-60d6-4e35-b93b-0fe2c390efbb.jpg?v=6bd686ba693cc8f0951847bf3170d767)

Having tried out the suggestions in #610 I opted not to use long form labels as it made the section look very crowded.  The smaller explainer paragraphs mean a regular user can get the information they need at a glance but the extra detail is still there if needed.

I've also threaded in some "live" information to the top and timing paragraph to help with the context of what a secure backend actually is.

Fixes #610 