### PR TITLE
Improve Env Vars Docs

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,4 +1,5 @@
-# Set this to your GitHub username
+# Set this to a comma-delimited list of User's username.
+# Note: the Users must exist first
 ADMIN_USERS=dummy
 
 # Set this to a comma-delimited list of GitHub Organisations you want to have

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -16,7 +16,7 @@ DEBUG=1
 # A long random string
 SECRET_KEY=12345
 
-# Get this from a GitHub Org admin, it's the Service User's PAT
+# A GitHub API token, we use a PAT for this
 GITHUB_TOKEN=dummy
 
 # Get these from a GitHub Org admin, you want the Dev application credentials

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -5,6 +5,10 @@ ADMIN_USERS=dummy
 # access to the platform
 AUTHORIZATION_ORGS=opensafely
 
+# Set this to a comma-delimited list of Backends you want to be enabled for the
+# platform
+BACKENDS=test
+
 # Turn on debug
 DEBUG=1
 


### PR DESCRIPTION
Add and improve env var docs.

Based on treating these docs like they're for staff working on the central service I opted not to document the DATABASE_URL which is set up with a default for local dev.

Fixes #607 