### PR TITLE
Add JobRequest Created

### DIFF
--- a/jobserver/templates/job_request_create.html
+++ b/jobserver/templates/job_request_create.html
@@ -329,6 +329,9 @@
     <h3>Latest Job Request</h3>
 
     <ul class="list-unstyled">
+      <li title="{{ latest_job_request.created_at|date:"Y-m-d H:i:sO" }}">
+        <strong>Created:</strong> {{ latest_job_request.created_at|naturaltime }}
+      </li>
       <li><strong>Total Runtime:</strong> {% runtime latest_job_request.runtime %}</li>
       <li><strong>Requested Actions:</strong> {{ latest_job_request.requested_actions|join:", " }}</li>
     </ul>


### PR DESCRIPTION
This adds a `Created` label to the latest JobRequest section of the Run Jobs page with a relative time, and the absolute date and time on hover.

The runtime column of the related Jobs already had the absolute date and time for when a Job started so I've left that as is.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/X6ul0reN/1940e15e-efcb-4bc5-ac5b-9c99625bb792.jpg?v=a78d08e92f12a2b5d2943a601d52db43)

Fixes #856 