### PR TITLE
Remove Duplicate Permissions from CoreDeveloper Role

### DIFF
--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -32,13 +32,8 @@ class CoreDeveloper:
     ]
     permissions = [
         backend_manage,
-        job_cancel,
-        job_run,
         org_create,
-        project_invite_members,
-        project_membership_edit,
         user_manage,
-        workspace_create,
     ]
 
 

--- a/tests/jobserver/api/test_jobs.py
+++ b/tests/jobserver/api/test_jobs.py
@@ -593,13 +593,8 @@ def test_userapidetail_success(api_rf):
     permissions = response.data["permissions"]
     assert permissions["global"] == [
         "backend_manage",
-        "job_cancel",
-        "job_run",
         "org_create",
-        "project_invite_members",
-        "project_membership_edit",
         "user_manage",
-        "workspace_create",
     ]
     assert permissions["orgs"] == [
         # we have no permissions for OrgCoordinator yet

--- a/tests/jobserver/models/test_core.py
+++ b/tests/jobserver/models/test_core.py
@@ -776,13 +776,8 @@ def test_user_get_all_permissions():
     expected = {
         "global": [
             "backend_manage",
-            "job_cancel",
-            "job_run",
             "org_create",
-            "project_invite_members",
-            "project_membership_edit",
             "user_manage",
-            "workspace_create",
         ],
         "orgs": [{"slug": org.slug, "permissions": []}],
         "projects": [


### PR DESCRIPTION
This removes the permissions attached to the CoreDeveloper role which were already on other roles.  This moves CoreDeveloper to being a more typical role rather than a bucket for "do everything".

Fixes #641 