### PR TITLE
Stop Validating Model Assignments for Roles

### DIFF
--- a/jobserver/authorization/fields.py
+++ b/jobserver/authorization/fields.py
@@ -62,23 +62,6 @@ class RolesField(models.JSONField):
         if not roles:
             return super().get_prep_value(roles)
 
-        # check each Role is valid for the calling class
-        invalid_roles = []
-        for role in roles:
-            # compare by dotted path because isinstance(self.model,
-            # apps.get_model(role.model)) doesn't work and I can't see why
-            if dotted_path(self.model) not in role.models:
-                invalid_roles.append(role)
-
-        if invalid_roles:
-            msg = f"Some roles could not be assigned to {self.model.__name__}"
-
-            for role in invalid_roles:
-                models = "\n".join(f"   - {model}" for model in role.models)
-                msg += f"\n - {role.__name__} can only be assigned to these models:\n{models}"
-
-            raise ValueError(msg)
-
         # convert each Role to a dotted path string
         paths = {dotted_path(r) for r in roles}
         paths = list(paths)

--- a/tests/jobserver/authorization/test_fields.py
+++ b/tests/jobserver/authorization/test_fields.py
@@ -5,7 +5,7 @@ from jobserver.authorization import CoreDeveloper, OutputChecker
 from jobserver.authorization.fields import ExtractRoles, RolesField
 from jobserver.models import User
 
-from ...factories import OrgFactory, OrgMembershipFactory, UserFactory
+from ...factories import UserFactory
 
 
 @pytest.mark.django_db
@@ -119,26 +119,3 @@ def test_roles_field_to_python_with_empty_list():
 def test_roles_field_to_python_with_falsey_value():
     assert RolesField().to_python(None) is None
     assert RolesField().to_python([]) == []
-
-
-@pytest.mark.django_db
-def test_roles_field_with_invalid_role():
-    org = OrgFactory()
-    user = UserFactory()
-
-    class ProjectRole:
-        models = ["jobserver.models.ProjectMembership"]
-        permissions = []
-
-    msg = "Some roles could not be assigned to OrgMembership\n"
-    msg += " - ProjectRole can only be assigned to these models:\n"
-    msg += "   - jobserver.models.ProjectMembership"
-    with pytest.raises(ValueError, match=msg):
-        # This checks the RolesField on OrgMembership correctly identifies that
-        # ProjectRole can't be assigned to it because it's models list defines
-        # ProjectMembership as a valid Model.
-        #
-        # We're testing this with an OrgMembership (and thus its factory)
-        # because RolesField makes use of the Model it's defined on to ensure
-        # the passed Role is valid for that model so we can't call it directly.
-        OrgMembershipFactory(org=org, user=user, roles=[ProjectRole])


### PR DESCRIPTION
In the original Roles & Permissions design we linked each Role to a list of Models via their dotted path, enforcing that any assignment of a Role was only done to a Model in that list.  As we've used the framework more it's become evident that most Roles need to at least be assignable to Users, if only for staff to administer the platform.

During the outputs voyage we also noticed that when we hit that validation we would edit the models field of the relevant Roles and carry on with building the feature, in essense circumventing the validation.

Separately we found that this validation broke in the context of migrations where the models provided are "fake" versions constructed by the migrations framework for state transition purposes.

In practice this validation was never used by the site since the UI is driven by `roles_for(Model)` and only existed to "help" developers out.

Fixes #662 