### PR TITLE
Update Tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,13 +10,6 @@ from .factories import OrgFactory, OrgMembershipFactory, UserFactory
 
 
 @pytest.fixture
-def api_client():
-    from rest_framework.test import APIClient
-
-    return APIClient()
-
-
-@pytest.fixture
 def api_rf():
     from rest_framework.test import APIRequestFactory
 

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -125,20 +125,20 @@ def test_releasenotificationapicreate_with_failed_slack_update(
 
 
 @pytest.mark.django_db
-def test_workspace_api_create_release_no_workspace(api_client):
+def test_releaseworkspaceapi_post_unknown_workspace(api_client):
     response = api_client.post("/api/v2/releases/workspace/notexists")
     assert response.status_code == 404
 
 
 @pytest.mark.django_db
-def test_workspace_api_create_release_no_backend_token(api_client):
+def test_releaseworkspaceapi_post_without_backend_token(api_client):
     workspace = WorkspaceFactory()
     response = api_client.post(f"/api/v2/releases/workspace/{workspace.name}")
     assert response.status_code == 403
 
 
 @pytest.mark.django_db
-def test_workspace_api_create_release_bad_backend_token(api_client):
+def test_releaseworkspaceapi_post_with_bad_backend_token(api_client):
     workspace = WorkspaceFactory()
     BackendFactory(auth_token="test")
 
@@ -151,7 +151,7 @@ def test_workspace_api_create_release_bad_backend_token(api_client):
 
 
 @pytest.mark.django_db
-def test_workspace_api_create_release_no_user(api_client):
+def test_releaseworkspaceapi_post_without_user(api_client):
     workspace = WorkspaceFactory()
     BackendFactory(auth_token="test")
     response = api_client.post(
@@ -163,7 +163,7 @@ def test_workspace_api_create_release_no_user(api_client):
 
 
 @pytest.mark.django_db
-def test_workspace_api_create_release_bad_user(api_client):
+def test_releaseworkspaceapi_post_with_bad_user(api_client):
     workspace = WorkspaceFactory()
     BackendFactory(auth_token="test")
     response = api_client.post(
@@ -176,7 +176,7 @@ def test_workspace_api_create_release_bad_user(api_client):
 
 
 @pytest.mark.django_db
-def test_workspace_api_create_release_created(api_client):
+def test_releaseworkspaceapi_post_create_release(api_client):
     user = UserFactory(roles=[OutputChecker])
     workspace = WorkspaceFactory()
     ProjectMembershipFactory(user=user, project=workspace.project)
@@ -203,7 +203,7 @@ def test_workspace_api_create_release_created(api_client):
 
 
 @pytest.mark.django_db
-def test_workspace_api_create_release_already_exists(api_client):
+def test_releaseworkspaceapi_post_release_already_exists(api_client):
     user = UserFactory(roles=[OutputChecker])
 
     release = ReleaseFactory(ReleaseUploadsFactory(["file.txt"]), created_by=user)
@@ -226,7 +226,7 @@ def test_workspace_api_create_release_already_exists(api_client):
 
 
 @pytest.mark.django_db
-def test_workspace_api_create_release_bad_json(api_client):
+def test_releaseworkspaceapi_post_with_bad_json(api_client):
     user = UserFactory(roles=[OutputChecker])
     workspace = WorkspaceFactory()
     ProjectMembershipFactory(user=user, project=workspace.project)
@@ -247,13 +247,13 @@ def test_workspace_api_create_release_bad_json(api_client):
 
 
 @pytest.mark.django_db
-def test_workspace_index_api_not_exists(api_client):
+def test_releaseworkspaceapi_get_unknown_workspace(api_client):
     response = api_client.get("/api/v2/releases/workspace/badid")
     assert response.status_code == 404
 
 
 @pytest.mark.django_db
-def test_workspace_index_api_anonymous(api_client):
+def test_releaseworkspaceapi_get_with_anonymous_user(api_client):
     workspace = WorkspaceFactory()
 
     response = api_client.get(f"/api/v2/releases/workspace/{workspace.name}")
@@ -262,7 +262,7 @@ def test_workspace_index_api_anonymous(api_client):
 
 
 @pytest.mark.django_db
-def test_workspace_index_api_logged_in_no_permission(api_client):
+def test_releaseworkspaceapi_get_without_permission(api_client):
     workspace = WorkspaceFactory()
     user = UserFactory()
 
@@ -272,7 +272,7 @@ def test_workspace_index_api_logged_in_no_permission(api_client):
 
 
 @pytest.mark.django_db
-def test_workspace_index_api_have_permission(api_client):
+def test_releaseworkspaceapi_get_with_permission(api_client):
     workspace = WorkspaceFactory()
     backend1 = BackendFactory(slug="backend1")
     backend2 = BackendFactory(slug="backend2")
@@ -328,14 +328,14 @@ def test_workspace_index_api_have_permission(api_client):
 
 
 @pytest.mark.django_db
-def test_release_index_api_not_exists(api_client):
+def test_releaseapi_get_unknown_release(api_client):
     # bad id
     response = api_client.get("/api/v2/releases/release/badid")
     assert response.status_code == 404
 
 
 @pytest.mark.django_db
-def test_release_index_api_anonymous(api_client):
+def test_releaseapi_get_with_anonymous_user(api_client):
     release = ReleaseFactory(ReleaseUploadsFactory(["file.txt"]))
 
     response = api_client.get(f"/api/v2/releases/release/{release.id}")
@@ -343,7 +343,7 @@ def test_release_index_api_anonymous(api_client):
 
 
 @pytest.mark.django_db
-def test_release_index_api_logged_in_no_permission(api_client):
+def test_releaseapi_get_without_permission(api_client):
     release = ReleaseFactory(ReleaseUploadsFactory(["file.txt"]))
 
     api_client.force_authenticate(user=UserFactory())
@@ -353,7 +353,7 @@ def test_release_index_api_logged_in_no_permission(api_client):
 
 
 @pytest.mark.django_db
-def test_release_index_api_have_permission(api_client):
+def test_releaseapi_get_with_permission(api_client):
     release = ReleaseFactory(ReleaseUploadsFactory(["file.txt"]))
     rfile = release.files.first()
 
@@ -385,13 +385,13 @@ def test_release_index_api_have_permission(api_client):
 
 
 @pytest.mark.django_db
-def test_release_api_upload_no_release(api_client):
+def test_releaseapi_post_unknown_release(api_client):
     response = api_client.post("/api/v2/releases/release/notexists")
     assert response.status_code == 404
 
 
 @pytest.mark.django_db
-def test_release_api_upload_no_backend_token(api_client):
+def test_releaseapi_post_with_no_backend_token(api_client):
     uploads = ReleaseUploadsFactory(["file.txt"])
     release = ReleaseFactory(uploads, uploaded=False)
 
@@ -401,7 +401,7 @@ def test_release_api_upload_no_backend_token(api_client):
 
 
 @pytest.mark.django_db
-def test_release_api_upload_bad_backend_token(api_client):
+def test_releaseapi_post_bad_backend_token(api_client):
     uploads = ReleaseUploadsFactory(["file.txt"])
     release = ReleaseFactory(uploads, uploaded=False)
     response = api_client.post(
@@ -412,7 +412,7 @@ def test_release_api_upload_bad_backend_token(api_client):
 
 
 @pytest.mark.django_db
-def test_release_api_upload_no_user(api_client):
+def test_releaseapi_post_no_user(api_client):
     uploads = ReleaseUploadsFactory(["file.txt"])
     release = ReleaseFactory(uploads, uploaded=False)
     response = api_client.post(
@@ -423,7 +423,7 @@ def test_release_api_upload_no_user(api_client):
 
 
 @pytest.mark.django_db
-def test_release_api_upload_bad_user(api_client):
+def test_releaseapi_post_bad_user(api_client):
     uploads = ReleaseUploadsFactory(["file.txt"])
     release = ReleaseFactory(uploads, uploaded=False)
     response = api_client.post(
@@ -435,7 +435,7 @@ def test_release_api_upload_bad_user(api_client):
 
 
 @pytest.mark.django_db
-def test_release_api_upload_no_files(api_client):
+def test_releaseapi_post_no_files(api_client):
     user = UserFactory(roles=[OutputChecker])
     uploads = ReleaseUploadsFactory(["file.txt"])
     release = ReleaseFactory(uploads, uploaded=False)
@@ -454,7 +454,7 @@ def test_release_api_upload_no_files(api_client):
 
 
 @pytest.mark.django_db
-def test_release_api_upload_bad_backend(api_client):
+def test_releaseapi_post_bad_backend(api_client):
     user = UserFactory(roles=[OutputChecker])
     uploads = ReleaseUploadsFactory(["output/file.txt"])
     release = ReleaseFactory(uploads, uploaded=False)
@@ -476,7 +476,7 @@ def test_release_api_upload_bad_backend(api_client):
 
 
 @pytest.mark.django_db
-def test_release_api_upload_bad_filename(api_client):
+def test_releaseapi_post_bad_filename(api_client):
     user = UserFactory(roles=[OutputChecker])
     uploads = ReleaseUploadsFactory(["file.txt"])
     release = ReleaseFactory(uploads, uploaded=False)
@@ -497,7 +497,7 @@ def test_release_api_upload_bad_filename(api_client):
 
 
 @pytest.mark.django_db
-def test_release_api_upload_success(api_client):
+def test_releaseapi_post_success(api_client):
     user = UserFactory(roles=[OutputChecker])
     uploads = ReleaseUploadsFactory(["file.txt"])
     release = ReleaseFactory(uploads, uploaded=False)
@@ -520,7 +520,7 @@ def test_release_api_upload_success(api_client):
 
 
 @pytest.mark.django_db
-def test_release_api_upload_already_uploaded(api_client):
+def test_releaseapi_post_already_uploaded(api_client):
     user = UserFactory(roles=[OutputChecker])
     uploads = ReleaseUploadsFactory(["file.txt"])
     release = ReleaseFactory(uploads, uploaded=True)
@@ -545,13 +545,13 @@ def test_release_api_upload_already_uploaded(api_client):
 
 
 @pytest.mark.django_db
-def test_release_file_api_release_not_exists(api_client):
+def test_releasefileapi_get_unknown_file(api_client):
     response = api_client.get("/api/v2/releases/release/badid/file.txt")
     assert response.status_code == 404
 
 
 @pytest.mark.django_db
-def test_release_file_api_anonymous(api_client):
+def test_releasefileapi_with_anonymous_user(api_client):
     release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
     rfile = release.files.first()
 
@@ -560,7 +560,7 @@ def test_release_file_api_anonymous(api_client):
 
 
 @pytest.mark.django_db
-def test_release_file_api_no_permission(api_client):
+def test_releasefileapi_without_permission(api_client):
     release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
     rfile = release.files.first()
 
@@ -572,7 +572,7 @@ def test_release_file_api_no_permission(api_client):
 
 
 @pytest.mark.django_db
-def test_release_file_api_have_permission(api_client):
+def test_releasefileapi_with_permission(api_client):
     uploads = ReleaseUploadsFactory({"file.txt": b"test"})
     release = ReleaseFactory(uploads)
     rfile = release.files.first()
@@ -594,7 +594,7 @@ def test_release_file_api_have_permission(api_client):
 
 
 @pytest.mark.django_db
-def test_release_file_api_nginx_redirect(api_client):
+def test_releasefileapi_with_nginx_redirect(api_client):
     uploads = ReleaseUploadsFactory({"file.txt": b"test"})
     release = ReleaseFactory(uploads)
     rfile = release.files.first()
@@ -620,7 +620,7 @@ def test_release_file_api_nginx_redirect(api_client):
 
 
 @pytest.mark.django_db
-def test_release_file_api_file_deleted(api_client):
+def test_releasefileapi_with_deleted_file(api_client):
     uploads = ReleaseUploadsFactory({"file.txt": b"test"})
     release = ReleaseFactory(uploads)
     rfile = release.files.first()
@@ -642,7 +642,7 @@ def test_release_file_api_file_deleted(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_api_published_anonymous(api_client, freezer):
+def test_snapshotapi_published_with_anonymous_user(api_client, freezer):
     snapshot = SnapshotFactory(published_at=timezone.now())
 
     response = api_client.get(
@@ -654,7 +654,7 @@ def test_snapshot_api_published_anonymous(api_client, freezer):
 
 
 @pytest.mark.django_db
-def test_snapshot_api_published_no_permission(api_client):
+def test_snapshotapi_published_without_permission(api_client):
     snapshot = SnapshotFactory(published_at=timezone.now())
 
     # logged in, but no permission
@@ -669,7 +669,7 @@ def test_snapshot_api_published_no_permission(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_api_published_with_permission(api_client):
+def test_snapshotapi_published_with_permission(api_client):
     snapshot = SnapshotFactory(published_at=timezone.now())
 
     api_client.force_authenticate(user=UserFactory(roles=[ProjectCollaborator]))
@@ -683,7 +683,7 @@ def test_snapshot_api_published_with_permission(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_api_unpublished_anonymous(api_client):
+def test_snapshotapi_unpublished_with_anonymous_user(api_client):
     snapshot = SnapshotFactory(published_at=None)
 
     response = api_client.get(
@@ -694,7 +694,7 @@ def test_snapshot_api_unpublished_anonymous(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_api_unpublished_no_permission(api_client):
+def test_snapshotapi_unpublished_without_permission(api_client):
     snapshot = SnapshotFactory(published_at=None)
 
     # logged in, but no permission
@@ -708,7 +708,7 @@ def test_snapshot_api_unpublished_no_permission(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_api_unpublished_with_permission(api_client):
+def test_snapshotapi_unpublished_with_permission(api_client):
     snapshot = SnapshotFactory(published_at=None)
 
     api_client.force_authenticate(user=UserFactory(roles=[ProjectCollaborator]))
@@ -722,7 +722,7 @@ def test_snapshot_api_unpublished_with_permission(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_create_unknown_files(api_client):
+def test_snapshotcreate_unknown_files(api_client):
     workspace = WorkspaceFactory()
     user = UserFactory()
     ProjectMembershipFactory(
@@ -741,7 +741,7 @@ def test_snapshot_create_unknown_files(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_create_with_existing_snapshot(api_client):
+def test_snapshotcreate_with_existing_snapshot(api_client):
     workspace = WorkspaceFactory()
     uploads = ReleaseUploadsFactory({"file1.txt": b"test1"})
     release = ReleaseFactory(uploads, workspace=workspace)
@@ -765,7 +765,7 @@ def test_snapshot_create_with_existing_snapshot(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_create_with_permission(api_client):
+def test_snapshotcreate_with_permission(api_client):
     workspace = WorkspaceFactory()
     uploads = ReleaseUploadsFactory(
         {
@@ -806,7 +806,7 @@ def test_snapshot_create_with_permission(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_create_without_permission(api_client):
+def test_snapshotcreate_without_permission(api_client):
     workspace = WorkspaceFactory()
 
     api_client.force_authenticate(user=UserFactory())
@@ -817,7 +817,7 @@ def test_snapshot_create_without_permission(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_publish_api_already_published(api_client):
+def test_snapshotpublishapi_already_published(api_client):
     snapshot = SnapshotFactory(published_at=timezone.now())
 
     assert snapshot.is_published
@@ -834,7 +834,7 @@ def test_snapshot_publish_api_already_published(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_publish_api_success(api_client):
+def test_snapshotpublishapi_success(api_client):
     snapshot = SnapshotFactory()
 
     assert snapshot.is_draft
@@ -851,7 +851,7 @@ def test_snapshot_publish_api_success(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_publish_api_unknown_snapshot(api_client):
+def test_snapshotpublishapi_unknown_snapshot(api_client):
     workspace = WorkspaceFactory()
 
     api_client.force_authenticate(user=UserFactory(roles=[OutputPublisher]))
@@ -863,7 +863,7 @@ def test_snapshot_publish_api_unknown_snapshot(api_client):
 
 
 @pytest.mark.django_db
-def test_snapshot_publish_api_without_permission(api_client):
+def test_snapshotpublishapi_without_permission(api_client):
     snapshot = SnapshotFactory()
 
     api_client.force_authenticate(user=UserFactory())

--- a/tests/unit/jobserver/test_urls.py
+++ b/tests/unit/jobserver/test_urls.py
@@ -1,0 +1,136 @@
+import inspect
+
+import pytest
+from django.contrib.auth.views import LogoutView
+from django.urls import resolve
+from social_django.views import auth as social_django_auth_view
+
+from jobserver.api.jobs import (
+    JobAPIUpdate,
+    JobRequestAPIList,
+    UserAPIDetail,
+    WorkspaceStatusesAPI,
+)
+from jobserver.api.releases import (
+    ReleaseAPI,
+    ReleaseFileAPI,
+    ReleaseNotificationAPICreate,
+    ReleaseWorkspaceAPI,
+    SnapshotAPI,
+    SnapshotCreateAPI,
+    SnapshotPublishAPI,
+    WorkspaceStatusAPI,
+)
+from jobserver.utils import dotted_path
+from jobserver.views import (
+    admin,
+    backends,
+    index,
+    job_requests,
+    jobs,
+    orgs,
+    projects,
+    releases,
+    status,
+    users,
+    workspaces,
+)
+
+
+@pytest.mark.parametrize(
+    "url,redirect",
+    [
+        ("/favicon.ico", "/static/favicon.ico"),
+        ("/event-list/", "/event-log/"),
+        ("/jobs/", "/event-log/"),
+        ("/workspaces/", "/"),
+    ],
+)
+@pytest.mark.django_db
+def test_url_redirects(client, url, redirect):
+    response = client.get(url)
+
+    assert response.status_code == 302
+    assert response.url == redirect
+
+
+@pytest.mark.parametrize(
+    "url,view",
+    [
+        ("/", index.Index),
+        ("/admin/approve-users", admin.ApproveUsers),
+        ("/api/v2/job-requests/", JobRequestAPIList),
+        ("/api/v2/jobs/", JobAPIUpdate),
+        ("/api/v2/release-notifications/", ReleaseNotificationAPICreate),
+        ("/api/v2/users/ben/", UserAPIDetail),
+        ("/api/v2/workspaces/w/statuses/", WorkspaceStatusesAPI),
+        ("/api/v2/workspaces/w/snapshots", SnapshotCreateAPI),
+        ("/api/v2/workspaces/w/snapshots/42", SnapshotAPI),
+        ("/api/v2/workspaces/w/snapshots/42/publish", SnapshotPublishAPI),
+        ("/api/v2/workspaces/w/status", WorkspaceStatusAPI),
+        ("/api/v2/releases/workspace/w", ReleaseWorkspaceAPI),
+        ("/api/v2/releases/release/42", ReleaseAPI),
+        ("/api/v2/releases/file/42", ReleaseFileAPI),
+        ("/backends/", backends.BackendList),
+        ("/backends/42/", backends.BackendDetail),
+        ("/backends/42/edit/", backends.BackendEdit),
+        ("/backends/42/rotate-token/", backends.BackendRotateToken),
+        ("/event-log/", job_requests.JobRequestList),
+        ("/job-requests/<pk>/", job_requests.JobRequestDetailRedirect),
+        ("/jobs/<identifier>/", jobs.JobDetailRedirect),
+        ("/login/github/", social_django_auth_view),
+        ("/logout/", LogoutView),
+        ("/orgs/", orgs.OrgList),
+        ("/orgs/new/", orgs.OrgCreate),
+        ("/settings/", users.Settings),
+        ("/status/", status.Status),
+        ("/users/", users.UserList),
+        ("/users/ben/", users.UserDetail),
+        ("/o/", orgs.OrgDetail),
+        ("/o/new-project/", projects.ProjectCreate),
+        ("/o/project-onboarding/", projects.ProjectOnboardingCreate),
+        ("/o/p/", projects.ProjectDetail),
+        ("/o/p/accept-invite/42/", projects.ProjectAcceptInvite),
+        ("/o/p/cancel-invite/", projects.ProjectCancelInvite),
+        ("/o/p/edit/", projects.ProjectEdit),
+        ("/o/p/invite-users/", projects.ProjectInvitationCreate),
+        ("/o/p/members/42/edit", projects.ProjectMembershipEdit),
+        ("/o/p/members/42/remove", projects.ProjectMembershipRemove),
+        ("/o/p/new-workspace/", workspaces.WorkspaceCreate),
+        ("/o/p/releases/", releases.ProjectReleaseList),
+        ("/o/p/settings/", projects.ProjectSettings),
+        ("/o/p/w/", workspaces.WorkspaceDetail),
+        ("/o/p/w/run-jobs/", job_requests.JobRequestCreate),
+        ("/o/p/w/archive-toggle/", workspaces.WorkspaceArchiveToggle),
+        ("/o/p/w/files/", workspaces.WorkspaceFileList),
+        ("/o/p/w/files/tpp/", workspaces.WorkspaceBackendFiles),
+        ("/o/p/w/files/tpp/file.txt", workspaces.WorkspaceBackendFiles),
+        ("/o/p/w/logs/", workspaces.WorkspaceLog),
+        ("/o/p/w/notifications-toggle/", workspaces.WorkspaceNotificationsToggle),
+        ("/o/p/w/outputs/", workspaces.WorkspaceOutputList),
+        ("/o/p/w/outputs/latest/", workspaces.WorkspaceLatestOutputsDetail),
+        ("/o/p/w/outputs/latest/download/", workspaces.WorkspaceLatestOutputsDownload),
+        ("/o/p/w/outputs/latest/file.txt", workspaces.WorkspaceLatestOutputsDetail),
+        ("/o/p/w/outputs/badge/", workspaces.WorkspaceOutputsBadge),
+        ("/o/p/w/outputs/42/", releases.SnapshotDetail),
+        ("/o/p/w/outputs/42/download/", releases.SnapshotDownload),
+        ("/o/p/w/outputs/42/file.txt", releases.SnapshotDetail),
+        ("/o/p/w/releases/", releases.WorkspaceReleaseList),
+        ("/o/p/w/releases/42/", releases.ReleaseDetail),
+        ("/o/p/w/releases/42/download/", releases.ReleaseDownload),
+        ("/o/p/w/releases/42/abc/delete/", releases.ReleaseFileDelete),
+        ("/o/p/w/releases/42/file.txt", releases.ReleaseDetail),
+        ("/o/p/w/42/", job_requests.JobRequestDetail),
+        ("/o/p/w/42/cancel/", job_requests.JobRequestCancel),
+        ("/o/p/w/42/abc/", jobs.JobDetail),
+        ("/o/p/w/42/abc/cancel/", jobs.JobCancel),
+    ],
+)
+def test_url_resolution(url, view):
+    """Test each URL resolves to the expected view function or class"""
+    resolved_view = resolve(url).func
+
+    assert dotted_path(resolved_view) == dotted_path(view)
+
+    msg = f"Resolved view '{resolved_view}' is a class. Did you forget `.as_view()`?"
+    assert not inspect.isclass(resolved_view), msg

--- a/tests/unit/jobserver/views/test_backends.py
+++ b/tests/unit/jobserver/views/test_backends.py
@@ -11,9 +11,6 @@ from jobserver.views.backends import (
 from ....factories import BackendFactory
 
 
-MEANINGLESS_URL = "/"
-
-
 @pytest.mark.django_db
 def test_backendedit_success(rf, core_developer):
     backend = BackendFactory()
@@ -34,7 +31,7 @@ def test_backendedit_success(rf, core_developer):
 def test_backenddetail_success(rf, core_developer):
     backend = BackendFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = core_developer
     response = BackendDetail.as_view()(request, pk=backend.pk)
 
@@ -44,7 +41,7 @@ def test_backenddetail_success(rf, core_developer):
 
 @pytest.mark.django_db
 def test_backendlist_success(rf, core_developer):
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = core_developer
     response = BackendList.as_view()(request)
 
@@ -56,7 +53,7 @@ def test_backendlist_success(rf, core_developer):
 def test_backendrotatetoken_success(rf, core_developer):
     backend = BackendFactory()
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = core_developer
     response = BackendRotateToken.as_view()(request, pk=backend.pk)
 

--- a/tests/unit/jobserver/views/test_index.py
+++ b/tests/unit/jobserver/views/test_index.py
@@ -11,15 +11,12 @@ from ....factories import (
 )
 
 
-MEANINGLESS_URL = "/"
-
-
 @pytest.mark.django_db
 def test_index_success(rf, user):
     workspace = WorkspaceFactory()
     JobRequestFactory.create_batch(10, workspace=workspace)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = Index.as_view()(request)
@@ -36,7 +33,7 @@ def test_index_with_authenticated_user_in_multiple_orgs(rf, user):
     # set up a second Org & tie the User to it
     OrgMembershipFactory(org=OrgFactory(), user=user)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = Index.as_view()(request)
@@ -50,7 +47,7 @@ def test_index_with_authenticated_user_in_one_org(rf, user):
     """Check the Add Workspace button is rendered for authenticated Users in a single Org."""
     WorkspaceFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = Index.as_view()(request)
@@ -67,7 +64,7 @@ def test_index_with_unauthenticated_user(rf):
     """
     WorkspaceFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = AnonymousUser()
 
     response = Index.as_view()(request)

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -26,9 +26,6 @@ from ....factories import (
 )
 
 
-MEANINGLESS_URL = "/"
-
-
 @pytest.mark.django_db
 def test_jobrequestcancel_already_completed(rf):
     job_request = JobRequestFactory(cancelled_actions=[])
@@ -40,7 +37,7 @@ def test_jobrequestcancel_already_completed(rf):
         project=job_request.workspace.project, user=user, roles=[ProjectDeveloper]
     )
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = user
 
     response = JobRequestCancel.as_view()(request, pk=job_request.pk)
@@ -64,7 +61,7 @@ def test_jobrequestcancel_success(rf):
         project=job_request.workspace.project, user=user, roles=[ProjectDeveloper]
     )
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = user
 
     response = JobRequestCancel.as_view()(request, pk=job_request.pk)
@@ -84,7 +81,7 @@ def test_jobrequestcancel_with_job_request_creator(rf):
     job_request = JobRequestFactory(cancelled_actions=[], created_by=user)
     JobFactory(job_request=job_request, action="test1")
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = user
 
     response = JobRequestCancel.as_view()(request, pk=job_request.pk)
@@ -101,7 +98,7 @@ def test_jobrequestcancel_unauthorized(rf):
     job_request = JobRequestFactory()
     user = UserFactory()
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = user
 
     with pytest.raises(Http404):
@@ -110,7 +107,7 @@ def test_jobrequestcancel_unauthorized(rf):
 
 @pytest.mark.django_db
 def test_jobrequestcancel_unknown_job_request(rf):
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -136,7 +133,7 @@ def test_jobrequestcreate_get_success(rf, mocker, user):
         return_value=dummy_yaml,
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = JobRequestCreate.as_view()(
@@ -174,7 +171,7 @@ def test_jobrequestcreate_get_with_permission(rf, mocker, user):
         return_value=dummy_yaml,
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = JobRequestCreate.as_view()(
@@ -208,7 +205,7 @@ def test_jobrequestcreate_get_with_project_yaml_errors(rf, mocker, user):
         side_effect=Exception("test error"),
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = JobRequestCreate.as_view()(
@@ -255,7 +252,7 @@ def test_jobrequestcreate_post_success(rf, mocker, monkeypatch, user):
         "requested_actions": ["twiddle"],
         "callback_url": "test",
     }
-    request = rf.post(MEANINGLESS_URL, data)
+    request = rf.post("/", data)
     request.user = user
 
     response = JobRequestCreate.as_view()(
@@ -308,7 +305,7 @@ def test_jobrequestcreate_post_with_invalid_backend(rf, mocker, monkeypatch, use
         "requested_actions": ["twiddle"],
         "callback_url": "test",
     }
-    request = rf.post(MEANINGLESS_URL, data)
+    request = rf.post("/", data)
     request.user = user
 
     response = JobRequestCreate.as_view()(
@@ -358,7 +355,7 @@ def test_jobrequestcreate_post_with_notifications_default(
         "callback_url": "test",
         "will_notify": "True",
     }
-    request = rf.post(MEANINGLESS_URL, data)
+    request = rf.post("/", data)
     request.user = user
 
     response = JobRequestCreate.as_view()(
@@ -414,7 +411,7 @@ def test_jobrequestcreate_post_with_notifications_override(
         "callback_url": "test",
         "will_notify": "False",
     }
-    request = rf.post(MEANINGLESS_URL, data)
+    request = rf.post("/", data)
     request.user = user
 
     response = JobRequestCreate.as_view()(
@@ -442,7 +439,7 @@ def test_jobrequestcreate_unknown_workspace(rf, user):
     org = user.orgs.first()
     project = ProjectFactory(org=org)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
     response = JobRequestCreate.as_view()(
         request,
@@ -522,7 +519,7 @@ def test_jobrequestdetail_with_job_request_creator(rf):
     user = UserFactory()
     job_request = JobRequestFactory(created_by=user)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = JobRequestDetail.as_view()(request, pk=job_request.pk)
@@ -540,7 +537,7 @@ def test_jobrequestdetail_with_permission(rf):
         project=job_request.workspace.project, user=user, roles=[ProjectDeveloper]
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = JobRequestDetail.as_view()(request, pk=job_request.pk)
@@ -553,7 +550,7 @@ def test_jobrequestdetail_with_permission(rf):
 def test_jobrequestdetail_with_unauthenticated_user(rf):
     job_request = JobRequestFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = AnonymousUser()
 
     response = JobRequestDetail.as_view()(request, pk=job_request.pk)
@@ -565,7 +562,7 @@ def test_jobrequestdetail_with_unauthenticated_user(rf):
 def test_jobrequestdetail_without_permission(rf):
     job_request = JobRequestFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     response = JobRequestDetail.as_view()(request, pk=job_request.pk)
@@ -578,7 +575,7 @@ def test_jobrequestdetail_without_permission(rf):
 def test_jobrequestdetailredirect_success(rf):
     job_request = JobRequestFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
 
     response = JobRequestDetailRedirect.as_view()(request, pk=job_request.pk)
 
@@ -588,7 +585,7 @@ def test_jobrequestdetailredirect_success(rf):
 
 @pytest.mark.django_db
 def test_jobrequestdetailredirect_with_unknown_job(rf):
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
 
     with pytest.raises(Http404):
         JobRequestDetailRedirect.as_view()(request, pk=0)
@@ -597,7 +594,7 @@ def test_jobrequestdetailredirect_with_unknown_job(rf):
 @pytest.mark.django_db
 def test_jobrequestlist_filters_exist(rf):
     # Build a RequestFactory instance
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
     response = JobRequestList.as_view()(request)
 
@@ -735,7 +732,7 @@ def test_jobrequestlist_filter_by_workspace_with_broken_pk(rf):
 
 @pytest.mark.django_db
 def test_jobrequestlist_find_job_request_by_identifier_form_invalid(rf):
-    request = rf.post(MEANINGLESS_URL, {"test-key": "test-value"})
+    request = rf.post("/", {"test-key": "test-value"})
     request.user = UserFactory()
     response = JobRequestList.as_view()(request)
 
@@ -749,7 +746,7 @@ def test_jobrequestlist_find_job_request_by_identifier_form_invalid(rf):
 def test_jobrequestlist_find_job_request_by_identifier_success(rf):
     job_request = JobRequestFactory(identifier="test-identifier")
 
-    request = rf.post(MEANINGLESS_URL, {"identifier": job_request.identifier})
+    request = rf.post("/", {"identifier": job_request.identifier})
     request.user = UserFactory()
     response = JobRequestList.as_view()(request)
 
@@ -759,7 +756,7 @@ def test_jobrequestlist_find_job_request_by_identifier_success(rf):
 
 @pytest.mark.django_db
 def test_jobrequestlist_find_job_request_by_identifier_unknown_job_request(rf):
-    request = rf.post(MEANINGLESS_URL, {"identifier": "test-value"})
+    request = rf.post("/", {"identifier": "test-value"})
     request.user = UserFactory()
     response = JobRequestList.as_view()(request)
 
@@ -813,7 +810,7 @@ def test_jobrequestlist_success(rf):
     JobFactory(job_request=job_request)
 
     # Build a RequestFactory instance
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
     response = JobRequestList.as_view()(request)
 
@@ -830,7 +827,7 @@ def test_jobrequestlist_with_core_developer(rf, core_developer):
     JobFactory(job_request=job_request)
     JobFactory(job_request=job_request)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = core_developer
     response = JobRequestList.as_view()(request)
 
@@ -844,7 +841,7 @@ def test_jobrequestlist_with_permission(rf):
     JobFactory(job_request=job_request)
     JobFactory(job_request=job_request)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory(is_superuser=False, roles=[])
     response = JobRequestList.as_view()(request)
 
@@ -858,7 +855,7 @@ def test_jobrequestlist_without_permission(rf):
     JobFactory(job_request=job_request)
     JobFactory(job_request=job_request)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = AnonymousUser()
     response = JobRequestList.as_view()(request)
     assert response.status_code == 200

--- a/tests/unit/jobserver/views/test_jobs.py
+++ b/tests/unit/jobserver/views/test_jobs.py
@@ -13,9 +13,6 @@ from ....factories import (
 )
 
 
-MEANINGLESS_URL = "/"
-
-
 @pytest.mark.django_db
 def test_jobcancel_already_cancelled(rf, user):
     job_request = JobRequestFactory(cancelled_actions=["another-action", "test"])
@@ -25,7 +22,7 @@ def test_jobcancel_already_cancelled(rf, user):
         project=job_request.workspace.project, user=user, roles=[ProjectDeveloper]
     )
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = user
 
     response = JobCancel.as_view()(request, identifier=job.identifier)
@@ -46,7 +43,7 @@ def test_jobcancel_already_completed(rf, user):
         project=job_request.workspace.project, user=user, roles=[ProjectDeveloper]
     )
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = user
 
     response = JobCancel.as_view()(request, identifier=job.identifier)
@@ -68,7 +65,7 @@ def test_jobcancel_success(rf):
         project=job_request.workspace.project, user=user, roles=[ProjectDeveloper]
     )
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = user
 
     response = JobCancel.as_view()(request, identifier=job.identifier)
@@ -86,7 +83,7 @@ def test_jobcancel_with_job_creator(rf):
     job_request = JobRequestFactory(cancelled_actions=[], created_by=user)
     job = JobFactory(job_request=job_request, action="test")
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = user
 
     response = JobCancel.as_view()(request, identifier=job.identifier)
@@ -102,7 +99,7 @@ def test_jobcancel_with_job_creator(rf):
 def test_jobcancel_without_permission(rf, user):
     job = JobFactory(job_request=JobRequestFactory())
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = user
 
     with pytest.raises(Http404):
@@ -111,7 +108,7 @@ def test_jobcancel_without_permission(rf, user):
 
 @pytest.mark.django_db
 def test_jobcancel_unknown_job(rf, user):
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = user
 
     with pytest.raises(Http404):
@@ -122,7 +119,7 @@ def test_jobcancel_unknown_job(rf, user):
 def test_jobdetail_with_anonymous_user(rf):
     job = JobFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = AnonymousUser()
 
     response = JobDetail.as_view()(
@@ -147,7 +144,7 @@ def test_jobdetail_with_permission(rf):
         project=job.job_request.workspace.project, user=user, roles=[ProjectDeveloper]
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = JobDetail.as_view()(
@@ -169,7 +166,7 @@ def test_jobdetail_with_job_creator(rf):
     job_request = JobRequestFactory(created_by=user)
     job = JobFactory(job_request=job_request)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = JobDetail.as_view()(
@@ -191,7 +188,7 @@ def test_jobdetail_with_partial_identifier_failure(rf, mocker):
     JobFactory(job_request=job_request, identifier="123abc")
     JobFactory(job_request=job_request, identifier="123def")
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -209,7 +206,7 @@ def test_jobdetail_with_partial_identifier_failure(rf, mocker):
 def test_jobdetail_with_partial_identifier_success(rf):
     job = JobFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     response = JobDetail.as_view()(
@@ -229,7 +226,7 @@ def test_jobdetail_with_partial_identifier_success(rf):
 def test_jobdetail_with_unknown_job(rf):
     job_request = JobRequestFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
 
     with pytest.raises(Http404):
         JobDetail.as_view()(
@@ -246,7 +243,7 @@ def test_jobdetail_with_unknown_job(rf):
 def test_jobdetail_without_permission(rf):
     job = JobFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     response = JobDetail.as_view()(
@@ -266,7 +263,7 @@ def test_jobdetail_without_permission(rf):
 def test_jobdetailredirect_success(rf):
     job = JobFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
 
     response = JobDetailRedirect.as_view()(request, identifier=job.identifier)
 
@@ -276,7 +273,7 @@ def test_jobdetailredirect_success(rf):
 
 @pytest.mark.django_db
 def test_jobdetailredirect_with_unknown_job(rf):
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
 
     with pytest.raises(Http404):
         JobDetailRedirect.as_view()(request, identifier="test")

--- a/tests/unit/jobserver/views/test_orgs.py
+++ b/tests/unit/jobserver/views/test_orgs.py
@@ -13,15 +13,12 @@ from ....factories import (
 )
 
 
-MEANINGLESS_URL = "/"
-
-
 @pytest.mark.django_db
 def test_orgcreate_get_success(rf, core_developer):
     oxford = OrgFactory(name="University of Oxford")
     ebmdatalab = OrgFactory(name="EBMDataLab")
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = core_developer
     response = OrgCreate.as_view()(request)
 
@@ -35,7 +32,7 @@ def test_orgcreate_get_success(rf, core_developer):
 
 @pytest.mark.django_db
 def test_orgcreate_post_success(rf, core_developer):
-    request = rf.post(MEANINGLESS_URL, {"name": "A New Org"})
+    request = rf.post("/", {"name": "A New Org"})
     request.user = core_developer
     response = OrgCreate.as_view()(request)
 
@@ -53,7 +50,7 @@ def test_orgcreate_post_success(rf, core_developer):
 def test_orgdetail_success(rf):
     org = OrgFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
     response = OrgDetail.as_view()(request, org_slug=org.slug)
 
@@ -62,7 +59,7 @@ def test_orgdetail_success(rf):
 
 @pytest.mark.django_db
 def test_orgdetail_unknown_org(rf):
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -75,7 +72,7 @@ def test_orgdetail_unknown_org_but_known_workspace(rf):
     project = ProjectFactory(org=org)
     workspace = WorkspaceFactory(project=project)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     response = OrgDetail.as_view()(request, org_slug=workspace.name)
@@ -90,7 +87,7 @@ def test_orgdetail_with_org_member(rf):
     user = UserFactory()
     OrgMembershipFactory(org=org, user=user)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = OrgDetail.as_view()(request, org_slug=org.slug)
@@ -103,7 +100,7 @@ def test_orgdetail_with_org_member(rf):
 def test_orgdetail_with_non_member_user(rf):
     org = OrgFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
     response = OrgDetail.as_view()(request, org_slug=org.slug)
 
@@ -115,7 +112,7 @@ def test_orgdetail_with_non_member_user(rf):
 def test_orglist_success(rf):
     org = OrgFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     response = OrgList.as_view()(request)

--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -46,9 +46,6 @@ from ....factories import (
 from ....utils import minutes_ago
 
 
-MEANINGLESS_URL = "/"
-
-
 @pytest.mark.django_db
 def test_projectacceptinvite_already_accepted(rf):
     org = OrgFactory()
@@ -63,7 +60,7 @@ def test_projectacceptinvite_already_accepted(rf):
         roles=[ProjectCollaborator],
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = ProjectAcceptInvite.as_view()(
@@ -90,7 +87,7 @@ def test_projectacceptinvite_success(rf):
     )
     assert invite.membership is None
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = ProjectAcceptInvite.as_view()(
@@ -115,7 +112,7 @@ def test_projectacceptinvite_unknown_invite(rf):
     org = OrgFactory()
     project = ProjectFactory(org=org)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -134,7 +131,7 @@ def test_projectacceptinvite_with_different_user(rf):
     invitee = UserFactory()
     invite = ProjectInvitationFactory(project=project, user=invitee)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     # set up messages framework
@@ -167,7 +164,7 @@ def test_projectcancelinvite_success(rf):
 
     invite = ProjectInvitationFactory(project=project, user=user)
 
-    request = rf.post(MEANINGLESS_URL, {"invite_pk": invite.pk})
+    request = rf.post("/", {"invite_pk": invite.pk})
     request.user = user
 
     response = ProjectCancelInvite.as_view()(
@@ -187,7 +184,7 @@ def test_projectcancelinvite_unknown_invitation(rf):
     user = UserFactory()
     ProjectMembershipFactory(project=project, user=user, roles=[ProjectCoordinator])
 
-    request = rf.post(MEANINGLESS_URL, {"invite_pk": 0})
+    request = rf.post("/", {"invite_pk": 0})
     request.user = user
 
     with pytest.raises(Http404):
@@ -202,7 +199,7 @@ def test_projectcancelinvite_without_manage_members_permission(rf):
     project = ProjectFactory(org=org)
     invite = ProjectInvitationFactory(project=project, user=UserFactory())
 
-    request = rf.post(MEANINGLESS_URL, {"invite_pk": invite.pk})
+    request = rf.post("/", {"invite_pk": invite.pk})
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -310,7 +307,7 @@ def test_projectdetail_success(rf, mocker):
         return_value=True,
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     response = ProjectDetail.as_view()(
@@ -358,7 +355,7 @@ def test_projectdetail_with_multiple_releases(rf, freezer, mocker):
         return_value=True,
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     # FIXME: remove this role when releases is deployed to all users
     request.user = UserFactory(roles=[CoreDeveloper])
 
@@ -394,7 +391,7 @@ def test_projectdetail_with_no_github(rf, mocker):
         side_effect=requests.HTTPError,
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     response = ProjectDetail.as_view()(
@@ -420,7 +417,7 @@ def test_projectdetail_with_no_releases(rf, mocker):
         return_value=True,
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     response = ProjectDetail.as_view()(
@@ -437,7 +434,7 @@ def test_projectdetail_with_no_releases(rf, mocker):
 def test_projectdetail_unknown_org(rf):
     project = ProjectFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -448,7 +445,7 @@ def test_projectdetail_unknown_org(rf):
 def test_projectdetail_unknown_project(rf):
     org = OrgFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -525,7 +522,7 @@ def test_projectinvitationcreate_get_success(rf):
         project=project, user=coordinator, roles=[ProjectCoordinator]
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = coordinator
 
     response = ProjectInvitationCreate.as_view()(
@@ -549,7 +546,7 @@ def test_projectinvitationcreate_post_success(rf):
     assert ProjectInvitation.objects.filter(project=project).count() == 0
 
     request = rf.post(
-        MEANINGLESS_URL,
+        "/",
         {
             "roles": ["jobserver.authorization.roles.ProjectDeveloper"],
             "users": [str(invitee.pk)],
@@ -589,7 +586,7 @@ def test_projectinvitationcreate_post_with_email_failure(rf, mocker):
     )
 
     request = rf.post(
-        MEANINGLESS_URL,
+        "/",
         {
             "roles": ["jobserver.authorization.roles.ProjectDeveloper"],
             "users": [str(invitee.pk)],
@@ -631,7 +628,7 @@ def test_projectinvitationcreate_post_with_incorrect_form(rf):
 
     assert ProjectInvitation.objects.filter(project=project).count() == 0
 
-    request = rf.post(MEANINGLESS_URL, {"roles": ["foo"], "users": ["not_a_pk"]})
+    request = rf.post("/", {"roles": ["foo"], "users": ["not_a_pk"]})
     request.user = coordinator
 
     response = ProjectInvitationCreate.as_view()(
@@ -651,7 +648,7 @@ def test_projectinvitationcreate_without_permission(rf):
     org = OrgFactory()
     project = ProjectFactory(org=org)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
     with pytest.raises(Http404):
         ProjectInvitationCreate.as_view()(
@@ -790,7 +787,7 @@ def test_projectmembershipremove_without_permission(rf):
 def test_projectonboardingcreate_get_success(rf):
     org = OrgFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     response = ProjectOnboardingCreate.as_view()(request, org_slug=org.slug)
@@ -800,7 +797,7 @@ def test_projectonboardingcreate_get_success(rf):
 
 @pytest.mark.django_db
 def test_projectonboardingcreate_get_unknown_org(rf):
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -821,7 +818,7 @@ def test_projectonboardingcreate_post_invalid_data(rf):
         "researcher-MAX_NUM": "1000",
     }
 
-    request = rf.post(MEANINGLESS_URL, data)
+    request = rf.post("/", data)
     request.user = UserFactory()
     response = ProjectOnboardingCreate.as_view()(request, org_slug=org.slug)
 
@@ -846,7 +843,7 @@ def test_projectonboardingcreate_post_success(rf):
         "researcher-0-is_ons_accredited_researcher": "on",
     }
 
-    request = rf.post(MEANINGLESS_URL, data)
+    request = rf.post("/", data)
     request.user = UserFactory()
     response = ProjectOnboardingCreate.as_view()(request, org_slug=org.slug)
 
@@ -865,7 +862,7 @@ def test_projectonboardingcreate_post_success(rf):
 
 @pytest.mark.django_db
 def test_projectonboardingcreate_post_unknown_org(rf):
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -882,7 +879,7 @@ def test_projectsettings_success(rf):
         project=project, user=coordinator, roles=[ProjectCoordinator]
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = coordinator
 
     response = ProjectSettings.as_view()(
@@ -897,7 +894,7 @@ def test_projectsettings_success(rf):
 
 @pytest.mark.django_db
 def test_projectsettings_unknown_project(rf):
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
     with pytest.raises(Http404):
         ProjectSettings.as_view()(request, org_slug="", project_slug="")
@@ -908,7 +905,7 @@ def test_projectsettings_without_permission(rf):
     org = OrgFactory()
     project = ProjectFactory(org=org)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
     with pytest.raises(Http404):
         ProjectSettings.as_view()(request, org_slug=org.slug, project_slug=project.slug)

--- a/tests/unit/jobserver/views/test_status.py
+++ b/tests/unit/jobserver/views/test_status.py
@@ -9,9 +9,6 @@ from ....factories import JobFactory, JobRequestFactory, StatsFactory
 from ....utils import minutes_ago
 
 
-MEANINGLESS_URL = "/"
-
-
 @pytest.mark.django_db
 def test_status_healthy(rf):
     tpp = Backend.objects.get(slug="tpp")
@@ -22,7 +19,7 @@ def test_status_healthy(rf):
     last_seen = minutes_ago(timezone.now(), 1)
     StatsFactory(backend=tpp, api_last_seen=last_seen)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     response = Status.as_view()(request)
 
     tpp_output = first(
@@ -37,7 +34,7 @@ def test_status_healthy(rf):
 
 @pytest.mark.django_db
 def test_status_no_last_seen(rf):
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     response = Status.as_view()(request)
 
     tpp_output = first(
@@ -55,7 +52,7 @@ def test_status_unacked_jobs_but_recent_api_contact(rf):
     last_seen = minutes_ago(timezone.now(), 1)
     StatsFactory(backend=tpp, api_last_seen=last_seen)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     response = Status.as_view()(request)
 
     tpp_output = first(
@@ -80,7 +77,7 @@ def test_status_unhealthy(rf):
     last_seen = minutes_ago(timezone.now(), 10)
     StatsFactory(backend=tpp, api_last_seen=last_seen, url="foo")
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     response = Status.as_view()(request)
 
     tpp_output = first(

--- a/tests/unit/jobserver/views/test_users.py
+++ b/tests/unit/jobserver/views/test_users.py
@@ -17,15 +17,12 @@ from ....factories import (
 )
 
 
-MEANINGLESS_URL = "/"
-
-
 @pytest.mark.django_db
 def test_settings_get(rf):
     UserFactory()
     user2 = UserFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user2
     response = Settings.as_view()(request)
 
@@ -41,7 +38,7 @@ def test_settings_post(rf):
     user2 = UserFactory(notifications_email="original@example.com")
 
     data = {"notifications_email": "changed@example.com"}
-    request = rf.post(MEANINGLESS_URL, data)
+    request = rf.post("/", data)
     request.user = user2
 
     # set up messages framework
@@ -307,7 +304,7 @@ def test_userlist_find_by_username(rf, core_developer):
 def test_userlist_success(rf, core_developer):
     UserFactory.create_batch(5)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = core_developer
 
     response = UserList.as_view()(request)

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -40,9 +40,6 @@ from ....factories import (
 from ....utils import minutes_ago
 
 
-MEANINGLESS_URL = "/"
-
-
 @pytest.mark.django_db
 def test_workspacearchivetoggle_success(rf):
     user = UserFactory()
@@ -52,7 +49,7 @@ def test_workspacearchivetoggle_success(rf):
         project=workspace.project, user=user, roles=[ProjectDeveloper]
     )
 
-    request = rf.post(MEANINGLESS_URL, {"is_archived": "True"})
+    request = rf.post("/", {"is_archived": "True"})
     request.user = user
 
     response = WorkspaceArchiveToggle.as_view()(
@@ -73,7 +70,7 @@ def test_workspacearchivetoggle_success(rf):
 def test_workspacearchivetoggle_unknown_workspace(rf):
     project = ProjectFactory()
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -89,7 +86,7 @@ def test_workspacearchivetoggle_unknown_workspace(rf):
 def test_workspacearchivetoggle_without_permission(rf):
     workspace = WorkspaceFactory()
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -241,7 +238,7 @@ def test_workspacecreate_get_success(rf, mocker, user):
         return_value=[{"name": "test", "url": "test", "branches": ["main"]}],
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = WorkspaceCreate.as_view()(
@@ -255,7 +252,7 @@ def test_workspacecreate_get_success(rf, mocker, user):
 def test_workspacecreate_get_without_permission(rf):
     project = ProjectFactory()
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     with pytest.raises(Http404):
@@ -283,7 +280,7 @@ def test_workspacecreate_post_success(rf, mocker, user):
         "repo": "test",
         "branch": "test",
     }
-    request = rf.post(MEANINGLESS_URL, data)
+    request = rf.post("/", data)
     request.user = user
 
     response = WorkspaceCreate.as_view()(
@@ -308,7 +305,7 @@ def test_workspacecreate_without_github(rf, mocker, user):
         side_effect=requests.HTTPError,
     )
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     # set up messages framework
@@ -340,7 +337,7 @@ def test_workspacecreate_without_github(rf, mocker, user):
 def test_workspacecreate_without_permission(rf, user):
     project = ProjectFactory()
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = user
 
     with pytest.raises(Http404):
@@ -894,7 +891,7 @@ def test_workspacelog_success(rf):
     job_request = JobRequestFactory(created_by=user, workspace=workspace)
     JobFactory(job_request=job_request)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = WorkspaceLog.as_view()(
@@ -915,7 +912,7 @@ def test_workspacelog_unknown_workspace(rf):
 
     ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = user
 
     response = WorkspaceLog.as_view()(
@@ -935,7 +932,7 @@ def test_workspacelog_with_authenticated_user(rf):
     job_request = JobRequestFactory(workspace=workspace)
     JobFactory(job_request=job_request)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = UserFactory()
 
     response = WorkspaceLog.as_view()(
@@ -954,7 +951,7 @@ def test_workspacelog_with_unauthenticated_user(rf):
     job_request = JobRequestFactory(workspace=workspace)
     JobFactory(job_request=job_request)
 
-    request = rf.get(MEANINGLESS_URL)
+    request = rf.get("/")
     request.user = AnonymousUser()
 
     response = WorkspaceLog.as_view()(
@@ -977,7 +974,7 @@ def test_workspacenotificationstoggle_success(rf):
         project=workspace.project, user=user, roles=[ProjectDeveloper]
     )
 
-    request = rf.post(MEANINGLESS_URL, {"should_notify": ""})
+    request = rf.post("/", {"should_notify": ""})
     request.user = user
 
     response = WorkspaceNotificationsToggle.as_view()(
@@ -1001,7 +998,7 @@ def test_workspacenotificationstoggle_without_permission(rf, user):
     workspace = WorkspaceFactory()
     user = UserFactory()
 
-    request = rf.post(MEANINGLESS_URL, {"should_notify": ""})
+    request = rf.post("/", {"should_notify": ""})
     request.user = user
 
     with pytest.raises(Http404):
@@ -1020,7 +1017,7 @@ def test_workspacenotificationstoggle_unknown_workspace(rf):
 
     ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post("/")
     request.user = user
 
     with pytest.raises(Http404):


### PR DESCRIPTION
This is a grab bag of changes, mostly to bring the tests inline with our testing expectations defined in TESTING.md.

The switch from Client -> RequestFactory saw a runtime drop of ~6s (~9.3s -> ~3.3s) in the release API tests, although I'm still unsure what about the use of Client (technically DRF's Client) was slowing them down.

I'd added a parametrized test to check all the URLs go where we think they do (with redirects in another test), but this doesn't currently check we have all configured URLs covered.  I have some ideas for that but wanted to get them out in another PR.

I've removed the `MEANINGLESS_URL` variable because it seemed rather meaningless (😜) and felt like an indirection when reading back through tests.