### PR TITLE
Enable ProjectDeveloper role being set on User instances

### DIFF
--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -182,6 +182,7 @@ class ProjectDeveloper:
     models = [
         "jobserver.models.core.ProjectInvitation",
         "jobserver.models.core.ProjectMembership",
+        "jobserver.models.core.User",
     ]
     permissions = [
         job_cancel,


### PR DESCRIPTION
This lets us set the ProjectDeveloper role "globally" on a User instance, so staff can have this role without having to be members of every Project.  This is more important now that running jobs is tied to the `run_job` permission provided by this role.