### PR TITLE
Tidier project.yaml Rendering

### DIFF
--- a/jobserver/project.py
+++ b/jobserver/project.py
@@ -85,7 +85,7 @@ def render_definition(content, link_func):
     project.yaml but since we're only convert the script-looking substrings
     currently this seems like the quicker path.
     """
-    lines = content.split("\n")
+    lines = content.strip().split("\n")
 
     for i, line in enumerate(lines):
         if "run:" not in line:

--- a/jobserver/project.py
+++ b/jobserver/project.py
@@ -96,6 +96,6 @@ def render_definition(content, link_func):
 
     # replace newlines with <br /> elements so the normal newlines aren't
     # collapsed when the browser renders them.
-    definition = "<br/>".join(lines)
+    definition = "\n".join(lines)
 
     return definition

--- a/tests/unit/jobserver/test_project.py
+++ b/tests/unit/jobserver/test_project.py
@@ -197,9 +197,7 @@ def test_render_definition():
         needs: [run_model]
         outputs:
           moderately_sensitive:
-            log: logs/analysis.log""".replace(
-        "\n", "<br/>"
-    )  # keep expected human readable
+            log: logs/analysis.log"""
 
     def link_func(path):
         return f"example.com/test/{path}"

--- a/tests/unit/jobserver/test_project.py
+++ b/tests/unit/jobserver/test_project.py
@@ -173,8 +173,7 @@ def test_render_definition():
             log: logs/analysis.log
     """
 
-    expected = """
-    version: "3.0"
+    expected = """version: "3.0"
 
     expectations:
       population_size: 100000
@@ -198,8 +197,7 @@ def test_render_definition():
         needs: [run_model]
         outputs:
           moderately_sensitive:
-            log: logs/analysis.log
-    """.replace(
+            log: logs/analysis.log""".replace(
         "\n", "<br/>"
     )  # keep expected human readable
 


### PR DESCRIPTION
We render project.yaml contents on JobRequest detail pages, but any reasonably sized file adds a lot of scrolling to the page.

In lieu of the upcoming parser library this makes some aesthetic changes in an attempt to make the page a little more usable.

**Before:**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/X6ulAEW0/c1c5ea5b-b1c8-48b7-aac9-dcf247fe028c.jpg?v=f5974ed241f0efdb62ab0bdfc409bb71)

**After:**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/jku4Pv12/883f2035-5428-4250-ac36-8cd462a4ef3d.jpg?v=b17224de345d0e3e7431c9446e585a86)