### PR TITLE
Add Backend to Index Endpoints

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -143,6 +143,7 @@ def generate_index(files):
                 sha256=rfile.filehash,
                 size=get_size(rfile),
                 is_deleted=rfile.deleted_at or not rfile.absolute_path().exists(),
+                backend=rfile.release.backend.name,
             )
             for name, rfile in files.items()
         ],

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -310,6 +310,7 @@ def test_workspace_index_api_have_permission(api_client):
                 "size": 8,
                 "sha256": release2.files.first().filehash,
                 "is_deleted": False,
+                "backend": release2.backend.name,
             },
             {
                 "name": "backend1/file1.txt",
@@ -320,6 +321,7 @@ def test_workspace_index_api_have_permission(api_client):
                 "size": 8,
                 "sha256": release1.files.first().filehash,
                 "is_deleted": False,
+                "backend": release1.backend.name,
             },
         ],
     }
@@ -376,6 +378,7 @@ def test_release_index_api_have_permission(api_client):
                 "size": 8,
                 "sha256": rfile.filehash,
                 "is_deleted": False,
+                "backend": release.backend.name,
             }
         ],
     }


### PR DESCRIPTION
This adds the the relevant Backend name to the various index endpoints ready for the UI to display it.

Fixes #755 