### PR TITLE
Filter Workspace Logs by Backend

### DIFF
--- a/assets/src/styles/main.scss
+++ b/assets/src/styles/main.scss
@@ -88,16 +88,6 @@ nav {
 
 #started-at-header {
   margin-right: 112px;
-
-  /* account for larger show/hide button */
-  @media (min-width: 768px) {
-    margin-right: 147px;
-  }
-
-  /* account for larger show/hide button */
-  @media (min-width: 992px) {
-    margin-right: 212px;
-  }
 }
 
 .status-icon {

--- a/jobserver/templates/workspace_log.html
+++ b/jobserver/templates/workspace_log.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% load selected_filter %}
+
 {% block metatitle %}Logs: {{ workspace.name }} | OpenSAFELY Jobs{% endblock metatitle %}
 
 {% block content %}
@@ -52,7 +54,7 @@
     based on the actions which were requested.
   </p>
 
-  <form class="form d-flex align-items-center mb-4" method="GET">
+  <form class="d-flex align-items-center mb-2" method="GET">
     <input
       class="form-control mr-2"
       type="search"
@@ -62,6 +64,25 @@
     <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
   </form>
 
+  <form class="d-flex justify-content-between align-items-center mb-2" method="GET">
+
+    <div class="form-group">
+      <div class="btn-group-toggle" data-toggle="buttons">
+        {% for backend in backends %}
+        {% is_filter_selected key="backend" value=backend.slug as is_active %}
+        <label class="btn btn-sm btn-outline-success">
+          <input type="checkbox" name="backend" {% if is_active %}checked {% endif %}value="{{ backend.slug }}" />
+          {{ backend.name }}
+        </label>
+        {% endfor %}
+      </div>
+    </div>
+
+    <div class="form-group">
+      <button class="btn btn-outline-success" type="submit">Filter</button>
+    </div>
+
+  </form>
 
   {% if not page_obj %}
   <div class="text-center">

--- a/jobserver/templatetags/selected_filter.py
+++ b/jobserver/templatetags/selected_filter.py
@@ -23,12 +23,12 @@ def is_filter_selected(context, *, key, value, **kwargs):
     # arg to is also a string
     value = str(value)
 
-    arg = request.GET.get(key)
+    args = request.GET.getlist(key)
 
-    if arg is None:
+    if not args:
         return False
 
-    if arg != value:
+    if value not in args:
         return False
 
     return True

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -360,7 +360,9 @@ class WorkspaceLog(ListView):
         qs = (
             JobRequest.objects.filter(workspace=self.workspace)
             .prefetch_related("jobs")
-            .select_related("workspace")
+            .select_related(
+                "backend", "workspace", "workspace__project", "workspace__project__org"
+            )
             .order_by("-pk")
         )
 


### PR DESCRIPTION
This adds a backend filter to the WorkspaceLog page, using GET args as we do with all our other filter pages:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/5zuNYbLq/dade8c78-2b0d-4dfe-88cc-2b43daadbc0a.jpg?v=5be6c21df4dfb135374747af1490bd5a)

Fixes #527 