### PR TITLE
Hide new workspace button when first signed up

### DIFF
--- a/jobserver/templates/index.html
+++ b/jobserver/templates/index.html
@@ -58,7 +58,7 @@
       {% endfor %}
     </div>
 
-    {% if request.user.is_authenticated %}
+    {% if request.user.is_authenticated and request.user.orgs.exists %}
     <div class="text-center">
       <p><strong>OR</strong></p>
 

--- a/tests/unit/jobserver/views/test_index.py
+++ b/tests/unit/jobserver/views/test_index.py
@@ -7,6 +7,7 @@ from ....factories import (
     JobRequestFactory,
     OrgFactory,
     OrgMembershipFactory,
+    UserFactory,
     WorkspaceFactory,
 )
 
@@ -54,6 +55,20 @@ def test_index_with_authenticated_user_in_one_org(rf, user):
 
     assert "Pick a project" in response.rendered_content
     assert "Add a New Workspace" in response.rendered_content
+
+
+@pytest.mark.django_db
+def test_index_with_authenticated_user_in_zero_orgs(rf):
+    """Check the Add Workspace button is rendered for authenticated Users in a single Org."""
+    WorkspaceFactory()
+
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    response = Index.as_view()(request)
+
+    assert "Pick a project" not in response.rendered_content
+    assert "Add a New Workspace" not in response.rendered_content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Currently when a User signs up/first logs in they have no related Org since we don't know which Org to place them in.  This removes the new workspace button from the homepage while a user is in that state.

Ref #632