### PR TITLE
Remove no-op compacting

### DIFF
--- a/jobserver/project.py
+++ b/jobserver/project.py
@@ -115,10 +115,6 @@ def map_run_scripts_to_links(content, link_func):
         (line, " ".join(link_run_scripts(line, link_func))) for line in run_lines
     )
 
-    # compact the list to remove Nones, from lines with no appropriate script
-    # as the run target (eg a generate_cohort action)
-    links_map = (m for m in links_map if m is not None)
-
     # finally convert to a dictionary so we can use it as a mapping
     return dict(links_map)
 


### PR DESCRIPTION
links_map is always going to have an (original, replacement) tuple for
every run line at this point, even if `replacement` is the same as
`original`, so we don't need to remove Nones which aren't there.