### PR TITLE
Permissions/actions spike

### DIFF
--- a/jobserver/actions.py
+++ b/jobserver/actions.py
@@ -1,13 +1,13 @@
 from django.db import transaction
 from django.utils import timezone
 
-from .authorization.utils import require_permission
+from .authorization import roles
+from .authorization.utils import require_role
 
 
-@require_permission("release_file_delete", "project")
+@require_role(roles.OutputChecker, "project")
 def release_file_delete(*, user, rfile, project):
     """Delete a release file"""
-
     with transaction.atomic():
         # delete file on disk
         rfile.absolute_path().unlink()

--- a/jobserver/actions.py
+++ b/jobserver/actions.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from django.utils import timezone
 
+from . import releases
 from .authorization import roles
 from .authorization.utils import require_role
 
@@ -20,3 +21,15 @@ def release_file_delete(*, user, rfile, project):
 @require_role(roles.ProjectCollaborator)
 def release_file_view():
     """View a release file"""
+
+
+@require_role(roles.OutputChecker, "project")
+def release_file_upload(*, user, release, backend, upload, filename, project):
+    """Upload a released file"""
+    return releases.handle_file_upload(release, backend, user, upload, filename)
+
+
+@require_role(roles.OutputChecker, "project")
+def release_workspace_create(*, user, workspace, backend, files, project):
+    """Create a release in a workspace"""
+    return releases.create_release(workspace, backend, user, files)

--- a/jobserver/actions.py
+++ b/jobserver/actions.py
@@ -1,0 +1,14 @@
+from django.db import transaction
+from django.utils import timezone
+
+
+def release_file_delete(rfile, user):
+    """Delete a release file"""
+
+    with transaction.atomic():
+        # delete file on disk
+        rfile.absolute_path().unlink()
+
+        rfile.deleted_by = user
+        rfile.deleted_at = timezone.now()
+        rfile.save()

--- a/jobserver/actions.py
+++ b/jobserver/actions.py
@@ -6,6 +6,12 @@ from .authorization import roles
 from .authorization.utils import require_role
 
 
+@require_role(roles.ProjectCoordinator, "project")
+def cancel_project_invite(*, user, invite, project):
+    """Cancel an existing Project invitation"""
+    invite.delete()
+
+
 @require_role(roles.OutputChecker, "project")
 def delete_release_file(*, user, rfile, project):
     """Delete a release file"""

--- a/jobserver/actions.py
+++ b/jobserver/actions.py
@@ -1,8 +1,11 @@
 from django.db import transaction
 from django.utils import timezone
 
+from .authorization.utils import require_permission
 
-def release_file_delete(rfile, user):
+
+@require_permission("release_file_delete", "project")
+def release_file_delete(*, user, rfile, project):
     """Delete a release file"""
 
     with transaction.atomic():

--- a/jobserver/actions.py
+++ b/jobserver/actions.py
@@ -7,7 +7,7 @@ from .authorization.utils import require_role
 
 
 @require_role(roles.OutputChecker, "project")
-def release_file_delete(*, user, rfile, project):
+def delete_release_file(*, user, rfile, project):
     """Delete a release file"""
     with transaction.atomic():
         # delete file on disk
@@ -19,17 +19,17 @@ def release_file_delete(*, user, rfile, project):
 
 
 @require_role(roles.ProjectCollaborator)
-def release_file_view():
+def view_release_file():
     """View a release file"""
 
 
 @require_role(roles.OutputChecker, "project")
-def release_file_upload(*, user, release, backend, upload, filename, project):
+def upload_release_file(*, user, release, backend, upload, filename, project):
     """Upload a released file"""
     return releases.handle_file_upload(release, backend, user, upload, filename)
 
 
 @require_role(roles.OutputChecker, "project")
-def release_workspace_create(*, user, workspace, backend, files, project):
+def create_workspace_release(*, user, workspace, backend, files, project):
     """Create a release in a workspace"""
     return releases.create_release(workspace, backend, user, files)

--- a/jobserver/actions.py
+++ b/jobserver/actions.py
@@ -15,3 +15,8 @@ def release_file_delete(*, user, rfile, project):
         rfile.deleted_by = user
         rfile.deleted_at = timezone.now()
         rfile.save()
+
+
+@require_role(roles.ProjectCollaborator)
+def release_file_view():
+    """View a release file"""

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -166,7 +166,7 @@ class ReleaseWorkspaceAPI(APIView):
         files = serializer.validated_data["files"]
 
         try:
-            release = actions.release_workspace_create(
+            release = actions.create_workspace_release(
                 user=user,
                 workspace=workspace,
                 backend=backend,
@@ -227,7 +227,7 @@ class ReleaseAPI(APIView):
             )
 
         try:
-            rfile = actions.release_file_upload(
+            rfile = actions.upload_release_file(
                 user=user,
                 release=release,
                 backend=backend,

--- a/jobserver/authorization/__init__.py
+++ b/jobserver/authorization/__init__.py
@@ -13,6 +13,7 @@ from .roles import (
 )
 from .utils import (
     PermissionDenied,
+    can_do_action,
     has_permission,
     has_role,
     roles_for,
@@ -32,6 +33,7 @@ __all__ = [
     "ProjectCoordinator",
     "ProjectDeveloper",
     "TechnicalReviewer",
+    "can_do_action",
     "has_permission",
     "has_role",
     "roles_for",

--- a/jobserver/authorization/__init__.py
+++ b/jobserver/authorization/__init__.py
@@ -11,7 +11,13 @@ from .roles import (
     ProjectDeveloper,
     TechnicalReviewer,
 )
-from .utils import has_permission, has_role, roles_for, strings_to_roles
+from .utils import (
+    PermissionDenied,
+    has_permission,
+    has_role,
+    roles_for,
+    strings_to_roles,
+)
 
 
 __all__ = [
@@ -30,4 +36,5 @@ __all__ = [
     "has_role",
     "roles_for",
     "strings_to_roles",
+    "PermissionDenied",
 ]

--- a/jobserver/authorization/utils.py
+++ b/jobserver/authorization/utils.py
@@ -112,6 +112,11 @@ def has_permission(user, permission, **context):
     return permission in permissions
 
 
+def can_do_action(user, action_fn, **context):
+    """Return whether user has permission to do an action."""
+    return has_role(user, action_fn.required_role, **context)
+
+
 def has_role(user, role, **context):
     if not user.is_authenticated:
         return False
@@ -173,10 +178,12 @@ def require_role(role, *context_keys):
     """
 
     def decorator(fn):
+        fn.required_role = role
+
         @functools.wraps(fn)
         def wrapper(**kwargs):
             context = {key: kwargs[key] for key in context_keys}
-            if not has_role(kwargs["user"], role, **context):
+            if not can_do_action(kwargs["user"], fn, **context):
                 raise PermissionDenied
             return fn(**kwargs)
 

--- a/jobserver/authorization/utils.py
+++ b/jobserver/authorization/utils.py
@@ -2,8 +2,6 @@ import functools
 import inspect
 import itertools
 
-from django.http import Http404
-
 from ..utils import dotted_path
 from . import roles
 from .mappers import get_org_roles_for_user, get_project_roles_for_user
@@ -177,9 +175,14 @@ def require_permission(permission, *context_keys):
         def wrapper(**kwargs):
             context = {key: kwargs[key] for key in context_keys}
             if not has_permission(kwargs["user"], permission, **context):
-                raise Http404
+                raise PermissionDenied
             return fn(**kwargs)
 
         return wrapper
 
     return decorator
+
+
+class PermissionDenied(Exception):
+    """Indicates that a user has tried to perform an action for which they do not have
+    permission."""

--- a/jobserver/authorization/utils.py
+++ b/jobserver/authorization/utils.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 import itertools
+from collections import defaultdict
 
 from ..utils import dotted_path
 from . import roles
@@ -195,3 +196,15 @@ def require_role(role, *context_keys):
 class PermissionDenied(Exception):
     """Indicates that a user has tried to perform an action for which they do not have
     permission."""
+
+
+def build_role_to_actions():
+    from .. import actions
+
+    role_to_actions = defaultdict(list)
+    for k, v in vars(actions).items():
+        if not (required_role := getattr(v, "required_role", None)):
+            continue
+        role_to_actions[required_role].append(v)
+
+    return role_to_actions

--- a/jobserver/authorization/utils.py
+++ b/jobserver/authorization/utils.py
@@ -161,9 +161,11 @@ def strings_to_roles(strings):
     return [value for name, value in available_roles if name in strings]
 
 
-def require_permission(permission, *context_keys):
+def require_role(role, *context_keys):
     """Build decorator which decorates function to ensure that it can only be called by
-    user with appropriate permission.
+    user with requried role.
+
+    This could be adapted to support allowing multiple roles.
 
     The decorated function must only take kwargs, which must include "user", and all of
     the context_keys, which are used to create the context which is passed to
@@ -174,7 +176,7 @@ def require_permission(permission, *context_keys):
         @functools.wraps(fn)
         def wrapper(**kwargs):
             context = {key: kwargs[key] for key in context_keys}
-            if not has_permission(kwargs["user"], permission, **context):
+            if not has_role(kwargs["user"], role, **context):
                 raise PermissionDenied
             return fn(**kwargs)
 

--- a/jobserver/management/commands/report_roles.py
+++ b/jobserver/management/commands/report_roles.py
@@ -1,0 +1,22 @@
+from django.core.management.base import BaseCommand
+
+from ...authorization.utils import build_role_to_actions
+
+
+class Command(BaseCommand):
+    def handle(self, **kwargs):
+        role_to_actions = build_role_to_actions()
+
+        for role in sorted(role_to_actions, key=lambda role: role.__name__):
+            role_name = role.__name__
+            print(role_name)
+            print("=" * len(role_name))
+            print()
+            print("can perform the following actions:")
+
+            for action in sorted(
+                role_to_actions[role], key=lambda action: action.__name__
+            ):
+                print(f"  * {action.__name__}")
+                print(f"    => {action.__doc__}")
+            print()

--- a/jobserver/middleware.py
+++ b/jobserver/middleware.py
@@ -1,0 +1,16 @@
+from django.http import Http404
+
+from .authorization import PermissionDenied
+
+
+class PermissionDeniedMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_exception(self, request, exception):
+        if isinstance(exception, PermissionDenied):
+            # If this raised a 403 we could provide more context to the user.
+            raise Http404

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -72,6 +72,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_structlog.middlewares.RequestMiddleware",
     "social_django.middleware.SocialAuthExceptionMiddleware",
+    "jobserver.middleware.PermissionDeniedMiddleware",
 ]
 
 ROOT_URLCONF = "jobserver.urls"

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -12,6 +12,7 @@ from django.views.generic import CreateView, DetailView, UpdateView, View
 from furl import furl
 from sentry_sdk import capture_exception
 
+from .. import actions
 from ..authorization import (
     CoreDeveloper,
     ProjectDeveloper,
@@ -64,15 +65,11 @@ class ProjectCancelInvite(View):
             pk=self.request.POST.get("invite_pk"),
         )
 
-        can_manage_members = has_permission(
-            request.user,
-            "project_membership_edit",
+        actions.cancel_project_invite(
+            user=request.user,
+            invite=invite,
             project=invite.project,
         )
-        if not can_manage_members:
-            raise Http404
-
-        invite.delete()
 
         return redirect(invite.project.get_settings_url())
 

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -151,14 +151,11 @@ class ReleaseFileDelete(View):
         if not rfile.absolute_path().exists():
             raise Http404
 
-        if not has_permission(
-            request.user,
-            "release_file_delete",
+        actions.release_file_delete(
+            user=request.user,
+            rfile=rfile,
             project=rfile.release.workspace.project,
-        ):
-            raise Http404
-
-        actions.release_file_delete(rfile, request.user)
+        )
 
         return redirect(rfile.release.workspace.get_releases_url())
 

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -7,7 +7,7 @@ from django.utils.safestring import mark_safe
 from django.views.generic import View
 
 from .. import actions
-from ..authorization import has_permission
+from ..authorization import can_do_action, has_permission
 from ..models import Project, Release, ReleaseFile, Snapshot, Workspace
 from ..releases import build_outputs_zip, build_spa_base_url, workspace_files
 
@@ -28,8 +28,10 @@ class ProjectReleaseList(View):
         if not releases.exists():
             raise Http404
 
-        can_delete_files = has_permission(
-            request.user, "release_file_delete", project=project
+        can_delete_files = can_do_action(
+            request.user,
+            actions.release_file_delete,
+            project=project,
         )
         can_view_files = has_permission(
             request.user, "release_file_view", project=project
@@ -237,8 +239,10 @@ class WorkspaceReleaseList(View):
         if not workspace.releases.exists():
             raise Http404
 
-        can_delete_files = has_permission(
-            request.user, "release_file_delete", project=workspace.project
+        can_delete_files = can_do_action(
+            request.user,
+            actions.release_file_delete,
+            project=workspace.project,
         )
         can_view_files = has_permission(
             request.user,

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -30,12 +30,12 @@ class ProjectReleaseList(View):
 
         can_delete_files = can_do_action(
             request.user,
-            actions.release_file_delete,
+            actions.delete_release_file,
             project=project,
         )
         can_view_files = can_do_action(
             request.user,
-            actions.release_file_view,
+            actions.view_release_file,
             project=project,
         )
 
@@ -95,7 +95,7 @@ class ReleaseDetail(View):
 
         if not can_do_action(
             request.user,
-            actions.release_file_view,
+            actions.view_release_file,
             project=release.workspace.project,
         ):
             raise Http404
@@ -128,7 +128,7 @@ class ReleaseDownload(View):
 
         if not can_do_action(
             request.user,
-            actions.release_file_view,
+            actions.view_release_file,
             project=release.workspace.project,
         ):
             raise Http404
@@ -155,7 +155,7 @@ class ReleaseFileDelete(View):
         if not rfile.absolute_path().exists():
             raise Http404
 
-        actions.release_file_delete(
+        actions.delete_release_file(
             user=request.user,
             rfile=rfile,
             project=rfile.release.workspace.project,
@@ -176,7 +176,7 @@ class SnapshotDetail(View):
 
         has_permission_to_view = can_do_action(
             request.user,
-            actions.release_file_view,
+            actions.view_release_file,
             project=snapshot.workspace.project,
         )
         if snapshot.is_draft and not has_permission_to_view:
@@ -217,7 +217,7 @@ class SnapshotDownload(View):
 
         can_view_unpublished_files = can_do_action(
             request.user,
-            actions.release_file_view,
+            actions.view_release_file,
             project=snapshot.workspace.project,
         )
         if snapshot.is_draft and not can_view_unpublished_files:
@@ -245,12 +245,12 @@ class WorkspaceReleaseList(View):
 
         can_delete_files = can_do_action(
             request.user,
-            actions.release_file_delete,
+            actions.delete_release_file,
             project=workspace.project,
         )
         can_view_files = can_do_action(
             request.user,
-            actions.release_file_view,
+            actions.view_release_file,
             project=workspace.project,
         )
 

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -1,13 +1,12 @@
 from django.contrib.humanize.templatetags.humanize import naturaltime
-from django.db import transaction
 from django.http import FileResponse, Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.views.generic import View
 
+from .. import actions
 from ..authorization import has_permission
 from ..models import Project, Release, ReleaseFile, Snapshot, Workspace
 from ..releases import build_outputs_zip, build_spa_base_url, workspace_files
@@ -159,13 +158,7 @@ class ReleaseFileDelete(View):
         ):
             raise Http404
 
-        with transaction.atomic():
-            # delete file on disk
-            rfile.absolute_path().unlink()
-
-            rfile.deleted_by = request.user
-            rfile.deleted_at = timezone.now()
-            rfile.save()
+        actions.release_file_delete(rfile, request.user)
 
         return redirect(rfile.release.workspace.get_releases_url())
 

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -33,8 +33,10 @@ class ProjectReleaseList(View):
             actions.release_file_delete,
             project=project,
         )
-        can_view_files = has_permission(
-            request.user, "release_file_view", project=project
+        can_view_files = can_do_action(
+            request.user,
+            actions.release_file_view,
+            project=project,
         )
 
         def build_title(release):
@@ -91,9 +93,9 @@ class ReleaseDetail(View):
         if not release.files.exists():
             raise Http404
 
-        if not has_permission(
+        if not can_do_action(
             request.user,
-            "release_file_view",
+            actions.release_file_view,
             project=release.workspace.project,
         ):
             raise Http404
@@ -124,9 +126,9 @@ class ReleaseDownload(View):
         if not release.files.exists():
             raise Http404
 
-        if not has_permission(
+        if not can_do_action(
             request.user,
-            "release_file_view",
+            actions.release_file_view,
             project=release.workspace.project,
         ):
             raise Http404
@@ -172,8 +174,10 @@ class SnapshotDetail(View):
             pk=self.kwargs["pk"],
         )
 
-        has_permission_to_view = has_permission(
-            request.user, "release_file_view", project=snapshot.workspace.project
+        has_permission_to_view = can_do_action(
+            request.user,
+            actions.release_file_view,
+            project=snapshot.workspace.project,
         )
         if snapshot.is_draft and not has_permission_to_view:
             raise Http404
@@ -211,9 +215,9 @@ class SnapshotDownload(View):
         if not snapshot.files.exists():
             raise Http404
 
-        can_view_unpublished_files = has_permission(
+        can_view_unpublished_files = can_do_action(
             request.user,
-            "release_file_view",
+            actions.release_file_view,
             project=snapshot.workspace.project,
         )
         if snapshot.is_draft and not can_view_unpublished_files:
@@ -244,9 +248,9 @@ class WorkspaceReleaseList(View):
             actions.release_file_delete,
             project=workspace.project,
         )
-        can_view_files = has_permission(
+        can_view_files = can_do_action(
             request.user,
-            "release_file_view",
+            actions.release_file_view,
             project=workspace.project,
         )
 

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -941,27 +941,9 @@ def test_snapshotpublishapi_without_permission(api_rf):
     assert response.status_code == 403
 
 
-def test_validate_upload_access_no_permission(rf):
-    backend = BackendFactory()
-    user = UserFactory()
-    workspace = WorkspaceFactory()
-
-    BackendMembershipFactory(backend=backend, user=user)
-
-    request = rf.get(
-        "/",
-        HTTP_AUTHORIZATION=backend.auth_token,
-        HTTP_OS_USER=user.username,
-    )
-
-    with pytest.raises(NotAuthenticated):
-        validate_upload_access(request, workspace)
-
-
 def test_validate_upload_access_not_a_backend_member(rf):
     backend = BackendFactory()
     user = UserFactory(roles=[OutputChecker])
-    workspace = WorkspaceFactory()
 
     request = rf.get(
         "/",
@@ -970,19 +952,18 @@ def test_validate_upload_access_not_a_backend_member(rf):
     )
 
     with pytest.raises(NotAuthenticated):
-        validate_upload_access(request, workspace)
+        validate_upload_access(request)
 
 
 def test_validate_upload_access_unknown_user(rf):
     backend = BackendFactory()
-    workspace = WorkspaceFactory()
 
     BackendMembershipFactory(backend=backend)
 
     request = rf.get("/", HTTP_AUTHORIZATION=backend.auth_token, HTTP_OS_USER="test")
 
     with pytest.raises(NotAuthenticated):
-        validate_upload_access(request, workspace)
+        validate_upload_access(request)
 
 
 def test_workspacestatusapi_success(api_rf):

--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -12,6 +12,7 @@ from jobserver.authorization import (
     ProjectCoordinator,
     ProjectDeveloper,
 )
+from jobserver.authorization.utils import PermissionDenied
 from jobserver.models import (
     Org,
     Project,
@@ -194,7 +195,7 @@ def test_projectcancelinvite_without_manage_members_permission(rf):
     request = rf.post("/", {"invite_pk": invite.pk})
     request.user = UserFactory()
 
-    with pytest.raises(Http404):
+    with pytest.raises(PermissionDenied):
         ProjectCancelInvite.as_view()(
             request, org_slug=org.slug, project_slug=project.slug
         )

--- a/tests/unit/jobserver/views/test_releases.py
+++ b/tests/unit/jobserver/views/test_releases.py
@@ -3,7 +3,12 @@ from django.contrib.auth.models import AnonymousUser
 from django.http import Http404
 from django.utils import timezone
 
-from jobserver.authorization import OutputChecker, OutputPublisher, ProjectCollaborator
+from jobserver.authorization import (
+    OutputChecker,
+    OutputPublisher,
+    PermissionDenied,
+    ProjectCollaborator,
+)
 from jobserver.views.releases import (
     ProjectReleaseList,
     ReleaseDetail,
@@ -337,7 +342,7 @@ def test_releasefiledelete_without_permission(rf):
     request = rf.post("/")
     request.user = UserFactory()
 
-    with pytest.raises(Http404):
+    with pytest.raises(PermissionDenied):
         ReleaseFileDelete.as_view()(
             request,
             org_slug=release.workspace.project.org.slug,


### PR DESCRIPTION
[As discussed in Slack](https://ebmdatalab.slack.com/archives/C63UXGB8E/p1631034320271200), here's a spike that demonstrates how we can replace permissions (which are opaque strings) with functions in actions.py.

The main benefit is that to understand what a user with a role can do, we now only have to look at the functions in actions.py that are annotated with that role.  (And if we rolled out actions across the project, we would then only have one place to look to understand what can be done by users.)

I had planned to add a template filter that would let us do something like `{% if user|can_do_action:"delete_release_file" %}` but I haven't worked out how to pass kwargs (the "context") to a template filter.  It's a nice-to-have, but beyond the scope of this spike.

What do you think?