### PR TITLE
Set --tb=native by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ skip_glob = [".direnv", "venv", ".venv"]
 use_parentheses = true
 
 [tool.pytest.ini_options]
-addopts = "--disable-network"
+addopts = "--disable-network --tb=native"
 DJANGO_SETTINGS_MODULE = "jobserver.settings"
 env = [
   "AUTHORIZATION_ORGS=opensafely",


### PR DESCRIPTION
I find this gives more manageable output.

Compare:

```
(job-server) inglesp@gronk:~/work/ebmdatalab/opensafely/job-server$ pytest tests/unit/jobserver/api/test_releases.py 
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.9.3, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
django: settings: jobserver.settings (from ini)
rootdir: /home/inglesp/work/ebmdatalab/opensafely/job-server, configfile: pyproject.toml
plugins: network-0.0.1, subtests-0.5.0, django-4.4.0, env-0.6.2, Faker-8.10.1, freezegun-0.4.2, cov-2.12.1, mock-3.6.1
collected 53 items                                                                                                                                                                                        

tests/unit/jobserver/api/test_releases.py .....................F...............................                                                                                                     [100%]

================================================================================================ FAILURES =================================================================================================
______________________________________________________________________________ test_releaseworkspaceapi_post_create_release _______________________________________________________________________________

api_rf = <rest_framework.test.APIRequestFactory object at 0x7fcd7802e550>

    def test_releaseworkspaceapi_post_create_release(api_rf):
        user = UserFactory(roles=[OutputChecker])
        workspace = WorkspaceFactory()
        ProjectMembershipFactory(user=user, project=workspace.project)
    
        backend = BackendFactory(auth_token="test")
        BackendMembershipFactory(backend=backend, user=user)
    
        assert Release.objects.count() == 0
    
        request = api_rf.post(
            "/",
            content_type="application/json",
            data=json.dumps({"files": {"file1.txt": "hash"}}),
            HTTP_AUTHORIZATION="test",
            HTTP_OS_USER=user.username,
        )
    
>       response = ReleaseWorkspaceAPI.as_view()(request, workspace_name=workspace.name)

tests/unit/jobserver/api/test_releases.py:472: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../../../.pyenv/versions/3.9.3/envs/job-server/lib/python3.9/site-packages/django/views/decorators/csrf.py:54: in wrapped_view
    return view_func(*args, **kwargs)
../../../../.pyenv/versions/3.9.3/envs/job-server/lib/python3.9/site-packages/django/views/generic/base.py:70: in view
    return self.dispatch(request, *args, **kwargs)
../../../../.pyenv/versions/3.9.3/envs/job-server/lib/python3.9/site-packages/rest_framework/views.py:509: in dispatch
    response = self.handle_exception(exc)
../../../../.pyenv/versions/3.9.3/envs/job-server/lib/python3.9/site-packages/rest_framework/views.py:469: in handle_exception
    self.raise_uncaught_exception(exc)
../../../../.pyenv/versions/3.9.3/envs/job-server/lib/python3.9/site-packages/rest_framework/views.py:480: in raise_uncaught_exception
    raise exc
../../../../.pyenv/versions/3.9.3/envs/job-server/lib/python3.9/site-packages/rest_framework/views.py:506: in dispatch
    response = handler(request, *args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <jobserver.api.releases.ReleaseWorkspaceAPI object at 0x7fcd78124220>, request = <rest_framework.request.Request: POST '/'>, workspace_name = 'workspace-15'

    def post(self, request, workspace_name):
        """Create a new Release for this workspace."""
        workspace = get_object_or_404(Workspace, name=workspace_name)
        backend, user = validate_upload_access(request, workspace)
    
        # parse the requested files
        serializer = self.FilesSerializer(data=request.data)
        serializer.is_valid(raise_exception=True)
        files = serializer.validated_data["files"]
    
        try:
            release = releases.create_release(workspace, backend, user, files)
        except releases.ReleaseFileAlreadyExists as exc:
            raise ValidationError({"detail": str(exc)})
    
        esponse = Response(status=201)
>       response["Location"] = request.build_absolute_uri(release.get_api_url())
E       NameError: name 'response' is not defined

jobserver/api/releases.py:177: NameError
========================================================================================= short test summary info =========================================================================================
FAILED tests/unit/jobserver/api/test_releases.py::test_releaseworkspaceapi_post_create_release - NameError: name 'response' is not defined
====================================================================================== 1 failed, 52 passed in 3.28s =======================================================================================
```

With:

```
(job-server) inglesp@gronk:~/work/ebmdatalab/opensafely/job-server$ pytest tests/unit/jobserver/api/test_releases.py 
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.9.3, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
django: settings: jobserver.settings (from ini)
rootdir: /home/inglesp/work/ebmdatalab/opensafely/job-server, configfile: pyproject.toml
plugins: network-0.0.1, subtests-0.5.0, django-4.4.0, env-0.6.2, Faker-8.10.1, freezegun-0.4.2, cov-2.12.1, mock-3.6.1
collected 53 items                                                                                                                                                                                        

tests/unit/jobserver/api/test_releases.py .....................F...............................                                                                                                     [100%]

================================================================================================ FAILURES =================================================================================================
______________________________________________________________________________ test_releaseworkspaceapi_post_create_release _______________________________________________________________________________
Traceback (most recent call last):
  File "/home/inglesp/work/ebmdatalab/opensafely/job-server/tests/unit/jobserver/api/test_releases.py", line 472, in test_releaseworkspaceapi_post_create_release
    response = ReleaseWorkspaceAPI.as_view()(request, workspace_name=workspace.name)
  File "/home/inglesp/.pyenv/versions/3.9.3/envs/job-server/lib/python3.9/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/home/inglesp/.pyenv/versions/3.9.3/envs/job-server/lib/python3.9/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/inglesp/.pyenv/versions/3.9.3/envs/job-server/lib/python3.9/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/home/inglesp/.pyenv/versions/3.9.3/envs/job-server/lib/python3.9/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/home/inglesp/.pyenv/versions/3.9.3/envs/job-server/lib/python3.9/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/home/inglesp/.pyenv/versions/3.9.3/envs/job-server/lib/python3.9/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/home/inglesp/work/ebmdatalab/opensafely/job-server/jobserver/api/releases.py", line 177, in post
    response["Location"] = request.build_absolute_uri(release.get_api_url())
NameError: name 'response' is not defined
========================================================================================= short test summary info =========================================================================================
FAILED tests/unit/jobserver/api/test_releases.py::test_releaseworkspaceapi_post_create_release - NameError: name 'response' is not defined
====================================================================================== 1 failed, 52 passed in 2.95s =======================================================================================
```

If you disagree, no need to explain why -- I fully accept these things are subjective!