### PR TITLE
break all staff index search config dicts across multiple lines

### DIFF
--- a/staff/views/index.py
+++ b/staff/views/index.py
@@ -13,13 +13,21 @@ from jobserver.models import Backend, User, Workspace
 
 # configure searchable models here, each must have get_staff_url defined
 configured_searches = [
-    {"model": Backend, "fields": ["name", "slug"], "order_by": "name"},
+    {
+        "model": Backend,
+        "fields": ["name", "slug"],
+        "order_by": "name",
+    },
     {
         "model": User,
         "fields": ["first_name", "last_name", "username"],
         "order_by": "username",
     },
-    {"model": Workspace, "fields": ["name", "repo"], "order_by": "name"},
+    {
+        "model": Workspace,
+        "fields": ["name", "repo"],
+        "order_by": "name",
+    },
 ]
 
 


### PR DESCRIPTION
as per https://github.com/opensafely-core/job-server/pull/844/files?file-filters%5B%5D=.py#r704314663

This adds a bit of consistency and thus readability to the config.