### PR TITLE
Notify Slack when a New User Registers

### DIFF
--- a/jobserver/pipeline.py
+++ b/jobserver/pipeline.py
@@ -1,3 +1,22 @@
+from django.conf import settings
+from furl import furl
+
+from services.slack import client as slack_client
+
+
+def notify_on_new_user(user, is_new, *args, **kwargs):
+    if not is_new:
+        return
+
+    f = furl(settings.BASE_URL)
+    f.path = user.get_staff_url()
+
+    slack_client.chat_postMessage(
+        channel="job-server-registrations",
+        text=f"New user ({user.username}) registered: {f.url}",
+    )
+
+
 def set_notifications_email(user, *args, **kwargs):
     """
     Set a User's notifications_email if it's not already set

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -243,6 +243,7 @@ SOCIAL_AUTH_PIPELINE = [
     "social_core.pipeline.social_auth.load_extra_data",
     "social_core.pipeline.user.user_details",
     "jobserver.pipeline.set_notifications_email",
+    "jobserver.pipeline.notify_on_new_user",
 ]
 
 # Sentry

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -5,7 +5,7 @@ from furl import furl
 from jobserver.models import User
 
 
-def test_login_pipeline(client):
+def test_login_pipeline(client, mocker):
     """
     Test the Auth Pipeline with an incoming request
 
@@ -48,6 +48,8 @@ def test_login_pipeline(client):
 
         membership_url = "https://api.github.com/orgs/opensafely/members/dummy-user"
         rsps.add(responses.GET, membership_url, status=204)
+
+        mocker.patch("jobserver.pipeline.slack_client", autospec=True)
 
         # set a dummy state value in the test Client's session to match the
         # value in redirect_url below

--- a/tests/unit/jobserver/test_pipeline.py
+++ b/tests/unit/jobserver/test_pipeline.py
@@ -1,6 +1,32 @@
-from jobserver.pipeline import set_notifications_email
+from jobserver.pipeline import notify_on_new_user, set_notifications_email
 
 from ...factories import UserFactory
+
+
+def test_notify_on_new_user_with_existing_user(mocker):
+    user = UserFactory()
+
+    mock = mocker.patch("jobserver.pipeline.slack_client", autospec=True)
+
+    notify_on_new_user(user, is_new=False)
+
+    mock.chat_postMessage.assert_not_called()
+
+
+def test_notify_on_new_user_with_new_user(mocker):
+    user = UserFactory()
+
+    mock = mocker.patch("jobserver.pipeline.slack_client", autospec=True)
+
+    notify_on_new_user(user, is_new=True)
+
+    mock.chat_postMessage.assert_called_once()
+
+    url = f"http://localhost:8000{user.get_staff_url()}"
+    mock.chat_postMessage.assert_called_with(
+        channel="job-server-registrations",
+        text=f"New user ({user.username}) registered: {url}",
+    )
 
 
 def test_set_notifications_email_already_set():


### PR DESCRIPTION
Some duct tape to tell us when a user first logs into the job-server while we build a better onboarding story.