### PR TITLE
Display All User Roles

### DIFF
--- a/staff/templates/staff/user_detail.html
+++ b/staff/templates/staff/user_detail.html
@@ -80,8 +80,13 @@
 
         <ul class="list-group mb-3">
           {% for org in orgs %}
-          <li class="list-group-item">
-            <a href="{{ org.get_staff_url }}">{{ org.name }}</a>
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <a href="{{ org.staff_url }}">{{ org.name }}</a>
+            <div>
+              {% for role in org.roles %}
+              <span class="badge badge-secondary ml-2">{{ role }}</span>
+              {% endfor %}
+            </div>
           </li>
           {% endfor %}
         </ul>
@@ -92,8 +97,13 @@
 
         <ul class="list-group mb-3">
           {% for project in projects %}
-          <li class="list-group-item">
-            <a href="{{ project.get_staff_url }}">{{ project.name }}</a>
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <a href="{{ project.staff_url }}">{{ project.name }}</a>
+            <div>
+              {% for role in project.roles %}
+              <span class="badge badge-secondary ml-2">{{ role }}</span>
+              {% endfor %}
+            </div>
           </li>
           {% endfor %}
         </ul>

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -39,9 +39,25 @@ class UserDetail(UpdateView):
         return redirect(self.object.get_staff_url())
 
     def get_context_data(self, **kwargs):
+        orgs = [
+            {
+                "name": m.org.name,
+                "roles": [r.display_name for r in m.roles],
+                "staff_url": m.org.get_staff_url(),
+            }
+            for m in self.object.org_memberships.order_by("org__name")
+        ]
+        projects = [
+            {
+                "name": m.project.name,
+                "roles": [r.display_name for r in m.roles],
+                "staff_url": m.project.get_staff_url(),
+            }
+            for m in self.object.project_memberships.order_by("project__name")
+        ]
         return super().get_context_data(**kwargs) | {
-            "orgs": self.object.orgs.order_by("name"),
-            "projects": self.object.projects.order_by("name"),
+            "orgs": orgs,
+            "projects": projects,
         }
 
     def get_form_kwargs(self):


### PR DESCRIPTION
This displays the roles for Projects and Orgs against the relevant Projects/Orgs on the user page of the staff admin:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/E0ujLApE/47459027-5015-405a-a83a-148771ab7547.jpg?v=000e3590e33016a07d29c60e7aaf6d44)

Note: we don't use roles on OrgMemberships currently, but this will display them when we do.