### PR TITLE
Fix 403 Pages

### DIFF
--- a/jobserver/authorization/decorators.py
+++ b/jobserver/authorization/decorators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from django.http import HttpResponseForbidden
+from django.core.exceptions import PermissionDenied
 
 from .permissions import backend_manage
 from .utils import has_permission, has_role
@@ -17,7 +17,7 @@ def require_permission(permission):
         @wraps(f)
         def wrapper_require_role(request, *args, **kwargs):
             if not has_permission(request.user, permission):
-                return HttpResponseForbidden()
+                raise PermissionDenied
 
             return f(request, *args, **kwargs)
 
@@ -33,7 +33,7 @@ def require_role(role):
         @wraps(f)
         def wrapper_require_role(request, *args, **kwargs):
             if not has_role(request.user, role):
-                return HttpResponseForbidden()
+                raise PermissionDenied
 
             return f(request, *args, **kwargs)
 

--- a/tests/unit/jobserver/authorization/test_decorators.py
+++ b/tests/unit/jobserver/authorization/test_decorators.py
@@ -1,3 +1,6 @@
+import pytest
+from django.core.exceptions import PermissionDenied
+
 from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_manage_backends, require_role
 
@@ -21,9 +24,8 @@ def test_require_manage_backends_without_core_dev_role(rf):
     request = rf.get("/")
     request.user = UserFactory(roles=[])
 
-    response = require_manage_backends(None)(request)
-
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        require_manage_backends(None)(request)
 
 
 def test_require_role_success(rf):
@@ -42,6 +44,5 @@ def test_require_role_without_role(rf):
     request = rf.get("/")
     request.user = UserFactory(roles=[])
 
-    response = require_role(CoreDeveloper)(None)(request)
-
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        require_role(CoreDeveloper)(None)(request)

--- a/tests/unit/staff/views/test_orgs.py
+++ b/tests/unit/staff/views/test_orgs.py
@@ -1,5 +1,6 @@
 import pytest
 from django.contrib.messages.storage.fallback import FallbackStorage
+from django.core.exceptions import PermissionDenied
 from django.http import Http404
 
 from jobserver.utils import set_from_qs
@@ -62,9 +63,8 @@ def test_orgdetail_unauthorized(rf):
     request = rf.get("/")
     request.user = UserFactory()
 
-    response = OrgDetail.as_view()(request, slug=org.slug)
-
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        OrgDetail.as_view()(request, slug=org.slug)
 
 
 def test_orgedit_get_success(rf, core_developer):
@@ -84,9 +84,8 @@ def test_orgedit_get_unauthorized(rf):
     request = rf.get("/")
     request.user = UserFactory()
 
-    response = OrgEdit.as_view()(request, slug=org.slug)
-
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        OrgEdit.as_view()(request, slug=org.slug)
 
 
 def test_orgedit_post_success(rf, core_developer):
@@ -110,9 +109,8 @@ def test_orgedit_post_unauthorized(rf):
     request = rf.post("/")
     request.user = UserFactory()
 
-    response = OrgEdit.as_view()(request, slug=org.slug)
-
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        OrgEdit.as_view()(request, slug=org.slug)
 
 
 def test_orglist_find_by_name(rf, core_developer):
@@ -146,9 +144,8 @@ def test_orglist_unauthorized(rf):
     request = rf.post("/")
     request.user = UserFactory()
 
-    response = OrgList.as_view()(request)
-
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        OrgList.as_view()(request)
 
 
 def test_orgremovemember_success(rf, core_developer):
@@ -183,9 +180,8 @@ def test_orgremovemember_unauthorized(rf):
     request = rf.post("/")
     request.user = UserFactory()
 
-    response = OrgRemoveMember.as_view()(request)
-
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        OrgRemoveMember.as_view()(request)
 
 
 def test_orgremovemember_unknown_org(rf, core_developer):

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -1,3 +1,6 @@
+import pytest
+from django.core.exceptions import PermissionDenied
+
 from jobserver.utils import set_from_qs
 from staff.views.projects import ProjectDetail, ProjectEdit, ProjectList
 
@@ -36,9 +39,8 @@ def test_projectedit_get_unauthorized(rf):
     request = rf.get("/")
     request.user = UserFactory()
 
-    response = ProjectEdit.as_view()(request, slug=project.slug)
-
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        ProjectEdit.as_view()(request, slug=project.slug)
 
 
 def test_projectedit_post_success(rf, core_developer):
@@ -67,9 +69,8 @@ def test_projectedit_post_unauthorized(rf):
     request = rf.post("/")
     request.user = UserFactory()
 
-    response = ProjectEdit.as_view()(request, slug=project.slug)
-
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        ProjectEdit.as_view()(request, slug=project.slug)
 
 
 def test_projectlist_filter_by_org(rf, core_developer):
@@ -117,8 +118,9 @@ def test_projectlist_unauthorized(rf):
     request = rf.post("/")
     request.user = UserFactory()
 
-    response = ProjectList.as_view()(
-        request, org_slug=project.org.slug, project_slug=project.slug
-    )
-
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        ProjectList.as_view()(
+            request,
+            org_slug=project.org.slug,
+            project_slug=project.slug,
+        )

--- a/tests/unit/staff/views/test_users.py
+++ b/tests/unit/staff/views/test_users.py
@@ -1,5 +1,5 @@
 import pytest
-from django.core.exceptions import BadRequest
+from django.core.exceptions import BadRequest, PermissionDenied
 from django.http import Http404
 
 from jobserver.authorization import (
@@ -208,9 +208,8 @@ def test_userdetail_without_core_dev_role(rf):
     request = rf.get("/")
     request.user = UserFactory()
 
-    response = UserDetail.as_view()(request, username="test")
-
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        UserDetail.as_view()(request, username="test")
 
 
 def test_userlist_filter_by_backend(rf, core_developer):

--- a/tests/unit/staff/views/test_workspaces.py
+++ b/tests/unit/staff/views/test_workspaces.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core.exceptions import PermissionDenied
 from django.http import Http404
 
 from staff.views.workspaces import WorkspaceDetail, WorkspaceList
@@ -33,9 +34,8 @@ def test_workspacedetail_without_core_dev_role(rf):
     request = rf.get("/")
     request.user = UserFactory()
 
-    response = WorkspaceDetail.as_view()(request, slug=workspace.name)
-
-    assert response.status_code == 403
+    with pytest.raises(PermissionDenied):
+        WorkspaceDetail.as_view()(request, slug=workspace.name)
 
 
 def test_workspacelist_search(rf, core_developer):


### PR DESCRIPTION
Django's defaults.permission_denied will handle these exceptions and return a 403 with our 403.html template as well.