### PR TITLE
Set Default GitHub Org

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -330,7 +330,7 @@ class Org(models.Model):
     logo = models.TextField(default="", blank=True)
 
     # track which GitHub Organisations this Org has access to
-    github_orgs = models.JSONField(default=list)
+    github_orgs = models.JSONField(default=lambda: list(["opensafely"]))
 
     created_at = models.DateTimeField(default=timezone.now)
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -75,8 +75,6 @@ class OrgFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f"Organisation {n}")
     slug = factory.Sequence(lambda n: f"organisation-{n}")
 
-    github_orgs = ["opensafely"]
-
 
 class OrgMembershipFactory(factory.django.DjangoModelFactory):
     class Meta:

--- a/tests/unit/jobserver/models/test_core.py
+++ b/tests/unit/jobserver/models/test_core.py
@@ -465,6 +465,22 @@ def test_jobrequest_status_without_prefetching_jobs(django_assert_num_queries):
         job_request.status
 
 
+def test_org_default_for_github_orgs():
+    org1 = OrgFactory()
+    assert org1.github_orgs == ["opensafely"]
+
+    org2 = OrgFactory()
+    assert org2.github_orgs == ["opensafely"]
+
+    # does mutating the field affect the other object?
+    org1.github_orgs += ["test"]
+    org1.save()
+    org1.refresh_from_db()
+
+    assert org1.github_orgs == ["opensafely", "test"]
+    assert org2.github_orgs == ["opensafely"]
+
+
 def test_org_get_absolute_url():
     org = OrgFactory()
     url = org.get_absolute_url()


### PR DESCRIPTION
This sets a default for `Org.github_orgs` so that we at least have something in the field to stop the site being broken for users.

Fixes #960 