### PR TITLE
Further Staff Searches

### DIFF
--- a/staff/views/index.py
+++ b/staff/views/index.py
@@ -20,7 +20,13 @@ configured_searches = [
     },
     {
         "model": User,
-        "fields": ["first_name", "last_name", "username"],
+        "fields": [
+            "first_name",
+            "last_name",
+            "orgs__name",
+            "projects__name",
+            "username",
+        ],
         "order_by": "username",
     },
     {

--- a/staff/views/index.py
+++ b/staff/views/index.py
@@ -8,13 +8,23 @@ from django.views.generic import View
 
 from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_role
-from jobserver.models import Backend, User, Workspace
+from jobserver.models import Backend, Org, Project, User, Workspace
 
 
 # configure searchable models here, each must have get_staff_url defined
 configured_searches = [
     {
         "model": Backend,
+        "fields": ["name", "slug"],
+        "order_by": "name",
+    },
+    {
+        "model": Org,
+        "fields": ["name", "slug"],
+        "order_by": "name",
+    },
+    {
+        "model": Project,
         "fields": ["name", "slug"],
         "order_by": "name",
     },


### PR DESCRIPTION
This enhances the Staff Area search items with Orgs, Projects, and a Users membership in either, eg searching `bristol` will find the Org and any users who are members of it.