### PR TITLE
Show all orgs on the User's set orgs page

### DIFF
--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -139,12 +139,8 @@ class UserSetOrgs(FormView):
         return redirect(self.user.get_staff_url())
 
     def get_form_kwargs(self):
-        existing_membership_orgs = self.user.orgs.values_list("pk", flat=True)
-        available_orgs = Org.objects.exclude(pk__in=existing_membership_orgs).order_by(
-            "name"
-        )
         return super().get_form_kwargs() | {
-            "available_orgs": available_orgs,
+            "available_orgs": Org.objects.order_by("name"),
         }
 
     def get_initial(self):


### PR DESCRIPTION
Reinstate showing all orgs on the set orgs page for a user as per: https://github.com/opensafely-core/job-server/pull/955#discussion_r708297056