### PR TITLE
Set workers in prod to 3, rather than the default of 1.

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -8,3 +8,6 @@ errorlog = "-"
 # Configure log structure
 # http://docs.gunicorn.org/en/stable/settings.html#logconfig-dict
 logconfig_dict = logging_config_dict
+
+# workers
+workers = 3


### PR DESCRIPTION
A single sync worker is usually not a good idea with gunicorn, as one
long request will block everything, and we're using whitenoise so there
are more requests for a pageload.

I temporarily added up to 4 workers in prod, but only 2 were every
really used, so 3 seemed a good start.
