### PR TITLE
Pass field name to form component for ProjectCreate

### DIFF
--- a/jobserver/templates/project_create.html
+++ b/jobserver/templates/project_create.html
@@ -51,7 +51,7 @@
             </ul>
           {% endif %}
 
-          {% include "components/form_text.html" with field=form.name label="Project name" %}
+          {% include "components/form_text.html" with field=form.name label="Project name" name="name" %}
 
         </fieldset>
 


### PR DESCRIPTION
We need a name kwarg so Django knows which field to validate the POST data with, however we have no guards to ensure this is defined.

Ref #922 