### PR TITLE
Require Auth for Applications

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 
@@ -6,6 +7,7 @@ from .models import Application
 from .wizard import Wizard
 
 
+@login_required
 def page(request, pk, page_num):
     application = get_object_or_404(Application, pk=pk)
     page = Wizard(application, form_specs).get_page(page_num)
@@ -45,6 +47,7 @@ def sign_in(request):
     return redirect("applications:terms")
 
 
+@login_required
 def terms(request):
     if request.method == "GET":
         return TemplateResponse(request, "applications/terms.html")
@@ -53,6 +56,7 @@ def terms(request):
     return redirect("applications:page", pk=application.pk, page_num=1)
 
 
+@login_required
 def confirmation(request, pk):
     application = get_object_or_404(Application, pk=pk)
     wizard = Wizard(application, form_specs)

--- a/jobserver/authorization/permissions.py
+++ b/jobserver/authorization/permissions.py
@@ -1,3 +1,4 @@
+application_manage = "application_manage"
 backend_manage = "backend_manage"
 job_cancel = "job_cancel"
 job_run = "job_run"

--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -1,4 +1,5 @@
 from .permissions import (
+    application_manage,
     backend_manage,
     job_cancel,
     job_run,
@@ -31,6 +32,7 @@ class CoreDeveloper:
         "jobserver.models.core.User",
     ]
     permissions = [
+        application_manage,
         backend_manage,
         org_create,
         user_manage,

--- a/tests/unit/applications/test_views.py
+++ b/tests/unit/applications/test_views.py
@@ -27,6 +27,7 @@ def test_page_get_success(rf):
     application = ApplicationFactory()
 
     request = rf.get("/")
+    request.user = UserFactory()
 
     response = page(request, pk=application.pk, page_num=3)
 
@@ -39,6 +40,7 @@ def test_page_post_final_page(rf):
     application = ApplicationFactory()
 
     request = rf.post("/", {"evidence_of_sharing_in_public_domain_before": "evidence"})
+    request.user = UserFactory()
 
     response = page(request, pk=application.pk, page_num=15)
 
@@ -52,6 +54,7 @@ def test_page_post_non_final_page(rf):
     application = ApplicationFactory()
 
     request = rf.post("/", {"previous_experience_with_ehr": "experience"})
+    request.user = UserFactory()
 
     response = page(request, pk=application.pk, page_num=13)
 
@@ -69,6 +72,7 @@ def test_page_post_with_invalid_continue_state(rf):
     )
 
     request = rf.post("/", {})
+    request.user = UserFactory()
 
     response = page(request, pk=application.pk, page_num=6)
 
@@ -83,6 +87,7 @@ def test_page_post_with_invalid_prerequisite(rf):
     application = ApplicationFactory(is_study_research=False)
 
     request = rf.post("/", {})
+    request.user = UserFactory()
 
     response = page(request, pk=application.pk, page_num=7)
 

--- a/tests/unit/applications/test_views.py
+++ b/tests/unit/applications/test_views.py
@@ -1,18 +1,49 @@
+import pytest
 from django.contrib.auth.models import AnonymousUser
+from django.http import Http404
 from django.urls import reverse
 
 from applications.form_specs import form_specs
 from applications.models import Application
-from applications.views import confirmation, page, sign_in, terms
+from applications.views import (
+    confirmation,
+    page,
+    sign_in,
+    terms,
+    validate_application_access,
+)
+from jobserver.authorization import CoreDeveloper
 
 from ...factories import ApplicationFactory, UserFactory
 
 
-def test_confirmation_success(rf):
+def test_validate_application_access_error():
     application = ApplicationFactory()
+    user = UserFactory()
+
+    with pytest.raises(Http404):
+        validate_application_access(user, application)
+
+
+def test_validate_application_access_with_permission():
+    application = ApplicationFactory()
+    user = UserFactory(roles=[CoreDeveloper])
+    assert validate_application_access(user, application) is None
+
+
+def test_validate_application_access_with_owner():
+    user = UserFactory()
+    application = ApplicationFactory(created_by=user)
+
+    assert validate_application_access(user, application) is None
+
+
+def test_confirmation_success(rf):
+    user = UserFactory()
+    application = ApplicationFactory(created_by=user)
 
     request = rf.get("/")
-    request.user = UserFactory()
+    request.user = user
 
     response = confirmation(request, pk=application.pk)
 
@@ -24,10 +55,11 @@ def test_confirmation_success(rf):
 
 
 def test_page_get_success(rf):
-    application = ApplicationFactory()
+    user = UserFactory()
+    application = ApplicationFactory(created_by=user)
 
     request = rf.get("/")
-    request.user = UserFactory()
+    request.user = user
 
     response = page(request, pk=application.pk, page_num=3)
 
@@ -37,10 +69,11 @@ def test_page_get_success(rf):
 
 
 def test_page_post_final_page(rf):
-    application = ApplicationFactory()
+    user = UserFactory()
+    application = ApplicationFactory(created_by=user)
 
     request = rf.post("/", {"evidence_of_sharing_in_public_domain_before": "evidence"})
-    request.user = UserFactory()
+    request.user = user
 
     response = page(request, pk=application.pk, page_num=15)
 
@@ -51,10 +84,11 @@ def test_page_post_final_page(rf):
 
 
 def test_page_post_non_final_page(rf):
-    application = ApplicationFactory()
+    user = UserFactory()
+    application = ApplicationFactory(created_by=user)
 
     request = rf.post("/", {"previous_experience_with_ehr": "experience"})
-    request.user = UserFactory()
+    request.user = user
 
     response = page(request, pk=application.pk, page_num=13)
 
@@ -65,14 +99,16 @@ def test_page_post_non_final_page(rf):
 
 
 def test_page_post_with_invalid_continue_state(rf):
+    user = UserFactory()
     application = ApplicationFactory(
+        created_by=user,
         is_study_research=False,
         is_study_service_evaluation=False,
         is_study_audit=False,
     )
 
     request = rf.post("/", {})
-    request.user = UserFactory()
+    request.user = user
 
     response = page(request, pk=application.pk, page_num=6)
 
@@ -84,10 +120,11 @@ def test_page_post_with_invalid_continue_state(rf):
 
 
 def test_page_post_with_invalid_prerequisite(rf):
-    application = ApplicationFactory(is_study_research=False)
+    user = UserFactory()
+    application = ApplicationFactory(created_by=user, is_study_research=False)
 
     request = rf.post("/", {})
-    request.user = UserFactory()
+    request.user = user
 
     response = page(request, pk=application.pk, page_num=7)
 
@@ -130,7 +167,6 @@ def test_terms_post_success(rf):
     request.user = UserFactory()
 
     assert Application.objects.count() == 0
-
     response = terms(request)
 
     assert response.status_code == 302

--- a/tests/unit/jobserver/api/test_jobs.py
+++ b/tests/unit/jobserver/api/test_jobs.py
@@ -605,6 +605,7 @@ def test_userapidetail_success(api_rf):
     # permissions
     permissions = response.data["permissions"]
     assert permissions["global"] == [
+        "application_manage",
         "backend_manage",
         "org_create",
         "user_manage",

--- a/tests/unit/jobserver/models/test_core.py
+++ b/tests/unit/jobserver/models/test_core.py
@@ -747,6 +747,7 @@ def test_user_get_all_permissions():
     output = user.get_all_permissions()
     expected = {
         "global": [
+            "application_manage",
             "backend_manage",
             "org_create",
             "user_manage",


### PR DESCRIPTION
This adds a requirement that users are logged in, and either created the application or have the `application_manage` permission (the idea being that staff will use the latter).