### PR TITLE
Add Field Types for the Wizard Forms

### DIFF
--- a/applications/form_spec_helpers.py
+++ b/applications/form_spec_helpers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Callable
 
 from applications.models import Application
@@ -67,6 +67,7 @@ class Field:
     label: str
     help_text: str = ""
     template_name: str | None = None
+    attributes: Attributes | None = None
 
     def template_context(self, form):
         template_lut = {
@@ -100,7 +101,23 @@ class Field:
             "template_name": template_name,
         }
 
+        if self.attributes:
+            context |= {"attributes": self.attributes.template_context()}
+
         return context
+
+
+@dataclass
+class Attributes:
+    type: str = "text"  # noqa: A003
+    inputmode: str | None = None
+    autocomplete: str | None = None
+    autocapitalize: str | None = None
+    spellcheck: str | None = None
+    autocorrect: str | None = None
+
+    def template_context(self):
+        return {k: v for k, v in asdict(self).items() if v is not None}
 
 
 def maybe_replace_value_with_snippet(value, key):

--- a/applications/form_spec_helpers.py
+++ b/applications/form_spec_helpers.py
@@ -66,6 +66,7 @@ class Field:
     name: str
     label: str
     help_text: str = ""
+    template_name: str | None = None
 
     def template_context(self, form):
         template_lut = {
@@ -78,9 +79,13 @@ class Field:
         # Note: doing this with form.fields gets the plain field instance
         bound_field = form[self.name]
 
-        # get the component template using the field class name
-        # Note: this is original field class, not the bound version
-        template_name = template_lut[bound_field.field.__class__.__name__]
+        if self.template_name is not None:
+            template_name = self.template_name
+        else:
+            # fall back to getting the component template using the field class
+            # name
+            # Note: this is original field class, not the bound version
+            template_name = template_lut[bound_field.field.__class__.__name__]
 
         label = maybe_replace_value_with_snippet(self.label, f"{self.key}-label")
         bound_field.help_text = maybe_replace_value_with_snippet(

--- a/applications/form_specs.py
+++ b/applications/form_specs.py
@@ -1,6 +1,15 @@
 from .form_spec_helpers import SNIPPET, Attributes, Field, Fieldset, Form
 
 
+email_attrs = Attributes(
+    type="email",
+    inputmode="email",
+    autocomplete="email",
+    autocapitalize="off",
+    spellcheck="false",
+    autocorrect="off",
+)
+
 form_specs = [
     Form(
         key=1,
@@ -22,6 +31,7 @@ form_specs = [
                     Field(
                         name="email",
                         label="Email",
+                        attributes=email_attrs,
                     ),
                     Field(
                         name="telephone",
@@ -106,6 +116,7 @@ form_specs = [
                     Field(
                         name="author_email",
                         label="Work email address",
+                        attributes=email_attrs,
                     ),
                     Field(
                         name="author_organisation",
@@ -245,6 +256,7 @@ form_specs = [
                     Field(
                         name="sponsor_email",
                         label="Sponsor email address",
+                        attributes=email_attrs,
                     ),
                     Field(
                         name="sponsor_job_role",

--- a/applications/form_specs.py
+++ b/applications/form_specs.py
@@ -36,6 +36,11 @@ form_specs = [
                     Field(
                         name="telephone",
                         label="Telephone number",
+                        attributes=Attributes(
+                            type="tel",
+                            inputmode="tel",
+                            autocomplete="tel",
+                        ),
                     ),
                 ],
             ),

--- a/applications/form_specs.py
+++ b/applications/form_specs.py
@@ -1,4 +1,4 @@
-from .form_spec_helpers import SNIPPET, Field, Fieldset, Form
+from .form_spec_helpers import SNIPPET, Attributes, Field, Fieldset, Form
 
 
 form_specs = [
@@ -14,6 +14,10 @@ form_specs = [
                     Field(
                         name="full_name",
                         label="Full name",
+                        attributes=Attributes(
+                            autocomplete="name",
+                            autocapitalize="words",
+                        ),
                     ),
                     Field(
                         name="email",
@@ -31,6 +35,9 @@ form_specs = [
                     Field(
                         name="job_title",
                         label="Job title",
+                        attributes=Attributes(
+                            autocomplete="organization-title",
+                        ),
                     ),
                     Field(
                         name="team_name",
@@ -39,6 +46,9 @@ form_specs = [
                     Field(
                         name="organisation",
                         label="Organisation",
+                        attributes=Attributes(
+                            autocomplete="organization",
+                        ),
                     ),
                 ],
             ),
@@ -89,6 +99,9 @@ form_specs = [
                     Field(
                         name="author_name",
                         label="Name of application owner",
+                        attributes=Attributes(
+                            autocomplete="name",
+                        ),
                     ),
                     Field(
                         name="author_email",
@@ -97,6 +110,9 @@ form_specs = [
                     Field(
                         name="author_organisation",
                         label="Affiliated organisation",
+                        attributes=Attributes(
+                            autocomplete="organization",
+                        ),
                     ),
                 ],
             ),
@@ -222,6 +238,9 @@ form_specs = [
                     Field(
                         name="sponsor_name",
                         label="Sponsor name",
+                        attributes=Attributes(
+                            autocapitalize="words",
+                        ),
                     ),
                     Field(
                         name="sponsor_email",

--- a/applications/form_specs.py
+++ b/applications/form_specs.py
@@ -62,6 +62,7 @@ form_specs = [
                         name="study_purpose",
                         label="What is the purpose for which you are requesting access to the OpenSAFELY data?",
                         help_text=SNIPPET,
+                        template_name="components/form_textarea.html",
                     ),
                 ],
             ),
@@ -113,6 +114,7 @@ form_specs = [
                     Field(
                         name="data_meets_purpose",
                         label="State how the data you have requested meets your purpose",
+                        template_name="components/form_textarea.html",
                     ),
                     Field(
                         name="need_record_level_data",
@@ -134,6 +136,7 @@ form_specs = [
                     Field(
                         name="record_level_data_reasons",
                         label="Explain why you require access to record level data",
+                        template_name="components/form_textarea.html",
                     ),
                 ],
             ),
@@ -265,6 +268,7 @@ form_specs = [
                         name="legal_basis_for_accessing_data_under_dpa",
                         label="State the legal basis for accessing the data under data protection law",
                         help_text=SNIPPET,
+                        template_name="components/form_textarea.html",
                     ),
                 ],
             ),
@@ -275,6 +279,7 @@ form_specs = [
                         name="how_is_duty_of_confidentiality_satisfied",
                         label="State how you are satisfying or setting aside the common law duty of confidentiality",
                         help_text=SNIPPET,
+                        template_name="components/form_textarea.html",
                     ),
                 ],
             ),
@@ -292,6 +297,7 @@ form_specs = [
                     Field(
                         name="funding_details",
                         label="Provide details of how your research study is funded",
+                        template_name="components/form_textarea.html",
                     ),
                 ],
             ),
@@ -309,6 +315,7 @@ form_specs = [
                     Field(
                         name="team_details",
                         label="Provide details of the team involved in the proposed research",
+                        template_name="components/form_textarea.html",
                     ),
                 ],
             ),
@@ -326,6 +333,7 @@ form_specs = [
                     Field(
                         name="previous_experience_with_ehr",
                         label="Describe your previous experience of working with primary care electronic health record data (e.g. CPRD)",
+                        template_name="components/form_textarea.html",
                     ),
                 ],
             ),
@@ -344,6 +352,7 @@ form_specs = [
                         name="evidence_of_coding",
                         label="Provide evidence of you/your research group experience of using a script-based coding language",
                         help_text=SNIPPET,
+                        template_name="components/form_textarea.html",
                     ),
                     Field(
                         name="all_applicants_completed_getting_started",
@@ -366,6 +375,7 @@ form_specs = [
                     Field(
                         name="evidence_of_sharing_in_public_domain_before",
                         label="Provide evidence of you/your research group sharing and documenting analytic code in the public domain",
+                        template_name="components/form_textarea.html",
                     ),
                 ],
             ),

--- a/applications/templates/applications/page.html
+++ b/applications/templates/applications/page.html
@@ -64,7 +64,7 @@
               <h2 class="h3 mb-3">{{ fieldset.label }}</h2>
             </legend>
             {% for field in fieldset.fields %}
-              {% include field.template_name with field=field.field label=field.label name=field.name %}
+              {% include field.template_name with field=field.field label=field.label name=field.name extra_attributes=field.attributes %}
             {% endfor %}
           </fieldset>
         {% endfor %}

--- a/jobserver/templates/components/form_email.html
+++ b/jobserver/templates/components/form_email.html
@@ -1,0 +1,46 @@
+<div class="form-group">
+
+  <label class="font-weight-bold" for="id_{{ name }}">
+    {{ label }}
+  </label>
+
+  <input
+    type="email"
+    inputmode="email"
+    autocomplete="email"
+    autocapitalize="off"
+    spellcheck="false"
+    autocorrect="off"
+    class="form-control"
+    id="id_{{ name }}"
+    name="{{ name }}"
+
+    {% if field.help_text %}
+    aria-describedby="{{ name }}HelpBlock"
+    {% endif %}
+
+    {% if field.field.required %}
+    required
+    {% endif %}
+
+    {% if field.value %}
+    value="{{ field.value }}"
+    {% endif %}
+
+  />
+
+  {% if field.help_text %}
+    <small id="{{ name }}HelpBlock" class="form-text text-muted">
+      {{ field.help_text }}
+    </small>
+  {% endif %}
+
+  {% if field.errors %}
+    <ul class="pl-3 mb-1">
+      {% for error in field.errors %}
+        <li class="text-danger">{{ error }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+
+</div>

--- a/jobserver/templates/components/form_text.html
+++ b/jobserver/templates/components/form_text.html
@@ -8,7 +8,10 @@
   </label>
 
   <input
+    {% if 'type' not in extra_attributes %}
     type="text"
+    {% endif %}
+
     class="form-control"
     id="id_{{ name }}"
     name="{{ name }}"
@@ -25,6 +28,10 @@
     value="{{ field.value }}"
     {% endif %}
 
+    {# add extra form attributes here #}
+    {% for attr_name, attr_value in extra_attributes.items %}
+    {{ attr_name }}={{ attr_value }}
+    {% endfor %}
   />
 
   {% if field.help_text %}

--- a/jobserver/templates/components/form_textarea.html
+++ b/jobserver/templates/components/form_textarea.html
@@ -1,0 +1,39 @@
+<div class="form-group">
+
+  <label class="font-weight-bold" for="id_{{ name }}">
+    {{ label }}
+  </label>
+
+  <textarea
+    class="form-control"
+    id="id_{{ name }}"
+    name="{{ name }}"
+
+    {% if field.help_text %}
+    aria-describedby="{{ name }}HelpBlock"
+    {% endif %}
+
+    {% if field.field.required %}
+    required
+    {% endif %}
+
+    {% if field.value %}
+    value="{{ field.value }}"
+    {% endif %}
+  ></textarea>
+
+  {% if field.help_text %}
+    <small id="{{ name }}HelpBlock" class="form-text text-muted">
+      {{ field.help_text }}
+    </small>
+  {% endif %}
+
+  {% if field.errors %}
+    <ul class="pl-3 mb-1">
+      {% for error in field.errors %}
+        <li class="text-danger">{{ error }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+
+</div>

--- a/tests/unit/applications/test_form_spec_helpers.py
+++ b/tests/unit/applications/test_form_spec_helpers.py
@@ -1,0 +1,21 @@
+from django import forms
+
+from applications.form_spec_helpers import Field
+
+
+def test_field_template_context_template_name_override():
+    class Form(forms.Form):
+        field_name = forms.CharField()
+
+    field = Field(
+        name="field_name",
+        label="Field Label",
+        template_name="test",
+    )
+    field.key = 42
+
+    form = Form()
+
+    context = field.template_context(form)
+
+    assert context["template_name"] == "test"


### PR DESCRIPTION
This adds the ability to override field templates and add attrs to fields in the spec module.  Some extra form component types are added for the overrides, and the Attributes class handles a very specific subset of overrides for the component templates.  Currently only the text component implements the extra attributes.