### PR TITLE
Update Django Vite package and remove scripts_attrs

### DIFF
--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -97,10 +97,3 @@ def nav(request):
             },
         ],
     }
-
-
-def scripts_attrs(request):
-    """Generate script attributes for use with the Vite plugin"""
-    return {
-        "scripts_attrs": {"nomodule": ""},
-    }

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -91,7 +91,6 @@ TEMPLATES = [
                 "jobserver.context_processors.can_view_staff_area",
                 "jobserver.context_processors.staff_nav",
                 "jobserver.context_processors.nav",
-                "jobserver.context_processors.scripts_attrs",
             ],
         },
     },

--- a/jobserver/templates/base.html
+++ b/jobserver/templates/base.html
@@ -45,8 +45,8 @@
     <script src="{% static 'vendor/bootstrap.bundle.min.js' %}"></script>
     <script src="{% static 'js/main.js' %}"></script>
 
-    {% vite_asset 'vite/legacy-polyfills' scripts_attrs=scripts_attrs %}
-    {% vite_asset 'assets/src/scripts/main-legacy.js' scripts_attrs=scripts_attrs %}
+    {% vite_legacy_polyfills %}
+    {% vite_legacy_asset 'assets/src/scripts/main-legacy.js' %}
     {% block extra_js %}{% endblock %}
   </body>
 </html>

--- a/jobserver/templates/index.html
+++ b/jobserver/templates/index.html
@@ -128,5 +128,6 @@
 {% block extra_js %}
   <script src="{% static 'vendor/list.min.js' %}"></script>
   {% vite_asset 'assets/src/scripts/index.js' %}
+  {% vite_legacy_polyfills %}
   {% vite_legacy_asset 'assets/src/scripts/index-legacy.js' %}
 {% endblock %}

--- a/jobserver/templates/index.html
+++ b/jobserver/templates/index.html
@@ -128,5 +128,5 @@
 {% block extra_js %}
   <script src="{% static 'vendor/list.min.js' %}"></script>
   {% vite_asset 'assets/src/scripts/index.js' %}
-  {% vite_asset 'assets/src/scripts/index-legacy.js' scripts_attrs=scripts_attrs %}
+  {% vite_legacy_asset 'assets/src/scripts/index-legacy.js' %}
 {% endblock %}

--- a/jobserver/templates/job_request_create.html
+++ b/jobserver/templates/job_request_create.html
@@ -366,6 +366,7 @@
   {% if request.user.is_authenticated %}
     <div id="apiUrl" class="d-none">{{ workspace.get_statuses_url }}</div>
     {% vite_asset 'assets/src/scripts/job_request_create.js' %}
+    {% vite_legacy_polyfills %}
     {% vite_legacy_asset 'assets/src/scripts/job_request_create-legacy.js' %}
   {% endif %}
 {% endblock %}

--- a/jobserver/templates/job_request_create.html
+++ b/jobserver/templates/job_request_create.html
@@ -366,6 +366,6 @@
   {% if request.user.is_authenticated %}
     <div id="apiUrl" class="d-none">{{ workspace.get_statuses_url }}</div>
     {% vite_asset 'assets/src/scripts/job_request_create.js' %}
-    {% vite_asset 'assets/src/scripts/job_request_create-legacy.js' scripts_attrs=scripts_attrs %}
+    {% vite_legacy_asset 'assets/src/scripts/job_request_create-legacy.js' %}
   {% endif %}
 {% endblock %}

--- a/jobserver/templates/outputs-spa.html
+++ b/jobserver/templates/outputs-spa.html
@@ -14,5 +14,6 @@
 
 {% block extra_js %}
   {% vite_asset 'assets/src/scripts/outputs-viewer/index.jsx' %}
+  {% vite_legacy_polyfills %}
   {% vite_legacy_asset 'assets/src/scripts/outputs-viewer/index-legacy.jsx' %}
 {% endblock %}

--- a/jobserver/templates/outputs-spa.html
+++ b/jobserver/templates/outputs-spa.html
@@ -12,7 +12,5 @@
 
 {% block extra_js %}
   {% vite_asset 'assets/src/scripts/outputs-viewer/index.jsx' %}
-
-  {% vite_asset 'vite/legacy-polyfills' scripts_attrs=scripts_attrs %}
-  {% vite_asset 'assets/src/scripts/outputs-viewer/index-legacy.jsx' scripts_attrs=scripts_attrs %}
+  {% vite_legacy_asset 'assets/src/scripts/outputs-viewer/index-legacy.jsx' %}
 {% endblock %}

--- a/jobserver/templates/outputs-spa.html
+++ b/jobserver/templates/outputs-spa.html
@@ -1,13 +1,15 @@
 {% load django_vite %}
 
-<div
-  data-auth-token="{{ auth_token }}"
-  data-base-path="{{ base_path }}"
-  data-csrf-token="{{ csrf_token }}"
-  data-files-url="{{ files_url }}"
-  data-prepare-url="{{ prepare_url }}"
-  data-publish-url="{{ publish_url }}"
-  id="outputsSPA">
+<div class="container-fluid">
+  <div
+    data-auth-token="{{ auth_token }}"
+    data-base-path="{{ base_path }}"
+    data-csrf-token="{{ csrf_token }}"
+    data-files-url="{{ files_url }}"
+    data-prepare-url="{{ prepare_url }}"
+    data-publish-url="{{ publish_url }}"
+    id="outputsSPA">
+  </div>
 </div>
 
 {% block extra_js %}

--- a/jobserver/templates/project_create.html
+++ b/jobserver/templates/project_create.html
@@ -65,5 +65,6 @@
 
 {% block extra_js %}
 {% vite_asset 'assets/src/scripts/project_create.js' %}
+{% vite_legacy_polyfills %}
 {% vite_legacy_asset 'assets/src/scripts/project_create-legacy.js' %}
 {% endblock %}

--- a/jobserver/templates/project_create.html
+++ b/jobserver/templates/project_create.html
@@ -65,5 +65,5 @@
 
 {% block extra_js %}
 {% vite_asset 'assets/src/scripts/project_create.js' %}
-{% vite_asset 'assets/src/scripts/project_create-legacy.js' scripts_attrs=scripts_attrs %}
+{% vite_legacy_asset 'assets/src/scripts/project_create-legacy.js' %}
 {% endblock %}

--- a/jobserver/templates/project_onboarding_create.html
+++ b/jobserver/templates/project_onboarding_create.html
@@ -654,5 +654,5 @@
 
 {% block extra_js %}
 {% vite_asset 'assets/src/scripts/project_create.js' %}
-{% vite_asset 'assets/src/scripts/project_create-legacy.js' scripts_attrs=scripts_attrs %}
+{% vite_legacy_asset 'assets/src/scripts/project_create-legacy.js' %}
 {% endblock %}

--- a/jobserver/templates/project_onboarding_create.html
+++ b/jobserver/templates/project_onboarding_create.html
@@ -654,5 +654,6 @@
 
 {% block extra_js %}
 {% vite_asset 'assets/src/scripts/project_create.js' %}
+{% vite_legacy_polyfills %}
 {% vite_legacy_asset 'assets/src/scripts/project_create-legacy.js' %}
 {% endblock %}

--- a/jobserver/templates/workspace_create.html
+++ b/jobserver/templates/workspace_create.html
@@ -124,5 +124,5 @@
 {% block extra_js %}
 {{ repos_with_branches|json_script:"reposWithBranches" }}
 {% vite_asset 'assets/src/scripts/workspace_create.js' %}
-{% vite_asset 'assets/src/scripts/workspace_create-legacy.js' scripts_attrs=scripts_attrs %}
+{% vite_legacy_asset 'assets/src/scripts/workspace_create-legacy.js' %}
 {% endblock %}

--- a/jobserver/templates/workspace_create.html
+++ b/jobserver/templates/workspace_create.html
@@ -124,5 +124,6 @@
 {% block extra_js %}
 {{ repos_with_branches|json_script:"reposWithBranches" }}
 {% vite_asset 'assets/src/scripts/workspace_create.js' %}
+{% vite_legacy_polyfills %}
 {% vite_legacy_asset 'assets/src/scripts/workspace_create-legacy.js' %}
 {% endblock %}

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -185,9 +185,9 @@ django-structlog==2.1.2 \
     --hash=sha256:3d2003f1dd389c77055f6e2351cfbe0098569abd0468e57656b920ea06472ec6 \
     --hash=sha256:9566c7fdf6bfe7e4de9c6138e096a1b8d9d6d57a2fda517c50fe45963a38d1ae
     # via -r requirements.prod.in
-django-vite==1.1.1 \
-    --hash=sha256:25ed9257fc104c1dfecb18805b165f6750297296ba2cfa86d9bd48a099c8946e \
-    --hash=sha256:4bcf05f6e79350109cbabbeec57ecb11d3c457608c6908a25e1c499765833c5f
+django-vite==1.2 \
+    --hash=sha256:2419da8575b180632e987bd9f34a84ed26804cdd1801496cc59e2cee6760b85c \
+    --hash=sha256:41834a66500c0d7de484347e4669f9f76ed9dffaa53b2ddd2190fdd2ea1352a9
     # via -r requirements.prod.in
 djangorestframework==3.12.4 \
     --hash=sha256:6d1d59f623a5ad0509fe0d6bfe93cbdfe17b8116ebc8eda86d45f6e16e819aaf \

--- a/tests/unit/jobserver/test_context_processors.py
+++ b/tests/unit/jobserver/test_context_processors.py
@@ -7,7 +7,6 @@ from jobserver.context_processors import (
     backend_warnings,
     can_view_staff_area,
     nav,
-    scripts_attrs,
     staff_nav,
 )
 from jobserver.models import Backend
@@ -110,9 +109,3 @@ def test_nav_status(rf):
 
     assert jobs["is_active"] is False
     assert status["is_active"] is True
-
-
-def test_scriptsattrs_success(rf):
-    request = rf.get("/")
-
-    assert scripts_attrs(request) == {"scripts_attrs": {"nomodule": ""}}


### PR DESCRIPTION
As part of the `django-vite` package upgrade, we now don't need our custom `scripts_attrs` from the content processors.

Closes https://github.com/opensafely-core/job-server/pull/1015

(Also a small fix for the display width of the Outputs SPA)