### PR TITLE
Apply login_required to ProjectCreate

### DIFF
--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -72,6 +72,7 @@ class ProjectCancelInvite(View):
         return redirect(invite.project.get_settings_url())
 
 
+@method_decorator(login_required, name="dispatch")
 class ProjectCreate(CreateView):
     fields = ["name"]
     model = Project

--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -245,8 +245,10 @@ def test_projectcreate_unauthenticated(rf):
     request = rf.post("/", {"name": "test"})
     request.user = AnonymousUser()
 
-    with pytest.raises(Http404):
-        ProjectCreate.as_view()(request, org_slug=org.slug)
+    response = ProjectCreate.as_view()(request, org_slug=org.slug)
+
+    assert response.status_code == 302
+    assert response.url == "/login/github/?next=/"
 
 
 def test_projectcreate_user_not_in_org(rf):


### PR DESCRIPTION
ProjectCreate checks request.user is a member of the project and 404s if
not, but login_required will get a user to login and return them to the
view so this is a slightly nicer UX for users who should have access but
are just logged out but doesn't change anything for non-members.