### PR TITLE
Add `rel="nofollow"` to login links

### DIFF
--- a/applications/templates/applications/sign_in.html
+++ b/applications/templates/applications/sign_in.html
@@ -49,6 +49,7 @@
       <a
         class="btn btn-success"
         href="{% url "social:begin" "github" %}?next={% url 'applications:terms' %}"
+        rel="nofollow"
       >
         Sign in to GitHub
       </a>

--- a/jobserver/templates/partials/header.html
+++ b/jobserver/templates/partials/header.html
@@ -17,7 +17,7 @@
       </ul>
 
       {% if not user.is_authenticated %}
-        <a class="btn btn-outline-light mt-2 mb-3 my-lg-0" href="{% url "social:begin" "github" %}?next={{ request.path }}">Login</a>
+        <a class="btn btn-outline-light mt-2 mb-3 my-lg-0" href="{% url "social:begin" "github" %}?next={{ request.path }}" rel="nofollow">Login</a>
       {% else %}
         <div class="dropdown mt-2 mb-3 my-lg-0">
           <button class="btn btn-link text-white nav-link dropdown-toggle px-0 px-md-2" id="navbarUserDropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
This is sort of redundant following #1036 which disallows these URLs in
`robots.txt`. But this might have a more immediate effect than the
`robots.txt` changes and so seems worth trying.