### PR TITLE
Remove Releases Feature Flag

### DIFF
--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -114,40 +114,6 @@
         <code>moderately_sensitive</code> can be requested for release to the public, via a controlled output review service.
       </p>
 
-      {% if can_use_releases %}
-        <div class="card border-0">
-          <h2 class="h5 card-header border border-bottom-0">
-            Releases
-          </h2>
-
-          <div class="list-group list-group-flush">
-            <ul class="list-unstyled mb-0">
-              {% if user_can_view_files %}
-                <li class="list-group-item">
-                  <a href="{{ workspace.get_files_url }}">
-                    Level 4 Outputs
-                  </a>
-                </li>
-              {% endif %}
-              {% if user_can_view_releases %}
-                <li class="list-group-item">
-                  <a href="{{ workspace.get_releases_url }}">
-                    Released Outputs
-                  </a>
-                </li>
-              {% endif %}
-              {% if user_can_view_outputs %}
-                <li class="list-group-item">
-                  <a href="{{ workspace.get_outputs_url }}">
-                    Published Outputs
-                  </a>
-                </li>
-              {% endif %}
-            </ul>
-          </div>
-        </div>
-      {% endif %}
-
       {% if not jobrequest.is_invalid %}
         <section class="pt-3">
           <h2 class="h3">Jobs</h2>

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -136,22 +136,23 @@
           </ul>
         </li>
 
-        {% if can_use_releases and outputs %}
-          <li class="card">
-            <h2 class="card-header h5">
-              Outputs
-            </h2>
-            <ul class="card-body list-unstyled">
-              {% for snapshot in outputs %}
-                <li>
-                  <a href="{{ snapshot.get_absolute_url }}">
-                    Published on {{ snapshot.created_at|date:"Y-m-d" }}
-                  </a>
-                </li>
-              {% endfor %}
-            </ul>
-          </li>
+        {% if outputs %}
+        <li class="card">
+          <h2 class="card-header h5">
+            Outputs
+          </h2>
+          <ul class="card-body list-unstyled">
+            {% for snapshot in outputs %}
+              <li>
+                <a href="{{ snapshot.get_absolute_url }}">
+                  Published on {{ snapshot.created_at|date:"Y-m-d" }}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </li>
         {% endif %}
+
       </ul>
     </div>
   </div>

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -182,39 +182,40 @@
         request jobs are run from this page.
       </p>
 
-      {% if can_use_releases %}
-        <div class="card border-0">
-          <h2 class="h5 card-header border border-bottom-0">
-            Releases
-          </h2>
+      {% if user_can_use_releases %}
+      <div class="card border-0">
+        <h2 class="h5 card-header border border-bottom-0">
+          Releases
+        </h2>
 
-          <div class="list-group list-group-flush">
-            <ul class="list-unstyled mb-0">
-              {% if user_can_view_files %}
-                <li class="list-group-item">
-                  <a href="{{ workspace.get_files_url }}">
-                    Level 4 Outputs
-                  </a>
-                </li>
-              {% endif %}
-              {% if user_can_view_releases %}
-                <li class="list-group-item">
-                  <a href="{{ workspace.get_releases_url }}">
-                    Released Outputs
-                  </a>
-                </li>
-              {% endif %}
-              {% if user_can_view_outputs %}
-                <li class="list-group-item">
-                  <a href="{{ workspace.get_outputs_url }}">
-                    Published Outputs
-                  </a>
-                </li>
-              {% endif %}
-            </ul>
-          </div>
+        <div class="list-group list-group-flush">
+          <ul class="list-unstyled mb-0">
+            {% if user_can_view_files %}
+              <li class="list-group-item">
+                <a href="{{ workspace.get_files_url }}">
+                  Level 4 Outputs
+                </a>
+              </li>
+            {% endif %}
+            {% if user_can_view_releases %}
+              <li class="list-group-item">
+                <a href="{{ workspace.get_releases_url }}">
+                  Released Outputs
+                </a>
+              </li>
+            {% endif %}
+            {% if user_can_view_outputs %}
+              <li class="list-group-item">
+                <a href="{{ workspace.get_outputs_url }}">
+                  Published Outputs
+                </a>
+              </li>
+            {% endif %}
+          </ul>
         </div>
+      </div>
       {% endif %}
+
     </div>
   </div>
 </div>

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -12,13 +12,7 @@ from django.views.generic import CreateView, DetailView, UpdateView, View
 from furl import furl
 from sentry_sdk import capture_exception
 
-from ..authorization import (
-    CoreDeveloper,
-    ProjectDeveloper,
-    has_permission,
-    has_role,
-    roles_for,
-)
+from ..authorization import ProjectDeveloper, has_permission, roles_for
 from ..emails import send_project_invite_email
 from ..forms import ProjectInvitationForm, ProjectMembershipForm
 from ..github import get_repo_is_private
@@ -128,7 +122,6 @@ class ProjectDetail(DetailView):
             "project_membership_edit",
             project=self.object,
         )
-        can_use_releases = has_role(self.request.user, CoreDeveloper)
 
         workspaces = self.object.workspaces.order_by("name")
 
@@ -137,7 +130,6 @@ class ProjectDetail(DetailView):
         return super().get_context_data(**kwargs) | {
             "can_create_workspaces": can_create_workspaces,
             "can_manage_members": can_manage_members,
-            "can_use_releases": can_use_releases,
             "outputs": self.get_outputs(workspaces),
             "repos": list(self.get_repos(repos)),
             "workspaces": workspaces,

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -8,7 +8,7 @@ from django.views.generic import CreateView, ListView, View
 from furl import furl
 from pybadges import badge
 
-from ..authorization import CoreDeveloper, has_permission, has_role
+from ..authorization import has_permission
 from ..forms import (
     WorkspaceArchiveToggleForm,
     WorkspaceCreateForm,
@@ -173,8 +173,6 @@ class WorkspaceDetail(View):
             name=self.kwargs["workspace_slug"],
         )
 
-        can_use_releases = has_role(request.user, CoreDeveloper)
-
         is_privileged_user = has_permission(
             request.user, "release_file_view", project=workspace.project
         )
@@ -208,6 +206,11 @@ class WorkspaceDetail(View):
             request.user, "job_run", project=workspace.project
         )
 
+        # should we display the releases section for this workspace?
+        can_use_releases = workspace.project.uses_new_release_flow and (
+            can_view_files or can_view_releases or can_view_outputs
+        )
+
         try:
             repo_is_private = get_repo_is_private(
                 workspace.repo_owner, workspace.repo_name
@@ -216,10 +219,10 @@ class WorkspaceDetail(View):
             repo_is_private = None
 
         context = {
-            "can_use_releases": can_use_releases,
             "repo_is_private": repo_is_private,
             "user_can_archive_workspace": can_archive_workspace,
             "user_can_run_jobs": can_run_jobs,
+            "user_can_use_releases": can_use_releases,
             "user_can_view_files": can_view_files,
             "user_can_view_outputs": can_view_outputs,
             "user_can_view_releases": can_view_releases,


### PR DESCRIPTION
This removes our feature flag for releases, swapping in some conditionals for the Releases section on Project and Workspace pages so we aren't left with empty card bodies.