### PR TITLE
Make post requests from a new login page

### DIFF
--- a/applications/templates/applications/sign_in.html
+++ b/applications/templates/applications/sign_in.html
@@ -46,13 +46,9 @@
         request is associated with your GitHub user account.
       </p>
 
-      <a
-        class="btn btn-success"
-        href="{% url "social:begin" "github" %}?next={% url 'applications:terms' %}"
-        rel="nofollow"
-      >
-        Sign in to GitHub
-      </a>
+      <form method="POST" action="{% url "auth-login" "github" %}?next={% url 'applications:terms' %}">
+        <button type="submit" class="btn btn-success">Sign in to GitHub</button>
+      </form>
     </div>
   </div>
 </div>

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -165,7 +165,7 @@ AUTH_USER_MODEL = "jobserver.User"
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 LOGIN_ERROR_URL = "/"
-LOGIN_URL = reverse_lazy("social:begin", kwargs={"backend": "github"})
+LOGIN_URL = reverse_lazy("auth-login", kwargs={"backend": "github"})
 SOCIAL_AUTH_GITHUB_KEY = env.str("SOCIAL_AUTH_GITHUB_KEY")
 SOCIAL_AUTH_GITHUB_SECRET = env.str("SOCIAL_AUTH_GITHUB_SECRET")
 SOCIAL_AUTH_GITHUB_SCOPE = ["user:email"]

--- a/jobserver/templates/login.html
+++ b/jobserver/templates/login.html
@@ -30,12 +30,11 @@
 {% block content %}
 <div class="container">
   <div class="row">
-    <div class="col-sm-12">
+    <div class="col col-sm-8 offset-sm-2 col-md-6 offset-md-3 col-lg-4 offset-lg-4">
       <form method="POST" action="{% url "auth-login" "github" %}?next={{ next_url }}">
-        <div class="w-25 mx-auto">
-          <button type="submit" class="btn btn-outline-primary btn-block">Login with GitHub</button>
-          <button type="submit" class="btn btn-outline-secondary btn-block">Register with GitHub</button>
-        </div>
+        <button type="submit" class="btn btn-primary btn-block">Sign in with GitHub</button>
+        <p class="text-center my-2">or</p>
+        <button type="submit" class="btn btn-outline-secondary btn-block">Create a GitHub account</button>
       </form>
     </div>
   </div>

--- a/jobserver/templates/login.html
+++ b/jobserver/templates/login.html
@@ -1,5 +1,32 @@
 {% extends "base.html" %}
 
+{% block metatitle %}Login | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="/">Home</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        Login
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid pt-md-2">
+  <div class="container">
+    <h1 class="pt-4 pt-md-0">Login</h1>
+    <p class="lead">OpenSAFELY Jobs uses your GitHub Account to sign to confirm your identity.</p>
+    <p>If you do not have a GitHub account, you will need to create one before signing in.</p>
+  </div>
+</div>
+{% endblock jumbotron %}
+
 {% block content %}
 <div class="container">
   <div class="row">

--- a/jobserver/templates/login.html
+++ b/jobserver/templates/login.html
@@ -4,7 +4,7 @@
 <div class="container">
   <div class="row">
     <div class="col-sm-12">
-      <form method="POST" action="{% url "auth-login" "github" %}?next={{ request.path }}">
+      <form method="POST" action="{% url "auth-login" "github" %}?next={{ request.GET.next|default:"/" }}">
         <div class="w-25 mx-auto">
           <button type="submit" class="btn btn-outline-primary btn-block">Login with GitHub</button>
           <button type="submit" class="btn btn-outline-secondary btn-block">Register with GitHub</button>

--- a/jobserver/templates/login.html
+++ b/jobserver/templates/login.html
@@ -21,8 +21,8 @@
 <div class="jumbotron jumbotron-fluid pt-md-2">
   <div class="container">
     <h1 class="pt-4 pt-md-0">Login</h1>
-    <p class="lead">OpenSAFELY Jobs uses your GitHub Account to sign to confirm your identity.</p>
-    <p>If you do not have a GitHub account, you will need to create one before signing in.</p>
+    <p class="lead">OpenSAFELY Jobs uses your GitHub account to confirm your identity.</p>
+    <p>If you do not have a GitHub account, then you will need to create one before signing in.</p>
   </div>
 </div>
 {% endblock jumbotron %}

--- a/jobserver/templates/login.html
+++ b/jobserver/templates/login.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div class="col-sm-12">
+      <form method="POST" action="{% url "auth-login" "github" %}?next={{ request.path }}">
+        <div class="w-25 mx-auto">
+          <button type="submit" class="btn btn-outline-primary btn-block">Login with GitHub</button>
+          <button type="submit" class="btn btn-outline-secondary btn-block">Register with GitHub</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/jobserver/templates/login.html
+++ b/jobserver/templates/login.html
@@ -4,7 +4,7 @@
 <div class="container">
   <div class="row">
     <div class="col-sm-12">
-      <form method="POST" action="{% url "auth-login" "github" %}?next={{ request.GET.next|default:"/" }}">
+      <form method="POST" action="{% url "auth-login" "github" %}?next={{ next_url }}">
         <div class="w-25 mx-auto">
           <button type="submit" class="btn btn-outline-primary btn-block">Login with GitHub</button>
           <button type="submit" class="btn btn-outline-secondary btn-block">Register with GitHub</button>

--- a/jobserver/templates/partials/header.html
+++ b/jobserver/templates/partials/header.html
@@ -17,7 +17,7 @@
       </ul>
 
       {% if not user.is_authenticated %}
-        <a class="btn btn-outline-light mt-2 mb-3 my-lg-0" href="{% url "social:begin" "github" %}?next={{ request.path }}" rel="nofollow">Login</a>
+        <a class="btn btn-outline-light mt-2 mb-3 my-lg-0" href="{% url "login" %}" rel="nofollow">Login</a>
       {% else %}
         <div class="dropdown mt-2 mb-3 my-lg-0">
           <button class="btn btn-link text-white nav-link dropdown-toggle px-0 px-md-2" id="navbarUserDropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/jobserver/templates/partials/header.html
+++ b/jobserver/templates/partials/header.html
@@ -17,7 +17,7 @@
       </ul>
 
       {% if not user.is_authenticated %}
-        <a class="btn btn-outline-light mt-2 mb-3 my-lg-0" href="{% url "login" %}" rel="nofollow">Login</a>
+        <a class="btn btn-outline-light mt-2 mb-3 my-lg-0" href="{% url "login" %}?next={{ request.path }}" rel="nofollow">Login</a>
       {% else %}
         <div class="dropdown mt-2 mb-3 my-lg-0">
           <button class="btn btn-link text-white nav-link dropdown-toggle px-0 px-md-2" id="navbarUserDropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -5,7 +5,7 @@ from django.contrib.auth.views import LogoutView
 from django.urls import include, path
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
-from django.views.generic import RedirectView, TemplateView
+from django.views.generic import RedirectView
 
 from jobserver.api.jobs import (
     JobAPIUpdate,
@@ -54,7 +54,7 @@ from .views.releases import (
     WorkspaceReleaseList,
 )
 from .views.status import Status
-from .views.users import Settings
+from .views.users import Login, Settings
 from .views.workspaces import (
     WorkspaceArchiveToggle,
     WorkspaceBackendFiles,
@@ -269,7 +269,7 @@ urlpatterns = [
         name="job-request-detail",
     ),
     path("jobs/<identifier>/", JobDetailRedirect.as_view(), name="job-detail"),
-    path("login/", TemplateView.as_view(template_name="login.html"), name="login"),
+    path("login/", Login.as_view(), name="login"),
     path("logout/", LogoutView.as_view(), name="logout"),
     path("orgs/", include(org_urls)),
     path("settings/", Settings.as_view(), name="settings"),

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -1,8 +1,11 @@
 import debug_toolbar
+import social_django.views as social_django_views
 from django.conf import settings
 from django.contrib.auth.views import LogoutView
 from django.urls import include, path
-from django.views.generic import RedirectView
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+from django.views.generic import RedirectView, TemplateView
 
 from jobserver.api.jobs import (
     JobAPIUpdate,
@@ -247,6 +250,11 @@ org_urls = [
 
 urlpatterns = [
     path("", Index.as_view()),
+    path(
+        "login/<str:backend>/",
+        csrf_exempt(require_POST(social_django_views.auth)),
+        name="auth-login",
+    ),
     path("", include("social_django.urls", namespace="social")),
     path("", include("applications.urls")),
     path("favicon.ico", RedirectView.as_view(url=settings.STATIC_URL + "favicon.ico")),
@@ -261,6 +269,7 @@ urlpatterns = [
         name="job-request-detail",
     ),
     path("jobs/<identifier>/", JobDetailRedirect.as_view(), name="job-detail"),
+    path("login/", TemplateView.as_view(template_name="login.html"), name="login"),
     path("logout/", LogoutView.as_view(), name="logout"),
     path("orgs/", include(org_urls)),
     path("settings/", Settings.as_view(), name="settings"),

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -54,7 +54,7 @@ from .views.releases import (
     WorkspaceReleaseList,
 )
 from .views.status import Status
-from .views.users import Login, Settings
+from .views.users import Settings, login_view
 from .views.workspaces import (
     WorkspaceArchiveToggle,
     WorkspaceBackendFiles,
@@ -269,7 +269,7 @@ urlpatterns = [
         name="job-request-detail",
     ),
     path("jobs/<identifier>/", JobDetailRedirect.as_view(), name="job-detail"),
-    path("login/", Login.as_view(), name="login"),
+    path("login/", login_view, name="login"),
     path("logout/", LogoutView.as_view(), name="logout"),
     path("orgs/", include(org_urls)),
     path("settings/", Settings.as_view(), name="settings"),

--- a/jobserver/utils.py
+++ b/jobserver/utils.py
@@ -1,9 +1,21 @@
+from urllib.parse import urlparse
+
 from django.core.exceptions import BadRequest
 
 
 def dotted_path(cls):
     """Get the dotted path for a given class"""
     return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def is_safe_path(path):
+    """If `path` is safe, then returns `True`. Otherwise returns `False`.
+
+    A safe path has neither a scheme (e.g. "https") nor a location (e.g.
+    "www.opensafely.org").
+    """
+    parse_result = urlparse(path)
+    return not (parse_result.scheme or parse_result.netloc)
 
 
 def raise_if_not_int(value):

--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -14,8 +14,9 @@ class Login(TemplateView):
     template_name = "login.html"
 
     def get(self, request, *args, **kwargs):
-        if is_safe_path(request.GET.get("next", "")):
-            return render(request, self.template_name)
+        next_url = request.GET.get("next", "/")
+        if is_safe_path(next_url):
+            return render(request, self.template_name, {"next_url": next_url})
         else:
             return bad_request(request, SuspiciousOperation)
 

--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -1,9 +1,23 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import SuspiciousOperation
+from django.shortcuts import render
 from django.utils.decorators import method_decorator
-from django.views.generic import UpdateView
+from django.views.defaults import bad_request
+from django.views.generic import TemplateView, UpdateView
 
 from ..forms import SettingsForm
+from ..utils import is_safe_path
+
+
+class Login(TemplateView):
+    template_name = "login.html"
+
+    def get(self, request, *args, **kwargs):
+        if is_safe_path(request.GET.get("next", "")):
+            return render(request, self.template_name)
+        else:
+            return bad_request(request, SuspiciousOperation)
 
 
 @method_decorator(login_required, name="dispatch")

--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -1,24 +1,21 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import SuspiciousOperation
-from django.shortcuts import render
+from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.views.defaults import bad_request
-from django.views.generic import TemplateView, UpdateView
+from django.views.generic import UpdateView
 
 from ..forms import SettingsForm
 from ..utils import is_safe_path
 
 
-class Login(TemplateView):
-    template_name = "login.html"
-
-    def get(self, request, *args, **kwargs):
-        next_url = request.GET.get("next", "/")
-        if is_safe_path(next_url):
-            return render(request, self.template_name, {"next_url": next_url})
-        else:
-            return bad_request(request, SuspiciousOperation)
+def login_view(request):
+    next_url = request.GET.get("next", "/")
+    if is_safe_path(next_url):
+        return TemplateResponse(request, "login.html", {"next_url": next_url})
+    else:
+        return bad_request(request, SuspiciousOperation)
 
 
 @method_decorator(login_required, name="dispatch")

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -102,6 +102,13 @@ def test_login_redirects_correctly(client):
     assert f.args["scope"] == "user:email"
 
 
+def test_login_with_get_request_fails(client):
+    login_url = reverse("auth-login", kwargs={"backend": "github"})
+    response = client.get(login_url)
+
+    assert response.status_code == 405
+
+
 def test_login_pipeline_without_gitub_token(client):
     """
     Test the Auth Pipeline with an incoming request but no GitHub API access

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -87,8 +87,8 @@ def test_login_pipeline(client, mocker):
 
 
 def test_login_redirects_correctly(client):
-    login_url = reverse("social:begin", kwargs={"backend": "github"})
-    response = client.get(login_url)
+    login_url = reverse("auth-login", kwargs={"backend": "github"})
+    response = client.post(login_url)
 
     assert response.status_code == 302
 

--- a/tests/unit/jobserver/test_utils.py
+++ b/tests/unit/jobserver/test_utils.py
@@ -1,12 +1,20 @@
 from jobserver.authorization import OutputChecker
 from jobserver.models import Job
-from jobserver.utils import dotted_path, set_from_qs
+from jobserver.utils import dotted_path, is_safe_path, set_from_qs
 
 from ...factories import JobFactory
 
 
 def test_dotted_path():
     assert dotted_path(OutputChecker) == "jobserver.authorization.roles.OutputChecker"
+
+
+def test_is_safe_path_with_safe_path():
+    assert is_safe_path("/")
+
+
+def test_is_safe_path_with_unsafe_path():
+    assert not is_safe_path("https://steal-your-bank-details.com/")
 
 
 def test_set_from_qs():

--- a/tests/unit/jobserver/test_utils.py
+++ b/tests/unit/jobserver/test_utils.py
@@ -11,6 +11,7 @@ def test_dotted_path():
 
 def test_is_safe_path_with_safe_path():
     assert is_safe_path("/")
+    assert is_safe_path("/status/")
 
 
 def test_is_safe_path_with_unsafe_path():

--- a/tests/unit/jobserver/views/test_users.py
+++ b/tests/unit/jobserver/views/test_users.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
 
-from jobserver.views.users import Login, Settings
+from jobserver.views.users import Settings, login_view
 
 from ....factories import UserFactory
 
@@ -9,7 +9,7 @@ from ....factories import UserFactory
 def test_login_get_no_path(rf):
     request = rf.get("login/")
     request.user = AnonymousUser()
-    response = Login.as_view()(request)
+    response = login_view(request)
 
     assert response.status_code == 200
 
@@ -17,7 +17,7 @@ def test_login_get_no_path(rf):
 def test_login_get_safe_path(rf):
     request = rf.get("login/?next=/")
     request.user = AnonymousUser()
-    response = Login.as_view()(request)
+    response = login_view(request)
 
     assert response.status_code == 200
 
@@ -25,7 +25,7 @@ def test_login_get_safe_path(rf):
 def test_login_get_unsafe_path(rf):
     request = rf.get("login/?next=https://steal-your-bank-details.com/")
     request.user = AnonymousUser()
-    response = Login.as_view()(request)
+    response = login_view(request)
 
     assert response.status_code == 400
 

--- a/tests/unit/jobserver/views/test_users.py
+++ b/tests/unit/jobserver/views/test_users.py
@@ -1,8 +1,33 @@
+from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
 
-from jobserver.views.users import Settings
+from jobserver.views.users import Login, Settings
 
 from ....factories import UserFactory
+
+
+def test_login_get_no_path(rf):
+    request = rf.get("login/")
+    request.user = AnonymousUser()
+    response = Login.as_view()(request)
+
+    assert response.status_code == 200
+
+
+def test_login_get_safe_path(rf):
+    request = rf.get("login/?next=/")
+    request.user = AnonymousUser()
+    response = Login.as_view()(request)
+
+    assert response.status_code == 200
+
+
+def test_login_get_unsafe_path(rf):
+    request = rf.get("login/?next=https://steal-your-bank-details.com/")
+    request.user = AnonymousUser()
+    response = Login.as_view()(request)
+
+    assert response.status_code == 400
 
 
 def test_settings_get(rf):


### PR DESCRIPTION
Previously, get requests were made to GH from each page. Now, post requests are made to GH from a new login page. Post requests don't create new sessions in the database; the new login page is simply a nice-to-have.

Thanks for the discussion about this PR, both here and on Slack ([open redirects](https://ebmdatalab.slack.com/archives/C63UXGB8E/p1633341732201500); [the applications flow](https://ebmdatalab.slack.com/archives/C63UXGB8E/p1633342236207800)).

I'm going to squash and merge, if this PR is approved, so the commit messages are terse. However, I have:

* ensured post requests are made to GH by switching from links to buttons and by decorating `social_django_views.auth` with `csrf_exempt` and `require_POST`
* created a new `Login` view that checks whether the value of the `next` URL attribute is safe; this guards against an [open redirect](https://cwe.mitre.org/data/definitions/601.html)
* persisted the current URL, which is perhaps better described as *the last non-login URL*, through the `next` URL attribute
* updated the `LOGIN_URL` setting

I haven't:

* tidied up our nomenclature: we "Login with GitHub" from the normal flow, but "Sign in to GitHub" from the applications flow. I'm happy to tidy up, but feel we should clarify our nomenclature first.
* asked @tomodwyer to review my use of Bootstrap. If this PR is approved, then I will do so before squashing and merging.

---

I wasn't able to determine how to test the changes introduced by this PR. Ideally, we'd like to test that the `auth-login` path points to the twice-decorated `social_django_views.auth` view function: once decorated with `csrf_exempt` and once decorated with `require_POST`. Whilst it's straightforward to fetch the view function that corresponds to a path, it's less straightforward to determine whether this view function has been decorated:

```python
from django.urls import resolve

match = resolve("/login/github/")
match.func  # <function social_django.views.auth(request, backend)>
match.func.__wrapped__  # <function social_django.views.auth(request, backend)> Same as above
```

I briefly looked at the [`inspect`](https://docs.python.org/3.9/library/inspect.html#module-inspect) module for guidance, but this seemed hacky.

I also took a somewhat "quick and dirty" approach to applying classes to the HTML elements in *jobserver/templates/login.html*. Perhaps @tomodwyer would be able to 👀?

Closes #1037