### PR TITLE
Add Applications to the Staff Area

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -34,6 +34,9 @@ class Application(models.Model):
     def get_absolute_url(self):
         return reverse("applications:detail", kwargs={"pk": self.pk})
 
+    def get_staff_url(self):
+        return reverse("staff:application-detail", kwargs={"pk": self.pk})
+
     @property
     def is_study_research(self):
         try:

--- a/applications/models.py
+++ b/applications/models.py
@@ -31,6 +31,9 @@ class Application(models.Model):
 
     has_reached_confirmation = models.BooleanField(default=False)
 
+    def __str__(self):
+        return f"Application {self.pk} by {self.created_by.name}"
+
     def get_absolute_url(self):
         return reverse("applications:detail", kwargs={"pk": self.pk})
 

--- a/applications/models.py
+++ b/applications/models.py
@@ -31,6 +31,9 @@ class Application(models.Model):
 
     has_reached_confirmation = models.BooleanField(default=False)
 
+    def get_absolute_url(self):
+        return reverse("applications:detail", kwargs={"pk": self.pk})
+
     @property
     def is_study_research(self):
         try:

--- a/applications/urls.py
+++ b/applications/urls.py
@@ -3,6 +3,7 @@ from django.views.generic import RedirectView, TemplateView
 
 from .views import (
     ApplicationList,
+    PageRedirect,
     ResearcherCreate,
     ResearcherDelete,
     ResearcherEdit,
@@ -34,6 +35,7 @@ urlpatterns = [
     path("apply/sign-in", sign_in, name="sign-in"),
     path("apply/terms/", terms, name="terms"),
     path("applications/", ApplicationList.as_view(), name="list"),
+    path("applications/<int:pk>/", PageRedirect.as_view(), name="detail"),
     path("applications/<int:pk>/page/<str:key>/", page, name="page"),
     path("applications/<int:pk>/confirmation/", confirmation, name="confirmation"),
     path("applications/<int:pk>/researchers/", include(researcher_urls)),

--- a/applications/views.py
+++ b/applications/views.py
@@ -4,7 +4,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
-from django.views.generic import CreateView, ListView, UpdateView, View
+from django.views.generic import CreateView, ListView, RedirectView, UpdateView, View
 
 from jobserver.authorization import has_permission
 
@@ -37,6 +37,17 @@ class ApplicationList(ListView):
 
     def get_queryset(self):
         return Application.objects.filter(created_by=self.request.user)
+
+
+class PageRedirect(RedirectView):
+    def get_redirect_url(self, *args, **kwargs):
+        return reverse(
+            "applications:page",
+            kwargs={
+                "pk": self.kwargs["pk"],
+                "key": form_specs[0].key,
+            },
+        )
 
 
 class ResearcherCreate(CreateView):

--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -51,6 +51,11 @@ def staff_nav(request):
 
     options = [
         {
+            "name": "Applications",
+            "is_active": _active(reverse("staff:application-list")),
+            "url": reverse("staff:application-list"),
+        },
+        {
             "name": "Backends",
             "is_active": _active(reverse("staff:backend-list")),
             "url": reverse("staff:backend-list"),

--- a/staff/templates/staff/application_detail.html
+++ b/staff/templates/staff/application_detail.html
@@ -1,0 +1,203 @@
+{% extends "staff/base.html" %}
+
+{% block metatitle %}Application {{ application.pk }}: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:index' %}">Staff area</a>
+      </li>
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:application-list' %}">Applications</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        Application {{ application.pk }}
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
+  <div class="container">
+    <h1 class="display-4">Application {{ application.pk }}</h1>
+
+    <ul class="list-unstyled lead">
+      {% if application.created_by %}
+      <li>
+        <strong>Created by:</strong>
+        <a href="{{ application.created_by.get_staff_url }}">{{ application.created_by.name }}</a>
+      </li>
+      {% endif %}
+
+      <li>
+        <strong>Created at:</strong> {{ application.created_at }}
+      </li>
+    </ul>
+
+    <div class="d-flex">
+      <a class="btn btn-primary" href="{{ application.get_absolute_url }}">View on Site</a>
+    </div>
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block staff_content %}
+<div class="container">
+  <div class="row">
+    <div class="col">
+
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Full name</dt>
+        <dd class="col-6">{{ application.contactdetailspage.full_name }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Email</dt>
+        <dd class="col-6">{{ applicatio.contactdetailspagen.email }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Telephone number</dt>
+        <dd class="col-6">{{ application.contactdetailspage.telephone }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Job title</dt>
+        <dd class="col-6">{{ application.contactdetailspage.job_title }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Team or division</dt>
+        <dd class="col-6">{{ application.contactdetailspage.team_name }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Organisation</dt>
+        <dd class="col-6">{{ application.contactdetailspage.organisation }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Study name</dt>
+        <dd class="col-6">{{ application.studyinformationpage.study_name }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Purpose for requesting access to OpenSAFELY data</dt>
+        <dd class="col-6">{{ application.studyinformationpage.study_purpose }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Simple description of study</dt>
+        <dd class="col-6">{{ application.studypurposepage.description }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Name of application owner</dt>
+        <dd class="col-6">{{ application.studypurposepage.author_name }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Work email address</dt>
+        <dd class="col-6">{{ application.studypurposepage.author_email }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Affiliated organisation</dt>
+        <dd class="col-6">{{ application.studypurposepage.author_organisation }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">How does the requested data meet the study purpose</dt>
+        <dd class="col-6">{{ application.studydatapage.data_meets_purpose }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Needs record level data?</dt>
+        <dd class="col-6">{{ application.studydatapage.need_record_level_data }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Access to data reasons</dt>
+        <dd class="col-6">{{ application.recordleveldatapage.record_level_data_reasons }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Type of study is Research?</dt>
+        <dd class="col-6">{{ application.typeofstudypage.is_study_research }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Type of study is Service evaluation?</dt>
+        <dd class="col-6">{{ application.typeofstudypage.is_study_service_evaluation }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Type of study is Audit?</dt>
+        <dd class="col-6">{{ application.typeofstudypage.is_study_audit }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">HRA/IRSE ID</dt>
+        <dd class="col-6">{{ application.referencespage.hra_ires_id }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">HRA/REC reference</dt>
+        <dd class="col-6">{{ application.referencespage.hra_rec_reference }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Institutional REC reference</dt>
+        <dd class="col-6">{{ application.referencespage.institutional_rec_reference }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Sponsor name</dt>
+        <dd class="col-6">{{ application.sponsordetailspage.sponsor_name }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Sponsor email</dt>
+        <dd class="col-6">{{ application.sponsordetailspage.sponsor_email }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Sponsor job role</dt>
+        <dd class="col-6">{{ application.sponsordetailspage.sponsor_job_role }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Is research on CMO priority list?</dt>
+        <dd class="col-6">{{ application.cmoprioritylistpage.is_on_cmo_priority_list }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Legal basis for accessing data under DPA</dt>
+        <dd class="col-6">{{ application.legalbasispage.legal_basis_for_accessing_data_under_dpa }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">How is duty of confidentiality satisfied or set aside</dt>
+        <dd class="col-6">{{ application.legalbasispage.how_is_duty_of_confidentiality_satisfied }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Funding details</dt>
+        <dd class="col-6">{{ application.studyfundingpage.funding_details }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Team details</dt>
+        <dd class="col-6">{{ application.teamdetails.team_details }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Previous experience with EHR</dt>
+        <dd class="col-6">{{ application.previousehrexperiencepage.previous_experience_with_ehr }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Evidence of coding</dt>
+        <dd class="col-6">{{ application.softwaredevelopmentexperiencepage.evidence_of_coding }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">All applications have completed gettting started</dt>
+        <dd class="col-6">{{ application.softwaredevelopmentexperiencepage.all_applicants_completed_getting_started }}</dd>
+      </dl>
+      <dl class="row mb-1">
+        <dt class="col-6 mb-2">Evidence of sharing in public domain before</dt>
+        <dd class="col-6">{{ application.sharingcodepage.evidence_of_sharing_in_public_domain_before }}</dd>
+      </dl>
+
+      <h2 class="h3 mt-5">Researchers</h2>
+
+      <div class="list-group list-unstyled">
+        {% for researcher in researchers %}
+        <div class="d-flex justify-content-between align-items-center list-group-item">
+          <span class="mr-3">
+            {{ researcher.name }}
+            <small class="text-muted">({{ researcher.email }})</small>
+          </span>
+          <a class="btn btn-sm btn-primary" href="{{ researcher.get_edit_url }}">View on Site</a>
+        </a>
+        {% endfor %}
+      </div>
+    </div>
+
+  </div>
+</div>
+{% endblock staff_content %}

--- a/staff/templates/staff/application_list.html
+++ b/staff/templates/staff/application_list.html
@@ -1,0 +1,61 @@
+{% extends "staff/base.html" %}
+
+{% block metatitle %}Applications: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:index' %}">Staff area</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        Applications
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
+  <div class="container">
+    <h1 class="display-4">Applications</h1>
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block staff_content %}
+<div class="container">
+  <div class="row">
+    <div class="col col-lg-9 col-xl-8">
+      <form method="GET" class="mb-4">
+        <div class="form-inline w-100 d-flex flex-nowrap">
+          <label for="applicationSearch" class="sr-only">Search by name of application author</label>
+          <input
+            class="form-control mr-sm-2 w-100"
+            id="applicationSearch"
+            name="q"
+            placeholder="Search by name of application author"
+            type="search"
+            {% if q %}
+              value="{{ q }}"
+            {% endif %}
+          >
+          <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
+        </div>
+      </form>
+      <div class="list-group list-unstyled">
+        {% for application in application_list %}
+        <a href="{{ application.get_staff_url }}" class="d-flex align-items-center list-group-item list-group-item-action">
+          <span class="mr-3">
+            {{ application.pk }} by {{ application.created_by.name }}
+            <small class="text-muted">(started {{ application.created_at|date }})</small>
+          </span>
+        </a>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock staff_content %}

--- a/staff/templates/staff/index.html
+++ b/staff/templates/staff/index.html
@@ -42,7 +42,7 @@
   <div class="row">
     <div class="col-lg-4">
       <div class="list-group">
-        <a href="#" class="list-group-item list-group-item-action disabled" aria-disabled="true">Applications</a>
+        <a href="{% url 'staff:application-list' %}" class="list-group-item list-group-item-action">Applications</a>
         <a href="{% url 'staff:backend-list' %}" class="list-group-item list-group-item-action">Backends</a>
         <a href="{% url 'staff:org-list' %}" class="list-group-item list-group-item-action">Organisations</a>
         <a href="{% url 'staff:project-list' %}" class="list-group-item list-group-item-action">Projects</a>

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -1,5 +1,6 @@
 from django.urls import include, path
 
+from .views.applications import ApplicationDetail, ApplicationList
 from .views.backends import BackendDetail, BackendEdit, BackendList, BackendRotateToken
 from .views.index import Index
 from .views.orgs import OrgDetail, OrgEdit, OrgList, OrgRemoveMember
@@ -9,6 +10,11 @@ from .views.workspaces import WorkspaceDetail, WorkspaceList
 
 
 app_name = "staff"
+
+application_urls = [
+    path("", ApplicationList.as_view(), name="application-list"),
+    path("<int:pk>/", ApplicationDetail.as_view(), name="application-detail"),
+]
 
 backend_urls = [
     path("", BackendList.as_view(), name="backend-list"),
@@ -46,6 +52,7 @@ workspace_urls = [
 
 urlpatterns = [
     path("", Index.as_view(), name="index"),
+    path("applications/", include(application_urls)),
     path("backends/", include(backend_urls)),
     path("orgs/", include(org_urls)),
     path("projects/", include(project_urls)),

--- a/staff/views/applications.py
+++ b/staff/views/applications.py
@@ -1,0 +1,43 @@
+from django.db.models import Q
+from django.utils.decorators import method_decorator
+from django.views.generic import DetailView, ListView
+
+from applications.models import Application
+from jobserver.authorization import CoreDeveloper
+from jobserver.authorization.decorators import require_role
+
+
+@method_decorator(require_role(CoreDeveloper), name="dispatch")
+class ApplicationDetail(DetailView):
+    model = Application
+    template_name = "staff/application_detail.html"
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(**kwargs) | {
+            "researchers": self.object.researcher_registrations.order_by("created_at"),
+        }
+
+
+@method_decorator(require_role(CoreDeveloper), name="dispatch")
+class ApplicationList(ListView):
+    model = Application
+    ordering = "-created_at"
+    template_name = "staff/application_list.html"
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(**kwargs) | {
+            "q": self.request.GET.get("q", ""),
+        }
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+
+        q = self.request.GET.get("q")
+        if q:
+            qs = qs.filter(
+                Q(created_by__first_name__icontains=q)
+                | Q(created_by__last_name__icontains=q)
+                | Q(created_by__username__icontains=q)
+            )
+
+        return qs

--- a/staff/views/index.py
+++ b/staff/views/index.py
@@ -6,6 +6,7 @@ from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import View
 
+from applications.models import Application
 from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_role
 from jobserver.models import Backend, Org, Project, User, Workspace
@@ -13,6 +14,15 @@ from jobserver.models import Backend, Org, Project, User, Workspace
 
 # configure searchable models here, each must have get_staff_url defined
 configured_searches = [
+    {
+        "model": Application,
+        "fields": [
+            "created_by__first_name",
+            "created_by__last_name",
+            "created_by__username",
+        ],
+        "order_by": "created_at",
+    },
     {
         "model": Backend,
         "fields": ["name", "slug"],

--- a/tests/unit/applications/test_models.py
+++ b/tests/unit/applications/test_models.py
@@ -1,6 +1,14 @@
 from django.urls import reverse
 
-from ...factories import ResearcherRegistrationFactory
+from ...factories import ApplicationFactory, ResearcherRegistrationFactory
+
+
+def test_application_get_absolute_url():
+    application = ApplicationFactory()
+
+    url = application.get_absolute_url()
+
+    return url == reverse("applications:detail", kwargs={"pk": application.pk})
 
 
 def test_researcherregistration_get_delete_url():

--- a/tests/unit/applications/test_models.py
+++ b/tests/unit/applications/test_models.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 
-from ...factories import ApplicationFactory, ResearcherRegistrationFactory
+from ...factories import ApplicationFactory, ResearcherRegistrationFactory, UserFactory
 
 
 def test_application_get_absolute_url():
@@ -17,6 +17,13 @@ def test_application_get_staff_url():
     url = application.get_staff_url()
 
     return url == reverse("staff:application-detail", kwargs={"pk": application.pk})
+
+
+def test_application_str():
+    user = UserFactory(first_name="Ben", last_name="Seb")
+    application = ApplicationFactory(created_by=user)
+
+    assert str(application) == f"Application {application.pk} by Ben Seb"
 
 
 def test_researcherregistration_get_delete_url():

--- a/tests/unit/applications/test_models.py
+++ b/tests/unit/applications/test_models.py
@@ -11,6 +11,14 @@ def test_application_get_absolute_url():
     return url == reverse("applications:detail", kwargs={"pk": application.pk})
 
 
+def test_application_get_staff_url():
+    application = ApplicationFactory()
+
+    url = application.get_staff_url()
+
+    return url == reverse("staff:application-detail", kwargs={"pk": application.pk})
+
+
 def test_researcherregistration_get_delete_url():
     researcher = ResearcherRegistrationFactory()
 

--- a/tests/unit/applications/test_views.py
+++ b/tests/unit/applications/test_views.py
@@ -8,6 +8,7 @@ from applications.form_specs import form_specs
 from applications.models import Application, ResearcherRegistration, TypeOfStudyPage
 from applications.views import (
     ApplicationList,
+    PageRedirect,
     ResearcherCreate,
     ResearcherDelete,
     ResearcherEdit,
@@ -51,6 +52,19 @@ def test_getnexturl_without_next_arg(rf):
     output = get_next_url(request.GET)
 
     assert output == reverse("applications:list")
+
+
+def test_pageredirect_success(rf):
+    request = rf.get("/")
+
+    response = PageRedirect.as_view()(request, pk=0)
+
+    assert response.status_code == 302
+
+    assert response.url == reverse(
+        "applications:page",
+        kwargs={"pk": 0, "key": form_specs[0].key},
+    )
 
 
 def test_researchercreate_get_success(rf):

--- a/tests/unit/jobserver/test_urls.py
+++ b/tests/unit/jobserver/test_urls.py
@@ -44,6 +44,7 @@ from staff.views import workspaces as staff_workspaces
 @pytest.mark.parametrize(
     "url,redirect",
     [
+        ("/applications/42/", "/applications/42/page/contact-details/"),
         ("/applications/42/researchers/", "/applications/42/researchers/add"),
         ("/favicon.ico", "/static/favicon.ico"),
         ("/event-list/", "/event-log/"),

--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -1,0 +1,68 @@
+import pytest
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+
+from jobserver.utils import set_from_qs
+from staff.views.applications import ApplicationDetail, ApplicationList
+
+from ....factories import ApplicationFactory, UserFactory
+
+
+def test_applicationdetail_success(rf, core_developer):
+    application = ApplicationFactory()
+
+    request = rf.get("/")
+    request.user = core_developer
+
+    response = ApplicationDetail.as_view()(request, pk=application.pk)
+
+    assert response.status_code == 200
+
+    assert response.context_data["application"] == application
+
+
+def test_applicationdetail_with_unknown_user(rf, core_developer):
+    request = rf.get("/")
+    request.user = core_developer
+
+    with pytest.raises(Http404):
+        ApplicationDetail.as_view()(request, pk=0)
+
+
+def test_applicationdetail_without_core_dev_role(rf):
+    application = ApplicationFactory()
+
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    with pytest.raises(PermissionDenied):
+        ApplicationDetail.as_view()(request, pk=application.pk)
+
+
+def test_applicationlist_search(rf, core_developer):
+    app1 = ApplicationFactory(created_by=UserFactory(first_name="ben"))
+    app2 = ApplicationFactory(created_by=UserFactory(username="ben"))
+    ApplicationFactory(created_by=UserFactory(username="seb"))
+
+    request = rf.get("/?q=ben")
+    request.user = core_developer
+
+    response = ApplicationList.as_view()(request)
+
+    assert response.status_code == 200
+
+    assert len(response.context_data["object_list"]) == 2
+    assert set_from_qs(response.context_data["object_list"]) == {app1.pk, app2.pk}
+
+
+def test_applicationlist_success(rf, core_developer):
+    ApplicationFactory.create_batch(5)
+
+    request = rf.get("/")
+    request.user = core_developer
+
+    response = ApplicationList.as_view()(request)
+
+    assert response.status_code == 200
+
+    assert len(response.context_data["object_list"]) == 5


### PR DESCRIPTION
This adds list and detail pages for Applications to the Staff area and makes applications searchable by their creator on the homepage.

The fields listed on the detail pages have all been manually added for now since we're not quite sure how it's going to work so I just did some vim macro magic with the intention that we should definitely do something better there once we have an idea how the application-dependent models are going to work.