### PR TITLE
Avoid setting blank shortNames for single file outputs responses

### DIFF
--- a/assets/src/scripts/outputs-viewer/hooks/use-file-list.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file-list.js
@@ -4,6 +4,11 @@ import useStore from "../stores/use-store";
 import { toastError } from "../utils/toast";
 
 export function longestStartingSubstr(array) {
+  if (array.length < 2) {
+    // don't match the entire string for single item arrays
+    return "";
+  }
+
   const A = array.concat().sort();
   const a1 = A[0];
   const a2 = A[A.length - 1];

--- a/assets/src/scripts/outputs-viewer/tests/hooks/use-file-list.test.js
+++ b/assets/src/scripts/outputs-viewer/tests/hooks/use-file-list.test.js
@@ -26,5 +26,7 @@ describe("useFileList hook", () => {
     expect(longestStartingSubstr(["nodata-001.csv", "data-002.csv"])).toEqual(
       ""
     );
+
+    expect(longestStartingSubstr(["data-001.csv"])).toEqual("");
   });
 });


### PR DESCRIPTION
We pull a common prefix from the filenames served to the outputs viewer
app.  We use this prefix to create a `shortName` value on the files
array for display in the file list UI.  However with one file the
longest common prefix is the entire filename, leading to an empty
shortName, and showing an empty file list.

Fixes #1073 