### PR TITLE
Always show orgs and projects section of the user detail staff page

### DIFF
--- a/staff/templates/staff/user_detail.html
+++ b/staff/templates/staff/user_detail.html
@@ -95,7 +95,6 @@
 
         </div>
 
-        {% if orgs %}
         <div class="form-group mb-5">
           <div class="d-flex justify-content-between align-items-center">
             <h2 class="h4">Organisations</h2>
@@ -115,9 +114,7 @@
             {% endfor %}
           </div>
         </div>
-        {% endif %}
 
-        {% if projects %}
         <div class="form-group mb-5">
           <h2 class="h4">Projects</h2>
 
@@ -132,7 +129,6 @@
             {% endfor %}
           </div>
         </div>
-        {% endif %}
 
         {% include "components/form_roles.html" with field=form.roles label="Roles" name="roles" %}
 


### PR DESCRIPTION
This adds Orgs & Projects to the UserDetail page even if there are no items to display.  For Orgs this is because this is where we get to the page to select which orgs are valid.  For both lists it's useful to see when they are empty as this is something to fix with the user.