### PR TITLE
Filter Users by Org

### DIFF
--- a/staff/templates/staff/user_list.html
+++ b/staff/templates/staff/user_list.html
@@ -83,6 +83,29 @@
         {% endfor %}
       </div>
       {% endif %}
+
+      {% if orgs %}
+      <h3 class="h4">Orgs</h3>
+      <div class="btn-group-vertical w-100 mb-4" role="group" aria-label="Filter by orgs">
+        {% for org in orgs %}
+        {% is_filter_selected key="org" value=org.slug as is_active %}
+        <a
+          {% if is_active %}aria-pressed="true"{% endif %}
+          class="btn btn-outline-primary btn-block text-left {% if is_active %}active{% endif %}"
+          href="
+            {% if is_active %}
+              {% url_without_querystring org=org.slug %}
+            {% else %}
+              {% url_with_querystring org=org.slug %}
+            {% endif %}
+          "
+        >
+            {{ org.name }}
+        </a>
+        {% endfor %}
+      </div>
+      {% endif %}
+
     </div>
 
     <div class="col col-lg-9 col-xl-8">

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -107,16 +107,14 @@ class UserList(ListView):
                 | Q(last_name__icontains=q)
             )
 
-        backend = self.request.GET.get("backend")
-        if backend:
+        if backend := self.request.GET.get("backend"):
             raise_if_not_int(backend)
             qs = qs.filter(backends__pk=backend)
 
         if org := self.request.GET.get("org"):
             qs = qs.filter(orgs__slug=org)
 
-        role = self.request.GET.get("role")
-        if role:
+        if role := self.request.GET.get("role"):
             qs = qs.filter_by_role(role)
 
         return qs

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -92,6 +92,7 @@ class UserList(ListView):
         return super().get_context_data(**kwargs) | {
             "backends": Backend.objects.order_by("slug"),
             "q": self.request.GET.get("q", ""),
+            "orgs": Org.objects.order_by("name"),
             "roles": all_roles,
         }
 
@@ -110,6 +111,9 @@ class UserList(ListView):
         if backend:
             raise_if_not_int(backend)
             qs = qs.filter(backends__pk=backend)
+
+        if org := self.request.GET.get("org"):
+            qs = qs.filter(orgs__slug=org)
 
         role = self.request.GET.get("role")
         if role:

--- a/tests/unit/staff/views/test_users.py
+++ b/tests/unit/staff/views/test_users.py
@@ -235,6 +235,30 @@ def test_userlist_filter_by_invalid_backend(rf, core_developer):
         UserList.as_view()(request)
 
 
+def test_userlist_filter_by_org(rf, core_developer):
+    org1 = OrgFactory()
+    org2 = OrgFactory()
+
+    OrgMembershipFactory(user=UserFactory(), org=org1)
+    OrgMembershipFactory(user=UserFactory(), org=org2)
+
+    request = rf.get(f"/?org={org1.slug}")
+    request.user = core_developer
+
+    response = UserList.as_view()(request)
+
+    assert len(response.context_data["object_list"]) == 1
+
+
+def test_userlist_filter_by_invalid_org(rf, core_developer):
+    request = rf.get("/?org=test")
+    request.user = core_developer
+
+    response = UserList.as_view()(request)
+
+    assert len(response.context_data["object_list"]) == 0
+
+
 def test_userlist_filter_by_role(rf, core_developer):
     UserFactory(roles=[OutputPublisher])
     UserFactory(roles=[TechnicalReviewer])
@@ -248,10 +272,10 @@ def test_userlist_filter_by_role(rf, core_developer):
 
 
 def test_userlist_filter_by_invalid_role(rf, core_developer):
-    request = rf.get("/?backend=unknown")
+    request = rf.get("/?role=unknown")
     request.user = core_developer
 
-    with pytest.raises(BadRequest):
+    with pytest.raises(Exception, match="^Unknown Roles:"):
         UserList.as_view()(request)
 
 


### PR DESCRIPTION
This adds an org filter to the staff area's UserList page.  This will be useful when setting up new user's orgs to confirm that all the required users have been done.