### PR TITLE
Remove transaction wrapper from `JobAPIUpdate.post` view

### DIFF
--- a/jobserver/api/jobs.py
+++ b/jobserver/api/jobs.py
@@ -3,7 +3,6 @@ import operator
 
 import sentry_sdk
 import structlog
-from django.db import transaction
 from django.http import Http404
 from django.utils import timezone
 from first import first
@@ -50,7 +49,6 @@ class JobAPIUpdate(APIView):
 
         return super().initial(request, *args, **kwargs)
 
-    @transaction.atomic
     def post(self, request, *args, **kwargs):
         log = logger.new()
 


### PR DESCRIPTION
This creates locking problems under SQLite (see #1087 and #1032). But we
don't actually need transactionaility here because the sync process this
endpoint participates in is self-healing: the caller just declares the
full state of every active job and we persist that. If we only manage a
partial update then we'll correct that the next time we get polled.