### PR TITLE
Validate Entire Application on Confirmation Page

### DIFF
--- a/applications/form_spec_helpers.py
+++ b/applications/form_spec_helpers.py
@@ -33,6 +33,9 @@ class Form:
             "template_name": self.template_name,
         }
 
+    def is_valid(self, page_instance):
+        return all(fieldset.is_valid(page_instance) for fieldset in self.fieldsets)
+
     def review_context(self, page_instance):
         return {
             "title": self.title,
@@ -53,6 +56,9 @@ class Fieldset:
             "label": self.label,
             "fields": [field_spec.form_context(form) for field_spec in self.fields],
         }
+
+    def is_valid(self, page_instance):
+        return all(field.is_valid(page_instance) for field in self.fields)
 
     def review_context(self, page_instance):
         return {

--- a/applications/templates/applications/confirmation.html
+++ b/applications/templates/applications/confirmation.html
@@ -27,6 +27,21 @@
       {% endfor %}
 
       {% endfor %}
+
+      <form method="POST">
+        {% csrf_token %}
+        <button
+          class="btn btn-lg btn-success mt-3"
+          type="submit"
+          {% if not is_valid %}
+          disabled
+          aria-disabled="true"
+          {% endif %}
+        >
+          Submit
+        </button>
+      </form>
+
     </div>
   </div>
 </article>

--- a/applications/urls.py
+++ b/applications/urls.py
@@ -3,11 +3,11 @@ from django.views.generic import RedirectView, TemplateView
 
 from .views import (
     ApplicationList,
+    Confirmation,
     PageRedirect,
     ResearcherCreate,
     ResearcherDelete,
     ResearcherEdit,
-    confirmation,
     page,
     sign_in,
     terms,
@@ -37,6 +37,10 @@ urlpatterns = [
     path("applications/", ApplicationList.as_view(), name="list"),
     path("applications/<int:pk>/", PageRedirect.as_view(), name="detail"),
     path("applications/<int:pk>/page/<str:key>/", page, name="page"),
-    path("applications/<int:pk>/confirmation/", confirmation, name="confirmation"),
+    path(
+        "applications/<int:pk>/confirmation/",
+        Confirmation.as_view(),
+        name="confirmation",
+    ),
     path("applications/<int:pk>/researchers/", include(researcher_urls)),
 ]

--- a/applications/wizard.py
+++ b/applications/wizard.py
@@ -36,6 +36,9 @@ class Wizard:
             if page.status == UNSTARTED:
                 return page.key
 
+    def is_valid(self):
+        return all(p.form_spec.is_valid(p.page_instance) for p in self.get_pages())
+
     def progress_percent(self):
         """Return user's progress through wizard as a percentage."""
 

--- a/tests/unit/jobserver/test_urls.py
+++ b/tests/unit/jobserver/test_urls.py
@@ -80,7 +80,7 @@ def test_url_redirects(client, url, redirect):
         ("/apply/terms/", applications.terms),
         ("/applications/", applications.ApplicationList),
         ("/applications/42/page/42/", applications.page),
-        ("/applications/42/confirmation/", applications.confirmation),
+        ("/applications/42/confirmation/", applications.Confirmation),
         ("/applications/42/researchers/add", applications.ResearcherCreate),
         ("/applications/42/researchers/42/delete/", applications.ResearcherDelete),
         ("/applications/42/researchers/42/edit/", applications.ResearcherEdit),


### PR DESCRIPTION
*Rebuilt after switching to mirroring the staff template and using Field to define value and validity*

This adds final validation to the Wizard so we know if the confirmation can be submitted or not.  Validation is bubbled up through the form_spec helpers since Field already knows if it's valid or not so we build up from there to the Wizard.