### PR TITLE
Update LOGIN_URL

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -176,7 +176,7 @@ AUTH_USER_MODEL = "jobserver.User"
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 LOGIN_ERROR_URL = "/"
-LOGIN_URL = reverse_lazy("auth-login", kwargs={"backend": "github"})
+LOGIN_URL = reverse_lazy("login")
 SOCIAL_AUTH_GITHUB_KEY = env.str("SOCIAL_AUTH_GITHUB_KEY")
 SOCIAL_AUTH_GITHUB_SECRET = env.str("SOCIAL_AUTH_GITHUB_SECRET")
 SOCIAL_AUTH_GITHUB_SCOPE = ["user:email"]

--- a/tests/unit/jobserver/test_login.py
+++ b/tests/unit/jobserver/test_login.py
@@ -1,0 +1,20 @@
+from django.contrib.auth.decorators import login_required
+from django.test.utils import override_settings
+from django.urls import path
+
+from jobserver.urls import urlpatterns as base_urlpatterns
+
+
+@login_required
+def view_fn(request):
+    return "Hello"  # pragma: no cover
+
+
+urlpatterns = [path("test/", view_fn, name="test")] + base_urlpatterns
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_login_required_redirect(client):
+    response = client.get("/test/", follow=True)
+    assert response.status_code == 200
+    assert response.redirect_chain == [("/login/?next=/test/", 302)]

--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -248,7 +248,7 @@ def test_projectcreate_unauthenticated(rf):
     response = ProjectCreate.as_view()(request, org_slug=org.slug)
 
     assert response.status_code == 302
-    assert response.url == "/login/github/?next=/"
+    assert response.url == "/login/?next=/"
 
 
 def test_projectcreate_user_not_in_org(rf):


### PR DESCRIPTION
Since d21a8bdf, when an anonymous user hits a view decorated by
@login_required, they are redirected to a view decorated by
@require_POST.