### PR TITLE
Confirm Researchers

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -55,3 +55,61 @@ class ResearcherRegistrationPageForm(forms.ModelForm):
             "training_passed_at",
         ]
         model = ResearcherRegistration
+
+
+class ResearcherRegistrationSubmissionForm(ResearcherRegistrationPageForm):
+    """
+    Submission form for Researchers
+
+    When submitting an application we want to do extra validation of the
+    fields, however researchers are separate to pages so we can't use the
+    existing submission validation to do that.  Instead we take the form used
+    to create/edit researchers and add cross-field validation to it.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["does_researcher_need_server_access"].required = True
+        self.fields["has_taken_safe_researcher_training"].required = True
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        # require number and phone type if the user is going to need server
+        # access.
+        does_researcher_need_server_access = cleaned_data.get(
+            "does_researcher_need_server_access", False
+        )
+        telephone = cleaned_data["telephone"]
+        phone_type = cleaned_data.get("phone_type", None)
+        if does_researcher_need_server_access:
+            if not telephone:
+                msg = "A phone number is required to access the results server."
+                self.add_error("telephone", msg)
+
+            if not phone_type:
+                msg = "A phone type is required to access the results server."
+                self.add_error("phone_type", msg)
+
+        # require training org and pass date when researcher has taken safe
+        # researcher training.
+        has_taken_safe_researcher_training = cleaned_data.get(
+            "has_taken_safe_researcher_training", False
+        )
+        training_with_org = cleaned_data["training_with_org"]
+        training_passed_at = cleaned_data["training_passed_at"]
+        if has_taken_safe_researcher_training:
+            if not training_with_org:
+                msg = (
+                    "When a researcher has undertaken safe researcher training we "
+                    "need to know the organisation they completed it with."
+                )
+                self.add_error("training_with_org", msg)
+
+            if not training_passed_at:
+                msg = (
+                    "When a researcher has undertaken safe researcher training we "
+                    "need to know the date they passed the course."
+                )
+                self.add_error("training_passed_at", msg)

--- a/applications/researchers.py
+++ b/applications/researchers.py
@@ -1,0 +1,19 @@
+from django.forms.models import model_to_dict
+
+from .forms import ResearcherRegistrationSubmissionForm
+
+
+def build_researcher_form(researcher):
+    """
+    Create a bound ResearcherRegistrationSubmissionForm
+
+    Errors can only be generated on a Django form once it is bound to data,
+    which doesn't include a model instance in the case of a ModelForm.  This
+    function takes the given ResearcherRegistration instance, creates a
+    dictionary from it, and then builds the submission form with both that and
+    the passed in instance.  We get fields defined from the the forms parent
+    class, and a bound form which we can call is_valid() to get errors from.
+    """
+    data = model_to_dict(researcher)
+
+    return ResearcherRegistrationSubmissionForm(data, instance=researcher)

--- a/applications/templates/applications/confirmation.html
+++ b/applications/templates/applications/confirmation.html
@@ -31,6 +31,87 @@
 
       {% endfor %}
 
+      <section class="mb-3 pb-3 border-bottom">
+
+        {% for form in researchers %}
+        <div class="card mb-3">
+          <div class="card-header">
+            <h2 class="h5">Researcher {{ forloop.counter }}</h2>
+          </div>
+
+          <div class="card-body">
+            <dl class="row">
+              <dt class="col-7{% if form.name.errors %} text-danger{% endif %}">
+                Name{% if form.name.errors %}*{% endif %}:
+              </dt>
+              <dd class="col-5">{{ form.name.value }}</dd>
+
+              <dt class="col-7{% if form.job_title.errors %} text-danger{% endif %}">
+                Job title{% if form.job_title.errors %}*{% endif %}:
+              </dt>
+              <dd class="col-5">{{ form.job_title.value }}</dd>
+
+              <dt class="col-7{% if form.email.errors %} text-danger{% endif %}">
+                Email{% if form.email.errors %}*{% endif %}:
+              </dt>
+              <dd class="col-5">{{ form.email.value }}</dd>
+            </dl>
+
+            <dl class="row">
+              <dt class="col-7{% if form.does_researcher_need_server_access.errors %} text-danger{% endif %}">
+                Do they need access to the results server?
+                {% if form.does_researcher_need_server_access.errors %}*{% endif %}
+              </dt>
+              <dd class="col-5">{{ form.does_researcher_need_server_access.value|default_if_none:"Not supplied"}}</dd>
+
+              <dt class="col-7{% if form.telephone.errors %} text-danger{% endif %}">
+                Phone number{% if form.telephone.errors %}*{% endif %}:
+                {% for error in form.telephone.errors %}
+                <p>{{ error }}</p>
+                {% endfor %}
+              </dt>
+              <dd class="col-5">{{ form.telephone.value|default:"Not supplied" }}</dd>
+
+              <dt class="col-7{% if form.phone_type.errors %} text-danger{% endif %}">
+                Type of phone{% if form.phone_type.errors %}*{% endif %}:
+                {% for error in form.phone_type.errors %}
+                <p>{{ error }}</p>
+                {% endfor %}
+              </dt>
+              <dd class="col-5">{{ form.get_phone_type_display|default:"Not supplied" }}</dd>
+            </dl>
+
+            <dl class="row">
+              <dt class="col-7{% if form.has_taken_safe_researcher_training.errors %} text-danger{% endif %}">
+                Have they undertaken safe researcher training?
+                {% if form.has_taken_safe_researcher_training.errors %}*{% endif %}
+              </dt>
+              <dd class="col-5">{{ form.has_taken_safe_researcher_training.value|default_if_none:"Not supplied" }}</dd>
+
+              <dt class="col-7{% if form.training_with_org.errors %} text-danger{% endif %}">
+                Organisation training completed with{% if form.training_with_org.errors %}*{% endif %}:
+                {% for error in form.training_with_org.errors %}
+                <p>{{ error }}</p>
+                {% endfor %}
+              </dt>
+              <dd class="col-5">{{ form.training_with_org.value|default:"Not supplied" }}</dd>
+
+              <dt class="col-7{% if form.training_passed_at.errors %} text-danger{% endif %}">
+                Training passed on{% if form.training_passed_at.errors %}*{% endif %}:
+                {% for error in form.training_passed_at.errors %}
+                <p>{{ error }}</p>
+                {% endfor %}
+              </dt>
+              <dd class="col-5">
+                {{ form.training_passed_at.value|date:"Y-m-d"|default:"Not supplied" }}
+              </dd>
+            </dl>
+          </div>
+        </div>
+        {% endfor %}
+
+      </section>
+
       <form method="POST">
         {% csrf_token %}
         <button

--- a/applications/templates/applications/page_researchers.html
+++ b/applications/templates/applications/page_researchers.html
@@ -23,27 +23,25 @@
 
       <dl class="row">
         <dt class="col-7">Do they need access to the results server?</dt>
-        <dd class="col-5">{{ researcher.get_does_researcher_need_server_access_display |default_if_none:"N/A"}}</dd>
+        <dd class="col-5">{{ researcher.get_does_researcher_need_server_access_display |default_if_none:"Not supplied"}}</dd>
 
         <dt class="col-7">Phone number:</dt>
-        <dd class="col-5">{{ researcher.telephone|default:"N/A" }}</dd>
+        <dd class="col-5">{{ researcher.telephone|default:"Not supplied" }}</dd>
 
         <dt class="col-7">Type of phone:</dt>
-        <dd class="col-5">{{ researcher.get_phone_type_display|default:"N/A" }}</dd>
+        <dd class="col-5">{{ researcher.get_phone_type_display|default:"Not supplied" }}</dd>
       </dl>
 
       <dl class="row">
         <dt class="col-7">Have they undertaken safe researcher training?</dt>
-        <dd class="col-5">{{ researcher.get_has_taken_safe_researcher_training_display|default_if_none:"N/A" }}</dd>
+        <dd class="col-5">{{ researcher.get_has_taken_safe_researcher_training_display|default_if_none:"Not supplied" }}</dd>
 
         <dt class="col-7">Organisation training completed with:</dt>
-        <dd class="col-5">{{ researcher.training_with_org|default:"N/A" }}</dd>
+        <dd class="col-5">{{ researcher.training_with_org|default:"Not supplied" }}</dd>
 
         <dt class="col-7">Training passed on:</dt>
         <dd class="col-5">
-          {% if researcher.training_passed_at %}
-          {{ researcher.training_passed_at|date:"Y-m-d"|default:"N/A" }}
-          {% endif %}
+          {{ researcher.training_passed_at|date:"Y-m-d"|default:"Not supplied" }}
         </dd>
       </dl>
 

--- a/applications/views.py
+++ b/applications/views.py
@@ -16,6 +16,7 @@ from .emails import send_submitted_application_email
 from .form_specs import form_specs
 from .forms import ResearcherRegistrationPageForm
 from .models import Application, ResearcherRegistration
+from .researchers import build_researcher_form
 from .wizard import Wizard
 
 
@@ -196,10 +197,15 @@ class Confirmation(View):
     def get(self, request, *args, **kwargs):
         pages = [page.review_context() for page in self.wizard.get_pages()]
 
+        researchers = [
+            build_researcher_form(r)
+            for r in self.wizard.application.researcher_registrations.order_by("name")
+        ]
         context = {
             "application": self.wizard.application,
             "is_valid": self.wizard.is_valid(),
             "pages": pages,
+            "researchers": researchers,
         }
 
         return TemplateResponse(

--- a/applications/wizard.py
+++ b/applications/wizard.py
@@ -3,6 +3,7 @@ from django.shortcuts import redirect
 from django.utils.functional import cached_property
 
 from .forms import PageFormBase
+from .researchers import build_researcher_form
 
 
 UNSTARTED = "unstarted"
@@ -37,7 +38,18 @@ class Wizard:
                 return page.key
 
     def is_valid(self):
-        return all(p.form_spec.is_valid(p.page_instance) for p in self.get_pages())
+        pages_valid = all(
+            p.form_spec.is_valid(p.page_instance) for p in self.get_pages()
+        )
+        if not pages_valid:
+            return False
+
+        for researcher in self.application.researcher_registrations.all():
+            form = build_researcher_form(researcher)
+            if not form.is_valid():
+                return False
+
+        return True
 
     def progress_percent(self):
         """Return user's progress through wizard as a percentage."""

--- a/tests/unit/applications/test_forms.py
+++ b/tests/unit/applications/test_forms.py
@@ -1,6 +1,84 @@
 from django import forms
 
-from applications.forms import YesNoField
+from applications.forms import ResearcherRegistrationSubmissionForm, YesNoField
+
+
+def test_required_fields():
+    data = {
+        "name": "ben",
+        "job_title": "The Boss",
+        "email": "ben@example.com",
+        "does_researcher_need_server_access": None,
+        "has_taken_safe_researcher_training": None,
+    }
+    form = ResearcherRegistrationSubmissionForm(data)
+    assert not form.is_valid()
+    assert "does_researcher_need_server_access" in form.errors
+    assert "has_taken_safe_researcher_training" in form.errors
+
+    data = {
+        "name": "ben",
+        "job_title": "The Boss",
+        "email": "ben@example.com",
+        "does_researcher_need_server_access": False,
+        "has_taken_safe_researcher_training": False,
+    }
+    form = ResearcherRegistrationSubmissionForm(data)
+    assert form.is_valid(), form.errors
+
+
+def test_researcherregistrationsubmissionform_does_researcher_need_server_access_related_validation():
+    data = {
+        "name": "ben",
+        "job_title": "The Boss",
+        "email": "ben@example.com",
+        "does_researcher_need_server_access": True,
+        "has_taken_safe_researcher_training": False,
+    }
+    form = ResearcherRegistrationSubmissionForm(data)
+    assert not form.is_valid()
+
+    assert "telephone" in form.errors
+    assert "phone_type" in form.errors
+
+    data = {
+        "name": "ben",
+        "job_title": "The Boss",
+        "email": "ben@example.com",
+        "does_researcher_need_server_access": True,
+        "telephone": "07777777777",
+        "phone_type": "iphone",
+        "has_taken_safe_researcher_training": False,
+    }
+    form = ResearcherRegistrationSubmissionForm(data)
+    assert form.is_valid()
+
+
+def test_researcherregistrationsubmissionform_has_taken_safe_reseasrcher_training_validation():
+    data = {
+        "name": "ben",
+        "job_title": "The Boss",
+        "email": "ben@example.com",
+        "does_researcher_need_server_access": False,
+        "has_taken_safe_researcher_training": True,
+    }
+    form = ResearcherRegistrationSubmissionForm(data)
+    assert not form.is_valid()
+
+    assert "training_with_org" in form.errors
+    assert "training_passed_at" in form.errors
+
+    data = {
+        "name": "ben",
+        "job_title": "The Boss",
+        "email": "ben@example.com",
+        "does_researcher_need_server_access": False,
+        "has_taken_safe_researcher_training": True,
+        "training_with_org": "Oxford",
+        "training_passed_at": "2021-06-01",
+    }
+    form = ResearcherRegistrationSubmissionForm(data)
+    assert form.is_valid()
 
 
 def test_yesnofield_coerce():

--- a/tests/unit/applications/test_wizard.py
+++ b/tests/unit/applications/test_wizard.py
@@ -1,5 +1,36 @@
+from django.utils import timezone
+
 from applications.form_specs import form_specs
 from applications.wizard import Wizard
+
+from ...factories import ResearcherRegistrationFactory
+
+
+def test_is_valid_false(complete_application):
+    wizard = Wizard(complete_application, form_specs)
+
+    # create a ResearcherRegistration with no values so we know the wizard is
+    # invalid because of that and not the application and its pages.
+    ResearcherRegistrationFactory(application=complete_application)
+
+    assert not wizard.is_valid()
+
+
+def test_is_valid(complete_application):
+    wizard = Wizard(complete_application, form_specs)
+    ResearcherRegistrationFactory(
+        application=complete_application,
+        name="ben",
+        email="ben@example.com",
+        job_title="The Boss",
+        does_researcher_need_server_access=True,
+        telephone="07777777777",
+        phone_type="iphone",
+        has_taken_safe_researcher_training=True,
+        training_with_org="Oxford",
+        training_passed_at=timezone.now(),
+    )
+    assert wizard.is_valid()
 
 
 def test_get_next_page_key_for_complete_application(complete_application):


### PR DESCRIPTION
This adds researchers to the confirmation page, including validating them.  I've added a second researcher form, subclassing the one used on the add/edit researcher pages, which adds validation for the submission of the application.  We're displaying errors from that by treating the confirmation page like the `form_invalid` method of a GCBV (so rendering an invalid bound form).

This lets gives us a few benefits:
* stick to common error presentation methods (eg `{% if form.field.errors %}`)
* make use of form_instance.is_valid()
* avoid having to re-specify the fields necessary for the form
* add validation for this page without impacting the add/edit researcher pages
