### PR TITLE
Identify applications by reference number

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -3,6 +3,8 @@ from django.db import models
 from django.urls import reverse
 from django.utils import timezone
 
+from jobserver import hash_utils
+
 
 YES_NO_CHOICES = [
     (True, "Yes"),
@@ -30,13 +32,18 @@ class Application(models.Model):
     completed_at = models.DateTimeField(null=True)
 
     def __str__(self):
-        return f"Application {self.pk} by {self.created_by.name}"
+        return f"Application {self.pk_hash} by {self.created_by.name}"
+
+    @property
+    def pk_hash(self):
+        """Return the short hash identifying this Application."""
+        return hash_utils.hash(self.pk)
 
     def get_absolute_url(self):
-        return reverse("applications:detail", kwargs={"pk": self.pk})
+        return reverse("applications:detail", kwargs={"pk_hash": self.pk_hash})
 
     def get_staff_url(self):
-        return reverse("staff:application-detail", kwargs={"pk": self.pk})
+        return reverse("staff:application-detail", kwargs={"pk_hash": self.pk_hash})
 
     @property
     def is_study_research(self):
@@ -215,11 +222,11 @@ class ResearcherRegistration(models.Model):
     def get_delete_url(self):
         return reverse(
             "applications:researcher-delete",
-            kwargs={"pk": self.application.pk, "researcher_pk": self.pk},
+            kwargs={"pk_hash": self.application.pk_hash, "researcher_pk": self.pk},
         )
 
     def get_edit_url(self):
         return reverse(
             "applications:researcher-edit",
-            kwargs={"pk": self.application.pk, "researcher_pk": self.pk},
+            kwargs={"pk_hash": self.application.pk_hash, "researcher_pk": self.pk},
         )

--- a/applications/urls.py
+++ b/applications/urls.py
@@ -35,12 +35,12 @@ urlpatterns = [
     path("apply/sign-in", sign_in, name="sign-in"),
     path("apply/terms/", terms, name="terms"),
     path("applications/", ApplicationList.as_view(), name="list"),
-    path("applications/<int:pk>/", PageRedirect.as_view(), name="detail"),
-    path("applications/<int:pk>/page/<str:key>/", page, name="page"),
+    path("applications/<str:pk_hash>/", PageRedirect.as_view(), name="detail"),
+    path("applications/<str:pk_hash>/page/<str:key>/", page, name="page"),
     path(
-        "applications/<int:pk>/confirmation/",
+        "applications/<str:pk_hash>/confirmation/",
         Confirmation.as_view(),
         name="confirmation",
     ),
-    path("applications/<int:pk>/researchers/", include(researcher_urls)),
+    path("applications/<str:pk_hash>/researchers/", include(researcher_urls)),
 ]

--- a/applications/wizard.py
+++ b/applications/wizard.py
@@ -162,8 +162,10 @@ class WizardPage:
 
     def redirect_to_next_page(self):
         if (next_page_key := self.wizard.get_next_page_key(self.key)) is None:
-            return redirect("applications:confirmation", pk=self.application.pk)
+            return redirect(
+                "applications:confirmation", pk_hash=self.application.pk_hash
+            )
         else:
             return redirect(
-                "applications:page", pk=self.application.pk, key=next_page_key
+                "applications:page", pk_hash=self.application.pk_hash, key=next_page_key
             )

--- a/jobserver/hash_utils.py
+++ b/jobserver/hash_utils.py
@@ -1,0 +1,116 @@
+"""Provides a pair of methods for converting between sequential IDs and random-looking
+hex strings.
+
+>>> for m in range(5):
+...   print(hash(m))
+...
+0000
+1edd
+3dba
+5c97
+7b74
+>>> for m in range(16 ** 4):
+...   assert unhash(hash(m)) == m
+...
+>>>
+
+Implementation is based on modular multiplicative inverses, as described in
+https://stackoverflow.com/a/38240325.
+
+To produce a string of length l, we find N = 16 ** l.
+
+Then, for odd k, for every m between 0 and N - 1, we can map m to m_hash:
+
+    m_hash = (m * k) % N.
+
+Each m maps to a different m_hash, and so we can unambigously map from m_hash to m:
+
+    m = (m_hash * inv_k) % N
+
+where inv_k is the multiplicative inverse of k modulo N:
+
+    inv_k = pow(k, -1, N)
+
+To convert m_hash to a string of length l, we convert it to a hex value and then right
+pad it with zeros.
+
+The following output should demonstrate how this works in practice:
+
+>>> l = 4
+>>> N = 16 ** l
+>>> N
+65536
+>>> k = 999
+>>> inv_k = pow(k, -1, N)
+>>> inv_k
+24535
+>>>
+>>> m = 1181
+>>> m_hash = (m * k) % N
+>>> m_hash
+171
+>>> (m_hash * inv_k) % N
+1181
+>>> (m_hash * inv_k) % N == m
+True
+>>>
+>>> hex(m_hash)
+'0xab'
+>>> h = hex(m_hash)[2:].rjust(l, "0")
+>>> h
+'00ab'
+>>> int(h, 16)
+171
+>>> int(h, 16) == m_hash
+True
+"""
+
+from django.http import Http404
+
+
+# Sensible defaults.  There are 2 ** 16 unique hex strings of length 4.  This is
+# probably enough for things like project applications.  (Using up 1 string per day will
+# last ~180 years.)
+DEFAULT_LENGTH = 4
+DEFAULT_KEY = 7901
+
+
+def hash(m, length=DEFAULT_LENGTH, key=DEFAULT_KEY):  # noqa: A001
+    """Hash integer m to give a string."""
+
+    N = 16 ** length
+    assert key % 2 == 1
+
+    if not 0 <= m < N:
+        raise ValueError(f"Input m ({m}) must satisfy 0 <= m < {N}")
+
+    m_hash = (m * key) % N
+    assert 0 <= m_hash < N
+
+    return hex(m_hash)[2:].rjust(length, "0")
+
+
+def unhash(h, length=DEFAULT_LENGTH, key=DEFAULT_KEY):
+    """Unhash string h to give an integer."""
+
+    N = 16 ** length
+    assert key % 2 == 1
+
+    if len(h) != length:
+        raise ValueError(f"Input h ({h}) must be {length} characters long")
+
+    inv_key = pow(key, -1, N)
+
+    m_hash = int(h, 16)
+    assert 0 <= m_hash < N
+
+    return (m_hash * inv_key) % N
+
+
+def unhash_or_404(h, length=DEFAULT_LENGTH, key=DEFAULT_KEY):
+    """Unhash string h, raising 404 if h is invalid."""
+
+    try:
+        return unhash(h, length, key)
+    except ValueError:
+        raise Http404

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -20,7 +20,7 @@ app_name = "staff"
 
 application_urls = [
     path("", ApplicationList.as_view(), name="application-list"),
-    path("<int:pk>/", ApplicationDetail.as_view(), name="application-detail"),
+    path("<str:pk_hash>/", ApplicationDetail.as_view(), name="application-detail"),
 ]
 
 backend_urls = [

--- a/tests/unit/applications/test_models.py
+++ b/tests/unit/applications/test_models.py
@@ -8,7 +8,9 @@ def test_application_get_absolute_url():
 
     url = application.get_absolute_url()
 
-    return url == reverse("applications:detail", kwargs={"pk": application.pk})
+    return url == reverse(
+        "applications:detail", kwargs={"pk_hash": application.pk_hash}
+    )
 
 
 def test_application_get_staff_url():
@@ -16,14 +18,16 @@ def test_application_get_staff_url():
 
     url = application.get_staff_url()
 
-    return url == reverse("staff:application-detail", kwargs={"pk": application.pk})
+    return url == reverse(
+        "staff:application-detail", kwargs={"pk_hash": application.pk_hash}
+    )
 
 
 def test_application_str():
     user = UserFactory(first_name="Ben", last_name="Seb")
     application = ApplicationFactory(created_by=user)
 
-    assert str(application) == f"Application {application.pk} by Ben Seb"
+    assert str(application) == f"Application {application.pk_hash} by Ben Seb"
 
 
 def test_researcherregistration_get_delete_url():
@@ -33,7 +37,10 @@ def test_researcherregistration_get_delete_url():
 
     assert url == reverse(
         "applications:researcher-delete",
-        kwargs={"pk": researcher.application.pk, "researcher_pk": researcher.pk},
+        kwargs={
+            "pk_hash": researcher.application.pk_hash,
+            "researcher_pk": researcher.pk,
+        },
     )
 
 
@@ -44,7 +51,10 @@ def test_researcherregistration_get_edit_url():
 
     assert url == reverse(
         "applications:researcher-edit",
-        kwargs={"pk": researcher.application.pk, "researcher_pk": researcher.pk},
+        kwargs={
+            "pk_hash": researcher.application.pk_hash,
+            "researcher_pk": researcher.pk,
+        },
     )
 
 

--- a/tests/unit/jobserver/test_hash_utils.py
+++ b/tests/unit/jobserver/test_hash_utils.py
@@ -1,0 +1,47 @@
+import pytest
+from django.http import Http404
+
+from jobserver import hash_utils
+
+
+def test_roundtrip_1():
+    # Verify that for every integer between 0 and 65535, hashing the integer and
+    # unhashing the result returns the same integer.
+    for m in range(2 ** 16):
+        assert hash_utils.unhash(hash_utils.hash(m)) == m
+
+
+def test_roundtrip_2():
+    # Verify that for every hash string between "0000" and "ffff", unhashing the has and
+    # hashing the result returns the same string.
+    for m_hash in range(2 ** 16):
+        # Construct a hash from an integer.  For the meaning of m_hash and h, see module
+        # docstring in hash_utils.py.
+        h = hex(m_hash)[2:].rjust(4, "0")
+        assert hash_utils.hash(hash_utils.unhash(h)) == h
+
+
+def test_invalid_hash_input():
+    with pytest.raises(ValueError):
+        hash_utils.hash(-1)
+
+    with pytest.raises(ValueError):
+        hash_utils.hash(2 ** 16 + 1)
+
+
+def test_invalid_unhash_input():
+    with pytest.raises(ValueError):
+        hash_utils.unhash("123")
+
+    with pytest.raises(ValueError):
+        hash_utils.unhash("12345")
+
+    with pytest.raises(ValueError):
+        hash_utils.unhash("WXYZ")
+
+
+def test_unhash_or_404():
+    assert hash_utils.unhash_or_404("0000") == 0
+
+    with pytest.raises(Http404):
+        hash_utils.unhash_or_404("WXYZ")

--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -20,7 +20,7 @@ def test_applicationdetail_success_with_complete_application(
     request = rf.get("/")
     request.user = core_developer
 
-    response = ApplicationDetail.as_view()(request, pk=application.pk)
+    response = ApplicationDetail.as_view()(request, pk_hash=application.pk_hash)
 
     assert response.status_code == 200
     assert response.context_data["pages"][0]["title"] == "Contact details"
@@ -40,7 +40,7 @@ def test_applicationdetail_success_with_incomplete_application(
     request = rf.get("/")
     request.user = core_developer
 
-    response = ApplicationDetail.as_view()(request, pk=application.pk)
+    response = ApplicationDetail.as_view()(request, pk_hash=application.pk_hash)
 
     assert response.status_code == 200
     assert response.context_data["pages"][0]["title"] == "Contact details"
@@ -54,7 +54,7 @@ def test_applicationdetail_with_unknown_user(rf, core_developer):
     request.user = core_developer
 
     with pytest.raises(Http404):
-        ApplicationDetail.as_view()(request, pk=0)
+        ApplicationDetail.as_view()(request, pk_hash="0000")
 
 
 def test_applicationdetail_without_core_dev_role(rf):
@@ -64,7 +64,7 @@ def test_applicationdetail_without_core_dev_role(rf):
     request.user = UserFactory()
 
     with pytest.raises(PermissionDenied):
-        ApplicationDetail.as_view()(request, pk=application.pk)
+        ApplicationDetail.as_view()(request, pk_hash=application.pk_hash)
 
 
 def test_applicationdetail_post_with_complete_application(
@@ -90,7 +90,7 @@ def test_applicationdetail_post_with_complete_application(
     request = rf.post("/", data)
     request.user = core_developer
 
-    response = ApplicationDetail.as_view()(request, pk=application.pk)
+    response = ApplicationDetail.as_view()(request, pk_hash=application.pk_hash)
 
     assert response.status_code == 302
 
@@ -131,7 +131,7 @@ def test_applicationdetail_post_with_incomplete_application(
     request = rf.post("/", data)
     request.user = core_developer
 
-    response = ApplicationDetail.as_view()(request, pk=application.pk)
+    response = ApplicationDetail.as_view()(request, pk_hash=application.pk_hash)
 
     assert response.status_code == 302
 


### PR DESCRIPTION
Each application is given a reference number.  This is a four-digit hex
code, which is a reversable hash of the primary key.

This is currently only used in URLs (changing eg /applications/1/ to
/applications/1edd/), but should be made visible in the UI so that users
and reviewers can user the reference number in conversation.