### PR TITLE
Mark Required Fields on Confirmation Page

### DIFF
--- a/applications/form_spec_helpers.py
+++ b/applications/form_spec_helpers.py
@@ -7,6 +7,8 @@ from django.db.models import Model
 
 from applications.models import Application
 
+from .utils import value_for_presentation
+
 
 @dataclass
 class Form:
@@ -107,9 +109,10 @@ class Field:
         return context
 
     def review_context(self, page_instance):
+        value = value_for_presentation(self.value(page_instance))
         return {
             "label": self.label,
-            "value": self.value(page_instance),
+            "value": value,
             "is_valid": self.is_valid(page_instance),
         }
 

--- a/applications/form_specs.py
+++ b/applications/form_specs.py
@@ -160,11 +160,11 @@ form_specs = [
                 ],
             ),
             Fieldset(
-                label="Are you requesting record level data?",
+                label="",
                 fields=[
                     Field(
                         name="need_record_level_data",
-                        label="",
+                        label="Are you requesting record level data?",
                     ),
                 ],
             ),
@@ -300,11 +300,11 @@ form_specs = [
         rubric="",
         fieldsets=[
             Fieldset(
-                label="Is your research on the CMO Priority list?",
+                label="",
                 fields=[
                     Field(
                         name="is_on_cmo_priority_list",
-                        label="",
+                        label="Is your research on the CMO Priority list?",
                         help_text=snippet("is_on_cmo_priority_list_help_text"),
                     ),
                 ],
@@ -421,11 +421,11 @@ form_specs = [
                 ],
             ),
             Fieldset(
-                label="Have all applicants for OpenSAFELY access completed the Getting Started tutorial?",
+                label="",
                 fields=[
                     Field(
                         name="all_applicants_completed_getting_started",
-                        label="",
+                        label="Have all applicants for OpenSAFELY access completed the Getting Started tutorial?",
                         help_text=snippet("14-fieldset0-field1-help_text"),
                     ),
                 ],

--- a/applications/templates/applications/confirmation.html
+++ b/applications/templates/applications/confirmation.html
@@ -20,7 +20,10 @@
 
       {% for field in fieldset.fields %}
       <dl class="row mb-1">
-        <dt class="col-6 mb-2">{{ field.label }}</dt>
+        <dt class="col-6 mb-2{% if not field.is_valid %} text-danger{% endif %}">
+          {{ field.label }}
+          {% if not field.is_valid %}*{% endif %}
+        </dt>
         <dd class="col-6">{{ field.value }}</dd>
       </dl>
       {% endfor %}

--- a/applications/templates/applications/page.html
+++ b/applications/templates/applications/page.html
@@ -81,9 +81,11 @@
 
         {% for fieldset in fieldsets %}
           <fieldset class="d-flex flex-column mb-4 {% if not forloop.last %}pb-4 border-bottom{% endif %}">
+            {% if fieldset.label %}
             <legend class="mb-0">
               <h2 class="h3 mb-3">{{ fieldset.label }}</h2>
             </legend>
+            {% endif %}
             {% for field in fieldset.fields %}
               {% include field.template_name with field=field.field label=field.label name=field.name extra_attributes=field.attributes %}
             {% endfor %}

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -1,0 +1,15 @@
+from django.template.defaultfilters import yesno
+
+
+def value_for_presentation(value):
+    """Convert a value ready for presentation in a template"""
+    # we only deal with values that are the literals True, False, & None
+    # currently.
+    if value not in [True, False, None]:
+        return value
+
+    # Use Django's yesno template filter to map:
+    #  * True->Yes
+    #  * False->No
+    #  * None->"" (empty string)
+    return yesno(value, "Yes,No,")

--- a/jobserver/templates/components/form_radio.html
+++ b/jobserver/templates/components/form_radio.html
@@ -1,3 +1,4 @@
+<h2 class="h3 mb-3">{{ label }}</h2>
 <div class="form-group mb-0">
   {% for value, label in field.field.choices %}
   <div class="custom-control custom-radio mb-1">

--- a/tests/unit/applications/test_utils.py
+++ b/tests/unit/applications/test_utils.py
@@ -1,0 +1,16 @@
+import pytest
+
+from applications.utils import value_for_presentation
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, "Yes"),
+        (False, "No"),
+        (None, ""),
+        ("test", "test"),
+    ],
+)
+def test_value_for_presentation(value, expected):
+    assert value_for_presentation(value) == expected


### PR DESCRIPTION
This sets field labels to red and suffixes them with an `*` to denote they are required.

We haven't set labels for the yes/no radio fields previously so this switches them from using fieldset titles to field titles.

It also adds a helper for True/False/None values so we can display meaningful values in the templates.