### PR TITLE
Remove form URLs from robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,7 +1,5 @@
 User-agent: *
 Disallow: /api/
-Disallow: /applications/
-Disallow: /apply/
 Disallow: /complete/
 Disallow: /disconnect/
 Disallow: /login/

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Disallow: /api/
+Disallow: /applications/
 Disallow: /complete/
 Disallow: /disconnect/
 Disallow: /login/


### PR DESCRIPTION
So that search engines can index the form start page.