### PR TITLE
Tidy up Application List

### DIFF
--- a/applications/templates/applications/application_list.html
+++ b/applications/templates/applications/application_list.html
@@ -50,7 +50,7 @@
   </div>
   {% else %}
   <p class="lead">
-    There are no projects for this organisation yet.
+    You have no applications, <a href="{% url 'applications:start' %}">apply</a> to start one.
   </p>
   {% endif %}
 </article>

--- a/applications/views.py
+++ b/applications/views.py
@@ -45,6 +45,7 @@ def get_next_url(get_args):
         return reverse("applications:list")
 
 
+@method_decorator(login_required, name="dispatch")
 class ApplicationList(ListView):
     context_object_name = "applications"
     template_name = "applications/application_list.html"


### PR DESCRIPTION
This requires users are logged in when viewing the application list page, since we use the current user to get their applications, and applies a better message when there are no applications to view.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/L1uexlb6/985d9097-7979-4974-bedf-8a3548987c37.jpg?v=212b805e057c8b4f02ec7db7e0e35184)