### PR TITLE
Fix review details on staff review page

### DIFF
--- a/staff/templates/staff/application_detail.html
+++ b/staff/templates/staff/application_detail.html
@@ -77,8 +77,8 @@
             {% include "components/form_textarea.html" with name=page.wizard_page.notes_field_name label="Notes" field=page.wizard_page.get_unbound_approval_form.notes %}
             {% include "components/form_radio.html" with name=page.wizard_page.is_approved_field_name label="Approved?" field=page.wizard_page.get_unbound_approval_form.is_approved %}
             <ul>
-              <li>Last reviewed at: {{ page.wizard_page.instance.last_reviewed_at|default_if_none:"Never"}}</li>
-              <li>Last reviewed by: {{ page.wizard_page.instance.reviewed_by|default_if_none:"Not yet reviewed"}}</li>
+              <li>Last reviewed at: {{ page.wizard_page.page_instance.last_reviewed_at|default_if_none:"Never"}}</li>
+              <li>Last reviewed by: {{ page.wizard_page.page_instance.reviewed_by|default_if_none:"Not yet reviewed"}}</li>
             </ul>
           {% else %}
           <p>User has not started this page</p>


### PR DESCRIPTION
Following change in 9261afbb09f4573f4a8167bd259c0e160173f652 which
renamed `instance` to `page_instance`.