### PR TITLE
Application Fixes

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -21,6 +21,9 @@ from .wizard import Wizard
 
 
 def notify_slack(application, msg):
+    if settings.DEBUG:
+        return
+
     f = furl(settings.BASE_URL)
     f.path = application.get_staff_url()
     slack_client.chat_postMessage(

--- a/staff/views/applications.py
+++ b/staff/views/applications.py
@@ -20,6 +20,7 @@ class ApplicationDetail(View):
         pages = [page.review_context() for page in wizard.get_pages()]
 
         ctx = {
+            "application": application,
             "researchers": application.researcher_registrations.order_by("created_at"),
             "pages": pages,
         }

--- a/tests/unit/applications/test_views.py
+++ b/tests/unit/applications/test_views.py
@@ -14,6 +14,7 @@ from applications.views import (
     ResearcherDelete,
     ResearcherEdit,
     get_next_url,
+    notify_slack,
     page,
     sign_in,
     terms,
@@ -107,6 +108,15 @@ def test_getnexturl_without_next_arg(rf):
     output = get_next_url(request.GET)
 
     assert output == reverse("applications:list")
+
+
+def test_notify_slack_not_called_in_debug_mode(mocker, settings):
+    mocked_slack = mocker.patch("applications.views.slack_client", autospec=True)
+    settings.DEBUG = True
+
+    assert notify_slack(ApplicationFactory(), "test") is None
+
+    assert mocked_slack.chat_postMessage.call_count == 0
 
 
 def test_pageredirect_success(rf):


### PR DESCRIPTION
* Add `application` instances to context on staff Application detail page
* Don't notifiy slack of new or submitte applications in debug mode