### PR TITLE
Turn migrations back on during deploys

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 ./manage.py check --deploy
-# ./manage.py migrate
+./manage.py migrate
 ./manage.py ensure_admins
 ./manage.py collectstatic --no-input
 


### PR DESCRIPTION
This re-enables migrations during deploys and can only be merged and deployed once #1173 has been merged&deployed, and the migrations fixed in production.