### PR TITLE
Ignore More Directories in Black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,21 @@
 exclude = '''
 (
   /(
-      \.git         # exclude a few common directories in the
-    | \.direnv
+      \.direnv
+    | \.git
+    | \.github
+    | \.ipynb_checkpoints
+    | \.pytest_cache
     | \.venv
+    | assets
+    | coverage
+    | htmlcov
+    | node_modules
+    | outputs
+    | releases
+    | snippets
+    | static
+    | staticfiles
     | venv
   )/
 )


### PR DESCRIPTION
This adds a selection of directories we don't want black to traverse into when looking for files to check/fix.