### PR TITLE
Reinstate ensuring admins now we've migrated

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ./manage.py check --deploy
 ./manage.py migrate
-# ./manage.py ensure_admins
+./manage.py ensure_admins
 ./manage.py collectstatic --no-input
 
 exec "$@"


### PR DESCRIPTION
This was disabled as part of #1184 so the deploy of that branch wouldn't fail due to an empty database.