### PR TITLE
Redirect From Login When Already Logged In

### DIFF
--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import SuspiciousOperation
+from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.views.defaults import bad_request
@@ -12,10 +13,13 @@ from ..utils import is_safe_path
 
 def login_view(request):
     next_url = request.GET.get("next", "/")
-    if is_safe_path(next_url):
-        return TemplateResponse(request, "login.html", {"next_url": next_url})
-    else:
+    if not is_safe_path(next_url):
         return bad_request(request, SuspiciousOperation)
+
+    if request.user.is_authenticated:
+        return redirect(next_url)
+
+    return TemplateResponse(request, "login.html", {"next_url": next_url})
 
 
 @method_decorator(login_required, name="dispatch")

--- a/tests/unit/jobserver/views/test_users.py
+++ b/tests/unit/jobserver/views/test_users.py
@@ -30,6 +30,26 @@ def test_login_unsafe_path(rf):
     assert response.status_code == 400
 
 
+def test_login_already_logged_with_next_url(rf):
+    request = rf.get("/?next=/next-url/")
+    request.user = UserFactory()
+
+    response = login_view(request)
+
+    assert response.status_code == 302
+    assert response.url == "/next-url/"
+
+
+def test_login_already_logged_with_no_next_url(rf):
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    response = login_view(request)
+
+    assert response.status_code == 302
+    assert response.url == "/"
+
+
 def test_settings_get(rf):
     UserFactory()
     user2 = UserFactory()


### PR DESCRIPTION
This redirects already logged in Users to either the contents of the `next` query arg or `/` on the login page.

Fixes #1088