### PR TITLE
Display first run date for repos

### DIFF
--- a/assets/src/js/tablesorter.js
+++ b/assets/src/js/tablesorter.js
@@ -16,6 +16,7 @@ $(() => {
         "form-control",
         "form-control",
         "form-control",
+        "form-control",
       ],
     },
   });

--- a/staff/templates/staff/repo_list.html
+++ b/staff/templates/staff/repo_list.html
@@ -37,6 +37,7 @@
           <thead>
             <tr>
               <th>Created</th>
+              <th>First Run</th>
               <th>Repo</th>
               <th>Workspace</th>
               <th>Project</th>
@@ -46,6 +47,7 @@
             {% for repo in repos %}
             <tr>
               <td class="text-nowrap">{{ repo.created_at|date:"d M Y" }}</td>
+              <td class="text-nowrap">{{ repo.workspace.first_run|date:"d M Y" }}</td>
               <td><a href="{{ repo.url }}">{{ repo.name }}</a></td>
               <td><a href="{{ repo.workspace.get_staff_url }}">{{ repo.workspace.name }}</a></td>
               <td><a href="{{ repo.workspace.project.get_staff_url }}">{{ repo.workspace.project.name }}</a></td>

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -1,6 +1,11 @@
+from datetime import datetime
+
+from django.db.models import Min
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import View
+from first import first
+from pytz import utc
 
 from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_role
@@ -15,9 +20,57 @@ class RepoList(View):
 
         private_repos = [repo for repo in all_repos if repo["is_private"]]
 
-        repo_lut = {w.repo: w for w in Workspace.objects.select_related("project")}
+        # get workspaces with the first run job started_at annotated on
+        workspaces = Workspace.objects.select_related("project").annotate(
+            first_run=Min("job_requests__jobs__started_at")
+        )
 
-        repos = [r | {"workspace": repo_lut.get(r["url"], None)} for r in private_repos]
+        # build up a list of dicts with repo URL and the first started_at date
+        # as keys alongside the workspace.  This allows us to order by
+        # first_run below.
+        workspaces = [
+            {
+                "first_run": w.first_run,
+                "repo": w.repo,
+                "workspace": w,
+            }
+            for w in workspaces
+        ]
+
+        def sort_by_first_run(w):
+            if w["first_run"] is not None:
+                return w["first_run"]
+
+            # sorted won't compare NoneType and datetime, rightly so, but
+            # we want Nones pushed to the end of our list so we sort them
+            # by a date in the far flung future.  Should this code still be
+            # running on that date, sorry!
+            return datetime(9999, 1, 1, tzinfo=utc)
+
+        workspaces = sorted(workspaces, key=sort_by_first_run)
+
+        def merge_data(repo):
+            """
+            Merge our workspace and first run data with the data from GitHub
+
+            Repos aren't unique to a workspace.  At the time of writing ~2/3 of
+            repo URLs were duplicates, but we only care about the first time
+            repo code was executed against patient data.
+
+            Since the workspaces list has been ordered by the first started_at
+            date of any Job in the Workspace we can use first() to find the
+            first occurance of a repo URL based on Job.started_at.
+            """
+            workspace = first(workspaces, key=lambda w: w["repo"] == repo["url"])
+
+            if workspace is not None:
+                # extract the workspace object from our wrapper dictionary
+                workspace = workspace["workspace"]
+
+            # merge GitHub and our Workspace
+            return repo | {"workspace": workspace}
+
+        repos = list(merge_data(r) for r in private_repos)
         repos = sorted(repos, key=lambda r: r["created_at"])
 
         return TemplateResponse(request, "staff/repo_list.html", {"repos": repos})

--- a/tests/unit/staff/views/test_repos.py
+++ b/tests/unit/staff/views/test_repos.py
@@ -2,8 +2,31 @@ from django.utils import timezone
 
 from staff.views.repos import RepoList
 
+from ....factories import JobFactory, JobRequestFactory, WorkspaceFactory
+from ....utils import minutes_ago
+
 
 def test_workspacelist_success(rf, core_developer, mocker):
+    now = timezone.now()
+
+    workspace1 = WorkspaceFactory(repo="https://github.com/opensafely-core/job-server")
+    jr_1 = JobRequestFactory(workspace=workspace1)
+    JobFactory(job_request=jr_1, started_at=minutes_ago(now, 3))
+    JobFactory(job_request=jr_1, started_at=minutes_ago(now, 2))
+    JobFactory(job_request=jr_1, started_at=minutes_ago(now, 1))
+
+    workspace2 = WorkspaceFactory(repo="https://github.com/opensafely-core/job-runner")
+    jr_2 = JobRequestFactory(workspace=workspace2)
+    JobFactory(job_request=jr_2, started_at=minutes_ago(now, 2))
+
+    workspace3 = WorkspaceFactory(repo="https://github.com/opensafely-core/job-server")
+    jr_3 = JobRequestFactory(workspace=workspace3)
+    JobFactory(job_request=jr_3, started_at=minutes_ago(now, 10))
+
+    workspace4 = WorkspaceFactory(repo="https://github.com/opensafely-core/job-server")
+    jr_4 = JobRequestFactory(workspace=workspace4)
+    JobFactory(job_request=jr_4, started_at=None)
+
     request = rf.get("/")
     request.user = core_developer
 
@@ -12,15 +35,32 @@ def test_workspacelist_success(rf, core_developer, mocker):
         autospec=True,
         return_value=[
             {
+                "name": "job-runner",
+                "url": "https://github.com/opensafely-core/job-runner",
+                "is_private": True,
+                "created_at": timezone.now(),
+            },
+            {
+                "name": "job-server",
+                "url": "https://github.com/opensafely-core/job-server",
+                "is_private": True,
+                "created_at": timezone.now(),
+            },
+            {
                 "name": "test",
                 "url": "test",
                 "is_private": True,
                 "created_at": timezone.now(),
-            }
+            },
         ],
     )
 
     response = RepoList.as_view()(request)
 
     assert response.status_code == 200
-    assert len(response.context_data["repos"]) == 1
+
+    job_runner, job_server, _ = sorted(
+        response.context_data["repos"], key=lambda r: r["name"]
+    )
+    assert job_runner["workspace"].first_run == minutes_ago(now, 2)
+    assert job_server["workspace"].first_run == minutes_ago(now, 10)


### PR DESCRIPTION
Add a "first run" column to the repos list page, showing the first time a job was _started_ for a related workspace.

The rather involved implementation in the view deals with our repos being non-unique to workspaces, and this page needs to know about the first time any code from a repo was run in a research backend.  I've heavily commented it, hopefully explaining the situation well enough for fresh eyes.