### PR TITLE
Install Postgres Client Tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,11 @@ ENV PIP_NO_CACHE_DIR=1 \
 
 WORKDIR /app
 
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y postgresql-client=13+225 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Only requirements to cache them in docker layer so we can skip package
 # installation if they haven't changed
 COPY requirements.prod.txt .


### PR DESCRIPTION
This bumps our base images to Debian Bullseye so we can install the Postgres 13 (instead of 11) tools so psql, pg_dump, and pg_restore are available in production.

I've kept the two base images on the same debian base image on the assumption that it will reduce debugging down the line.

Fixes #1196 