### PR TITLE
Link to User in Application Slack Notifcations

### DIFF
--- a/tests/unit/applications/test_views.py
+++ b/tests/unit/applications/test_views.py
@@ -114,7 +114,7 @@ def test_notify_slack_not_called_in_debug_mode(mocker, settings):
     mocked_slack = mocker.patch("applications.views.slack_client", autospec=True)
     settings.DEBUG = True
 
-    assert notify_slack(ApplicationFactory(), "test") is None
+    assert notify_slack(ApplicationFactory(), UserFactory(), "test") is None
 
     assert mocked_slack.chat_postMessage.call_count == 0
 


### PR DESCRIPTION
This adds in a link to the UserDetail page of an Application's creator when notifying slack about the application:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/z8u1xD07/17ee6f6f-5bc9-44a1-a3b7-5fbc19d31c9f.jpg?v=1001744477be6f44bacf2edf171f9462)

Fixes #1205 