### PR TITLE
Coerce Bools and Strings for YesNoField

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -21,11 +21,43 @@ class PageFormBase(forms.ModelForm):
                 self.fields[name] = YesNoField()
 
 
+def coerce_to_bool(value):
+    """
+    Coerce the given value to a boolean
+
+    Expects a boolean, or a string with the values:
+        * true
+        * True
+        * false
+        * False
+
+    Field.has_changed() calls this function with the initial value of the field
+    when testing if it has changed.  Since this is used with YesNoField this
+    means initial will be a boolean value.  It also guards against unexpected
+    strings since it's parsing POST data.
+    """
+    if isinstance(value, bool):
+        return value
+
+    if not isinstance(value, str):
+        msg = f'"{value}" was of type {type(value).__name__}, expected bool or string'
+        raise TypeError(msg)
+
+    if value.lower() == "true":
+        return True
+
+    if value.lower() == "false":
+        return False
+
+    msg = f'Expected string value to be one of: true, True, false, or False, got "{value}"'
+    raise ValueError(msg)
+
+
 class YesNoField(forms.TypedChoiceField):
     def __init__(self, *args, **kwargs):
         super().__init__(
             choices=YES_NO_CHOICES,
-            coerce=lambda x: x == "True",
+            coerce=coerce_to_bool,
             empty_value=None,
             required=False,
             widget=forms.RadioSelect,

--- a/tests/unit/applications/test_forms.py
+++ b/tests/unit/applications/test_forms.py
@@ -1,6 +1,37 @@
+import pytest
 from django import forms
 
-from applications.forms import ResearcherRegistrationSubmissionForm, YesNoField
+from applications.forms import (
+    ResearcherRegistrationSubmissionForm,
+    YesNoField,
+    coerce_to_bool,
+)
+
+
+def test_coerce_with_booleans():
+    assert coerce_to_bool(True)
+    assert not coerce_to_bool(False)
+
+
+def test_coerce_with_expected_strings():
+    assert coerce_to_bool("true")
+    assert coerce_to_bool("True")
+    assert not coerce_to_bool("false")
+    assert not coerce_to_bool("False")
+
+
+def test_coerce_with_incorrect_type():
+    msg = '^"3" was of type int, expected bool or string$'
+    with pytest.raises(TypeError, match=msg):
+        coerce_to_bool(3)
+
+
+def test_coerce_with_unexpected_string():
+    msg = (
+        '^Expected string value to be one of: true, True, false, or False, got "test"$'
+    )
+    with pytest.raises(ValueError, match=msg):
+        coerce_to_bool("test")
 
 
 def test_required_fields():


### PR DESCRIPTION
This lets us submit `"False"` ("No" in the UI) for a YesNoField and use `form.has_changed()`.  Previously the check to see if value was the string `"True"` meant we returned the boolean `False` for boolean values, even though our initial data was `True` we got `False` back, which matched the coercion of `"False"` -> `False`, so the field thought it hadn't changed.

This also has guards against unexpected data types and values to help users debug problems should they arise in the future.

Fixes #1190