### PR TITLE
Release List Optimisations

### DIFF
--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -143,13 +143,15 @@ def workspace_files(workspace):
 
     Returns a mapping of the workspace-relative file name (which includes
     backend) to its RequestFile model.
-
-    We use Python to find the latest version of each file because SQLite
-    doesn't support DISTINCT ON so we can't use
-    `.distinct("release__created_at")`.
     """
+
+    files = (
+        workspace.files.select_related("release", "release__backend")
+        .order_by("name", "-release__created_at")
+        .distinct("name", "release__created_at")
+    )
     index = {}
-    for rfile in workspace.files.order_by("-release__created_at"):
+    for rfile in files:
         workspace_path = f"{rfile.release.backend.slug}/{rfile.name}"
         if workspace_path not in index:
             index[workspace_path] = rfile

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -283,7 +283,9 @@ class WorkspaceReleaseList(View):
                 "title": build_title(r),
                 "view_url": r.get_absolute_url(),
             }
-            for r in workspace.releases.order_by("-created_at")
+            for r in workspace.releases.select_related("created_by")
+            .prefetch_related("files")
+            .order_by("-created_at")
         ]
 
         context = {


### PR DESCRIPTION
After moving to Postgres the "list of releases" page for a Workspace suffered from some N+1 query issues. Locally, with 6 Releases, and the latest files item, it generated 3616 queries.

This removes the majority of query duplicates from the page.