### PR TITLE
More Query Optimisations

### DIFF
--- a/jobserver/templates/_release_list.html
+++ b/jobserver/templates/_release_list.html
@@ -39,7 +39,11 @@
             <td class="d-flex justify-content-between align-items-center">
 
               <div>
-                <a href="{{ file.get_absolute_url }}" {% if file.is_deleted %}class="btn-link disabled"{% endif %}>
+                <a href="{% url 'release-detail' org_slug=org_slug project_slug=project_slug workspace_slug=workspace_slug pk=r.id path=file.path %}"
+                  {% if file.is_deleted %}
+                  class="btn-link disabled"
+                  {% endif %}
+                  >
                   <code>{{ file.name }}</code>
                 </a>
 
@@ -52,7 +56,9 @@
               </div>
 
               {% if user_can_delete_files %}
-              <form method="POST" action="{{ file.get_delete_url }}">
+              <form method="POST"
+                action="{% url 'release-file-delete' org_slug=org_slug project_slug=project_slug workspace_slug=workspace_slug pk=r.id release_file_id=file.pk %}"
+                >
                 {% csrf_token %}
 
                 <button

--- a/jobserver/templates/project_release_list.html
+++ b/jobserver/templates/project_release_list.html
@@ -38,7 +38,7 @@
     </p>
 
     {% for release in releases %}
-    {% include "_release_list.html" with r=release %}
+    {% include "_release_list.html" with org_slug=project.org.slug project_slug=project.slug workspace_slug=release.workspace.name r=release %}
     {% endfor %}
 
   </div>

--- a/jobserver/templates/workspace_release_list.html
+++ b/jobserver/templates/workspace_release_list.html
@@ -50,11 +50,11 @@
 <div class="row">
   <div class="col-lg-8 offset-lg-2">
     {% if latest_files.can_view_files %}
-      {% include "_release_list.html" with r=latest_files %}
+      {% include "_release_list.html" with org_slug=workspace.project.org.slug project_slug=workspace.project.slug workspace_slug=workspace.name r=latest_files %}
     {% endif %}
 
     {% for release in releases %}
-      {% include "_release_list.html" with r=release %}
+      {% include "_release_list.html" with org_slug=workspace.project.org.slug project_slug=workspace.project.slug workspace_slug=workspace.name r=release %}
     {% endfor %}
   </div>
 </div>

--- a/tests/unit/jobserver/models/test_outputs.py
+++ b/tests/unit/jobserver/models/test_outputs.py
@@ -86,6 +86,26 @@ def test_releasefile_get_absolute_url():
     )
 
 
+def test_releasefile_get_delete_url():
+    files = {"file.txt": b"contents"}
+    release = ReleaseFactory(ReleaseUploadsFactory(files))
+
+    file = release.files.first()
+
+    url = file.get_delete_url()
+
+    assert url == reverse(
+        "release-file-delete",
+        kwargs={
+            "org_slug": release.workspace.project.org.slug,
+            "project_slug": release.workspace.project.slug,
+            "workspace_slug": release.workspace.name,
+            "pk": release.id,
+            "release_file_id": file.pk,
+        },
+    )
+
+
 def test_releasefile_ulid():
     release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
     rfile = release.files.first()


### PR DESCRIPTION
I somehow missed this round of optimisations on the same page as  #1236 

This is a tricky one, since both the Workspace and Project ReleaseList views are rendering N Releases _and_ N ReleaseFiles.  I couldn't find a way to tell Django to select_related the approrpiate objects for building URLs with the `get_FOO_url` methods of the ReleaseFiles.  This lead to every ReleaseFile on the page executing 2-3 extra queries.

I tried rebuilding WorkspaceReleaseList by getting all the ReleaseFiles for the Workspace, then grouping by Release using groupby, but hit the same issue because I wasn't passing QuerySets around again.

I suspect we might be able to break the view down but I have a feeling it will hurt readability and have already spent several hours on it.