### PR TITLE
Add Dump Database Command

### DIFF
--- a/jobserver/jobs/hourly/dump_db.py
+++ b/jobserver/jobs/hourly/dump_db.py
@@ -1,0 +1,39 @@
+import pathlib
+import subprocess
+import sys
+
+from django_extensions.management.jobs import HourlyJob
+from environs import Env
+
+
+env = Env()
+
+
+class Job(HourlyJob):
+    help = "Dump the database to storage for copying to local dev environments"  # noqa: A003
+
+    def execute(self):
+        database_url = env.str("DATABASE_URL")
+        output = pathlib.Path("/storage/jobserver.dump")
+
+        if not output.exists():
+            print(f"Unknown output path: {output}", file=sys.stderr)
+            sys.exit(1)
+
+        try:
+            with output.open() as f:
+                # We use the "custom" output format for pg_dump to get smaller
+                # files, the docs have more detail on why it can be useful:
+                # https://www.postgresql.org/docs/14/app-pgdump.html
+                subprocess.check_call(
+                    [
+                        "pg_dump",
+                        "--format=c",
+                        "--no-acl",
+                        "--no-owner",
+                        database_url,
+                    ],
+                    stdout=f,
+                )
+        except Exception as e:
+            sys.exit(e)


### PR DESCRIPTION
This adds a command to run pg_dump on our production database, putting it into the configured storage location for job-server in production.

This means developers can more easily copy down the production db for local work.