### PR TITLE
Validate Project Names on Application Approval

### DIFF
--- a/staff/forms.py
+++ b/staff/forms.py
@@ -48,6 +48,14 @@ class ApplicationApproveForm(forms.Form):
 
         self.fields["org"] = forms.ModelChoiceField(queryset=orgs)
 
+    def clean_project_name(self):
+        project_name = self.cleaned_data["project_name"]
+
+        if Project.objects.filter(name=project_name).exists():
+            raise forms.ValidationError(f'Project "{project_name}" already exists.')
+
+        return project_name
+
 
 class OrgAddMemberForm(PickUsersMixin, forms.Form):
     pass

--- a/tests/unit/staff/test_forms.py
+++ b/tests/unit/staff/test_forms.py
@@ -2,7 +2,7 @@ from jobserver.models import Backend
 from jobserver.utils import set_from_qs
 from staff.forms import ApplicationApproveForm, UserForm
 
-from ...factories import BackendFactory, OrgFactory
+from ...factories import BackendFactory, OrgFactory, ProjectFactory
 
 
 def test_applicationapproveform_success():
@@ -11,6 +11,18 @@ def test_applicationapproveform_success():
     form = ApplicationApproveForm({"project_name": "test project", "org": str(org.pk)})
 
     assert form.is_valid(), form.errors
+
+
+def test_applicationapproveform_with_duplicate_project_name():
+    org = OrgFactory()
+    project = ProjectFactory()
+
+    form = ApplicationApproveForm({"project_name": project.name, "org": str(org.pk)})
+
+    assert not form.is_valid()
+    assert form.errors == {
+        "project_name": [f'Project "{project.name}" already exists.']
+    }
 
 
 def test_userform_success():


### PR DESCRIPTION
This checks the Project name supplied during Application Approval is unique rather than throwing a 500.

Fixes #1249