### PR TITLE
Remove Custom GitHub Auth Backend

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -4,8 +4,6 @@ from datetime import datetime, timezone
 import requests
 from environs import Env
 from furl import furl
-from social_core.backends.github import GithubOAuth2
-from social_core.exceptions import AuthFailed
 
 
 env = Env()
@@ -283,47 +281,3 @@ def is_member_of_org(org, username):
         return False
 
     r.raise_for_status()
-
-
-class GithubOrganizationOAuth2(GithubOAuth2):
-    """Github OAuth2 authentication backend for organizations"""
-
-    no_member_string = "User doesn't belong to the organization"
-
-    # Mirror our initial Social Auth Backend choice (GithubOAuth2) provider's
-    # name because it's simpler than making a migration which modifies the
-    # UserSocialAuth table.  Our jobserver app defines a Custom User Model
-    # which social_django depends on in it's migrations dependency tree
-    # (because it FKs User).  This appears to make migrations hit a catch-22 in
-    # dependency resolution.  Rather than dig through the resolver, this is a
-    # much easier fix.
-    name = "github"
-
-    def user_data(self, access_token, *args, **kwargs):
-        """
-        Check the User is part of a configured GitHub Org
-
-        This is a near-complete reimplementation of GithubMemberOAuth2's
-        .user_data() which gets the correct URL from GithubOrganizationOAuth2's
-        .member_url().
-
-        We use our service-level PAT to avoid requesting further scopes from
-        the user (specifically admin:org) to make the call to the Org
-        membership endpoint.
-        """
-        user_data = super().user_data(access_token, *args, **kwargs)
-        username = user_data.get("login")
-
-        try:
-            for org in AUTHORIZATION_ORGS:
-                if is_member_of_org(org, username):
-                    return user_data  # succeed on the first valid org
-        except requests.HTTPError:
-            msg = "We were unable to reach GitHub, please try again."
-            raise AuthFailed(self, msg)
-
-        msg = (
-            f'"{username}" is not part of the OpenSAFELY GitHub Organization. '
-            '<a href="https://opensafely.org/contact/">Contact us</a> to request access.'
-        )
-        raise AuthFailed(self, msg)

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -194,7 +194,7 @@ LOGGING = logging_config_dict
 
 # Auth
 AUTHENTICATION_BACKENDS = [
-    "jobserver.github.GithubOrganizationOAuth2",
+    "social_core.backends.github.GithubOAuth2",
 ]
 AUTH_USER_MODEL = "jobserver.User"
 LOGIN_REDIRECT_URL = "/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from structlog.testing import LogCapture
 
 from applications.form_specs import form_specs
 from jobserver.authorization.roles import CoreDeveloper
-from jobserver.github import GithubOrganizationOAuth2
 
 from .factories import OrgFactory, OrgMembershipFactory, UserFactory
 from .factories import applications as application_factories
@@ -26,23 +25,6 @@ def api_rf():
 @pytest.fixture
 def core_developer():
     return UserFactory(roles=[CoreDeveloper])
-
-
-@pytest.fixture
-def dummy_backend():
-    """
-    Create a DummyBackend instance
-
-    Our GithubOrganizationOAuth2 backend will be instantiated in practice.
-    This allows us to test instances of it with _user_data() set (as it would
-    be in practice).
-    """
-
-    class DummyBackend(GithubOrganizationOAuth2):
-        def _user_data(self, *args, **kwargs):
-            return {"email": "test-email", "login": "test-username"}
-
-    return DummyBackend()
 
 
 @pytest.fixture(name="log_output")

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -47,9 +47,6 @@ def test_login_pipeline(client, mocker):
         ]
         rsps.add(responses.GET, emails_url, json=emails_data, status=200)
 
-        membership_url = "https://api.github.com/orgs/opensafely/members/dummy-user"
-        rsps.add(responses.GET, membership_url, status=204)
-
         mocker.patch("jobserver.pipeline.slack_client", autospec=True)
 
         # set a dummy state value in the test Client's session to match the
@@ -108,7 +105,7 @@ def test_login_with_get_request_fails(client):
     assert response.status_code == 405
 
 
-def test_login_pipeline_without_gitub_token(client):
+def test_login_pipeline_without_gitub_token(client, mocker):
     """
     Test the Auth Pipeline with an incoming request but no GitHub API access
 
@@ -149,8 +146,7 @@ def test_login_pipeline_without_gitub_token(client):
         ]
         rsps.add(responses.GET, emails_url, json=emails_data, status=200)
 
-        membership_url = "https://api.github.com/orgs/opensafely/members/dummy-user"
-        rsps.add(responses.GET, membership_url, status=401)
+        mocker.patch("jobserver.pipeline.slack_client", autospec=True)
 
         # set a dummy state value in the test Client's session to match the
         # value in redirect_url below

--- a/tests/unit/jobserver/test_github.py
+++ b/tests/unit/jobserver/test_github.py
@@ -1,9 +1,7 @@
 import pytest
 import requests
 import responses
-from social_core.exceptions import AuthFailed
 
-from jobserver import github
 from jobserver.github import (
     _iter_query_results,
     get_branch,
@@ -271,48 +269,6 @@ def test_get_repos_with_dates():
 
     assert len(output) == 2
     assert output[0]["name"] == "test-repo"
-
-
-@responses.activate
-def test_githuborganizationoauth2_user_data_204(monkeypatch, dummy_backend):
-    monkeypatch.setattr(github, "AUTHORIZATION_ORGS", ["opensafely"])
-
-    expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
-    responses.add(responses.GET, url=expected_url, status=204)
-
-    dummy_backend.user_data("access-token")
-
-    assert len(responses.calls) == 1
-
-
-@responses.activate
-def test_githuborganizationoauth2_user_data_302(monkeypatch, dummy_backend):
-    monkeypatch.setattr(github, "AUTHORIZATION_ORGS", ["opensafely"])
-
-    expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
-    responses.add(responses.GET, url=expected_url, status=302)
-
-    match = (
-        '"test-username" is not part of the OpenSAFELY GitHub Organization. '
-        '<a href="https://opensafely.org/contact/">Contact us</a> to request access.'
-    )
-    with pytest.raises(AuthFailed, match=match):
-        dummy_backend.user_data("access-token")
-
-
-@responses.activate
-def test_githuborganizationoauth2_user_data_404(monkeypatch, dummy_backend):
-    monkeypatch.setattr(github, "AUTHORIZATION_ORGS", ["opensafely"])
-
-    expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
-    responses.add(responses.GET, url=expected_url, status=404)
-
-    match = (
-        '"test-username" is not part of the OpenSAFELY GitHub Organization. '
-        '<a href="https://opensafely.org/contact/">Contact us</a> to request access.'
-    )
-    with pytest.raises(AuthFailed, match=match):
-        dummy_backend.user_data("access-token")
 
 
 @responses.activate


### PR DESCRIPTION
This removes our custom auth backend, and the need for users to be a part of the `opensafely` GitHub organisation, so that we can move to having applications happen in job-server.

Fix #1133 