### PR TITLE
Fix dump_db Command

### DIFF
--- a/jobserver/jobs/hourly/dump_db.py
+++ b/jobserver/jobs/hourly/dump_db.py
@@ -21,19 +21,18 @@ class Job(HourlyJob):
             sys.exit(1)
 
         try:
-            with output.open() as f:
-                # We use the "custom" output format for pg_dump to get smaller
-                # files, the docs have more detail on why it can be useful:
-                # https://www.postgresql.org/docs/14/app-pgdump.html
-                subprocess.check_call(
-                    [
-                        "pg_dump",
-                        "--format=c",
-                        "--no-acl",
-                        "--no-owner",
-                        database_url,
-                    ],
-                    stdout=f,
-                )
+            # We use the "custom" output format for pg_dump to get smaller
+            # files, the docs have more detail on why it can be useful:
+            # https://www.postgresql.org/docs/14/app-pgdump.html
+            subprocess.check_call(
+                [
+                    "pg_dump",
+                    "--format=c",
+                    "--no-acl",
+                    "--no-owner",
+                    "--file={output}",
+                    database_url,
+                ],
+            )
         except Exception as e:
             sys.exit(e)

--- a/jobserver/jobs/hourly/dump_db.py
+++ b/jobserver/jobs/hourly/dump_db.py
@@ -20,19 +20,16 @@ class Job(HourlyJob):
             print(f"Unknown output path: {output}", file=sys.stderr)
             sys.exit(1)
 
-        try:
-            # We use the "custom" output format for pg_dump to get smaller
-            # files, the docs have more detail on why it can be useful:
-            # https://www.postgresql.org/docs/14/app-pgdump.html
-            subprocess.check_call(
-                [
-                    "pg_dump",
-                    "--format=c",
-                    "--no-acl",
-                    "--no-owner",
-                    "--file={output}",
-                    database_url,
-                ],
-            )
-        except Exception as e:
-            sys.exit(e)
+        # We use the "custom" output format for pg_dump to get smaller
+        # files, the docs have more detail on why it can be useful:
+        # https://www.postgresql.org/docs/14/app-pgdump.html
+        subprocess.check_call(
+            [
+                "pg_dump",
+                "--format=c",
+                "--no-acl",
+                "--no-owner",
+                "--file={output}",
+                database_url,
+            ],
+        )


### PR DESCRIPTION
This attempts to fix th dump_db command which was erroring with `pg_dump: error: could not write to output file: Bad file descriptor`.

Running `pg_dump` with `--file` directly in the container works so I'm hoping this works.

The removal of the try/catch should mean sentry flags up failures next time.