### PR TITLE
Switch Study lead email(s) field from email to text

### DIFF
--- a/applications/form_specs.py
+++ b/applications/form_specs.py
@@ -160,7 +160,6 @@ form_specs = [
                     Field(
                         name="author_email",
                         label="Email(s)",
-                        attributes=email_attrs,
                     ),
                     Field(
                         name="author_organisation",


### PR DESCRIPTION
We want to capture multiple emails in this field and type="email" stops the use of punctuation to delimit addresses.

Fixes #1365