### PR TITLE
Use red text for "not approved" status on confirmation page

### DIFF
--- a/applications/templates/applications/confirmation.html
+++ b/applications/templates/applications/confirmation.html
@@ -41,7 +41,7 @@
             Page is still awaiting an approval decision.
           </li>
           {% elif not page.wizard_page.page_instance.is_approved %}
-          <li>
+          <li class="text-danger">
             Page not approved &cross;
           </li>
           {% else %}


### PR DESCRIPTION
This sets the approval status text colour to red if a section isn't approved:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/xQujkYp9/5099dd51-49db-4a13-b3b8-ba8f1eea1258.jpg?v=0ef43f3035641f93bac87ce5bf44958b)

Fixes #1370 