### PR TITLE
Link to Application Sections from Staff Area

### DIFF
--- a/staff/templates/staff/application_detail.html
+++ b/staff/templates/staff/application_detail.html
@@ -98,7 +98,13 @@
 
         {% for page in pages %}
           <hr />
-          <h3 id="{{ page.key }}">{{ page.title }}</h3>
+          <div class="d-flex justify-content-between align-items-center">
+            <h3 id="{{ page.key }}">{{ page.title }}</h3>
+            <a class="btn btn-sm btn-primary"
+                href="{% url 'applications:page' application.pk_hash page.key %}">
+              View on Site
+            </a>
+          </div>
 
           {% if page.started %}
             {% for fieldset in page.fieldsets %}


### PR DESCRIPTION
Mirroring the confirmation page this adds links to each section of an Application in the Staff Area.  I've opted for `View on Site` to mirror the buttons else where in the Staff Area:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/BluDmQ6X/c30b0178-5b34-4f6e-b593-d8d220149c7d.jpg?v=fcf5bf8dee874cc038396e395c12f3ea)

Fixes #1286