### PR TITLE
Tweak JS Dep Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,11 @@ updates:
     reviewers:
       - "ghickman"
     open-pull-requests-limit: 20
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     reviewers:
       - "tomodwyer"
     open-pull-requests-limit: 20

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    allow:
+      dependency-type: "production"
     reviewers:
       - "tomodwyer"
     open-pull-requests-limit: 20


### PR DESCRIPTION
We currently have Dependabot raising JS dependency bumps throughout the week and @tomodwyer bunching them into a single PR on Monday mornings.

This tries to reduce some of the noise in the build up to Tom's typical routine, and hopefully lowers the number of dependencies he is required to deal with since we don't need regular updates to dev tooling.