### PR TITLE
Replace convertBlobToBase64 with createObjectURL

### DIFF
--- a/assets/src/scripts/outputs-viewer/hooks/use-file.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file.js
@@ -4,17 +4,6 @@ import { useFiles } from "../context/FilesProvider";
 import { canDisplay, isCsv, isImg } from "../utils/file-type-match";
 import { toastError } from "../utils/toast";
 
-// function convertBlobToBase64(blob) {
-//   return new Promise((resolve, reject) => {
-//     const reader = new FileReader();
-//     reader.onerror = reject;
-//     reader.onload = () => {
-//       resolve(reader.result);
-//     };
-//     reader.readAsDataURL(blob);
-//   });
-// }
-
 function useFile(file) {
   const {
     state: { authToken },

--- a/assets/src/scripts/outputs-viewer/hooks/use-file.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file.js
@@ -4,16 +4,16 @@ import { useFiles } from "../context/FilesProvider";
 import { canDisplay, isCsv, isImg } from "../utils/file-type-match";
 import { toastError } from "../utils/toast";
 
-function convertBlobToBase64(blob) {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onerror = reject;
-    reader.onload = () => {
-      resolve(reader.result);
-    };
-    reader.readAsDataURL(blob);
-  });
-}
+// function convertBlobToBase64(blob) {
+//   return new Promise((resolve, reject) => {
+//     const reader = new FileReader();
+//     reader.onerror = reject;
+//     reader.onload = () => {
+//       resolve(reader.result);
+//     };
+//     reader.readAsDataURL(blob);
+//   });
+// }
 
 function useFile(file) {
   const {
@@ -34,7 +34,7 @@ function useFile(file) {
       if (isCsv(file) && file.size > 5000000) return {};
 
       // If the file is an image
-      // grab the blob and encode it as Base64
+      // grab the blob and create a URL for the blob
       if (isImg(file))
         return axios
           .get(file.url, {
@@ -44,7 +44,7 @@ function useFile(file) {
             responseType: "blob",
           })
           .then((response) => response.data)
-          .then((blob) => convertBlobToBase64(blob))
+          .then((blob) => URL.createObjectURL(blob))
           .catch((error) => {
             throw error?.response?.data?.detail || error?.message;
           });

--- a/assets/src/scripts/outputs-viewer/tests/components/Viewer/Viewer.test.jsx
+++ b/assets/src/scripts/outputs-viewer/tests/components/Viewer/Viewer.test.jsx
@@ -159,25 +159,25 @@ describe("<Viewer />", () => {
     });
   });
 
-  it("returns <Image /> for PNG", async () => {
-    server.use(
-      rest.get(`http://localhost${pngFile.url}`, (req, res, ctx) =>
-        res.once(
-          ctx.set("Content-Type", "image/png"),
-          ctx.status(200),
-          ctx.body({ Blob: pngExample })
-        )
-      )
-    );
+  // it("returns <Image /> for PNG", async () => {
+  //   server.use(
+  //     rest.get(`http://localhost${pngFile.url}`, (req, res, ctx) =>
+  //       res.once(
+  //         ctx.set("Content-Type", "image/png"),
+  //         ctx.status(200),
+  //         ctx.body({ Blob: pngExample })
+  //       )
+  //     )
+  //   );
 
-    render(<Viewer />, {}, { file: pngFile });
+  //   render(<Viewer />, {}, { file: pngFile });
 
-    await waitFor(() =>
-      expect(screen.getByRole("img").src).toBe(
-        `data:image/png;base64,W29iamVjdCBPYmplY3Rd`
-      )
-    );
-  });
+  //   await waitFor(() =>
+  //     expect(screen.getByRole("img").src).toBe(
+  //       `data:image/png;base64,W29iamVjdCBPYmplY3Rd`
+  //     )
+  //   );
+  // });
 
   it("returns <Text /> for TXT", async () => {
     server.use(

--- a/assets/src/scripts/outputs-viewer/tests/components/Viewer/Viewer.test.jsx
+++ b/assets/src/scripts/outputs-viewer/tests/components/Viewer/Viewer.test.jsx
@@ -10,7 +10,7 @@ import {
   htmlFile,
   pngFile,
   jsFile,
-  // pngExample,
+  pngExample,
   txtFile,
   txtExample,
   jsonFile,
@@ -159,25 +159,23 @@ describe("<Viewer />", () => {
     });
   });
 
-  // it("returns <Image /> for PNG", async () => {
-  //   server.use(
-  //     rest.get(`http://localhost${pngFile.url}`, (req, res, ctx) =>
-  //       res.once(
-  //         ctx.set("Content-Type", "image/png"),
-  //         ctx.status(200),
-  //         ctx.body({ Blob: pngExample })
-  //       )
-  //     )
-  //   );
+  it("returns <Image /> for PNG", async () => {
+    server.use(
+      rest.get(`http://localhost${pngFile.url}`, (req, res, ctx) =>
+        res.once(
+          ctx.set("Content-Type", "image/png"),
+          ctx.status(200),
+          ctx.body({ Blob: pngExample })
+        )
+      )
+    );
 
-  //   render(<Viewer />, {}, { file: pngFile });
+    render(<Viewer />, {}, { file: pngFile });
 
-  //   await waitFor(() =>
-  //     expect(screen.getByRole("img").src).toBe(
-  //       `data:image/png;base64,W29iamVjdCBPYmplY3Rd`
-  //     )
-  //   );
-  // });
+    await waitFor(() =>
+      expect(screen.getByRole("img").src).toBe(`http://localhost/imgSrc`)
+    );
+  });
 
   it("returns <Text /> for TXT", async () => {
     server.use(

--- a/assets/src/scripts/outputs-viewer/tests/components/Viewer/Viewer.test.jsx
+++ b/assets/src/scripts/outputs-viewer/tests/components/Viewer/Viewer.test.jsx
@@ -10,7 +10,7 @@ import {
   htmlFile,
   pngFile,
   jsFile,
-  pngExample,
+  // pngExample,
   txtFile,
   txtExample,
   jsonFile,

--- a/assets/src/scripts/outputs-viewer/tests/jest-setup.js
+++ b/assets/src/scripts/outputs-viewer/tests/jest-setup.js
@@ -34,3 +34,11 @@ window.matchMedia =
       removeListener() {},
     };
   };
+
+function noOp() {
+  return "imgSrc";
+}
+
+if (typeof window.URL.createObjectURL === "undefined") {
+  Object.defineProperty(window.URL, "createObjectURL", { value: noOp });
+}


### PR DESCRIPTION
- Replace function converting images to base64 with [`URL.createObjectURL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL)
- Update tests to use mock for window functions