### PR TITLE
Stop sending internal error events to Sentry

### DIFF
--- a/jobserver/api/jobs.py
+++ b/jobserver/api/jobs.py
@@ -134,16 +134,6 @@ class JobAPIUpdate(APIView):
                     # notifications here to avoid creating false positives.
                     should_notify = False
 
-                if "internal error" in job.status_message.lower():
-                    # bubble internal errors encountered with a job up to
-                    # sentry so we can get notifications they've happened
-                    with sentry_sdk.push_scope() as scope:
-                        scope.set_tag("backend", job_request.backend.slug)
-                        scope.set_tag(
-                            "job", request.build_absolute_uri(job.get_absolute_url())
-                        )
-                        sentry_sdk.capture_message("Job encountered an internal error")
-
                 if not job_request.will_notify:
                     continue
 

--- a/tests/unit/jobserver/api/test_jobs.py
+++ b/tests/unit/jobserver/api/test_jobs.py
@@ -428,13 +428,11 @@ def test_jobapiupdate_post_only(api_rf):
     assert JobAPIUpdate.as_view()(request).status_code == 405
 
 
-def test_jobapiupdate_post_with_internal_error(api_rf, mocker):
+def test_jobapiupdate_post_with_internal_error(api_rf):
     backend = BackendFactory()
     job_request = JobRequestFactory()
 
     now = timezone.now()
-
-    mocked_sentry_sdk = mocker.patch("jobserver.api.jobs.sentry_sdk", autospec=True)
 
     data = [
         {
@@ -462,8 +460,6 @@ def test_jobapiupdate_post_with_internal_error(api_rf, mocker):
     response = JobAPIUpdate.as_view()(request_2)
 
     assert response.status_code == 200, response.data
-
-    mocked_sentry_sdk.capture_message.assert_called_once()
 
 
 def test_jobapiupdate_unknown_job_request(api_rf):
@@ -508,14 +504,12 @@ def test_jobrequestapilist_filter_by_backend(api_rf):
     assert len(response.data["results"]) == 1
 
 
-def test_jobrequestapilist_filter_by_backend_with_mismatched(api_rf, mocker):
+def test_jobrequestapilist_filter_by_backend_with_mismatched(api_rf):
     backend1 = BackendFactory()
     JobRequestFactory(backend=backend1)
 
     backend2 = BackendFactory()
     job_request = JobRequestFactory(backend=backend2)
-
-    mocked_sentry = mocker.patch("jobserver.api.jobs.sentry_sdk", autospec=True)
 
     request = api_rf.get(
         f"/?backend={backend2.slug}", HTTP_AUTHORIZATION=backend1.auth_token
@@ -525,8 +519,6 @@ def test_jobrequestapilist_filter_by_backend_with_mismatched(api_rf, mocker):
     assert response.status_code == 200, response.data
     assert len(response.data["results"]) == 1
     assert response.data["results"][0]["identifier"] == job_request.identifier
-
-    assert mocked_sentry.capture_message.call_count == 1
 
 
 def test_jobrequestapilist_filter_by_databricks(api_rf):


### PR DESCRIPTION
This is being done for every job included in an update, rather than any
job which transitions into this state, blowing through our Sentry quota
in a matter of days.