### PR TITLE
Remove ability to filter /api/v2/job-requests/ by backend in get args

### DIFF
--- a/tests/unit/jobserver/api/test_jobs.py
+++ b/tests/unit/jobserver/api/test_jobs.py
@@ -497,28 +497,11 @@ def test_jobrequestapilist_filter_by_backend(api_rf):
     JobRequestFactory(backend=backend)
     JobRequestFactory()
 
-    request = api_rf.get(f"/?backend={backend.slug}")
+    request = api_rf.get("/", HTTP_AUTHORIZATION=backend.auth_token)
     response = JobRequestAPIList.as_view()(request)
 
     assert response.status_code == 200, response.data
     assert len(response.data["results"]) == 1
-
-
-def test_jobrequestapilist_filter_by_backend_with_mismatched(api_rf):
-    backend1 = BackendFactory()
-    JobRequestFactory(backend=backend1)
-
-    backend2 = BackendFactory()
-    job_request = JobRequestFactory(backend=backend2)
-
-    request = api_rf.get(
-        f"/?backend={backend2.slug}", HTTP_AUTHORIZATION=backend1.auth_token
-    )
-    response = JobRequestAPIList.as_view()(request)
-
-    assert response.status_code == 200, response.data
-    assert len(response.data["results"]) == 1
-    assert response.data["results"][0]["identifier"] == job_request.identifier
 
 
 def test_jobrequestapilist_get_only(api_rf):


### PR DESCRIPTION
Currently we can talk to the the JobRequsts listing API (`/api/v2/job-requests/`) with either:
* `?backend=<backend.slug>`
* a valid Backend.auth_token in the Authorization header
* both

Should we find both values, we give the value from the query_arg precedence.

Recently we renamed the databricks Backend to NHSD, however we are not in control of their deploy of job-runner which is still querying this API with both a valid Backend token, and `?backend=databricks`.  Since we deployed the changes (as of writing) we've notified Sentry about this mismatch ~24k times since it triggers on every API query.

This removes all the logic and only filters the endpoint when a valid token is present.

In the short term (and as we burn through our Sentry quota) I think we should merge this as-is.  However, does this mean we might cause job-runner deployers problems in the future?  Can one set up a job-runner without a token, giving that deploy all JobRequests regardless of Backend?

cc @bloodearnest and @evansd who are probably best placed to discuss this one.

Fixes #1440 