### PR TITLE
address gunicorn loggers correctly

### DIFF
--- a/services/logging.py
+++ b/services/logging.py
@@ -73,7 +73,16 @@ logging_config_dict = {
             "level": env.str("DJANGO_LOG_LEVEL", default="INFO"),
             "propagate": False,
         },
-        "gunicorn": {"handlers": ["console"], "level": "INFO", "propagate": False},
+        "gunicorn.access": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "gunicorn.error": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
         "django_structlog": {
             "handlers": ["console"],
             "level": "INFO",


### PR DESCRIPTION
Gunicorn's loggers are called `gunicorn.access` and `gunicorn.error` so this actually configures those loggers.  Gunicorn's logs should now match the rest of the applications.