### PR TITLE
Update CI Caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,23 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Node.js
-      - name: Cache node_modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
           node-version: "16"
+          cache: 'npm'
 
       - name: Install node_modules
         run: npm ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,8 @@ jobs:
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.9"
+          cache: "pip"
+          cache-dependency-path: requirements.*.txt
       - uses: extractions/setup-just@v1
       - run: ls -lah ${{ github.workspace }}
       - name: Check formatting
@@ -57,6 +59,8 @@ jobs:
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.9"
+          cache: "pip"
+          cache-dependency-path: requirements.*.txt
       - uses: extractions/setup-just@v1
       - name: Check linting
         run: |
@@ -70,6 +74,8 @@ jobs:
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.9"
+          cache: "pip"
+          cache-dependency-path: requirements.*.txt
       - uses: extractions/setup-just@v1
       - name: Check import sorting
         run: |
@@ -83,6 +89,8 @@ jobs:
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.9"
+          cache: "pip"
+          cache-dependency-path: requirements.*.txt
       - uses: extractions/setup-just@v1
       - name: Check for syntax upgrades
         run: |
@@ -112,6 +120,8 @@ jobs:
       - uses: "actions/setup-python@v2"
         with:
           python-version: "3.9"
+          cache: "pip"
+          cache-dependency-path: requirements.*.txt
       - uses: extractions/setup-just@v1
 
       - name: Retrieve assets


### PR DESCRIPTION
This moves to using the setup-* action's caching (which is just the cache action under the hood but with expected defaults), and turns Pip caching back on but in the expected manner.  I've been trialling this on some personal projects without issues yet.

I'd like to trial the Pip caching here for ~1 month before rolling out to other projects.