### PR TITLE
Edit ProjectMemberships in the Staff Area

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -624,6 +624,15 @@ class ProjectMembership(models.Model):
             },
         )
 
+    def get_staff_remove_url(self):
+        return reverse(
+            "staff:project-membership-remove",
+            kwargs={
+                "slug": self.project.slug,
+                "pk": self.pk,
+            },
+        )
+
 
 class UserQuerySet(models.QuerySet):
     def filter_by_role(self, role):

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -624,6 +624,15 @@ class ProjectMembership(models.Model):
             },
         )
 
+    def get_staff_edit_url(self):
+        return reverse(
+            "staff:project-membership-edit",
+            kwargs={
+                "slug": self.project.slug,
+                "pk": self.pk,
+            },
+        )
+
     def get_staff_remove_url(self):
         return reverse(
             "staff:project-membership-remove",

--- a/staff/forms.py
+++ b/staff/forms.py
@@ -85,6 +85,10 @@ class ProjectEditForm(forms.ModelForm):
         self.fields["copilot_support_ends_at"].required = False
 
 
+class ProjectMembershipForm(RolesForm):
+    pass
+
+
 class ResearcherRegistrationEditForm(forms.ModelForm):
     does_researcher_need_server_access = YesNoField()
     has_taken_safe_researcher_training = YesNoField()

--- a/staff/templates/staff/project_detail.html
+++ b/staff/templates/staff/project_detail.html
@@ -71,7 +71,7 @@
             <span class="badge badge-pill badge-secondary">{{ role.display_name }}</span>
             {% endfor %}
           </div>
-          <form method="POST" action="{% url 'staff:project-remove-member' slug=project.slug %}">
+          <form method="POST" action="{{ membership.get_staff_remove_url }}">
             {% csrf_token %}
             <input type="hidden" name="username" value="{{ membership.user.username }}" />
             <button class="btn btn-sm btn-danger" type="submit">

--- a/staff/templates/staff/project_detail.html
+++ b/staff/templates/staff/project_detail.html
@@ -71,13 +71,19 @@
             <span class="badge badge-pill badge-secondary">{{ role.display_name }}</span>
             {% endfor %}
           </div>
-          <form method="POST" action="{{ membership.get_staff_remove_url }}">
-            {% csrf_token %}
-            <input type="hidden" name="username" value="{{ membership.user.username }}" />
-            <button class="btn btn-sm btn-danger" type="submit">
-              Remove <span class="sr-only">from {{ project.name }}</span>
-            </button>
-          </form>
+          <div class="d-flex justify-content-between align-items-center">
+            <a class="btn btn-sm btn-outline-primary mr-1"
+               href="{{ membership.get_staff_edit_url }}">
+              Edit
+            </a>
+            <form method="POST" action="{{ membership.get_staff_remove_url }}">
+              {% csrf_token %}
+              <input type="hidden" name="username" value="{{ membership.user.username }}" />
+              <button class="btn btn-sm btn-danger" type="submit">
+                Remove <span class="sr-only">from {{ project.name }}</span>
+              </button>
+            </form>
+          </div>
         </div>
       {% empty %}
         <p class="list-group-item">No members</p>

--- a/staff/templates/staff/project_membership_edit.html
+++ b/staff/templates/staff/project_membership_edit.html
@@ -1,0 +1,86 @@
+{% extends "staff/base.html" %}
+
+{% block metatitle %}{{ membership.user.name }}: {{ membership.project.name }} | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="/">Home</a>
+      </li>
+      <li class="breadcrumb-item">
+        <a href="{{ membership.project.org.get_absolute_url }}">
+          {{ membership.project.org.name }}
+        </a>
+      </li>
+      <li class="breadcrumb-item">
+        <a href="{{ membership.project.get_absolute_url }}">
+          {{ membership.project.name }}
+        </a>
+      </li>
+      <li class="breadcrumb-item">
+        <a href="{{ membership.project.get_settings_url }}">
+          Settings
+        </a>
+      </li>
+      <li class="breadcrumb-item">
+        Members
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        {{ membership.user.name }}
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid">
+  <div class="container">
+    <h1>{{ membership.user.name }}</h1>
+    <p class="lead"><span class="sr-only">Username: </span>{{ membership.user.username }}</p>
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div class="col-lg-9 col-xl-8">
+
+      <form method="POST">
+        {% csrf_token %}
+
+        {% if form.non_field_errors %}
+        <ul>
+          {% for error in form.non_field_errors %}
+            <li class="text-danger">{{ error }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+        {% include "components/form_roles.html" with field=form.roles label="Roles" name="roles" %}
+
+        <button class="btn btn-primary" type="submit">Save</button>
+      </form>
+
+      <form class="pt-5 mt-5 border-top" method="POST" action="{{ membership.get_staff_remove_url }}">
+        {% csrf_token %}
+        <fieldset id="remove">
+          <legend class="h3 mb-3">
+            Remove member
+          </legend>
+          <input type="hidden" name="member_pk" value="{{ membership.pk }}" />
+
+          <p class="form-label">Do you want to remove {{ membership.user.name }} from {{ membership.project.name }}?</p>
+        </fieldset>
+
+        <button class="btn btn-danger" type="submit">Remove</button>
+      </form>
+
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -27,7 +27,7 @@ from .views.projects import (
     ProjectDetail,
     ProjectEdit,
     ProjectList,
-    ProjectRemoveMember,
+    ProjectMembershipRemove,
 )
 from .views.repos import RepoList
 from .views.researchers import ResearcherEdit
@@ -75,7 +75,7 @@ project_urls = [
     path("<slug>/edit/", ProjectEdit.as_view(), name="project-edit"),
     path(
         "<slug>/members/<pk>/remove/",
-        ProjectRemoveMember.as_view(),
+        ProjectMembershipRemove.as_view(),
         name="project-membership-remove",
     ),
 ]

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -27,6 +27,7 @@ from .views.projects import (
     ProjectDetail,
     ProjectEdit,
     ProjectList,
+    ProjectMembershipEdit,
     ProjectMembershipRemove,
 )
 from .views.repos import RepoList
@@ -73,6 +74,11 @@ project_urls = [
     path("<slug>/", ProjectDetail.as_view(), name="project-detail"),
     path("<slug>/add-member/", ProjectAddMember.as_view(), name="project-add-member"),
     path("<slug>/edit/", ProjectEdit.as_view(), name="project-edit"),
+    path(
+        "<slug>/members/<pk>/edit/",
+        ProjectMembershipEdit.as_view(),
+        name="project-membership-edit",
+    ),
     path(
         "<slug>/members/<pk>/remove/",
         ProjectMembershipRemove.as_view(),

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -74,9 +74,9 @@ project_urls = [
     path("<slug>/add-member/", ProjectAddMember.as_view(), name="project-add-member"),
     path("<slug>/edit/", ProjectEdit.as_view(), name="project-edit"),
     path(
-        "<slug>/remove-member/",
+        "<slug>/members/<pk>/remove/",
         ProjectRemoveMember.as_view(),
-        name="project-remove-member",
+        name="project-membership-remove",
     ),
 ]
 

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -110,7 +110,7 @@ class ProjectList(ListView):
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
-class ProjectRemoveMember(View):
+class ProjectMembershipRemove(View):
     def post(self, request, *args, **kwargs):
         project = get_object_or_404(Project, slug=self.kwargs["slug"])
         username = request.POST.get("username", None)

--- a/tests/unit/jobserver/models/test_core.py
+++ b/tests/unit/jobserver/models/test_core.py
@@ -700,6 +700,21 @@ def test_projectinvitation_str():
     assert str(invitation) == "ben | DataLab"
 
 
+def test_projectmembership_get_staff_edit_url():
+    project = ProjectFactory()
+    membership = ProjectMembershipFactory(project=project)
+
+    url = membership.get_staff_edit_url()
+
+    assert url == reverse(
+        "staff:project-membership-edit",
+        kwargs={
+            "slug": project.slug,
+            "pk": membership.pk,
+        },
+    )
+
+
 def test_projectmembership_get_staff_remove_url():
     project = ProjectFactory()
     membership = ProjectMembershipFactory(project=project)

--- a/tests/unit/jobserver/models/test_core.py
+++ b/tests/unit/jobserver/models/test_core.py
@@ -700,6 +700,21 @@ def test_projectinvitation_str():
     assert str(invitation) == "ben | DataLab"
 
 
+def test_projectmembership_get_staff_remove_url():
+    project = ProjectFactory()
+    membership = ProjectMembershipFactory(project=project)
+
+    url = membership.get_staff_remove_url()
+
+    assert url == reverse(
+        "staff:project-membership-remove",
+        kwargs={
+            "slug": project.slug,
+            "pk": membership.pk,
+        },
+    )
+
+
 def test_projectmembership_str():
     project = ProjectFactory(name="DataLab")
     user = UserFactory(username="ben")

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -10,7 +10,7 @@ from staff.views.projects import (
     ProjectDetail,
     ProjectEdit,
     ProjectList,
-    ProjectRemoveMember,
+    ProjectMembershipRemove,
 )
 
 from ....factories import ProjectFactory, ProjectMembershipFactory, UserFactory
@@ -65,7 +65,7 @@ def test_projectaddmember_unknown_project(rf, core_developer):
     request.user = core_developer
 
     with pytest.raises(Http404):
-        ProjectRemoveMember.as_view()(request, slug="test")
+        ProjectAddMember.as_view()(request, slug="test")
 
 
 def test_projectdetail_success(rf, core_developer):
@@ -195,7 +195,7 @@ def test_projectlist_unauthorized(rf):
         )
 
 
-def test_projectremovemember_success(rf, core_developer):
+def test_projectmembershipremove_success(rf, core_developer):
     project = ProjectFactory()
     user = UserFactory()
 
@@ -209,7 +209,7 @@ def test_projectremovemember_success(rf, core_developer):
     messages = FallbackStorage(request)
     request._messages = messages
 
-    response = ProjectRemoveMember.as_view()(request, slug=project.slug)
+    response = ProjectMembershipRemove.as_view()(request, slug=project.slug)
 
     assert response.status_code == 302
     assert response.url == project.get_staff_url()
@@ -223,23 +223,23 @@ def test_projectremovemember_success(rf, core_developer):
     assert str(messages[0]) == f"Removed {user.username} from {project.name}"
 
 
-def test_projectremovemember_unauthorized(rf):
+def test_projectmembershipremove_unauthorized(rf):
     request = rf.post("/")
     request.user = UserFactory()
 
     with pytest.raises(PermissionDenied):
-        ProjectRemoveMember.as_view()(request)
+        ProjectMembershipRemove.as_view()(request)
 
 
-def test_projectremovemember_unknown_project(rf, core_developer):
+def test_projectmembershipremove_unknown_project(rf, core_developer):
     request = rf.post("/")
     request.user = core_developer
 
     with pytest.raises(Http404):
-        ProjectRemoveMember.as_view()(request, slug="test")
+        ProjectMembershipRemove.as_view()(request, slug="test")
 
 
-def test_projectremovemember_unknown_member(rf, core_developer):
+def test_projectmembershipremove_unknown_member(rf, core_developer):
     project = ProjectFactory()
 
     assert project.memberships.count() == 0
@@ -252,7 +252,7 @@ def test_projectremovemember_unknown_member(rf, core_developer):
     messages = FallbackStorage(request)
     request._messages = messages
 
-    response = ProjectRemoveMember.as_view()(request, slug=project.slug)
+    response = ProjectMembershipRemove.as_view()(request, slug=project.slug)
     assert response.status_code == 302
     assert response.url == project.get_staff_url()
 


### PR DESCRIPTION
This enables editing a ProjectMembership in the Staff Area, linked from a given Membership on a given Project.

Fixes #1293