### PR TITLE
Handle Missing ReleaseFiles

### DIFF
--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -140,7 +140,7 @@ class ReleaseDownload(View):
         ):
             raise Http404
 
-        zf = build_outputs_zip(release.files.all())
+        zf = build_outputs_zip(release.files.all(), request.build_absolute_uri)
         return FileResponse(
             zf,
             as_attachment=True,
@@ -237,7 +237,7 @@ class SnapshotDownload(View):
         if snapshot.is_draft and not can_view_unpublished_files:
             raise Http404
 
-        zf = build_outputs_zip(snapshot.files.all())
+        zf = build_outputs_zip(snapshot.files.all(), request.build_absolute_uri)
         return FileResponse(
             zf,
             as_attachment=True,

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -337,7 +337,7 @@ class WorkspaceLatestOutputsDownload(View):
         # get the latest files as an iterable of ReleaseFile instances
         latest_files = workspace_files(workspace).values()
 
-        zf = build_outputs_zip(latest_files)
+        zf = build_outputs_zip(latest_files, request.build_absolute_uri)
         return FileResponse(
             zf,
             as_attachment=True,


### PR DESCRIPTION
This catches ReleaseFiles where their on-disk file is missing, which happens when we redact a file.  When building a zip for downloading a Release (or Snapshot) we now replace missing files with a short text template linking to the ReleaseFile and saying who deleted it.

Fixes #1070