### PR TITLE
Always render the outputs page even if there are no snapshots

### DIFF
--- a/jobserver/templates/workspace_output_list.html
+++ b/jobserver/templates/workspace_output_list.html
@@ -75,6 +75,8 @@
         </div>
 
       </li>
+      {% empty %}
+      <li><p>No outputs have been published for {{ workspace.name }} yet.</p></li>
       {% endfor %}
     </ul>
   </div>

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -448,10 +448,6 @@ class WorkspaceOutputList(ListView):
         if not can_view_all_files:
             snapshots = snapshots.exclude(published_at=None)
 
-        if not snapshots:
-            # if there are no snapshots for the user return 404
-            raise Http404
-
         context = {
             "user_can_view_all_files": can_view_all_files,
             "snapshots": snapshots,

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -1157,13 +1157,16 @@ def test_workspaceoutputlist_without_snapshots(rf, freezer):
     request = rf.get("/")
     request.user = UserFactory(roles=[ProjectCollaborator])
 
-    with pytest.raises(Http404):
-        WorkspaceOutputList.as_view()(
-            request,
-            org_slug=workspace.project.org.slug,
-            project_slug=workspace.project.slug,
-            workspace_slug=workspace.name,
-        )
+    response = WorkspaceOutputList.as_view()(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+    assert len(response.context_data["snapshots"]) == 0
+    assert "No outputs have been published" in response.rendered_content
 
 
 def test_workspaceoutputlist_unknown_workspace(rf):


### PR DESCRIPTION
We previously stopped the Outputs page for a Workspace from responding if there were no Snapshots but a change to the URL structure at some point made it easy to end up at a point where you are at `outputs/latest/`, at which point the parent page is 404ing.  Rather than meddle with the URLs (which I think still make sense), this takes the pragmatic route and just displays an explicit message that there is nothing to see here.

Fixes #1337