### PR TITLE
Display Roles on Project Page

### DIFF
--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -136,7 +136,22 @@
           </h2>
           <ul class="card-body list-unstyled">
             {% for user in project.members.all %}
+              {% if project.org not in request.user.orgs.all %}
               <li>{{ user.name }}</li>
+              {% else %}
+              <li class="mb-3">
+                <span>{{ user.name }}</span>
+                <ul class="list-unstyled">
+                  {% for role in user.roles %}
+                  <li>
+                    <span class="badge badge-pill badge-secondary">
+                      {{ role.display_name }}
+                    </span>
+                  </li>
+                  {% endfor %}
+                </ul>
+              </li>
+              {% endif %}
             {% endfor %}
           </ul>
         </li>


### PR DESCRIPTION
This adds the roles for each Project member when the user viewing the page is a member of the Project's Organisation.

For example, the `COVID-19 Vaccine Effectiveness` Project which is a member of the DataLab org will display role information for any viewer who is also a member of the DataLab org:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/nOu9BXzg/0a3d7aa1-3798-4db5-aa43-26b546591edb.jpg?v=ffaf33617ecf7b49f57b6d39ae602da7)

Fixes #904