### PR TITLE
Order backends on Status page using ORM query instead of dictsort

### DIFF
--- a/jobserver/templates/status.html
+++ b/jobserver/templates/status.html
@@ -28,7 +28,7 @@
 {% block content %}
 <div class="container">
   <div class="row">
-    {% for backend in backends|dictsort:"name.lower" %}
+    {% for backend in backends %}
       <div class="col-lg-6">
         <div class="card mb-5">
           <h2 class="card-header h3">{{ backend.name }}</h2>

--- a/jobserver/views/status.py
+++ b/jobserver/views/status.py
@@ -1,4 +1,5 @@
 from django.db.models import Count
+from django.db.models.functions import Lower
 from django.template.response import TemplateResponse
 from django.views.generic import View
 
@@ -43,6 +44,6 @@ class Status(View):
                 "show_warning": show_warning(last_seen),
             }
 
-        backends = Backend.objects.all()
+        backends = Backend.objects.order_by(Lower("name"))
         context = {"backends": [get_stats(b) for b in backends]}
         return TemplateResponse(request, "status.html", context)


### PR DESCRIPTION
dictsort's resolution logic was restricted in Django 4.0.1, dropping
support for indexing on dictionaries, to avoid a potentional information
disclosure bug.

https://docs.djangoproject.com/en/4.0/releases/4.0.1/#cve-2021-45116-potential-information-disclosure-in-dictsort-template-filter