### PR TITLE
fix: set EMIS level_4_url to be localhost (same as TPP)

### DIFF
--- a/jobserver/backends.py
+++ b/jobserver/backends.py
@@ -9,7 +9,7 @@ backends = [
         "name": "EMIS",
         "slug": "emis",
         "is_active": True,
-        "level_4_url": "",
+        "level_4_url": "https://localhost:8001",
     },
     {
         "id": 2,

--- a/jobserver/templates/workspace_backend_files.html
+++ b/jobserver/templates/workspace_backend_files.html
@@ -54,7 +54,7 @@
       You can see these outputs because you have access to the Level 4 environment on the
       {{ backend.name }} backend and have been assigned the ProjectDeveloper role.
     </p>
-    <a class="btn btn btn-success" href="{{ release.get_download_url }}">
+    <a class="btn disabled" aria-disabled="true" title="You cannot download files from the level 4, you must go through the release process first">
       Download
     </a>
   </div>

--- a/justfile
+++ b/justfile
@@ -46,6 +46,7 @@ clean:
 # ensure dev requirements installed and up to date
 devenv: prodenv requirements-dev && install-precommit
     #!/usr/bin/env bash
+    set -eu
     # exit if .txt file has not changed since we installed them (-nt == "newer than', but we negate with || to avoid error exit code)
     test requirements.dev.txt -nt $VIRTUAL_ENV/.dev || exit 0
 
@@ -79,6 +80,7 @@ lint: devenv
 # ensure prod requirements installed and up to date
 prodenv: requirements-prod
     #!/usr/bin/env bash
+    set -eu
     # exit if .txt file has not changed since we installed them (-nt == "newer than', but we negate with || to avoid error exit code)
     test requirements.prod.txt -nt $VIRTUAL_ENV/.prod || exit 0
 


### PR DESCRIPTION
Also, drive by fix for just file not erroring properly.

Also disabled the Download button on level 4 output viewer pages. It doesn't work, but it should be obvious that it doesn't work. I've opted to disable rather than remove, as I like UIs that don't disappear or change layout under you, but I'm not sure there's any styling to support `a.btn[disabled]`, at least I couldn't find any.