### PR TITLE
fix: remove the 5000 line limit on displaying CSVs

### DIFF
--- a/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Table/Table.jsx
@@ -2,7 +2,6 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { readString } from "react-papaparse";
-import NoPreview from "../NoPreview/NoPreview";
 
 function TableCell({ cell }) {
   return <td>{cell}</td>;
@@ -23,8 +22,6 @@ function Table({ data }) {
     chunk: true,
     complete: (results) => results,
   }).data;
-
-  if (jsonData.length >= 5000) return <NoPreview />;
 
   if (jsonData.length >= 1000) {
     return (

--- a/assets/src/scripts/outputs-viewer/tests/components/Table/Table.test.jsx
+++ b/assets/src/scripts/outputs-viewer/tests/components/Table/Table.test.jsx
@@ -4,9 +4,6 @@ import { csvExample, csvFile } from "../../helpers/files";
 import { render, screen } from "../../test-utils";
 
 describe("<Table />", () => {
-  const fiveThousandRows = `${Array(5000).fill(`a
-  `)}`.trimEnd();
-
   const twoThousandRows = `${Array(2000).fill(`b
   `)}`.trimEnd();
 
@@ -16,17 +13,6 @@ describe("<Table />", () => {
     const cells = screen.getAllByRole("cell");
     expect(cells[0].textContent).toEqual("gradually");
     expect(cells[cells.length - 1].textContent).toEqual("select");
-  });
-
-  it("displays the <NoPreview /> component for CSVs with more than 5000 rows", async () => {
-    render(<Table data={fiveThousandRows} />, {}, { file: csvFile });
-
-    expect(screen.getByRole("link").textContent).toBe(
-      "Open file in a new tab ↗"
-    );
-    expect(screen.getByRole("link").href).toEqual(
-      `http://localhost${csvFile.url}`
-    );
   });
 
   it("displays the first 1000 rows for CSVs with more than 1000 and fewer than 5000 rows", async () => {


### PR DESCRIPTION
We've already loaded the entire JSON, and we only display the first 1000
rows, so this is no more resource intensive, and more user friendly
