### PR TITLE
Switch dependabot allow items to an array

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     schedule:
       interval: "weekly"
     allow:
-      dependency-type: "production"
+      - dependency-type: "production"
     reviewers:
       - "tomodwyer"
     open-pull-requests-limit: 20


### PR DESCRIPTION
The dependabot config changed child items of `allow` to be an array, this updates to that syntax.