### PR TITLE
Pin hadolint action since it's a third party action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: hadolint/hadolint-action@v1.6.0
+      - uses: hadolint/hadolint-action@d7b38582334d9ac11c12021c16f21d63015fa250
 
   deploy:
     needs: [test, lint-dockerfile]


### PR DESCRIPTION
See Simon's comment [1] for context.

[1]: https://github.com/opensafely-core/job-server/pull/1564#issuecomment-1024151856