### PR TITLE
Convert Event Log Filters to Dropdowns

### DIFF
--- a/assets/src/styles/main.scss
+++ b/assets/src/styles/main.scss
@@ -82,7 +82,7 @@ nav {
   }
   .started-at {
     margin-right: 0.5rem;
-    width: 165px;
+    width: 200px;
   }
 }
 

--- a/jobserver/templates/job_request_list.html
+++ b/jobserver/templates/job_request_list.html
@@ -1,10 +1,14 @@
 {% extends "base.html" %}
 
 {% load humanize %}
-{% load querystring_tools %}
 {% load runtime %}
 {% load selected_filter %}
 {% load static %}
+
+{% block extra_styles %}
+<link rel="stylesheet" href="{% static 'vendor/select2.min.css' %}">
+<link rel="stylesheet" href="{% static 'vendor/select2-bootstrap4.min.css' %}">
+{% endblock %}
 
 {% block metatitle %}Event log | OpenSAFELY Jobs{% endblock metatitle %}
 
@@ -30,8 +34,7 @@
   <h2>All Jobs</h2>
 
   <div class="row">
-
-    <div class="col-lg-10">
+    <div class="col">
 
       <form class="form d-flex align-items-center mb-4" method="GET">
         <input
@@ -73,10 +76,63 @@
       </div>
       {% endif %}
 
+      <hr />
+
+      <form method="GET" class="form-inline justify-content-between">
+        <select id="filter_backend" class="mr-2" name="backend">
+          <option value="">------</option>
+          {% for backend in backends %}
+          {% is_filter_selected key="backend" value=backend.pk as is_active %}
+          <option value="{{ backend.pk }}"{% if is_active %} selected="selected"{% endif %}>
+            {{ backend.name }}
+          </option>
+          {% endfor %}
+        </select>
+
+        <select id="filter_status" class="mr-2" name="status">
+          <option value="">------</option>
+          {% for workspace in workspaces %}
+          {% is_filter_selected key="workspace" value=workspace.pk as is_active %}
+          <option value="{{ workspace.pk }}"{% if is_active %} selected="selected"{% endif %}>
+            {{ workspace.name }}
+          </option>
+          {% endfor %}
+        </select>
+
+        <select id="filter_user" class="mr-2" name="username">
+          <option value="">------</option>
+          {% for username, name in users.items %}
+          {% is_filter_selected key="username" value=username as is_active %}
+          <option value="{{ username }}"{% if is_active %}selected="selected"{% endif %}>
+            {{ name }}
+          </option>
+          {% endfor %}
+        </select>
+
+        <select id="filter_workspace" class="mr-2" name="workspace">
+          <option value="">------</option>
+          {% for workspace in workspaces %}
+          {% is_filter_selected key="workspace" value=workspace.pk as is_active %}
+          <option value="{{ workspace.pk }}"{% if is_active %} selected="selected"{% endif %}>
+            {{ workspace.name }}
+          </option>
+          {% endfor %}
+        </select>
+
+        <button type="submit" class="btn btn-sm btn-primary">Filter</button>
+      </form>
+
+      {% if request.GET or not page_obj %}
+      <div class="mt-4 mb-2 d-flex justify-content-center">
+        <a href="{% url 'job-list' %}">Clear all filters</a>
+      </div>
+      {% endif %}
+
+      <hr />
+
       {% if not page_obj %}
       <div class="text-center">
         <p>No results found.</p>
-        <a href="{% url 'job-list' %}">Clear all filters?</a>
       </div>
       {% else %}
 
@@ -85,124 +141,35 @@
       {% endif %}
     </div>
 
-    <div class="col-lg-2 filters">
-      <h4>Filters</h4>
-
-      {% if request.GET %}
-      <div class="mb-3">
-        <a href="{% url 'job-list' %}">Clear All</a>
-      </div>
-      {% endif %}
-
-      <h5>Status</h5>
-      <ul class="list-group list-unstyled mb-4">
-        {% for status in statuses %}
-        {% is_filter_selected key="status" value=status as is_active %}
-        <li class="list-group-item d-flex {% if is_active %} active{% endif %}">
-
-          <a class="text-truncate flex-grow-1" href="{% url_with_querystring status=status %}">
-            {{ status }}
-          </a>
-
-          {% if is_active %}
-          <a
-            type="button"
-            class="close"
-            aria-label="Close"
-            href="{% url_without_querystring status=status %}"
-            >
-            <span aria-hidden="true">&times;</span>
-          </a>
-          {% endif %}
-
-        </li>
-        {% endfor %}
-      </ul>
-
-      {% if users %}
-      <h5>User</h5>
-      <ul class="list-group list-unstyled mb-4 users">
-        {% for username, name in users.items %}
-        {% is_filter_selected key="username" value=username as is_active %}
-        <li class="list-group-item d-flex{% if is_active %} active{% endif %}">
-
-          <a class="text-truncate flex-grow-1" href="{% url_with_querystring username=username %}">
-            {{ name }}
-          </a>
-
-          {% if is_active %}
-          <a
-            type="button"
-            class="close"
-            aria-label="Close"
-            href="{% url_without_querystring username=username %}"
-            >
-            <span aria-hidden="true">&times;</span>
-          </a>
-          {% endif %}
-
-        </li>
-        {% endfor %}
-      </ul>
-      {% endif %}
-
-      {% if backends %}
-      <h5>Backends</h5>
-      <ul class="list-group list-unstyled mb-4">
-        {% for backend in backends %}
-        {% is_filter_selected key="backend" value=backend.pk as is_active %}
-        <li class="list-group-item d-flex{% if is_active %} active{% endif %}">
-
-          <a class="text-truncate flex-grow-1" href="{% url_with_querystring backend=backend.pk %}">
-            {{ backend.name }}
-          </a>
-
-          {% if is_active %}
-          <a
-            type="button"
-            class="close"
-            aria-label="Close"
-            href="{% url_without_querystring backend=backend.pk %}"
-            >
-            <span aria-hidden="true">&times;</span>
-          </a>
-          {% endif %}
-
-        </li>
-        {% endfor %}
-      </ul>
-      {% endif %}
-
-      {% if workspaces %}
-      <h5>Workspaces</h5>
-      <ul class="list-group list-unstyled">
-        {% for workspace in workspaces %}
-        {% is_filter_selected key="workspace" value=workspace.pk as is_active %}
-        <li class="list-group-item d-flex{% if is_active %} active{% endif %}">
-
-          <a class="text-truncate flex-grow-1" href="{% url_with_querystring workspace=workspace.pk %}">
-            {{ workspace.name }}
-          </a>
-
-          {% if is_active %}
-          <a
-            type="button"
-            class="close"
-            aria-label="Close"
-            href="{% url_without_querystring workspace=workspace.pk %}"
-            >
-            <span aria-hidden="true">&times;</span>
-          </a>
-          {% endif %}
-
-        </li>
-        {% endfor %}
-      </ul>
-      {% endif %}
-
-    </div>
-
   </div>
 
 </div>
 {% endblock content %}
+
+{% block extra_js %}
+<script type="text/javascript" src="{% static 'vendor/select2.min.js' %}"></script>
+<script type="text/javascript">
+  $(document).ready(function() {
+    $('#filter_backend').select2({
+      placeholder: "Backend",
+      selectionCssClass: ":all:",
+      theme: "bootstrap4",
+    });
+    $('#filter_status').select2({
+      placeholder: "Status",
+      selectionCssClass: ":all:",
+      theme: "bootstrap4",
+    });
+    $('#filter_user').select2({
+      placeholder: "User",
+      selectionCssClass: ":all:",
+      theme: "bootstrap4",
+    });
+    $('#filter_workspace').select2({
+      placeholder: "Workspace",
+      selectionCssClass: ":all: mr-2",
+      theme: "bootstrap4",
+    });
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
This switches the event log page to use dropdowns with select2.  As a bonus it makes it much clearer which filters are applied on page load.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/E0uoZ71o/e0cd6cc2-204e-4419-877c-9decd62f06a1.jpg?v=9a00e387ee59dfb44a453ee6d415e545)

Fixes #921 
Fixes #1298 