### PR TITLE
Investigate GHA Metadata

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,33 @@
+name: Explore dependabot metadata
+
+on:
+  pull_request_target:
+  push:
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Get metadata for Dependabot PRs
+        run: cat ${{ steps.dependabot-metadata.outputs.updated-dependencies-json }} > updated-dependencies.json
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Store json payload
+        uses: actions/upload-artifact@v2
+        with:
+          name: updated-dependencies
+          path: updated-dependencies.json


### PR DESCRIPTION
~This is waiting on Dependabot to raise a new PR we can test against.  In it's current form it will upload the full event payload (I hope) as an asset so we can work out if only running this for Python dependencies is possible.~

The plan is to have this workflow added to the repo template and applied to existing repos, auto-applying certain classes of dependency.  For job-server this will be all Python dependencies assuming all checks have passed.

---

We can't test this until it's on the default branch so the plan is to get it in, test with some dependabot PRs, then iterate from there, following [this seciton of the docs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request), but filtering on language type.