### PR TITLE
Get More Dependabot Metadata

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,9 +1,6 @@
 name: Explore dependabot metadata
 
-on:
-  pull_request_target:
-  push:
-  workflow_dispatch:
+on: pull_request_target
 
 permissions:
   pull-requests: write
@@ -21,7 +18,10 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Get metadata for Dependabot PRs
-        run: cat ${{ steps.dependabot-metadata.outputs.updated-dependencies-json }} > updated-dependencies.json
+        run: |
+          mkdir -p outputs
+          echo ${{ steps.dependabot-metadata }} > outputs/dependabot.json
+          echo ${{ github.event }} > outputs/event.json
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -29,5 +29,5 @@ jobs:
       - name: Store json payload
         uses: actions/upload-artifact@v2
         with:
-          name: updated-dependencies
-          path: updated-dependencies.json
+          name: outputs
+          path: outputs/


### PR DESCRIPTION
This does a few things:
* drop event types now that we can see #1597 triggers `pull_request_target`
* use echo instead of cat because context is a templating construct
* grab the entire dependabot metadata blob [because `outputs.updated-dependencies-json` doesn't appear to contain anything useful](https://github.com/opensafely-core/job-server/runs/5184168004?check_suite_focus=true#step:3:1)
* grab the event pyayload
* bundle both outputs to a directory and expose them as artefacts