### PR TITLE
echo to logs instead of a file

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,15 +19,8 @@ jobs:
 
       - name: Get metadata for Dependabot PRs
         run: |
-          mkdir -p outputs
-          echo ${{ steps.dependabot-metadata }} > outputs/dependabot.json
-          echo ${{ github.event }} > outputs/event.json
+          echo ${{ steps.dependabot-metadata }}
+          echo ${{ github.event }}
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Store json payload
-        uses: actions/upload-artifact@v2
-        with:
-          name: outputs
-          path: outputs/


### PR DESCRIPTION
Echoing to a file produces `Object` in both files (🤦‍♂️), so lets try getting the contents of the objects into logs instead.