### PR TITLE
Only run this workflow on PRs from Dependabot and the python label

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && contains(github.pull_request.labels.*.name, 'python') }}
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata


### PR DESCRIPTION
Dependabot appears to raise PRs with labels set so lets see if we can rely on that.

My only worry here is the labels are added after the PR is created so we might see the event come through initially without that data.  If that's the case then we'll need to checkout the head branch and grep `git-diff --stat` for the appropriate filename changes.  But since that's far more involved I think we can punt on it until we know it's required.