### PR TITLE
Check contains output in a run block

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' && contains(github.pull_request.labels.*.name, 'python') }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
@@ -19,6 +19,9 @@ jobs:
 
       - name: Get metadata for Dependabot PRs
         run: |
+          echo ${{ toJSON(github.actor) }}
+          echo ${{ toJSON(github.pull_request.labels) }}
+          echo ${{ contains(github.pull_request.labels.*.name, 'python') }}
           echo ${{ toJSON(steps.dependabot-metadata) }}
           echo ${{ toJSON(github.event) }}
         env:


### PR DESCRIPTION
The previous attempt didn't run the workflow so we also didn't get any output, so this attempts to see what the contains() expression gives us as well as outputting the other parts of the previous check so we can manually verify them.