### PR TITLE
update Sentry release config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,8 +123,8 @@ jobs:
       - name: Create Sentry release
         uses: getsentry/action-release@744e4b262278339b79fb39c8922efcae71e98e39
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_RELEASE_INTEGRATION_TOKEN }}
+          SENTRY_ORG: ebm-datalab
+          SENTRY_PROJECT: job-server
         with:
           environment: production


### PR DESCRIPTION
We don't gain anything from hiding our org and project names in the
config, and we now have an Org-level secret for the integration.