### PR TITLE
Expose Published Files to Unauthenticated User

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -2,16 +2,11 @@ import cgi
 
 import structlog
 from django.db import transaction
-from django.http import FileResponse
+from django.db.models import Value
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import serializers
-from rest_framework.exceptions import (
-    NotAuthenticated,
-    NotFound,
-    ParseError,
-    ValidationError,
-)
+from rest_framework.exceptions import NotAuthenticated, ParseError, ValidationError
 from rest_framework.generics import CreateAPIView, RetrieveAPIView
 from rest_framework.parsers import FileUploadParser, JSONParser
 from rest_framework.response import Response
@@ -21,6 +16,7 @@ from jobserver import releases, slacks
 from jobserver.api import get_backend_from_token
 from jobserver.authorization import has_permission
 from jobserver.models import Release, ReleaseFile, Snapshot, User, Workspace
+from jobserver.releases import serve_file
 from jobserver.utils import set_from_qs
 
 
@@ -81,7 +77,6 @@ def validate_release_access(request, workspace):
 
     This validation uses Django's regular User auth.
     """
-    # TODO: check if release is published
     if request.user.is_anonymous:
         raise NotAuthenticated("Invalid user or token")
 
@@ -248,12 +243,21 @@ class SnapshotAPI(APIView):
             pk=self.kwargs["snapshot_id"],
         )
 
+        # grab whether the Snapshot has been published so we can annotate a
+        # static value to each ReleaseFile in the query below.
+        is_published = snapshot.published_at is not None
+
         validate_snapshot_access(request, snapshot)
         files = {
             f.name: f
             for f in snapshot.files.select_related(
-                "created_by", "release", "release__backend"
-            )
+                "created_by",
+                "release",
+                "release__backend",
+                "workspace",
+                "workspace__project",
+                "workspace__project__org",
+            ).annotate(is_published=Value(is_published))
         }
 
         return Response(generate_index(files))
@@ -329,28 +333,3 @@ class WorkspaceStatusAPI(RetrieveAPIView):
 
     class serializer_class(serializers.Serializer):
         uses_new_release_flow = serializers.BooleanField()
-
-
-def serve_file(request, rfile):
-    """Serve a ReleaseFile as the response.
-
-    If Releases-Redirect header is set, use nginx's X-Accel-Redirect to serve
-    response. Else just serve the bytes directly (for dev).
-    """
-    path = rfile.absolute_path()
-    # check the file actually exists on disk
-    if not path.exists():
-        raise NotFound
-
-    internal_redirect = request.headers.get("Releases-Redirect")
-    if internal_redirect:
-        # we're behind nginx, so use X-Accel-Redirect to serve the file
-        # from nginx, relative to RELEASES_STORAGE.
-        response = Response()
-        response.headers["X-Accel-Redirect"] = f"{internal_redirect}/{rfile.path}"
-    else:
-        # serve directly from django in dev use regular django response to
-        # bypass DRFs renderer framework and just serve bytes
-        response = FileResponse(path.open("rb"))
-
-    return response

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -249,7 +249,12 @@ class SnapshotAPI(APIView):
         )
 
         validate_snapshot_access(request, snapshot)
-        files = {f.name: f for f in snapshot.files.select_related("created_by")}
+        files = {
+            f.name: f
+            for f in snapshot.files.select_related(
+                "created_by", "release", "release__backend"
+            )
+        }
 
         return Response(generate_index(files))
 

--- a/jobserver/models/outputs.py
+++ b/jobserver/models/outputs.py
@@ -158,6 +158,21 @@ class ReleaseFile(models.Model):
 
     def get_api_url(self):
         """The API url that will serve up this file."""
+        if getattr(self, "is_published", False):
+            # This is a hack so the view for viewing a published ReleaseFile
+            # can pass down the knowledge that a ReleaseFile has been
+            # published, avoid O(N) queries on views which aren't expecting to
+            # have to add `.select_related("snapshot")` to a QuerySet.
+            return reverse(
+                "published-file",
+                kwargs={
+                    "org_slug": self.workspace.project.org.slug,
+                    "project_slug": self.workspace.project.slug,
+                    "workspace_slug": self.workspace.name,
+                    "file_id": self.id,
+                },
+            )
+
         return reverse("api:release-file", kwargs={"file_id": self.id})
 
     def get_delete_url(self):

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -257,6 +257,9 @@ SERVER_EMAIL = "your-server@example.com"
 # REST Framework
 # https://www.django-rest-framework.org/api-guide/settings/
 REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication"
+    ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 100,
 }

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -46,6 +46,7 @@ from .views.projects import (
 )
 from .views.releases import (
     ProjectReleaseList,
+    PublishedSnapshotFile,
     ReleaseDetail,
     ReleaseDownload,
     ReleaseFileDelete,
@@ -167,6 +168,10 @@ outputs_urls = [
     ),
 ]
 
+published_files_urls = [
+    path("<file_id>/", PublishedSnapshotFile.as_view(), name="published-file"),
+]
+
 releases_urls = [
     path(
         "",
@@ -207,6 +212,7 @@ workspace_urls = [
         name="workspace-notifications-toggle",
     ),
     path("outputs/", include(outputs_urls)),
+    path("published/", include(published_files_urls)),
     path("releases/", include(releases_urls)),
     path("<int:pk>/", JobRequestDetail.as_view(), name="job-request-detail"),
     path("<int:pk>/cancel/", JobRequestCancel.as_view(), name="job-request-cancel"),

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -11,7 +11,12 @@ from django.views.generic import View
 
 from ..authorization import has_permission
 from ..models import Project, Release, ReleaseFile, Snapshot, Workspace
-from ..releases import build_outputs_zip, build_spa_base_url, workspace_files
+from ..releases import (
+    build_outputs_zip,
+    build_spa_base_url,
+    serve_file,
+    workspace_files,
+)
 
 
 class ProjectReleaseList(View):
@@ -78,6 +83,18 @@ class ProjectReleaseList(View):
             "project_release_list.html",
             context=context,
         )
+
+
+class PublishedSnapshotFile(View):
+    def get(self, request, *args, **kwargs):
+        """Return the content of a specific ReleaseFile which has been published"""
+        rfile = get_object_or_404(ReleaseFile, id=self.kwargs["file_id"])
+
+        is_published = rfile.snapshots.exclude(published_at=None).exists()
+        if not is_published:
+            raise Http404
+
+        return serve_file(request, rfile)
 
 
 class ReleaseDetail(View):

--- a/tests/unit/jobserver/models/test_outputs.py
+++ b/tests/unit/jobserver/models/test_outputs.py
@@ -107,6 +107,39 @@ def test_releasefile_get_delete_url():
     )
 
 
+def test_releasefile_get_api_url_without_is_published():
+    files = {"file.txt": b"contents"}
+    release = ReleaseFactory(ReleaseUploadsFactory(files))
+
+    file = release.files.first()
+
+    url = file.get_api_url()
+
+    assert url == reverse("api:release-file", kwargs={"file_id": file.id})
+
+
+def test_releasefile_get_api_url_with_is_published():
+    files = {"file.txt": b"contents"}
+    release = ReleaseFactory(ReleaseUploadsFactory(files))
+
+    file = release.files.first()
+
+    # mirror the SnapshotAPI view setting this value on the ReleaseFile object.
+    setattr(file, "is_published", True)
+
+    url = file.get_api_url()
+
+    assert url == reverse(
+        "published-file",
+        kwargs={
+            "org_slug": release.workspace.project.org.slug,
+            "project_slug": release.workspace.project.slug,
+            "workspace_slug": release.workspace.name,
+            "file_id": file.id,
+        },
+    )
+
+
 def test_releasefile_ulid():
     release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
     rfile = release.files.first()

--- a/tests/unit/jobserver/test_urls.py
+++ b/tests/unit/jobserver/test_urls.py
@@ -144,6 +144,7 @@ def test_url_redirects(client, url, redirect):
         ("/o/p/w/outputs/42/", releases.SnapshotDetail),
         ("/o/p/w/outputs/42/download/", releases.SnapshotDownload),
         ("/o/p/w/outputs/42/file.txt", releases.SnapshotDetail),
+        ("/o/p/w/published/42/", releases.PublishedSnapshotFile),
         ("/o/p/w/releases/", releases.WorkspaceReleaseList),
         ("/o/p/w/releases/42/", releases.ReleaseDetail),
         ("/o/p/w/releases/42/download/", releases.ReleaseDownload),


### PR DESCRIPTION
ReleaseFiles are currently served to the SPA (and directly when opening in a new tab) by the `ReleaseFileAPI` view.  This checks a file can be viewed by checking details about the requesting user and the workspace.  Unfortunately this doesn't let us check if a file has been published, or handle the user being anonymous.

To work around this situation this PR:
* removes the default BasicAuthentication auth class from DRF so unauthenticated users can get through to views, since we handle our own permissions inside each view.
* Adds a new `PublishedSnapshotFile` view under `/<org>/<project>/<workspace>/published/<file_id>/` from which we can serve a file.

This lets us serve publicly viewable files from a completely separate URL, meaning we could, if necessary, apply caching to those URLs should we be slashdotted.

There's also a drive-by optimisation since my local copy of the SRO measures Ouputs view was doing ~2100 queries and taking several seconds to load.