### PR TITLE
fix: do not ensure_backends on deployment

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 ./manage.py check --deploy
 ./manage.py migrate
 ./manage.py ensure_admins
-./manage.py ensure_backends
 ./manage.py collectstatic --no-input
 
 exec "$@"

--- a/jobserver/backends.py
+++ b/jobserver/backends.py
@@ -9,7 +9,7 @@ backends = [
         "name": "EMIS",
         "slug": "emis",
         "is_active": True,
-        "level_4_url": "http://localhost:8001",
+        "level_4_url": "https://emis.backends.opensafely.org:8001",
     },
     {
         "id": 2,


### PR DESCRIPTION
This was rewriting the db config in production.

ensure_backends command still works locally if needed in dev.
