### PR TITLE
Update policy link to production site

### DIFF
--- a/snippets/datasets-rubric.md
+++ b/snippets/datasets-rubric.md
@@ -1,3 +1,3 @@
-If you require access to any of the below datasets, the host organisations providing the data may also need to approve access to them; there will also be associated [acknowledgement and data sharing / publication policies](https://policies-for-researchers.opensafely.pages.dev/policies-for-researchers/#acknowledgment-and-data-sharing--publication-policy) that must be adhered to. 
+If you require access to any of the below datasets, the host organisations providing the data may also need to approve access to them; there will also be associated [acknowledgement and data sharing / publication policies](https://www.opensafely.org/policies-for-researchers/#acknowledgment-and-data-sharing--publication-policy) that must be adhered to. 
 
 OpenSAFELY will contact the applicant to discuss any additional approval processes.


### PR DESCRIPTION
In `snippets/terms.md`, the same page is linked, but on the production
site.

This change makes the links consistent.

The production site also has more content than the URL linked. For
example, the ONS-CIS information is "awaiting acknowledgement content"
in the page linked, but updated on the production site.