### PR TITLE
Cancelling jobs from a job request

### DIFF
--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -84,7 +84,7 @@
         </button>
       </form>
       <p class="text-muted">Cancelling this job will cancel both the current job and any subsequent jobs that depend on it.</p>
-      {% endif %}
+    {% endif %}
   </div>
 </div>
 {% endblock jumbotron %}

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -83,7 +83,8 @@
           Cancel
         </button>
       </form>
-    {% endif %}
+      <p class="text-muted">Cancelling this job will cancel both the current job and any subsequent jobs that depend on it.</p>
+      {% endif %}
   </div>
 </div>
 {% endblock jumbotron %}

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -51,7 +51,15 @@ class JobRequestCancel(View):
         if job_request.is_completed:
             return redirect(job_request)
 
-        actions = list(set(job_request.jobs.values_list("action", flat=True)))
+        # Exclude succeeded jobs (failed or succeeded status, consistent with Job.is_completed method)
+        actions = list(
+            set(
+                job_request.jobs.exclude(
+                    status__in=["failed", "succeeded"]
+                ).values_list("action", flat=True)
+            )
+        )
+
         job_request.cancelled_actions = actions
         job_request.save()
 


### PR DESCRIPTION
Cancelling a job request previously added all the jobs to the request's cancelled_actions.  This resulted in jobs that had already completed (both failed and succeeded jobs) being marked as cancelled too.  This PR filters the request's jobs to cancel only those that have not yet completed.

Also adds some explanatory text to the individual job Cancel button.

Fixes #1629 