### PR TITLE
Check Code Changes to get Language Type

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-name: Auto-merge Dependabot Python updates
+name: Approve and enable auto-merge for Dependabot updates
 
 on: pull_request
 
@@ -9,8 +9,28 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'python') }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Check we're dealing with Python updates
+        id: check-labels
+        run: |
+          if gh pr view --json labels -q .labels | grep -q '"name":"python"'; then
+            echo ::set-output name=is-python-dependency::'y'
+          fi
+
+      - name: Fail if dependency update did not update a requirements file
+        if: ${{ ! startsWith(steps.check-labels.outputs.is-python-dependency, 'y') }}
+        run: /bin/false
+
       - name: Enable auto-merge for Dependabot PRs
         run: |
           set -eu


### PR DESCRIPTION
The current version of this workflow hasn't been triggering, from which I can assume that labels are applied after the PR is raised, so they're not present in the event payload we're receiving.

This looks at the PR branch to look for Python-specific requirements changes done in a Dependabot PR.  Mirroring how we look for tag updates in Data Builder it sets an output which we check in the subsequent step so non-Python updates (from Dependabot) should be ignored _without_ a failing Job.

---

This extra set of steps probably isn't required for most of our projects, which can rely on tests passing alone.  However, for job-server don't want to automatically merge Javascript changes without testing them out manually.  We're confident-enoiugh that our tests will catch problems with the Python dependencies.