### PR TITLE
Display application on Staff Area ProjectDetail page if it exists

### DIFF
--- a/staff/templates/staff/project_detail.html
+++ b/staff/templates/staff/project_detail.html
@@ -38,6 +38,14 @@
       <li>
         <strong>Created at:</strong> {{ project.created_at }}
       </li>
+
+      {% if application %}
+      <li>
+        <strong>Application:</strong>
+        <a href="{{ application.get_staff_url }}">{{ application.pk_hash }} by {{ application.created_by.name }}</a>
+      </li>
+      {% endif %}
+
     </ul>
 
     <div class="d-flex">

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -90,6 +90,7 @@ class ProjectDetail(DetailView):
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {
+            "application": self.object.applications.first(),
             "memberships": self.object.memberships.select_related("user").order_by(
                 Lower("user__username")
             ),


### PR DESCRIPTION
Now that we're handling application approvals via the Staff Area this puts a link to a Project's application, if one exists, on the ProjectDetail page.