### PR TITLE
Set Project.created_by when approving an Application

### DIFF
--- a/staff/views/applications.py
+++ b/staff/views/applications.py
@@ -47,7 +47,10 @@ class ApplicationApprove(FormView):
         project_name = form.cleaned_data["project_name"]
 
         # create Project with the chosen org
-        project = org.projects.create(name=project_name)
+        project = org.projects.create(
+            name=project_name,
+            created_by=self.request.user,
+        )
 
         self.application.approved_at = timezone.now()
         self.application.approved_by = self.request.user

--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -70,6 +70,8 @@ def test_applicationapprove_post_success(rf, core_developer, complete_applicatio
 
     assert complete_application.approved_at
     assert complete_application.approved_by == core_developer
+    assert complete_application.project
+    assert complete_application.project.created_by == core_developer
 
 
 def test_applicationapprove_with_deleted_application(


### PR DESCRIPTION
This should be set so we always have an audit trail.