### PR TITLE
Link Project to Application UI

### DIFF
--- a/staff/templates/staff/project_detail.html
+++ b/staff/templates/staff/project_detail.html
@@ -1,6 +1,7 @@
 {% extends "staff/base.html" %}
 
 {% load humanize %}
+{% load static %}
 
 {% block metatitle %}{{ project.name }}: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
 
@@ -39,12 +40,22 @@
         <strong>Created at:</strong> {{ project.created_at }}
       </li>
 
-      {% if application %}
       <li>
         <strong>Application:</strong>
-        <a href="{{ application.get_staff_url }}">{{ application.pk_hash }} by {{ application.created_by.name }}</a>
+
+        {% if application %}
+        <a href="{{ application.get_staff_url }}">
+          {{ application.pk_hash }} by {{ application.created_by.name }}
+        </a>
+        {% else %}
+        <a href="{% url 'staff:project-link-application' slug=project.slug %}"
+          class="btn btn-sm btn-primary"
+          >
+          Find and Link
+        </a>
+        {% endif %}
+
       </li>
-      {% endif %}
 
     </ul>
 

--- a/staff/templates/staff/project_link_application.html
+++ b/staff/templates/staff/project_link_application.html
@@ -1,0 +1,92 @@
+{% extends "staff/base.html" %}
+
+{% load static %}
+
+{% block metatitle %}{{ project.name }}: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:index' %}">Staff area</a>
+      </li>
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:project-list' %}">Projects</a>
+      </li>
+      <li class="breadcrumb-item">
+        <a href="{{ project.get_staff_url }}">{{ project.name }}</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        Link Application
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
+  <div class="container">
+    <h1 class="display-4">Link to an Application</h1>
+    <ul class="list-unstyled lead">
+      <li>
+        <strong>Project:</strong>
+        <a href="{{ project.get_staff_url }}">{{ project.name }}</a>
+      </li>
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block staff_content %}
+<div class="container">
+  <div class="row">
+    <div class="col col-lg-9 col-xl-8">
+
+      <p>
+        Projects for external researchers should all have an approved
+        application linked to them.  Use this form to find the application and
+        link it to the {{ project.name }} project.
+      </p>
+
+      <p><em>Note: Older Projects may not have an application in the system yet.</em></p>
+
+      {% if form.non_field_errors %}
+      <ul>
+        {% for error in form.non_field_errors %}
+        <li class="text-danger">{{ error }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+
+      <ul class="list-group">
+
+        {% for application in applications %}
+        <li class="list-group-item">
+
+          <form method="POST">
+            {% csrf_token %}
+
+            <input type="hidden" name="application" value="{{ application.pk }}" />
+
+            <div class="d-flex justify-content-between align-items-center">
+              <span>
+                <a href="{{ application.get_staff_url }}">
+                  {{ application.pk_hash }} by {{ application.created_by.name }}
+                </a>
+                <small>({{ application.status }})</small>
+              </span>
+
+              <button class="btn btn-sm btn-primary" type="submit">Link</button>
+            </div>
+          </form>
+
+        </li>
+        {% endfor %}
+
+      </ul>
+
+    </div>
+  </div>
+</div>
+{% endblock staff_content %}

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -32,6 +32,7 @@ from .views.projects import (
     ProjectDetail,
     ProjectEdit,
     ProjectFeatureFlags,
+    ProjectLinkApplication,
     ProjectList,
     ProjectMembershipEdit,
     ProjectMembershipRemove,
@@ -99,6 +100,11 @@ project_urls = [
         "<slug>/feature-flags/",
         ProjectFeatureFlags.as_view(),
         name="project-feature-flags",
+    ),
+    path(
+        "<slug>/link-application/",
+        ProjectLinkApplication.as_view(),
+        name="project-link-application",
     ),
     path(
         "<slug>/members/<pk>/edit/",

--- a/tests/unit/staff/test_forms.py
+++ b/tests/unit/staff/test_forms.py
@@ -1,8 +1,13 @@
 from jobserver.models import Backend
 from jobserver.utils import set_from_qs
-from staff.forms import ApplicationApproveForm, ProjectFeatureFlagsForm, UserForm
+from staff.forms import (
+    ApplicationApproveForm,
+    ProjectFeatureFlagsForm,
+    ProjectLinkApplicationForm,
+    UserForm,
+)
 
-from ...factories import BackendFactory, OrgFactory, ProjectFactory
+from ...factories import ApplicationFactory, BackendFactory, OrgFactory, ProjectFactory
 
 
 def test_applicationapproveform_success():
@@ -34,6 +39,39 @@ def test_projectfeatureflagsform_with_unknown_value():
         "flip_to": ["Select a valid choice. test is not one of the available choices."]
     }
     assert form.errors == expected
+
+
+def test_projectlinkapplicationform_success():
+    application = ApplicationFactory(project=None)
+
+    form = ProjectLinkApplicationForm(
+        data={"application": application.pk}, instance=None
+    )
+    assert form.is_valid(), form.errors
+
+    assert form.cleaned_data["application"] == application
+
+
+def test_projectlinkapplicationform_with_already_linked_application():
+    application = ApplicationFactory(project=ProjectFactory())
+
+    form = ProjectLinkApplicationForm(
+        data={"application": application.pk}, instance=None
+    )
+
+    assert not form.is_valid()
+
+    assert form.errors == {
+        "application": ["Can't link Application to multiple Projects"]
+    }
+
+
+def test_projectlinkapplicationform_with_unknown_application():
+    form = ProjectLinkApplicationForm(data={"application": "0"}, instance=None)
+
+    assert not form.is_valid()
+
+    assert form.errors == {"application": ["Unknown Application"]}
 
 
 def test_userform_success():


### PR DESCRIPTION
This adds a page to the Staff Area to help us (likely, only me though) link Projects to their Application.  We have a number of Projects which were created via the Staff Area since we weren't using the Approve Application UI (but now are) and so aren't linked to their relevant Application.  We need to manually reconcile that and this is intended to help with that process.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/8LuDJ2Z9/45d847b4-0fc6-425a-bfb4-a99846b2d20e.jpg?v=e3e614fe0e294503cfbadce1704e0153)