### PR TITLE
Add an Org via the Approve Application Page

### DIFF
--- a/staff/forms.py
+++ b/staff/forms.py
@@ -41,14 +41,8 @@ class PickUsersMixin:
 
 
 class ApplicationApproveForm(forms.Form):
+    org = forms.ModelChoiceField(queryset=Org.objects.order_by("name"))
     project_name = forms.CharField(help_text="Update the study name if necessary")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        orgs = Org.objects.order_by("name")
-
-        self.fields["org"] = forms.ModelChoiceField(queryset=orgs)
 
     def clean_project_name(self):
         project_name = self.cleaned_data["project_name"]

--- a/staff/templates/staff/application_approve.html
+++ b/staff/templates/staff/application_approve.html
@@ -64,18 +64,8 @@
           <legend class="h3 mb-3">Set project details</legend>
 
           <div class="form-group">
-            <div class="d-flex justify-content-between align-items-center">
-              <label class="font-weight-bold" for="id_org">Select an org</label>
-              <button
-                hx-get="{% url 'staff:application-add-org' pk_hash=application.pk_hash %}"
-                hx-target="#modal-container"
-                hx-trigger="click"
-                class="btn btn-sm btn-primary"
-                >
-                Add
-              </button>
-            </div>
-            <select id="id_org" name="org" required>
+            <label class="font-weight-bold" for="id_org">Select an org</label>
+            <select id="id_org" name="org" aria-describedby="orgHelpBlock" required>
               {% for value, label in form.fields.org.choices %}
                 <option
                   value="{{ value }}"
@@ -83,6 +73,17 @@
                   >{{ label }}</option>
               {% endfor %}
             </select>
+            <p id="orgHelpBlock" class="form-text text-muted">
+              If the org doesn't exist, you can
+              <button
+                hx-get="{% url 'staff:application-add-org' pk_hash=application.pk_hash %}"
+                hx-target="#dialog"
+                hx-trigger="click"
+                class="btn btn-link m-0 p-0 border-0 font-weight-bold align-baseline"
+                >
+                add a new org
+              </button>
+            </p>
 
             {% for error in form.orgs.errors %}
               <p class="text-danger">{{ error }}</p>
@@ -98,7 +99,9 @@
   </div>
 </div>
 
-<div id="modal-container"></div>
+<div id="modal" class="modal fade" tabindex="-1">
+  <div id="dialog" class="modal-dialog" hx-target="this"></div>
+</div>
 
 {% endblock %}
 
@@ -114,5 +117,28 @@
       width: "100%"
     });
   });
+</script>
+<script>
+  (function () {
+    htmx.on("htmx:afterSwap", (e) => {
+      // Response targeting #dialog => show the modal
+      if (e.detail.target.id == "dialog") {
+        $("#modal").modal("show");
+      }
+    });
+
+    htmx.on("htmx:beforeSwap", (e) => {
+      // Empty response targeting #dialog => hide the modal
+      if (e.detail.target.id == "dialog" && !e.detail.xhr.response) {
+        $("#modal").modal("hide");
+        e.detail.shouldSwap = false;
+      }
+    });
+
+    // Remove dialog content after hiding
+    $("#modal").on("hidden.bs.modal", () => {
+      $("#dialog").empty();
+    });
+  })();
 </script>
 {% endblock %}

--- a/staff/templates/staff/application_approve.html
+++ b/staff/templates/staff/application_approve.html
@@ -64,7 +64,17 @@
           <legend class="h3 mb-3">Set project details</legend>
 
           <div class="form-group">
-            <label class="font-weight-bold" for="id_org">Select an org</label>
+            <div class="d-flex justify-content-between align-items-center">
+              <label class="font-weight-bold" for="id_org">Select an org</label>
+              <button
+                hx-get="{% url 'staff:application-add-org' pk_hash=application.pk_hash %}"
+                hx-target="#modal-container"
+                hx-trigger="click"
+                class="btn btn-sm btn-primary"
+                >
+                Add
+              </button>
+            </div>
             <select id="id_org" name="org" required>
               {% for value, label in form.fields.org.choices %}
                 <option value="{{ value }}">{{ label }}</option>
@@ -85,9 +95,12 @@
   </div>
 </div>
 
+<div id="modal-container"></div>
+
 {% endblock %}
 
 {% block extra_js %}
+<script type="text/javascript" src="{% static 'vendor/htmx.min.js' %}"></script>
 <script type="text/javascript" src="{% static 'vendor/select2.min.js' %}"></script>
 <script type="text/javascript">
   $(document).ready(function() {

--- a/staff/templates/staff/application_approve.html
+++ b/staff/templates/staff/application_approve.html
@@ -77,7 +77,10 @@
             </div>
             <select id="id_org" name="org" required>
               {% for value, label in form.fields.org.choices %}
-                <option value="{{ value }}">{{ label }}</option>
+                <option
+                  value="{{ value }}"
+                  {% if form.org.value == value %}selected{% endif %}
+                  >{{ label }}</option>
               {% endfor %}
             </select>
 

--- a/staff/templates/staff/org_create.html
+++ b/staff/templates/staff/org_create.html
@@ -23,7 +23,7 @@
 {% block jumbotron %}
 <div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
   <div class="container">
-    <h1 class="display-4">Create a organisation</h1>
+    <h1 class="display-4">Create an organisation</h1>
   </div>
 </div>
 {% endblock jumbotron %}

--- a/staff/templates/staff/org_create.htmx.html
+++ b/staff/templates/staff/org_create.htmx.html
@@ -1,0 +1,61 @@
+{% load static %}
+
+<div id="modal-backdrop" class="modal-backdrop fade show" style="display:block;"></div>
+
+<div id="modal" class="modal fade show" tabindex="-1" style="display:block;" role="dialog">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+
+      <form method="POST">
+        {% csrf_token %}
+
+        <div class="modal-header">
+          <h5 class="modal-title">Create an organisation</h5>
+          <button type="button" class="close" onclick="closeModal()">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+
+        <div class="modal-body">
+          {% if form.non_field_errors %}
+            <ul>
+              {% for error in form.non_field_errors %}
+                <li class="text-danger">{{ error }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+
+          {% include "components/form_text.html" with field=form.name label="Organisation name" name="name" %}
+        </div>
+
+        <div class="modal-footer">
+          <button
+            class="btn btn-success"
+            hx-post="{% url 'staff:application-add-org' pk_hash=application.pk_hash %}"
+            hx-trigger="click"
+            hx-target="#modal-container"
+            hx-swap="outerHTML"
+            >
+            Create
+          </button>
+        </div>
+
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript">
+function closeModal() {
+  const container = document.getElementById("modal-container")
+  const backdrop = document.getElementById("modal-backdrop")
+  const modal = document.getElementById("modal")
+
+  modal.classList.remove("show")
+  backdrop.classList.remove("show")
+
+  setTimeout(function() {
+      container.removeChild(backdrop)
+      container.removeChild(modal)
+  }, 200)
+}
+</script>

--- a/staff/templates/staff/org_create.htmx.html
+++ b/staff/templates/staff/org_create.htmx.html
@@ -1,61 +1,35 @@
 {% load static %}
 
-<div id="modal-backdrop" class="modal-backdrop fade show" style="display:block;"></div>
+<div class="modal-dialog modal-dialog-centered" role="document">
+  <div class="modal-content">
 
-<div id="modal" class="modal fade show" tabindex="-1" style="display:block;" role="dialog">
-  <div class="modal-dialog modal-dialog-centered" role="document">
-    <div class="modal-content">
+    <form method="POST" hx-post="{% url 'staff:application-add-org' pk_hash=application.pk_hash %}">
+      {% csrf_token %}
 
-      <form method="POST">
-        {% csrf_token %}
+      <div class="modal-header">
+        <h5 class="modal-title">Create an organisation</h5>
+        <button type="button" class="close" data-dismiss="modal">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
 
-        <div class="modal-header">
-          <h5 class="modal-title">Create an organisation</h5>
-          <button type="button" class="close" onclick="closeModal()">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
+      <div class="modal-body">
+        {% if form.non_field_errors %}
+          <ul>
+            {% for error in form.non_field_errors %}
+              <li class="text-danger">{{ error }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
 
-        <div class="modal-body">
-          {% if form.non_field_errors %}
-            <ul>
-              {% for error in form.non_field_errors %}
-                <li class="text-danger">{{ error }}</li>
-              {% endfor %}
-            </ul>
-          {% endif %}
+        {% include "components/form_text.html" with field=form.name label="Organisation name" name="name" %}
+      </div>
 
-          {% include "components/form_text.html" with field=form.name label="Organisation name" name="name" %}
-        </div>
+      <div class="modal-footer">
+        <button class="btn btn-success" type="submit">
+          Create
+        </button>
+      </div>
 
-        <div class="modal-footer">
-          <button
-            class="btn btn-success"
-            hx-post="{% url 'staff:application-add-org' pk_hash=application.pk_hash %}"
-            hx-trigger="click"
-            hx-target="#modal-container"
-            hx-swap="outerHTML"
-            >
-            Create
-          </button>
-        </div>
-
-    </div>
   </div>
 </div>
-
-<script type="text/javascript">
-function closeModal() {
-  const container = document.getElementById("modal-container")
-  const backdrop = document.getElementById("modal-backdrop")
-  const modal = document.getElementById("modal")
-
-  modal.classList.remove("show")
-  backdrop.classList.remove("show")
-
-  setTimeout(function() {
-      container.removeChild(backdrop)
-      container.removeChild(modal)
-  }, 200)
-}
-</script>

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -7,6 +7,7 @@ from .views.applications import (
     ApplicationList,
     ApplicationRemove,
     ApplicationRestore,
+    application_add_org,
 )
 from .views.backends import (
     BackendCreate,
@@ -52,6 +53,11 @@ application_urls = [
         "<str:pk_hash>/approve/",
         ApplicationApprove.as_view(),
         name="application-approve",
+    ),
+    path(
+        "<str:pk_hash>/approve/add-org/",
+        application_add_org,
+        name="application-add-org",
     ),
     path("<str:pk_hash>/edit/", ApplicationEdit.as_view(), name="application-edit"),
     path(

--- a/staff/views/applications.py
+++ b/staff/views/applications.py
@@ -2,11 +2,13 @@ import functools
 
 from django.contrib import messages
 from django.db.models import Q
+from django.forms.models import modelform_factory
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.generic import FormView, ListView, UpdateView, View
+from django_htmx.http import HttpResponseClientRedirect
 
 from applications.form_specs import form_specs
 from applications.models import Application
@@ -14,8 +16,37 @@ from applications.wizard import Wizard
 from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_role
 from jobserver.hash_utils import unhash, unhash_or_404
+from jobserver.models import Org
 
 from ..forms import ApplicationApproveForm
+
+
+@require_role(CoreDeveloper)
+def application_add_org(request, pk_hash):
+    application = get_object_or_404(Application, pk=unhash_or_404(pk_hash))
+
+    if not request.htmx:
+        return redirect(application.get_approve_url())
+
+    OrgCreateForm = modelform_factory(Org, fields=["name"])
+
+    if request.POST:
+        form = OrgCreateForm(data=request.POST)
+    else:
+        form = OrgCreateForm()
+
+    if request.GET or not form.is_valid():
+        return TemplateResponse(
+            context={"form": form, "application": application},
+            request=request,
+            template="staff/org_create.htmx.html",
+        )
+
+    org = form.save(commit=False)
+    org.created_by = request.user
+    org.save()
+
+    return HttpResponseClientRedirect(application.get_approve_url())
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")

--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -120,6 +120,37 @@ def test_applicationapprove_get_success(rf, core_developer, complete_application
 
     assert response.status_code == 200
     assert response.context_data["application"] == complete_application
+    assert response.context_data["form"]["org"].initial is None
+
+
+def test_applicationapprove_get_with_org_slug(rf, core_developer, complete_application):
+    org = OrgFactory()
+
+    request = rf.get("/", {"org-slug": org.slug})
+    request.user = core_developer
+
+    response = ApplicationApprove.as_view()(
+        request, pk_hash=complete_application.pk_hash
+    )
+
+    assert response.status_code == 200
+    assert response.context_data["application"] == complete_application
+    assert response.context_data["form"]["org"].initial == org
+
+
+def test_applicationapprove_get_with_org_slug_and_unknown_org(
+    rf, core_developer, complete_application
+):
+    request = rf.get("/", {"org-slug": "0"})
+    request.user = core_developer
+
+    response = ApplicationApprove.as_view()(
+        request, pk_hash=complete_application.pk_hash
+    )
+
+    assert response.status_code == 200
+    assert response.context_data["application"] == complete_application
+    assert response.context_data["form"]["org"].initial is None
 
 
 def test_applicationapprove_post_success(rf, core_developer, complete_application):

--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from applications.models import Application
+from jobserver.models import Org
 from jobserver.utils import set_from_qs
 from staff.views.applications import (
     ApplicationApprove,
@@ -14,9 +15,83 @@ from staff.views.applications import (
     ApplicationList,
     ApplicationRemove,
     ApplicationRestore,
+    application_add_org,
 )
 
 from ....factories import ApplicationFactory, OrgFactory, UserFactory
+
+
+def test_applicationaddorg_get_success(rf, core_developer):
+    application = ApplicationFactory()
+
+    request = rf.get("/")
+    request.htmx = True
+    request.user = core_developer
+
+    response = application_add_org(request, pk_hash=application.pk_hash)
+
+    assert response.status_code == 200
+    assert "modal" in response.rendered_content
+
+
+def test_applicationaddorg_post_existing_org(rf, core_developer):
+    application = ApplicationFactory()
+    org = OrgFactory()
+
+    request = rf.post("/", {"name": org.name})
+    request.htmx = True
+    request.user = core_developer
+
+    response = application_add_org(request, pk_hash=application.pk_hash)
+
+    assert response.status_code == 200
+    assert response.context_data["form"].errors
+
+
+def test_applicationaddorg_post_success(rf, core_developer):
+    application = ApplicationFactory()
+
+    request = rf.post("/", {"name": "Test Org"})
+    request.htmx = True
+    request.user = core_developer
+
+    response = application_add_org(request, pk_hash=application.pk_hash)
+
+    assert response.status_code == 200
+
+    destination = application.get_approve_url() + "?org-slug=test-org"
+    assert response.headers["HX-Redirect"] == destination
+
+    assert Org.objects.filter(name="Test Org").exists()
+
+
+def test_applicationaddorg_unknown_application(rf, core_developer):
+    request = rf.get("/")
+    request.user = core_developer
+
+    with pytest.raises(Http404):
+        application_add_org(request, pk_hash="test")
+
+
+def test_applicationaddorg_without_core_dev_role(rf):
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    with pytest.raises(PermissionDenied):
+        application_add_org(request)
+
+
+def test_applicationaddorg_without_htmx(rf, core_developer):
+    application = ApplicationFactory()
+
+    request = rf.get("/")
+    request.htmx = False
+    request.user = core_developer
+
+    response = application_add_org(request, pk_hash=application.pk_hash)
+
+    assert response.status_code == 302
+    assert response.url == application.get_approve_url()
 
 
 def test_applicationapprove_already_approved(rf, core_developer, complete_application):


### PR DESCRIPTION
When approving an Application we need the Staff member to select an Org and decide on a title for the Project they're about to create.  When the Application is for a new Org the user has to go to the Org section of the Staff Area and create it there, which for a single field form feels like a bit much.  This uses HTMX to call a view which returns a Bootstrap modal with the Org create form in it.  On success it redirects the user back to the approval page with the new Org's slug in the query args so the Org dropdown can pre-select that Org for the user.

I attempted to break down the OrgCreate page's template so we could re-use the form but it ended up being a bit tricky.  The Form instance is generated under the hood by OrgCreate (which is a configured CreateView) so there's no definition to reuse in the HTMX view, and the HTML itself needed to handle being inside a modal (with the submit button being in the modal footer) so it was more readble to not combine them.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/GGulk5Px/c9b08179-d201-4815-84e1-9877c90b4764.jpg?v=e8441a7dc120cf98a564b36e3fb04cae)