### PR TITLE
Retrieve Release id from ReleaseFile path

### DIFF
--- a/jobserver/models/outputs.py
+++ b/jobserver/models/outputs.py
@@ -187,6 +187,17 @@ class ReleaseFile(models.Model):
             },
         )
 
+    def get_latest_url(self):
+        return reverse(
+            "workspace-latest-outputs-detail",
+            kwargs={
+                "org_slug": self.release.workspace.project.org.slug,
+                "project_slug": self.release.workspace.project.slug,
+                "workspace_slug": self.release.workspace.name,
+                "path": self.name,
+            },
+        )
+
     @property
     def is_deleted(self):
         """Has the file on disk been deleted?"""

--- a/jobserver/templates/_release_list.html
+++ b/jobserver/templates/_release_list.html
@@ -37,7 +37,7 @@
         {% for file in r.files %}
         <li class="list-group-item d-flex align-items-center justify-content-between">
           <span class="d-flex align-items-baseline">
-            <a href="{% url 'release-detail' org_slug=org_slug project_slug=project_slug workspace_slug=workspace_slug pk=r.id path=file.path %}"
+            <a href="{{ file.detail_url }}"
               {% if file.is_deleted %}
               class="btn-link disabled"
               {% endif %}

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -283,13 +283,25 @@ class WorkspaceReleaseList(View):
             project=workspace.project,
         )
 
+        def build_files(files, url_method_name):
+            return [
+                {
+                    "pk": f.pk,
+                    "name": f.name,
+                    "is_deleted": f.is_deleted,
+                    "deleted_by": f.deleted_by,
+                    "detail_url": getattr(f, url_method_name),
+                }
+                for f in files
+            ]
+
         latest_files = list(
             sorted(workspace_files(workspace).values(), key=lambda rf: rf.name)
         )
         latest_files = {
             "can_view_files": can_view_files and bool(latest_files),
             "download_url": workspace.get_latest_outputs_download_url(),
-            "files": latest_files,
+            "files": build_files(latest_files, "get_latest_url"),
             "id": "latest",
             "title": "All outputs - the most recent version of each file",
             "view_url": workspace.get_latest_outputs_url(),
@@ -305,7 +317,7 @@ class WorkspaceReleaseList(View):
             {
                 "can_view_files": can_view_files and r.files.exists(),
                 "download_url": r.get_download_url(),
-                "files": r.files.all(),
+                "files": build_files(r.files.all(), "get_absolute_url"),
                 "id": r.pk,
                 "title": build_title(r),
                 "view_url": r.get_absolute_url(),

--- a/tests/unit/jobserver/models/test_outputs.py
+++ b/tests/unit/jobserver/models/test_outputs.py
@@ -107,6 +107,25 @@ def test_releasefile_get_delete_url():
     )
 
 
+def test_releasefile_get_latest_url():
+    files = {"file.txt": b"contents"}
+    release = ReleaseFactory(ReleaseUploadsFactory(files))
+
+    file = release.files.first()
+
+    url = file.get_latest_url()
+
+    assert url == reverse(
+        "workspace-latest-outputs-detail",
+        kwargs={
+            "org_slug": release.workspace.project.org.slug,
+            "project_slug": release.workspace.project.slug,
+            "workspace_slug": release.workspace.name,
+            "path": file.name,
+        },
+    )
+
+
 def test_releasefile_get_api_url_without_is_published():
     files = {"file.txt": b"contents"}
     release = ReleaseFactory(ReleaseUploadsFactory(files))


### PR DESCRIPTION
The URL for files in the latest release are structured differently to
URLs in other releases, which contain the Release id. So, we need
another way of retrieving the Release id. This solution parses the file
path to retreive it.