### PR TITLE
remove the checkout step from auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,11 +17,6 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Checkout branch
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
       - name: Check we're dealing with Python updates
         id: check-labels
         run: |


### PR DESCRIPTION
we don't need the branch checked out and since we checkout a SHA instead
of HEAD anyway it seems to confuse GH CLI