### PR TITLE
checkout with the branch name so we get HEAD

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - uses: actions/checkout@v3
+        with:
+          # use ref here so we're on the HEAD of the PR branch
+          ref: ${{ github.event.pull_request.head.ref }}
+
       - name: Check we're dealing with Python updates
         id: check-labels
         run: |


### PR DESCRIPTION
actions/checkout checks out a ref by default which puts the git repo
into detached head state, so we check out the branch by name instead so
the `gh pr` calls know which PR we're working with.