### PR TITLE
Rename latest files to latest release

### DIFF
--- a/jobserver/templates/workspace_release_list.html
+++ b/jobserver/templates/workspace_release_list.html
@@ -49,8 +49,8 @@
 {% block content %}
 <div class="container">
   <ul class="list-group">
-    {% if latest_files.can_view_files %}
-      {% include "_release_list.html" with org_slug=workspace.project.org.slug project_slug=workspace.project.slug workspace_slug=workspace.name r=latest_files %}
+    {% if latest_release.can_view_files %}
+      {% include "_release_list.html" with org_slug=workspace.project.org.slug project_slug=workspace.project.slug workspace_slug=workspace.name r=latest_release %}
     {% endif %}
 
     {% for release in releases %}

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -298,7 +298,7 @@ class WorkspaceReleaseList(View):
         latest_files = list(
             sorted(workspace_files(workspace).values(), key=lambda rf: rf.name)
         )
-        latest_files = {
+        latest_release = {
             "can_view_files": can_view_files and bool(latest_files),
             "download_url": workspace.get_latest_outputs_download_url(),
             "files": build_files(latest_files, "get_latest_url"),
@@ -330,7 +330,7 @@ class WorkspaceReleaseList(View):
         ]
 
         context = {
-            "latest_files": latest_files,
+            "latest_release": latest_release,
             "releases": releases,
             "user_can_delete_files": can_delete_files,
             "workspace": workspace,

--- a/tests/unit/jobserver/views/test_releases.py
+++ b/tests/unit/jobserver/views/test_releases.py
@@ -751,8 +751,8 @@ def test_workspacereleaselist_build_files_for_latest(rf):
     )
 
     assert response.status_code == 200
-    assert response.context_data["latest_files"]["id"] == "latest"
-    files = response.context_data["latest_files"]["files"]
+    assert response.context_data["latest_release"]["id"] == "latest"
+    files = response.context_data["latest_release"]["files"]
     assert all(f["detail_url"].__func__ == ReleaseFile.get_latest_url for f in files)
 
 


### PR DESCRIPTION
The collection of most recent files forms a pseudo-release object,
containing a list of files and other data. This has been renamed to
latest_release.