### PR TITLE
Revert "feat: add OpenTelemetry Django auto-instrumentation"

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: opentelemetry-instrument gunicorn jobserver.wsgi --config=gunicorn.conf.py
+web: gunicorn jobserver.wsgi --config=gunicorn.conf.py

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -29,7 +29,3 @@ DJANGO_VITE_DEV_MODE=False
 
 # Token for frontend Sentry error tracking DSN
 VITE_SENTRY_DSN=
-
-export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=VALIDKEY1234,x-honeycomb-dataset=job-server"
-export OTEL_SERVICE_NAME="job-server"

--- a/justfile
+++ b/justfile
@@ -91,11 +91,6 @@ upgrade env package="": virtualenv
     FORCE=true {{ just_executable() }} requirements-{{ env }} $opts
 
 
-# Run the dev project with telemetry
-run-telemetry: devenv
-    $BIN/opentelemetry-instrument $BIN/python manage.py runserver --noreload
-
-
 # *ARGS is variadic, 0 or more. This allows us to do `just test -k match`, for example.
 # Run the tests
 test *ARGS: devenv

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -22,8 +22,6 @@ pydantic
 pygments
 python-ulid
 pyyaml
-opentelemetry-instrumentation-django
-opentelemetry-sdk
 requests
 sentry-sdk
 slack-sdk

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -138,10 +138,6 @@ defusedxml==0.7.1 \
     # via
     #   python3-openid
     #   social-auth-core
-deprecated==1.2.13 \
-    --hash=sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d \
-    --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
-    # via opentelemetry-api
 dj-database-url==0.5.0 \
     --hash=sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163 \
     --hash=sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9
@@ -308,45 +304,6 @@ oauthlib==3.1.1 \
     # via
     #   requests-oauthlib
     #   social-auth-core
-opentelemetry-api==1.10.0 \
-    --hash=sha256:210178a9bc0c3b62290d604b6351b17fbccbc5eb0ac475ec60dd22242529d226 \
-    --hash=sha256:ee56d74d8576807d86e0791bcfa44ec2c9abeec3f5ea080de09fd5fe7c442655
-    # via
-    #   opentelemetry-instrumentation
-    #   opentelemetry-instrumentation-django
-    #   opentelemetry-instrumentation-wsgi
-    #   opentelemetry-sdk
-opentelemetry-instrumentation==0.29b0 \
-    --hash=sha256:1fed636b5a82c6d6a78b4f9d4358295afdffa382e4b2bb509ffc88ac05e5090e \
-    --hash=sha256:c74f2a810ddad12199e25e893381cc082d304a8cd919571c369a08f35e3eff25
-    # via
-    #   opentelemetry-instrumentation-django
-    #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-django==0.29b0 \
-    --hash=sha256:5e5c35ae87339aeb3e330efc6504d56d241d0f8ec12bb1367034a755ca53d911 \
-    --hash=sha256:edb9753c1345c2b6f743aec3b3563bb028c257515a6cb8eb3fb42559d9b8aaa5
-    # via -r requirements.prod.in
-opentelemetry-instrumentation-wsgi==0.29b0 \
-    --hash=sha256:739e687fbd55e68d55da199f3c8a9a38ce6b451a34b3bd0d6ff1f26bc4318939 \
-    --hash=sha256:8f38a7b7416ad7c3ab043e0650611f709e171572bb16f3686314f1b281dbfc0b
-    # via opentelemetry-instrumentation-django
-opentelemetry-sdk==1.10.0 \
-    --hash=sha256:4cb82be52b99041c06ea172eab36f27f93c510877c0745f6ee79a108fb1764bd \
-    --hash=sha256:ce360e7e61384c13cc1e18de1c0cd866eab1f4cc50eea90fa5377ee8f74f48c4
-    # via -r requirements.prod.in
-opentelemetry-semantic-conventions==0.29b0 \
-    --hash=sha256:441ce60d2be9a5e9faddf3f009034b63f98417f7ec86c2976f65d9dc1dba5643 \
-    --hash=sha256:f0fef5d03a6815747ecb1ebd68ead31b0710414fa130e6c32f883465cbbaec5a
-    # via
-    #   opentelemetry-instrumentation-django
-    #   opentelemetry-instrumentation-wsgi
-    #   opentelemetry-sdk
-opentelemetry-util-http==0.29b0 \
-    --hash=sha256:85040bc866f391df05303993f8abdffda3c251e955e6d256b59a13ec65e1b026 \
-    --hash=sha256:c4adad35cf1ea0a8c6af58ff682fa877d9eaa1b6ebaf0751d345be79120af8b7
-    # via
-    #   opentelemetry-instrumentation-django
-    #   opentelemetry-instrumentation-wsgi
 orderedmultidict==1.0.1 \
     --hash=sha256:04070bbb5e87291cc9bfa51df413677faf2141c73c61d2a5f7b26bea3cd882ad \
     --hash=sha256:43c839a17ee3cdd62234c47deca1a8508a3f2ca1d0678a3bf791c87cf84adbf3
@@ -655,9 +612,7 @@ typing-extensions==3.10.0.0 \
     --hash=sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497 \
     --hash=sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342 \
     --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
-    # via
-    #   opentelemetry-sdk
-    #   pydantic
+    # via pydantic
 urllib3==1.26.6 \
     --hash=sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4 \
     --hash=sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f
@@ -674,81 +629,9 @@ whitenoise[brotli]==6.0.0 \
     --hash=sha256:08c42bc535f9777eea1a599289d9433f081921f97887eaf6f559446b2a080374 \
     --hash=sha256:5a4aff543ee860fbe40d743e556adf92ccd41b7df45697cae074afdf657056b9
     # via -r requirements.prod.in
-wrapt==1.14.0 \
-    --hash=sha256:00108411e0f34c52ce16f81f1d308a571df7784932cc7491d1e94be2ee93374b \
-    --hash=sha256:01f799def9b96a8ec1ef6b9c1bbaf2bbc859b87545efbecc4a78faea13d0e3a0 \
-    --hash=sha256:09d16ae7a13cff43660155383a2372b4aa09109c7127aa3f24c3cf99b891c330 \
-    --hash=sha256:14e7e2c5f5fca67e9a6d5f753d21f138398cad2b1159913ec9e9a67745f09ba3 \
-    --hash=sha256:167e4793dc987f77fd476862d32fa404d42b71f6a85d3b38cbce711dba5e6b68 \
-    --hash=sha256:1807054aa7b61ad8d8103b3b30c9764de2e9d0c0978e9d3fc337e4e74bf25faa \
-    --hash=sha256:1f83e9c21cd5275991076b2ba1cd35418af3504667affb4745b48937e214bafe \
-    --hash=sha256:21b1106bff6ece8cb203ef45b4f5778d7226c941c83aaaa1e1f0f4f32cc148cd \
-    --hash=sha256:22626dca56fd7f55a0733e604f1027277eb0f4f3d95ff28f15d27ac25a45f71b \
-    --hash=sha256:23f96134a3aa24cc50614920cc087e22f87439053d886e474638c68c8d15dc80 \
-    --hash=sha256:2498762814dd7dd2a1d0248eda2afbc3dd9c11537bc8200a4b21789b6df6cd38 \
-    --hash=sha256:28c659878f684365d53cf59dc9a1929ea2eecd7ac65da762be8b1ba193f7e84f \
-    --hash=sha256:2eca15d6b947cfff51ed76b2d60fd172c6ecd418ddab1c5126032d27f74bc350 \
-    --hash=sha256:354d9fc6b1e44750e2a67b4b108841f5f5ea08853453ecbf44c81fdc2e0d50bd \
-    --hash=sha256:36a76a7527df8583112b24adc01748cd51a2d14e905b337a6fefa8b96fc708fb \
-    --hash=sha256:3a0a4ca02752ced5f37498827e49c414d694ad7cf451ee850e3ff160f2bee9d3 \
-    --hash=sha256:3a71dbd792cc7a3d772ef8cd08d3048593f13d6f40a11f3427c000cf0a5b36a0 \
-    --hash=sha256:3a88254881e8a8c4784ecc9cb2249ff757fd94b911d5df9a5984961b96113fff \
-    --hash=sha256:47045ed35481e857918ae78b54891fac0c1d197f22c95778e66302668309336c \
-    --hash=sha256:4775a574e9d84e0212f5b18886cace049a42e13e12009bb0491562a48bb2b758 \
-    --hash=sha256:493da1f8b1bb8a623c16552fb4a1e164c0200447eb83d3f68b44315ead3f9036 \
-    --hash=sha256:4b847029e2d5e11fd536c9ac3136ddc3f54bc9488a75ef7d040a3900406a91eb \
-    --hash=sha256:59d7d92cee84a547d91267f0fea381c363121d70fe90b12cd88241bd9b0e1763 \
-    --hash=sha256:5a0898a640559dec00f3614ffb11d97a2666ee9a2a6bad1259c9facd01a1d4d9 \
-    --hash=sha256:5a9a1889cc01ed2ed5f34574c90745fab1dd06ec2eee663e8ebeefe363e8efd7 \
-    --hash=sha256:5b835b86bd5a1bdbe257d610eecab07bf685b1af2a7563093e0e69180c1d4af1 \
-    --hash=sha256:5f24ca7953f2643d59a9c87d6e272d8adddd4a53bb62b9208f36db408d7aafc7 \
-    --hash=sha256:61e1a064906ccba038aa3c4a5a82f6199749efbbb3cef0804ae5c37f550eded0 \
-    --hash=sha256:65bf3eb34721bf18b5a021a1ad7aa05947a1767d1aa272b725728014475ea7d5 \
-    --hash=sha256:6807bcee549a8cb2f38f73f469703a1d8d5d990815c3004f21ddb68a567385ce \
-    --hash=sha256:68aeefac31c1f73949662ba8affaf9950b9938b712fb9d428fa2a07e40ee57f8 \
-    --hash=sha256:6915682f9a9bc4cf2908e83caf5895a685da1fbd20b6d485dafb8e218a338279 \
-    --hash=sha256:6d9810d4f697d58fd66039ab959e6d37e63ab377008ef1d63904df25956c7db0 \
-    --hash=sha256:729d5e96566f44fccac6c4447ec2332636b4fe273f03da128fff8d5559782b06 \
-    --hash=sha256:748df39ed634851350efa87690c2237a678ed794fe9ede3f0d79f071ee042561 \
-    --hash=sha256:763a73ab377390e2af26042f685a26787c402390f682443727b847e9496e4a2a \
-    --hash=sha256:8323a43bd9c91f62bb7d4be74cc9ff10090e7ef820e27bfe8815c57e68261311 \
-    --hash=sha256:8529b07b49b2d89d6917cfa157d3ea1dfb4d319d51e23030664a827fe5fd2131 \
-    --hash=sha256:87fa943e8bbe40c8c1ba4086971a6fefbf75e9991217c55ed1bcb2f1985bd3d4 \
-    --hash=sha256:88236b90dda77f0394f878324cfbae05ae6fde8a84d548cfe73a75278d760291 \
-    --hash=sha256:891c353e95bb11abb548ca95c8b98050f3620a7378332eb90d6acdef35b401d4 \
-    --hash=sha256:89ba3d548ee1e6291a20f3c7380c92f71e358ce8b9e48161401e087e0bc740f8 \
-    --hash=sha256:8c6be72eac3c14baa473620e04f74186c5d8f45d80f8f2b4eda6e1d18af808e8 \
-    --hash=sha256:9a242871b3d8eecc56d350e5e03ea1854de47b17f040446da0e47dc3e0b9ad4d \
-    --hash=sha256:9a3ff5fb015f6feb78340143584d9f8a0b91b6293d6b5cf4295b3e95d179b88c \
-    --hash=sha256:9a5a544861b21e0e7575b6023adebe7a8c6321127bb1d238eb40d99803a0e8bd \
-    --hash=sha256:9d57677238a0c5411c76097b8b93bdebb02eb845814c90f0b01727527a179e4d \
-    --hash=sha256:9d8c68c4145041b4eeae96239802cfdfd9ef927754a5be3f50505f09f309d8c6 \
-    --hash=sha256:9d9fcd06c952efa4b6b95f3d788a819b7f33d11bea377be6b8980c95e7d10775 \
-    --hash=sha256:a0057b5435a65b933cbf5d859cd4956624df37b8bf0917c71756e4b3d9958b9e \
-    --hash=sha256:a65bffd24409454b889af33b6c49d0d9bcd1a219b972fba975ac935f17bdf627 \
-    --hash=sha256:b0ed6ad6c9640671689c2dbe6244680fe8b897c08fd1fab2228429b66c518e5e \
-    --hash=sha256:b21650fa6907e523869e0396c5bd591cc326e5c1dd594dcdccac089561cacfb8 \
-    --hash=sha256:b3f7e671fb19734c872566e57ce7fc235fa953d7c181bb4ef138e17d607dc8a1 \
-    --hash=sha256:b77159d9862374da213f741af0c361720200ab7ad21b9f12556e0eb95912cd48 \
-    --hash=sha256:bb36fbb48b22985d13a6b496ea5fb9bb2a076fea943831643836c9f6febbcfdc \
-    --hash=sha256:d066ffc5ed0be00cd0352c95800a519cf9e4b5dd34a028d301bdc7177c72daf3 \
-    --hash=sha256:d332eecf307fca852d02b63f35a7872de32d5ba8b4ec32da82f45df986b39ff6 \
-    --hash=sha256:d808a5a5411982a09fef6b49aac62986274ab050e9d3e9817ad65b2791ed1425 \
-    --hash=sha256:d9bdfa74d369256e4218000a629978590fd7cb6cf6893251dad13d051090436d \
-    --hash=sha256:db6a0ddc1282ceb9032e41853e659c9b638789be38e5b8ad7498caac00231c23 \
-    --hash=sha256:debaf04f813ada978d7d16c7dfa16f3c9c2ec9adf4656efdc4defdf841fc2f0c \
-    --hash=sha256:f0408e2dbad9e82b4c960274214af533f856a199c9274bd4aff55d4634dedc33 \
-    --hash=sha256:f2f3bc7cd9c9fcd39143f11342eb5963317bd54ecc98e3650ca22704b69d9653
-    # via
-    #   deprecated
-    #   opentelemetry-instrumentation
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==57.4.0 \
     --hash=sha256:6bac238ffdf24e8806c61440e755192470352850f3419a52f26ffe0a1a64f465 \
     --hash=sha256:a49230977aa6cfb9d933614d2f7b79036e9945c4cdd7583163f4e920b83418d6
-    # via
-    #   gunicorn
-    #   opentelemetry-api
-    #   opentelemetry-instrumentation
-    #   opentelemetry-sdk
+    # via gunicorn


### PR DESCRIPTION
Reverts opensafely-core/job-server#1703

In spite of some reports that this works - e.g. https://signoz.io/blog/opentelemetry-django - when deployed it appears not to work in the manner described in https://github.com/open-telemetry/opentelemetry-python/issues/2038 . It complains if there are missing config vars (so the code is there & running), but we don't receive any data. Reverting to try a different approach with a clean slate. 
