### PR TITLE
Revert "fix: move otel django instrumenter to gunicorn.conf"

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn jobserver.wsgi --config=gunicorn.conf.py
+web: opentelemetry-instrument gunicorn jobserver.wsgi --config=gunicorn.conf.py

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -11,9 +11,3 @@ logconfig_dict = logging_config_dict
 
 # workers
 workers = 3
-
-
-def post_fork(server, worker):
-    from opentelemetry.instrumentation.auto_instrumentation import (  # noqa: F401
-        sitecustomize,
-    )


### PR DESCRIPTION
Reverts opensafely-core/job-server#1708