### PR TITLE
Smooth Setting Up Users

### DIFF
--- a/jobserver/templates/workspace_create_error.html
+++ b/jobserver/templates/workspace_create_error.html
@@ -41,10 +41,7 @@
   <div class="row">
     <div class="col-lg-9 col-xl-8">
 
-      <p>
-        Your organisation, {{ project.org.name }}, has no GitHub organisations
-        associated with it, please contact support.
-      </p>
+      <p>{{ message }}</p>
 
     </div>
   </div>

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -123,10 +123,14 @@ class WorkspaceCreate(CreateView):
 
         gh_org = first(self.request.user.orgs.first().github_orgs)
         if gh_org is None:
+            message = (
+                f"Your organisation, {self.project.org.name}, has no GitHub "
+                "organisations associated with it, please contact support."
+            )
             return TemplateResponse(
                 request,
-                "workspace_create_no_github_orgs.html",
-                context={"project": self.project},
+                "workspace_create_error.html",
+                context={"message": message, "project": self.project},
             )
 
         try:

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -121,6 +121,17 @@ class WorkspaceCreate(CreateView):
         if not can_create_workspaces:
             raise Http404
 
+        if not self.request.user.orgs.exists():
+            message = (
+                "Your user account has no organisation associated with it, "
+                "please contact your Co-Pilot or support."
+            )
+            return TemplateResponse(
+                request,
+                "workspace_create_error.html",
+                context={"message": message, "project": self.project},
+            )
+
         gh_org = first(self.request.user.orgs.first().github_orgs)
         if gh_org is None:
             message = (

--- a/staff/templates/staff/user_detail.html
+++ b/staff/templates/staff/user_detail.html
@@ -45,6 +45,30 @@
 <div class="container">
   <div class="row">
     <div class="col col-lg-9 col-xl-8">
+
+      {% if not orgs or not user.backends.exists %}
+      <div class="alert alert-danger" role="alert">
+        <p>
+          A user <strong>requires</strong> access to certain resources to be
+          able to use the Jobs site.  The following are missing for this user:
+        </p>
+        <ul>
+          {% if not user.backends.exists %}
+          <li><a href="#backends">Backends</a></li>
+          {% endif %}
+          {% if not orgs %}
+          <li><a href="#orgs">Orgs</a></li>
+          {% endif %}
+        </ul>
+      </div>
+      {% endif %}
+
+      {% if not projects %}
+      <div class="alert alert-warning" role="alert">
+        A user would ideally have access to one or more <a href="#projects">Projects</a>.
+      </div>
+      {% endif %}
+
       <form method="POST">
         {% csrf_token %}
 
@@ -57,7 +81,7 @@
         {% endif %}
 
         <div class="form-group">
-          <h2 class="h4">Backends</h2>
+          <h2 id="backends" class="h4">Backends</h2>
 
           <p>
             A list of backends {{ user.username }} has access to.
@@ -105,7 +129,7 @@
 
         <div class="form-group mb-5">
           <div class="d-flex justify-content-between align-items-center">
-            <h2 class="h4">Organisations</h2>
+            <h2 id="orgs" class="h4">Organisations</h2>
             <a class="btn btn-sm btn-primary" href="{% url 'staff:user-set-orgs' username=user.username %}">
               Add to organisation
             </a>
@@ -124,7 +148,7 @@
         </div>
 
         <div class="form-group mb-5">
-          <h2 class="h4">Projects</h2>
+          <h2 id="projects" class="h4">Projects</h2>
 
           <div class="list-group mb-3">
             {% for project in projects %}

--- a/staff/templates/staff/user_list.html
+++ b/staff/templates/staff/user_list.html
@@ -62,6 +62,26 @@
       </div>
       {% endif %}
 
+      <h3 class="h4">Missing</h3>
+      <div class="btn-group-vertical w-100 mb-4" role="group" aria-label="Filter by missing links">
+        {% for missing_name in missing_names %}
+        {% is_filter_selected key="missing" value=missing_name as is_active %}
+        <a
+          {% if is_active %}aria-pressed="true"{% endif %}
+          class="btn btn-outline-primary btn-block text-left {% if is_active %}active{% endif %}"
+          href="
+            {% if is_active %}
+              {% url_without_querystring missing=missing_name %}
+            {% else %}
+              {% url_with_querystring missing=missing_name %}
+            {% endif %}
+          "
+        >
+            {{ missing_name|title }}
+        </a>
+        {% endfor %}
+      </div>
+
       {% if roles %}
       <h3 class="h4">Role</h3>
       <div class="btn-group-vertical w-100 mb-4" role="group" aria-label="Filter by role">

--- a/staff/templates/staff/user_list.html
+++ b/staff/templates/staff/user_list.html
@@ -124,12 +124,38 @@
 
       <div class="list-group list-unstyled">
         {% for user in object_list %}
-        <a href="{{ user.get_staff_url }}" class="d-flex align-items-center list-group-item list-group-item-action">
-          {{ user.username }}
-          {% if user.get_full_name %}
-          <span class="text-muted ml-2 font-weight-normal">({{ user.get_full_name }})</span>
-          {% endif %}
-        </a>
+        <div class="d-flex justify-content-between align-items-center list-group-item list-group-item-action">
+
+          <a href="{{ user.get_staff_url }}" class="d-flex align-items-center">
+            {{ user.username }}
+            {% if user.get_full_name %}
+            <span class="text-muted ml-2 font-weight-normal">({{ user.get_full_name }})</span>
+            {% endif %}
+          </a>
+
+          <div>
+
+            {% if not user.backend_exists %}
+            <span class="badge badge-danger" title="This user is missing a link to 1 or more Backends">
+              Backend
+            </span>
+            {% endif %}
+
+            {% if not user.org_exists %}
+            <span class="badge badge-danger" title="This user is missing a link to 1 or more Orgs">
+              Org
+            </span>
+            {% endif %}
+
+            {% if not user.project_exists %}
+            <span class="badge badge-warning"title="This user is missing a link to 1 or more Projects">
+              Project
+            </span>
+            {% endif %}
+
+          </div>
+
+        </div>
         {% endfor %}
       </div>
     </div>

--- a/staff/views/orgs.py
+++ b/staff/views/orgs.py
@@ -17,9 +17,6 @@ from ..forms import OrgAddGitHubOrgForm, OrgAddMemberForm
 def org_add_github_org(request, slug):
     org = get_object_or_404(Org, slug=slug)
 
-    if not request.htmx:
-        return redirect(org.get_staff_url())
-
     if request.POST:
         form = OrgAddGitHubOrgForm(data=request.POST)
     else:

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -1,7 +1,7 @@
 import inspect
 
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from django.db.models.functions import Lower
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
@@ -10,7 +10,7 @@ from django.views.generic import FormView, ListView, UpdateView
 from jobserver.authorization import roles
 from jobserver.authorization.decorators import require_permission
 from jobserver.authorization.utils import roles_for
-from jobserver.models import Backend, Org, User
+from jobserver.models import Backend, Org, Project, User
 from jobserver.utils import raise_if_not_int
 
 from ..forms import UserForm, UserOrgsForm
@@ -87,7 +87,7 @@ class UserDetail(UpdateView):
 
 @method_decorator(require_permission("user_manage"), name="dispatch")
 class UserList(ListView):
-    queryset = User.objects.order_by(Lower("username"))
+    model = User
     template_name = "staff/user_list.html"
 
     def get_context_data(self, **kwargs):
@@ -103,6 +103,21 @@ class UserList(ListView):
     def get_queryset(self):
         qs = super().get_queryset()
 
+        # lazily build up some queries for annotation below (Exists uses a
+        # subquery, hence the use of OuterRef)
+        backends = Org.objects.filter(members=OuterRef("pk"))
+        orgs = Org.objects.filter(members=OuterRef("pk"))
+        projects = Project.objects.filter(members=OuterRef("pk"))
+
+        # annotate the existance of various related objects so we can add
+        # badges if they're missing
+        qs = qs.annotate(
+            backend_exists=Exists(backends),
+            org_exists=Exists(orgs),
+            project_exists=Exists(projects),
+        ).order_by(Lower("username"))
+
+        # filter on the search query
         q = self.request.GET.get("q")
         if q:
             qs = qs.filter(

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -342,6 +342,23 @@ def test_workspacecreate_without_github_orgs(rf):
     assert response.template_name == "workspace_create_error.html"
 
 
+def test_workspacecreate_without_org(rf):
+    user = UserFactory()
+
+    project = ProjectFactory()
+    ProjectMembershipFactory(project=project, user=user, roles=[ProjectDeveloper])
+
+    request = rf.get("/")
+    request.user = user
+
+    response = WorkspaceCreate.as_view()(
+        request, org_slug=project.org.slug, project_slug=project.slug
+    )
+
+    assert response.status_code == 200
+    assert response.template_name == "workspace_create_error.html"
+
+
 def test_workspacecreate_without_permission(rf, user):
     project = ProjectFactory()
 

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -339,7 +339,7 @@ def test_workspacecreate_without_github_orgs(rf):
     )
 
     assert response.status_code == 200
-    assert response.template_name == "workspace_create_no_github_orgs.html"
+    assert response.template_name == "workspace_create_error.html"
 
 
 def test_workspacecreate_without_permission(rf, user):

--- a/tests/unit/staff/views/test_orgs.py
+++ b/tests/unit/staff/views/test_orgs.py
@@ -33,19 +33,6 @@ def test_orgaddgithuborg_get_success(rf, core_developer):
     assert response.context_data["form"]
 
 
-def test_orgaddgithuborg_not_htmx(rf, core_developer):
-    org = OrgFactory()
-
-    request = rf.get("/")
-    request.htmx = False
-    request.user = core_developer
-
-    response = org_add_github_org(request, slug=org.slug)
-
-    assert response.status_code == 302
-    assert response.url == org.get_staff_url()
-
-
 def test_orgaddgithuborg_post_invalid_form(rf, core_developer):
     org = OrgFactory(github_orgs=["one", "two"])
 

--- a/tests/unit/staff/views/test_users.py
+++ b/tests/unit/staff/views/test_users.py
@@ -237,6 +237,34 @@ def test_userlist_filter_by_invalid_backend(rf, core_developer):
         UserList.as_view()(request)
 
 
+def test_userlist_filter_by_invalid_missing(rf, core_developer):
+    request = rf.get("/?missing=test")
+    request.user = core_developer
+
+    response = UserList.as_view()(request)
+
+    assert list(response.context_data["object_list"]) == [core_developer]
+
+
+def test_userlist_filter_by_missing(rf, core_developer):
+    backend = BackendFactory()
+
+    BackendMembershipFactory(
+        user=UserFactory(),
+        created_by=core_developer,
+        backend=backend,
+    )
+
+    user = UserFactory()
+
+    request = rf.get("/?missing=backend")
+    request.user = core_developer
+
+    response = UserList.as_view()(request)
+
+    assert list(response.context_data["object_list"]) == [core_developer, user]
+
+
 def test_userlist_filter_by_org(rf, core_developer):
     org1 = OrgFactory()
     org2 = OrgFactory()
@@ -352,6 +380,5 @@ def test_usersetorgs_post_success(rf, core_developer):
 def test_usersetorgs_unknown_user(rf, core_developer):
     request = rf.get("/")
     request.user = core_developer
-
     with pytest.raises(Http404):
         UserSetOrgs.as_view()(request, username="")


### PR DESCRIPTION
This is a collection of changes aimed at making the setup of new Users easier for either co-pilots/staff or users themselves.

Specifically it flags up when a User is missing memberships to any one of Backends, Orgs, or Projects on their detail page in the Staff Area (fixing #1704), on the User list page using badges (fixing #1705), and tells a user to contact their copilot/support when they aren't linked to an Org (fixing #1706).