### PR TITLE
fix: include backend name in release lists

### DIFF
--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -56,7 +56,7 @@ class ProjectReleaseList(View):
             url = f'<a href="{release.workspace.get_absolute_url()}">{release.workspace.name}</a>'
 
             return mark_safe(
-                f"Files released by {name} in the {url} workspace {created_at}"
+                f"Files released by {name} from {release.backend.name} in the {url} workspace {created_at}"
             )
 
         releases = [
@@ -309,7 +309,7 @@ class WorkspaceReleaseList(View):
         }
 
         def build_title(release):
-            suffix = f" by {release.created_by.name} {naturaltime(release.created_at)}"
+            suffix = f" by {release.created_by.name} from {release.backend.name} {naturaltime(release.created_at)}"
             prefix = "Files released" if release.files else "Released"
 
             return prefix + suffix

--- a/tests/factories/jobserver.py
+++ b/tests/factories/jobserver.py
@@ -31,6 +31,7 @@ class BackendFactory(factory.django.DjangoModelFactory):
         model = Backend
 
     slug = factory.Sequence(lambda n: f"backend-{n}")
+    name = factory.Sequence(lambda n: f"Backend {n}")
     level_4_url = factory.Sequence(lambda n: f"http://example.com/{n}")
 
 

--- a/tests/unit/jobserver/views/test_releases.py
+++ b/tests/unit/jobserver/views/test_releases.py
@@ -47,7 +47,7 @@ def test_projectreleaselist_success(rf):
     workspace1 = WorkspaceFactory(project=project)
     workspace2 = WorkspaceFactory(project=project)
 
-    ReleaseFactory(
+    r1 = ReleaseFactory(
         ReleaseUploadsFactory(["test1", "test2"]),
         workspace=workspace1,
     )
@@ -69,6 +69,10 @@ def test_projectreleaselist_success(rf):
 
     assert response.context_data["project"] == project
     assert len(response.context_data["releases"]) == 2
+    assert (
+        f"Files released by {r1.created_by.name} from {r1.backend.name}"
+        in response.rendered_content
+    )
 
 
 def test_projectreleaselist_unknown_workspace(rf):
@@ -639,7 +643,7 @@ def test_snapshotdownload_with_no_files(rf):
 
 def test_workspacereleaselist_authenticated_to_view_not_delete(rf):
     workspace = WorkspaceFactory()
-    ReleaseFactory(ReleaseUploadsFactory(["test1"]), workspace=workspace)
+    release = ReleaseFactory(ReleaseUploadsFactory(["test1"]), workspace=workspace)
 
     request = rf.get("/")
     request.user = UserFactory(roles=[ProjectCollaborator])
@@ -660,6 +664,10 @@ def test_workspacereleaselist_authenticated_to_view_not_delete(rf):
 
     assert not response.context_data["user_can_delete_files"]
     assert "Delete" not in response.rendered_content
+    assert (
+        f"Files released by {release.created_by.name} from {release.backend.name}"
+        in response.rendered_content
+    )
 
 
 def test_workspacereleaselist_authenticated_to_view_and_delete(rf):


### PR DESCRIPTION
It was impossible to determine which backend a release came from without
it.

Fixes #1736
