### PR TITLE
Set a last-updated header when serving ReleaseFiles

### DIFF
--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from django.db import transaction
 from django.http import FileResponse
 from django.utils import timezone
+from django.utils.http import http_date
 from furl import furl
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
@@ -174,6 +175,10 @@ def serve_file(request, rfile):
         # serve directly from django in dev use regular django response to
         # bypass DRFs renderer framework and just serve bytes
         response = FileResponse(path.open("rb"))
+
+    # set Last-Modified header as per:
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified
+    response.headers["Last-Modified"] = http_date(rfile.created_at.timestamp())
 
     return response
 

--- a/tests/unit/jobserver/views/test_releases.py
+++ b/tests/unit/jobserver/views/test_releases.py
@@ -137,6 +137,7 @@ def test_publishedsnapshotfile_success(rf):
     assert response.status_code == 200
     assert b"".join(response.streaming_content) == b"test"
     assert response.headers["Content-Type"] == "text/plain"
+    assert response.headers["Last-Modified"]
 
 
 def test_publishedsnapshotfile_with_unknown_release_file(rf):


### PR DESCRIPTION
This adds a header to all responses which serve ReleaseFiles to add the date they were last updated.  This is for the reports site so it can display that information on the page along with the file contents.

Is there a better key for this header to show it's a custom one from job-server?