### PR TITLE
Don't gate CI tests on tooling checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         run: just check
 
   test:
-    needs: [assets, check]
+    needs: [assets]
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
This is generally slowing down feedback from CI.