### PR TITLE
Fix downloading published outputs

### DIFF
--- a/jobserver/templates/snapshot_detail.html
+++ b/jobserver/templates/snapshot_detail.html
@@ -79,7 +79,7 @@
           {{ snapshot.published_at|date:"D M Y" }} at {{ snapshot.published_at|date:"H:i" }}
         {% endif %}
       </p>
-      <a class="btn btn btn-{% if snapshot.is_draft %}success{% else %}light{% endif %}" href="{{ release.get_download_url }}">
+      <a class="btn btn btn-{% if snapshot.is_draft %}success{% else %}light{% endif %}" href="{{ snapshot.get_download_url }}">
         Download
       </a>
     </div>


### PR DESCRIPTION
This fixes two pieces of downloading Snapshots (published outputs).

The download URL was being created on the wrong object and we now only include existing ReleaseFiles in a Snapshot.  ReleaseFiles can be deleted after a Snapshot is created still but we won't add them by default.

Fixes #1784