### PR TITLE
Generate UUID to force a fresh download on reload

### DIFF
--- a/assets/src/scripts/outputs-viewer/context/FilesProvider.jsx
+++ b/assets/src/scripts/outputs-viewer/context/FilesProvider.jsx
@@ -15,6 +15,8 @@ function filesReducer(state, action) {
 }
 
 function FilesProvider({ children, initialValue }) {
+  const uuid = crypto.randomUUID();
+
   const [state, dispatch] = React.useReducer(filesReducer, {
     authToken: "",
     basePath: "",
@@ -27,6 +29,8 @@ function FilesProvider({ children, initialValue }) {
       name: "",
       url: "",
     },
+
+    uuid,
     ...initialValue,
   });
 

--- a/assets/src/scripts/outputs-viewer/hooks/use-file.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file.js
@@ -6,7 +6,7 @@ import { toastError } from "../utils/toast";
 
 function useFile(file) {
   const {
-    state: { authToken },
+    state: { authToken, uuid },
   } = useFiles();
 
   return useQuery(
@@ -22,11 +22,14 @@ function useFile(file) {
       // don't try to return the data
       if (isCsv(file) && file.size > 5000000) return {};
 
+      // Combine file URL with UUID
+      const fileURL = `${file.url}?${uuid}`;
+
       // If the file is an image
       // grab the blob and create a URL for the blob
       if (isImg(file))
         return axios
-          .get(file.url, {
+          .get(fileURL, {
             headers: {
               Authorization: authToken,
             },
@@ -39,7 +42,7 @@ function useFile(file) {
           });
 
       return axios
-        .get(file.url, {
+        .get(fileURL, {
           headers: {
             Authorization: authToken,
           },

--- a/assets/src/scripts/outputs-viewer/tests/jest-setup.js
+++ b/assets/src/scripts/outputs-viewer/tests/jest-setup.js
@@ -42,3 +42,11 @@ function noOp() {
 if (typeof window.URL.createObjectURL === "undefined") {
   Object.defineProperty(window.URL, "createObjectURL", { value: noOp });
 }
+
+if (typeof window.crypto === "undefined") {
+  window.crypto = {
+    randomUUID() {
+      return "bf45ec45-644c-4113-9ade-a87d0e5c5bcb";
+    },
+  };
+}


### PR DESCRIPTION
Currently the outputs viewer is caching `fetch` requests too aggressively. We want to refetch files from the server on page reload.

This PR generates a cryptographically random UUID each time the React app is mounted, and appends this as a query string to the fetched URL. This forces a file download on first attempt, but allows for cached queries when navigating between files.