### PR TITLE
feat: add links to two simple visualisations

### DIFF
--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -209,23 +209,20 @@
       <div class="card mb-3">
         <div class="card-header">
           <h2 class="h5">Monitoring</h2>
-          <p class="card-subtitle mb-0">Honeycomb.io login required.</p>
+          <p class="card-subtitle small mb-0">Honeycomb login required</p>
         </div>
         <div class="card-body">
-          <ul class="list-unstyled mb-0">
+          <h3 class="h6">Events count for:</h3>
+          <ul class="pl-3 mb-0">
             <li>
-              <strong>
-                <a href="https://ui.honeycomb.io/the-datalab/datasets/job-server?query=%7B%22start_time%22%3A{{ honeycomb_context_starttime|date:'U'|default_if_none:'1646312416' }}%2C%22end_time%22%3A{{ honeycomb_context_endtime|date:'U' }}%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22status%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D,%7B%22column%22%3A%22job_request_identifier%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ job_request.identifier }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D">
-                  Events count for this job request
-                </a>
-              </strong>
+              <a href="https://ui.honeycomb.io/the-datalab/datasets/job-server?query=%7B%22start_time%22%3A{{ honeycomb_context_starttime|date:'U'|default_if_none:'1646312416' }}%2C%22end_time%22%3A{{ honeycomb_context_endtime|date:'U' }}%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22status%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D,%7B%22column%22%3A%22job_request_identifier%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ job_request.identifier }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D">
+                This job request
+              </a>
             </li>
             <li>
-              <strong>
-                <a href="https://ui.honeycomb.io/the-datalab/datasets/job-server?query=%7B%22start_time%22%3A{{ honeycomb_context_starttime|date:'U'|default_if_none:'1646312416' }}%2C%22end_time%22%3A{{ honeycomb_context_endtime|date:'U' }}%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22status%22,%22action%22,%22job_identifier%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D,%7B%22column%22%3A%22status%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22running%22%7D,%7B%22column%22%3A%22job_request_identifier%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ job_request.identifier }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D">
-                  Events count for running jobs from this job request
-                </a>
-              </strong>
+              <a href="https://ui.honeycomb.io/the-datalab/datasets/job-server?query=%7B%22start_time%22%3A{{ honeycomb_context_starttime|date:'U'|default_if_none:'1646312416' }}%2C%22end_time%22%3A{{ honeycomb_context_endtime|date:'U' }}%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22status%22,%22action%22,%22job_identifier%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D,%7B%22column%22%3A%22status%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22running%22%7D,%7B%22column%22%3A%22job_request_identifier%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ job_request.identifier }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D">
+                Running jobs from this job request
+              </a>
             </li>
           </ul>
         </div>

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -207,6 +207,30 @@
         </div>
       </div>
       <div class="card mb-3">
+        <div class="card-header">
+          <h2 class="h5">Monitoring</h2>
+          <p class="card-subtitle mb-0">Honeycomb.io login required.</p>
+        </div>
+        <div class="card-body">
+          <ul class="list-unstyled mb-0">
+            <li>
+              <strong>
+                <a href="https://ui.honeycomb.io/the-datalab/datasets/job-server?query=%7B%22start_time%22%3A{{ honeycomb_context_starttime|date:'U'|default_if_none:'1646312416' }}%2C%22end_time%22%3A{{ honeycomb_context_endtime|date:'U' }}%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22status%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D,%7B%22column%22%3A%22job_request_identifier%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ job_request.identifier }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D">
+                  This job request
+                </a>
+              </strong>
+            </li>
+            <li>
+              <strong>
+                <a href="https://ui.honeycomb.io/the-datalab/datasets/job-server?query=%7B%22start_time%22%3A{{ honeycomb_context_starttime|date:'U'|default_if_none:'1646312416' }}%2C%22end_time%22%3A{{ honeycomb_context_endtime|date:'U' }}%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22status%22,%22action%22,%22job_identifier%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D,%7B%22column%22%3A%22status%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22running%22%7D,%7B%22column%22%3A%22job_request_identifier%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ job_request.identifier }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D">
+                  Running jobs from this job request
+                </a>
+              </strong>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div class="card mb-3">
         <h2 class="card-header h5">Config</h2>
         <ul class="list-group list-group-flush">
           <li class="list-group-item">

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -206,6 +206,7 @@
           </ul>
         </div>
       </div>
+      {% if honeycomb_can_view_links %}
       <div class="card mb-3">
         <div class="card-header">
           <h2 class="h5">Monitoring</h2>
@@ -227,6 +228,7 @@
           </ul>
         </div>
       </div>
+      {% endif %}
       <div class="card mb-3">
         <h2 class="card-header h5">Config</h2>
         <ul class="list-group list-group-flush">

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -216,14 +216,14 @@
             <li>
               <strong>
                 <a href="https://ui.honeycomb.io/the-datalab/datasets/job-server?query=%7B%22start_time%22%3A{{ honeycomb_context_starttime|date:'U'|default_if_none:'1646312416' }}%2C%22end_time%22%3A{{ honeycomb_context_endtime|date:'U' }}%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22status%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D,%7B%22column%22%3A%22job_request_identifier%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ job_request.identifier }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D">
-                  This job request
+                  Events count for this job request
                 </a>
               </strong>
             </li>
             <li>
               <strong>
                 <a href="https://ui.honeycomb.io/the-datalab/datasets/job-server?query=%7B%22start_time%22%3A{{ honeycomb_context_starttime|date:'U'|default_if_none:'1646312416' }}%2C%22end_time%22%3A{{ honeycomb_context_endtime|date:'U' }}%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22status%22,%22action%22,%22job_identifier%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D,%7B%22column%22%3A%22status%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22running%22%7D,%7B%22column%22%3A%22job_request_identifier%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ job_request.identifier }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D">
-                  Running jobs from this job request
+                  Events count for running jobs from this job request
                 </a>
               </strong>
             </li>

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -1,4 +1,5 @@
 import functools
+from datetime import timedelta
 
 from django.contrib import messages
 from django.core.exceptions import MultipleObjectsReturned
@@ -203,7 +204,12 @@ class JobRequestDetail(View):
             )
         )
 
+        honeycomb_context_starttime = job_request.created_at - timedelta(days=2)
+        honeycomb_context_endtime = job_request.completed_at + timedelta(days=2)
+
         context = {
+            "honeycomb_context_starttime": honeycomb_context_starttime,
+            "honeycomb_context_endtime": honeycomb_context_endtime,
             "job_request": job_request,
             "project_definition": project_definition,
             "project_yaml_url": job_request.get_file_url("project.yaml"),

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -205,7 +205,10 @@ class JobRequestDetail(View):
         )
 
         honeycomb_context_starttime = job_request.created_at - timedelta(days=2)
-        honeycomb_context_endtime = job_request.completed_at + timedelta(days=2)
+
+        honeycomb_context_endtime = None
+        if job_request.completed_at is not None:
+            honeycomb_context_endtime = job_request.completed_at + timedelta(days=2)
 
         context = {
             "honeycomb_context_starttime": honeycomb_context_starttime,

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -196,6 +196,7 @@ class JobRequestDetail(View):
         can_cancel_jobs = job_request.created_by == request.user or has_permission(
             request.user, "job_cancel", project=job_request.workspace.project
         )
+        honeycomb_can_view_links = has_role(self.request.user, CoreDeveloper)
 
         project_definition = mark_safe(
             render_definition(
@@ -211,6 +212,7 @@ class JobRequestDetail(View):
             honeycomb_context_endtime = job_request.completed_at + timedelta(days=2)
 
         context = {
+            "honeycomb_can_view_links": honeycomb_can_view_links,
             "honeycomb_context_starttime": honeycomb_context_starttime,
             "honeycomb_context_endtime": honeycomb_context_endtime,
             "job_request": job_request,

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -5,7 +5,11 @@ from django.core.exceptions import BadRequest
 from django.http import Http404
 from django.utils import timezone
 
-from jobserver.authorization import OpensafelyInteractive, ProjectDeveloper
+from jobserver.authorization import (
+    CoreDeveloper,
+    OpensafelyInteractive,
+    ProjectDeveloper,
+)
 from jobserver.models import JobRequest
 from jobserver.views.job_requests import (
     JobRequestCancel,
@@ -606,6 +610,26 @@ def test_jobrequestdetail_with_permission(rf):
     assert "Cancel" in response.rendered_content
 
 
+def test_jobrequestdetail_with_permission_core_developer(rf):
+    job_request = JobRequestFactory()
+
+    user = UserFactory(roles=[CoreDeveloper])
+
+    request = rf.get("/")
+    request.user = user
+
+    response = JobRequestDetail.as_view()(
+        request,
+        org_slug=job_request.workspace.project.org.slug,
+        project_slug=job_request.workspace.project.slug,
+        workspace_slug=job_request.workspace.name,
+        pk=job_request.pk,
+    )
+
+    assert response.status_code == 200
+    assert "Honeycomb" in response.rendered_content
+
+
 def test_jobrequestdetail_with_permission_with_completed_at(rf):
     job_request = JobRequestFactory()
 
@@ -651,6 +675,7 @@ def test_jobrequestdetail_with_unauthenticated_user(rf):
     )
 
     assert response.status_code == 200
+    assert "Honeycomb" not in response.rendered_content
 
 
 def test_jobrequestdetail_with_unknown_job_request(rf):


### PR DESCRIPTION
* matching documentation here: https://github.com/opensafely/documentation/pull/753 
* very open to suggestions on better layout/styling
* looks like this: 
<img width="363" alt="Screenshot 2022-06-02 at 11 41 55" src="https://user-images.githubusercontent.com/2082895/171612699-36b7d70e-b107-4982-83ef-382e3de290ae.png">
* nb. these links will be visible to everyone, but only users with honeycomb logins will be able to view the visualisations. There may be an argument for only showing the links to e.g. admin users.
