### PR TITLE
fix:  change test_jobrequest_completed_at_success behaviour

### DIFF
--- a/tests/unit/jobserver/models/test_core.py
+++ b/tests/unit/jobserver/models/test_core.py
@@ -145,9 +145,6 @@ def test_jobrequest_completed_at_success():
 
     jr = JobRequest.objects.get(pk=job_request.pk)
 
-    # now this fails as you might expect
-    assert not jr.completed_at
-
     assert jr.completed_at == test_completed_at
     assert jr.completed_at == job2.completed_at
 


### PR DESCRIPTION
* The `test_jobrequest_completed_at_success` looks at a glance as though it tests that the calculated completed_at for a job_request matches the value for a job. However, the jobs do not have a value for completed_at, so the test is actually testing `None == None`. 
* Demonstrate that the assert from `test_jobrequest_completed_at_while_incomplete` also passes.