### PR TITLE
update slack channel for release notifications

### DIFF
--- a/jobserver/slacks.py
+++ b/jobserver/slacks.py
@@ -29,7 +29,7 @@ def notify_github_release(
     slack.post(text="\n".join(message), channel=channel)
 
 
-def notify_release_created(release, channel="opensafely-outputs"):
+def notify_release_created(release, channel="opensafely-releases"):
     workspace_url = slack.link(
         release.workspace.get_absolute_url(), release.workspace.name
     )
@@ -41,7 +41,7 @@ def notify_release_created(release, channel="opensafely-outputs"):
     slack.post(message, channel)
 
 
-def notify_release_file_uploaded(rfile, channel="opensafely-outputs"):
+def notify_release_file_uploaded(rfile, channel="opensafely-releases"):
     release = rfile.release
     user = rfile.created_by
 

--- a/jobserver/slacks.py
+++ b/jobserver/slacks.py
@@ -10,7 +10,7 @@ from services import slack
 
 
 def notify_github_release(
-    path, created_by, files, backend, channel="opensafely-outputs"
+    path, created_by, files, backend, channel="opensafely-releases"
 ):
     """
     path: path on level 4 server

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -263,7 +263,7 @@ def test_releaseapi_post_success(api_rf, slack_messages):
 
     assert len(slack_messages) == 1
     text, channel = slack_messages[0]
-    assert channel == "opensafely-outputs"
+    assert channel == "opensafely-releases"
     assert f"{uploading_user.get_staff_url()}|{uploading_user.name}>" in text
     assert f"{release.get_absolute_url()}|release>" in text
     assert f"{rfile.get_absolute_url()}|{rfile.name}>" in text
@@ -306,7 +306,7 @@ def test_releasenotificationapicreate_success(api_rf, slack_messages):
     # check we called the slack API in the expected way
     assert len(slack_messages) == 1
     text, channel = slack_messages[0]
-    assert channel == "opensafely-outputs"
+    assert channel == "opensafely-releases"
     assert text == f"test user released outputs from /path/to/outputs on {backend.name}"
 
 
@@ -328,7 +328,7 @@ def test_releasenotificationapicreate_success_with_files(api_rf, slack_messages)
     # check we called the slack API in the expected way
     assert len(slack_messages) == 1
     text, channel = slack_messages[0]
-    assert channel == "opensafely-outputs"
+    assert channel == "opensafely-releases"
     assert text == (
         f"test user released 2 outputs from /path/to/outputs on {backend.name}:\n"
         "`output/file1.txt`\n"
@@ -452,7 +452,7 @@ def test_releaseworkspaceapi_post_create_release(api_rf, slack_messages):
     assert len(slack_messages) == 1
     text, channel = slack_messages[0]
 
-    assert channel == "opensafely-outputs"
+    assert channel == "opensafely-releases"
     assert f"{user.get_staff_url()}|{user.name}>" in text
     assert f"{release.get_absolute_url()}|release>" in text
     assert f"{workspace.get_absolute_url()}|{workspace.name}>" in text


### PR DESCRIPTION
`opensafely-outputs` was getting quite noisy. This moves notifications for releases from `opensafely-outputs` to the newly created `opensafely-releases`.

@ghickman is this all I need to do are is there more to it?