### PR TITLE
fix: add good default end_time for uncompleted job request detail

### DIFF
--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -8,6 +8,7 @@ from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
+from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.views.generic import CreateView, ListView, RedirectView, View
 from django.views.generic.edit import FormMixin
@@ -207,7 +208,7 @@ class JobRequestDetail(View):
 
         honeycomb_context_starttime = job_request.created_at - timedelta(days=2)
 
-        honeycomb_context_endtime = None
+        honeycomb_context_endtime = timezone.now()
         if job_request.completed_at is not None:
             honeycomb_context_endtime = job_request.completed_at + timedelta(days=2)
 

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -628,6 +628,7 @@ def test_jobrequestdetail_with_permission_core_developer(rf):
 
     assert response.status_code == 200
     assert "Honeycomb" in response.rendered_content
+    assert "end_time%22%3A1651959120" in response.rendered_content
 
 
 def test_jobrequestdetail_with_permission_with_completed_at(rf):

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -610,6 +610,7 @@ def test_jobrequestdetail_with_permission(rf):
     assert "Cancel" in response.rendered_content
 
 
+@pytest.mark.freeze_time("2022-06-16 12:00")
 def test_jobrequestdetail_with_permission_core_developer(rf):
     job_request = JobRequestFactory()
 
@@ -628,7 +629,7 @@ def test_jobrequestdetail_with_permission_core_developer(rf):
 
     assert response.status_code == 200
     assert "Honeycomb" in response.rendered_content
-    assert "end_time%22%3A1651959120" in response.rendered_content
+    assert "%22end_time%22%3A1655380800%2C" in response.rendered_content
 
 
 def test_jobrequestdetail_with_permission_with_completed_at(rf):


### PR DESCRIPTION
* uncompleted job requests were inadvertently passing through a `None`, which meant that we were generating invalid honeycomb.io query links
