### PR TITLE
Fix Project titles missing on User detail page

### DIFF
--- a/staff/templates/staff/user_detail.html
+++ b/staff/templates/staff/user_detail.html
@@ -153,7 +153,7 @@
           <div class="list-group mb-3">
             {% for project in projects %}
             <a class="list-group-item list-group-item-action d-flex align-items-center" href="{{ project.staff_url }}">
-              <span class="mr-auto">{{ project.title }}</span>
+              <span class="mr-auto">{{ project.name }}</span>
               {% for role in project.roles %}
               <span class="badge badge-secondary ml-1">{{ role }}</span>
               {% endfor %}

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -60,7 +60,9 @@ class UserDetail(UpdateView):
                 "roles": sorted(r.display_name for r in m.roles),
                 "staff_url": m.project.get_staff_url(),
             }
-            for m in self.object.project_memberships.order_by("project__name")
+            for m in self.object.project_memberships.order_by(
+                "project__number", Lower("project__name")
+            )
         ]
         return super().get_context_data(**kwargs) | {
             "applications": applications,


### PR DESCRIPTION
The `project` variable in the user detail template is a dictionary we build in the view.  This fixes the attribute we call and orders the projects by first number then name.