### PR TITLE
Add Workspace Contact to Private Repos Report

### DIFF
--- a/assets/src/js/tablesorter.js
+++ b/assets/src/js/tablesorter.js
@@ -17,6 +17,7 @@ $(() => {
         "form-control",
         "form-control",
         "form-control",
+        "form-control",
       ],
     },
   });

--- a/staff/templates/staff/repo_list.html
+++ b/staff/templates/staff/repo_list.html
@@ -28,7 +28,7 @@
 {% endblock jumbotron %}
 
 {% block staff_content %}
-<div class="container">
+<div class="container-fluid">
   <div class="row">
     <div class="col">
       <button type="button" class="reset btn btn-outline-primary mb-3" data-column="0" data-filter="">Reset filters</button>

--- a/staff/templates/staff/repo_list.html
+++ b/staff/templates/staff/repo_list.html
@@ -41,6 +41,7 @@
               <th>Repo</th>
               <th>Workspace</th>
               <th>Project</th>
+              <th>Contact</th>
             </tr>
           </thead>
           <tbody>
@@ -51,6 +52,7 @@
               <td><a href="{{ repo.url }}">{{ repo.name }}</a></td>
               <td><a href="{{ repo.workspace.get_staff_url }}">{{ repo.workspace.name }}</a></td>
               <td><a href="{{ repo.workspace.project.get_staff_url }}">{{ repo.workspace.project.title }}</a></td>
+              <td><a href="{{ repo.workspace.created_by.get_staff_url }}">{{ repo.workspace.created_by.email }}</a></td>
             </tr>
             {% endfor %}
           </tbody>

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -20,7 +20,7 @@ class RepoList(View):
         private_repos = [repo for repo in all_repos if repo["is_private"]]
 
         # get workspaces with the first run job started_at annotated on
-        workspaces = Workspace.objects.select_related("project").annotate(
+        workspaces = Workspace.objects.select_related("created_by", "project").annotate(
             first_run=Min("job_requests__jobs__started_at")
         )
 


### PR DESCRIPTION
This adds the contact column to the Private Repos report page of the Staff Area in an attempt to save Amir looking it up.