### PR TITLE
Make check a requirement for deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183
 
   deploy:
-    needs: [test, lint-dockerfile]
+    needs: [check, test, lint-dockerfile]
     runs-on: ubuntu-latest
 
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
`check` used to a requirement of `test` which was a requirement of deploy.  We removed that requirement to improve the feedback loop of running tests in CI in #1780 but missed this part.