### PR TITLE
Disable Creating Jobs

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -302,6 +302,7 @@ initialise_sentry()
 
 
 # PROJECT SETTINGS
+DISABLE_CREATING_JOBS = env.bool("DISABLE_CREATING_JOBS", default=False)
 
 # Releases storage location.
 # Note: we deliberately don't use MEDIA_ROOT/MEDIA_URL here, to avoid any

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -349,9 +349,16 @@ class JobRequestPickRef(View):
             messages.error(request, msg)
             return redirect(workspace)
 
+        # some backends might need to be disabled.  This view only uses
+        # backends the user can see so we look them up here, removing the
+        # relevant ones from the QS before we check if there are any below.
+        backends = request.user.backends.all()
+        if settings.DISABLE_CREATING_JOBS:
+            backends = backends.exclude(Q(slug="emis") | Q(slug="tpp"))
+
         # jobs need to be run on a backend so the user needs to have access to
         # at least one
-        if not request.user.backends.exists():
+        if not backends.exists():
             raise Http404
 
         response = functools.partial(

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -187,6 +187,31 @@ def test_jobrequestcreate_get_success(ref, rf, mocker, user):
     assert response.context_data["workspace"] == workspace
 
 
+def test_jobrequestcreate_get_with_all_backends_removed(rf, settings, user):
+    settings.DISABLE_CREATING_JOBS = True
+
+    tpp = BackendFactory(slug="tpp")
+    emis = BackendFactory(slug="emis")
+    workspace = WorkspaceFactory()
+
+    BackendMembershipFactory(backend=tpp, user=user)
+    BackendMembershipFactory(backend=emis, user=user)
+    ProjectMembershipFactory(
+        project=workspace.project, user=user, roles=[ProjectDeveloper]
+    )
+
+    request = rf.get("/")
+    request.user = user
+
+    with pytest.raises(Http404):
+        JobRequestCreate.as_view()(
+            request,
+            org_slug=workspace.project.org.slug,
+            project_slug=workspace.project.slug,
+            workspace_slug=workspace.name,
+        )
+
+
 def test_jobrequestcreate_get_with_permission(rf, mocker, user):
     workspace = WorkspaceFactory()
 
@@ -259,6 +284,55 @@ def test_jobrequestcreate_get_with_project_yaml_errors(rf, mocker, user):
 
     assert response.context_data["actions"] == []
     assert response.context_data["actions_error"] == "test error"
+
+
+def test_jobrequestcreate_get_with_some_backends_removed(rf, mocker, settings, user):
+    settings.DISABLE_CREATING_JOBS = True
+
+    backend = BackendFactory()
+    emis = BackendFactory(slug="emis")
+    tpp = BackendFactory(slug="tpp")
+
+    workspace = WorkspaceFactory()
+
+    BackendMembershipFactory(backend=backend, user=user)
+    BackendMembershipFactory(backend=emis, user=user)
+    BackendMembershipFactory(backend=tpp, user=user)
+    ProjectMembershipFactory(
+        project=workspace.project, user=user, roles=[ProjectDeveloper]
+    )
+
+    dummy_yaml = """
+    actions:
+      twiddle:
+    """
+    mocker.patch(
+        "jobserver.views.job_requests.get_project",
+        autospec=True,
+        return_value=dummy_yaml,
+    )
+    mocker.patch(
+        "jobserver.views.job_requests.get_branch_sha",
+        autospec=True,
+        return_value="abc123",
+    )
+
+    request = rf.get("/")
+    request.user = user
+
+    response = JobRequestCreate.as_view()(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+
+    # confirm we only have the one remaining backend in the form here
+    assert response.context_data["form"]["backend"].field.choices == [
+        (backend.slug, backend.name)
+    ]
 
 
 @pytest.mark.parametrize("ref", [None, "abc"])

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -1139,6 +1139,27 @@ def test_jobrequestpickref_with_archived_workspace(rf):
     assert str(messages[0]) == expected
 
 
+def test_jobrequestpickref_get_with_all_backends_removed(rf, settings, user):
+    settings.DISABLE_CREATING_JOBS = True
+
+    user = UserFactory(roles=[OpensafelyInteractive])
+    workspace = WorkspaceFactory()
+
+    BackendMembershipFactory(backend=BackendFactory(slug="tpp"), user=user)
+    BackendMembershipFactory(backend=BackendFactory(slug="emis"), user=user)
+
+    request = rf.get("/")
+    request.user = user
+
+    with pytest.raises(Http404):
+        JobRequestPickRef.as_view()(
+            request,
+            org_slug=workspace.project.org.slug,
+            project_slug=workspace.project.slug,
+            workspace_slug=workspace.name,
+        )
+
+
 def test_jobrequestpickref_with_commits_error(rf, mocker):
     user = UserFactory(roles=[OpensafelyInteractive])
     BackendMembershipFactory(user=user)


### PR DESCRIPTION
This adds a feature flag to disable creating jobs.

Previously we relied on the user's BackendMemberships QS being the full set of backends a user could access.  With this change I've hoisted that lookup into dispatch so we can selectively exclude some backends if the flag is enabled.  Then the access check and form kwargs builder can both use that maybe-modified QS.