### PR TITLE
Remove New Project Flow

### DIFF
--- a/jobserver/templates/org_detail.html
+++ b/jobserver/templates/org_detail.html
@@ -65,11 +65,7 @@
     </div>
   {% else %}
     <p class="lead">
-      {% if is_member %}
-        There are no projects for this organisation yet, click "Register Project" to create one.
-      {% else %}
-        There are no projects for this organisation yet.
-      {% endif %}
+      There are no projects for this organisation yet.
     </p>
   {% endif %}
 </div>

--- a/jobserver/templates/org_detail.html
+++ b/jobserver/templates/org_detail.html
@@ -39,11 +39,6 @@
             projects. Every project it has started is listed below.
           {% endif %}
         </p>
-        {% if is_member %}
-          <a class="btn btn-primary" href="{% url 'project-create' org_slug=org.slug %}">
-            Create a project
-          </a>
-        {% endif %}
       </div>
     </div>
   </div>

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -38,7 +38,6 @@ from .views.orgs import OrgDetail, OrgList
 from .views.projects import (
     ProjectAcceptInvite,
     ProjectCancelInvite,
-    ProjectCreate,
     ProjectDetail,
     ProjectInvitationCreate,
     ProjectMembershipEdit,
@@ -292,11 +291,6 @@ urlpatterns = [
         include(
             [
                 path("", OrgDetail.as_view(), name="org-detail"),
-                path(
-                    "new-project/",
-                    ProjectCreate.as_view(),
-                    name="project-create",
-                ),
                 path(
                     "<str:project_slug>/",
                     include(project_urls),

--- a/jobserver/views/orgs.py
+++ b/jobserver/views/orgs.py
@@ -26,14 +26,12 @@ class OrgDetail(DetailView):
 
             return redirect(workspace)
 
-        is_member = request.user in org.members.all()
         projects = org.projects.order_by("name")
 
         return TemplateResponse(
             request,
             "org_detail.html",
             context={
-                "is_member": is_member,
                 "org": org,
                 "projects": projects,
             },

--- a/tests/unit/jobserver/test_urls.py
+++ b/tests/unit/jobserver/test_urls.py
@@ -118,7 +118,6 @@ def test_url_redirects(client, url, redirect):
         ("/settings/", users.Settings),
         ("/status/", status.Status),
         ("/o/", orgs.OrgDetail),
-        ("/o/new-project/", projects.ProjectCreate),
         ("/o/p/", projects.ProjectDetail),
         ("/o/p/accept-invite/42/", projects.ProjectAcceptInvite),
         ("/o/p/cancel-invite/", projects.ProjectCancelInvite),

--- a/tests/unit/jobserver/views/test_orgs.py
+++ b/tests/unit/jobserver/views/test_orgs.py
@@ -3,13 +3,7 @@ from django.http import Http404
 
 from jobserver.views.orgs import OrgDetail, OrgList
 
-from ....factories import (
-    OrgFactory,
-    OrgMembershipFactory,
-    ProjectFactory,
-    UserFactory,
-    WorkspaceFactory,
-)
+from ....factories import OrgFactory, ProjectFactory, UserFactory, WorkspaceFactory
 
 
 def test_orgdetail_success(rf):
@@ -42,31 +36,6 @@ def test_orgdetail_unknown_org_but_known_workspace(rf):
 
     assert response.status_code == 302
     assert response.url == workspace.get_absolute_url()
-
-
-def test_orgdetail_with_org_member(rf):
-    org = OrgFactory()
-    user = UserFactory()
-    OrgMembershipFactory(org=org, user=user)
-
-    request = rf.get("/")
-    request.user = user
-
-    response = OrgDetail.as_view()(request, org_slug=org.slug)
-
-    assert response.status_code == 200
-    assert "Register Project" in response.rendered_content
-
-
-def test_orgdetail_with_non_member_user(rf):
-    org = OrgFactory()
-
-    request = rf.get("/")
-    request.user = UserFactory()
-    response = OrgDetail.as_view()(request, org_slug=org.slug)
-
-    assert response.status_code == 200
-    assert "Register Project" not in response.rendered_content
 
 
 def test_orglist_success(rf):


### PR DESCRIPTION
All Projects are expected to be created via an Application now.  Should we find any exceptions they can still be added via the Staff Area.