### PR TITLE
Remove unused AUTHORIZATION_ORGS variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     command: /app/manage.py runserver 0.0.0.0:8000
     environment:
       - ADMIN_USERS
-      - AUTHORIZATION_ORGS
       - DATABASE_URL=postgres://jobsuser:pass@db:5432/jobserver
       - DEBUG
       - GITHUB_TOKEN

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -2,10 +2,6 @@
 # Note: the Users must exist first
 ADMIN_USERS=dummy
 
-# Set this to a comma-delimited list of GitHub Organisations you want to have
-# access to the platform
-AUTHORIZATION_ORGS=opensafely
-
 # Update with relevant username/password if necessary
 DATABASE_URL=postgres://jobsuser:pass@localhost:5432/jobserver
 

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -9,7 +9,6 @@ from furl import furl
 env = Env()
 
 
-AUTHORIZATION_ORGS = env.list("AUTHORIZATION_ORGS")
 BASE_URL = "https://api.github.com"
 GITHUB_TOKEN = env.str("GITHUB_TOKEN")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ use_parentheses = true
 addopts = "--disable-network --tb=native --no-migrations"
 DJANGO_SETTINGS_MODULE = "jobserver.settings"
 env = [
-  "AUTHORIZATION_ORGS=opensafely",
   "GITHUB_TOKEN=empty",
   "SECRET_KEY=12345",
   "SOCIAL_AUTH_GITHUB_KEY=test",


### PR DESCRIPTION
We no longer limit the registration based on membership in a list of
GitHub orgs.