### PR TITLE
Require User.fullname is set

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from first import first
 
 from .authorization.forms import RolesForm
-from .models import JobRequest, User, Workspace
+from .models import JobRequest, Workspace
 
 
 class JobRequestCreateForm(forms.ModelForm):
@@ -63,14 +63,6 @@ class ProjectInvitationForm(RolesForm):
 
 class ProjectMembershipForm(RolesForm):
     pass
-
-
-class SettingsForm(forms.ModelForm):
-    class Meta:
-        fields = [
-            "notifications_email",
-        ]
-        model = User
 
 
 class WorkspaceArchiveToggleForm(forms.Form):

--- a/jobserver/middleware.py
+++ b/jobserver/middleware.py
@@ -1,0 +1,53 @@
+from django.shortcuts import redirect
+
+
+class RequireNameMiddleware:
+    """
+    Redirect users without `fullname` set to the settings page
+
+    We get a User's username from GitHub when they register with the site.  If
+    their GitHub profile has a name set we also get that, however we have many
+    (~50% at time of writing) users who have not set that.  We want to require
+    all users have their name set.  This middleware redirects any user with an
+    empty `fullname` value to their settings page.
+
+    We exempt various URL prefixes which don't make sense to do this on, eg if
+    we're not expecting traditional users there or it doesn't make sense for
+    the UX (in the case of applications).
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # Note: ordered by expected popularity then name
+        exemptions = (
+            "/api",
+            "/staff",
+            "/robots.txt",
+            "/__debug__",
+            "/__reload__",
+            "/applications",
+            "/apply",
+            "/complete",
+            "/disconnect",
+            "/favicon.ico",
+            "/login",
+            "/logout",
+            "/settings",
+            "/status",
+        )
+
+        # unauthenticated users can't set their name
+        if not request.user.is_authenticated:
+            return self.get_response(request)
+
+        # we don't want to redirect requests away from various URL paths
+        if request.path.startswith(exemptions):
+            return self.get_response(request)
+
+        # we only care about users without a fullname set
+        if request.user.fullname != "":
+            return self.get_response(request)
+
+        return redirect("settings")

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -78,6 +78,7 @@ MIDDLEWARE = [
     "django_structlog.middlewares.RequestMiddleware",
     "social_django.middleware.SocialAuthExceptionMiddleware",
     "django_htmx.middleware.HtmxMiddleware",
+    "jobserver.middleware.RequireNameMiddleware",
 ]
 
 ROOT_URLCONF = "jobserver.urls"

--- a/jobserver/templates/settings.html
+++ b/jobserver/templates/settings.html
@@ -31,6 +31,12 @@
   <div class="row">
     <div class="col-lg-9 col-xl-8">
 
+      {% if not form.fullname.value %}
+      <div class="alert alert-warning">
+        Your OpenSAFELY profile is missing information, please add your name to your account.
+      </div>
+      {% endif %}
+
       <form method="POST">
         {% csrf_token %}
 

--- a/jobserver/templates/settings.html
+++ b/jobserver/templates/settings.html
@@ -30,26 +30,16 @@
 <div class="container">
   <div class="row">
     <div class="col-lg-9 col-xl-8">
+
       <form method="POST">
         {% csrf_token %}
-        <fieldset>
-          <legend class="h3 mb-3">
-            Notification email
-          </legend>
-          <div class="form-group">
-            <label for="id_notifications_email">Email address</label>
-            <input
-              class="form-control"
-              id="id_notifications_email"
-              name="notifications_email"
-              required
-              type="email"
-              value="{{ form.notifications_email.value }}"
-            />
-          </div>
-        </fieldset>
+
+        {% include "components/form_text.html" with field=form.notifications_email label="Notification email" name="notifications_email" %}
+
         <button class="btn btn-primary" type="submit">Save</button>
+
       </form>
+
     </div>
   </div>
 </div>

--- a/jobserver/templates/settings.html
+++ b/jobserver/templates/settings.html
@@ -34,6 +34,8 @@
       <form method="POST">
         {% csrf_token %}
 
+        {% include "components/form_text.html" with field=form.fullname label="Name" name="fullname" %}
+
         {% include "components/form_text.html" with field=form.notifications_email label="Notification email" name="notifications_email" %}
 
         <button class="btn btn-primary" type="submit">Save</button>

--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -7,7 +7,6 @@ from django.utils.decorators import method_decorator
 from django.views.defaults import bad_request
 from django.views.generic import UpdateView
 
-from ..forms import SettingsForm
 from ..utils import is_safe_path
 
 
@@ -24,7 +23,9 @@ def login_view(request):
 
 @method_decorator(login_required, name="dispatch")
 class Settings(UpdateView):
-    form_class = SettingsForm
+    fields = [
+        "notifications_email",
+    ]
     template_name = "settings.html"
     success_url = "/"
 

--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -24,6 +24,7 @@ def login_view(request):
 @method_decorator(login_required, name="dispatch")
 class Settings(UpdateView):
     fields = [
+        "fullname",
         "notifications_email",
     ]
     template_name = "settings.html"

--- a/tests/unit/jobserver/test_middleware.py
+++ b/tests/unit/jobserver/test_middleware.py
@@ -1,0 +1,45 @@
+from django.contrib.auth.models import AnonymousUser
+
+from jobserver.middleware import RequireNameMiddleware
+
+from ...factories import UserFactory
+
+
+def get_response(request):
+    return "no match"
+
+
+def test_requirenamemiddleware_with_fullname_set(rf):
+    request = rf.get("/")
+    request.user = UserFactory(fullname="Ben Goldacre")
+
+    response = RequireNameMiddleware(get_response)(request)
+
+    assert response == "no match"
+
+
+def test_requirenamemiddleware_without_fullname_set(rf):
+    request = rf.get("/")
+    request.user = UserFactory(fullname="")
+
+    response = RequireNameMiddleware(get_response)(request)
+
+    assert response.status_code == 302
+
+
+def test_requirenamemiddleware_with_exempt_url(rf):
+    request = rf.get("/staff")
+    request.user = UserFactory(fullname="")
+
+    response = RequireNameMiddleware(get_response)(request)
+
+    assert response == "no match"
+
+
+def test_requirenamemiddleware_with_unauthenticated_user(rf):
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    response = RequireNameMiddleware(get_response)(request)
+
+    assert response == "no match"

--- a/tests/unit/jobserver/views/test_users.py
+++ b/tests/unit/jobserver/views/test_users.py
@@ -66,9 +66,15 @@ def test_settings_get(rf):
 
 def test_settings_post(rf):
     UserFactory()
-    user2 = UserFactory(notifications_email="original@example.com")
+    user2 = UserFactory(
+        fullname="Ben Goldacre",
+        notifications_email="original@example.com",
+    )
 
-    data = {"notifications_email": "changed@example.com"}
+    data = {
+        "fullname": "Mr Testerson",
+        "notifications_email": "changed@example.com",
+    }
     request = rf.post("/", data)
     request.user = user2
 
@@ -78,12 +84,14 @@ def test_settings_post(rf):
     request._messages = messages
 
     response = Settings.as_view()(request)
+
     assert response.status_code == 302
     assert response.url == "/"
 
     user2.refresh_from_db()
 
     assert user2.notifications_email == "changed@example.com"
+    assert user2.fullname == "Mr Testerson"
 
     messages = list(messages)
     assert len(messages) == 1


### PR DESCRIPTION
This redirects all users with an empty `fullname` value to their settings page where they will see an alert saying they need to fill in their fullname.

I'm always wary of adding more middleware but since we have so many (~50%) users who need to fill it in this is the easiest way to force them to the page where they can do so.  It also shouldn't result in more db requests since `request.user` is set on the request by a preceeding middleware (`AuthenticationMiddleware`).

I considered using Social Auth's partial pipeline machinery to kick a user out of the pipeline if they didn't have a name set on GitHub, so they could fill it in on a job-server page before returning to the pipeline.  However that seemed like more work and wouldn't cover our existing user base.

Fixes #1900 
Fixes #1903 