### PR TITLE
Order Projects of an Org by number then lowercase name

### DIFF
--- a/jobserver/views/orgs.py
+++ b/jobserver/views/orgs.py
@@ -1,3 +1,4 @@
+from django.db.models.functions import Lower
 from django.http import Http404
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
@@ -26,7 +27,7 @@ class OrgDetail(DetailView):
 
             return redirect(workspace)
 
-        projects = org.projects.order_by("name")
+        projects = org.projects.order_by("number", Lower("name"))
 
         return TemplateResponse(
             request,

--- a/staff/views/orgs.py
+++ b/staff/views/orgs.py
@@ -77,7 +77,7 @@ class OrgDetail(FormView):
             "github_orgs": sorted(self.object.github_orgs),
             "members": self.object.members.order_by(Lower("username")),
             "org": self.object,
-            "projects": self.object.projects.order_by("name"),
+            "projects": self.object.projects.order_by("number", Lower("name")),
         }
 
     def get_form_kwargs(self):


### PR DESCRIPTION
Fix this in a couple more places.

We can't order on `title` since it's a property which combines number and name.  I'm always wary of `Model.Meta.ordering` but if we find this continues to be an issue we should probably just use that.