### PR TITLE
Easier redirects

### DIFF
--- a/staff/forms.py
+++ b/staff/forms.py
@@ -96,6 +96,7 @@ class ProjectEditForm(forms.ModelForm):
     class Meta:
         fields = [
             "name",
+            "slug",
             "number",
             "copilot",
             "copilot_support_ends_at",

--- a/staff/forms.py
+++ b/staff/forms.py
@@ -5,7 +5,7 @@ from applications.forms import YesNoField
 from applications.models import Application, ResearcherRegistration
 from jobserver.authorization.forms import RolesForm
 from jobserver.backends import backends_to_choices
-from jobserver.models import Backend, Org, Project
+from jobserver.models import Backend, Org, Project, Workspace
 
 
 def user_label_from_instance(obj):
@@ -205,4 +205,20 @@ class UserOrgsForm(forms.Form):
             queryset=available_orgs,
             required=False,
             widget=forms.CheckboxSelectMultiple,
+        )
+
+
+class WorkspaceEditForm(forms.ModelForm):
+    class Meta:
+        fields = [
+            "project",
+            "uses_new_release_flow",
+        ]
+        model = Workspace
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["project"].queryset = Project.objects.order_by(
+            "number", Lower("name")
         )

--- a/staff/forms.py
+++ b/staff/forms.py
@@ -208,6 +208,11 @@ class UserOrgsForm(forms.Form):
         )
 
 
+class WorkspaceModelChoiceField(forms.ModelChoiceField):
+    def label_from_instance(self, obj):
+        return obj.title
+
+
 class WorkspaceEditForm(forms.ModelForm):
     class Meta:
         fields = [
@@ -219,6 +224,6 @@ class WorkspaceEditForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields["project"].queryset = Project.objects.order_by(
-            "number", Lower("name")
+        self.fields["project"] = WorkspaceModelChoiceField(
+            queryset=Project.objects.order_by("number", Lower("name")),
         )

--- a/staff/templates/staff/project_edit.html
+++ b/staff/templates/staff/project_edit.html
@@ -46,6 +46,7 @@
         {% csrf_token %}
 
         {% include "components/form_text.html" with field=form.name label="Project name" name="name" %}
+        {% include "components/form_text.html" with field=form.slug label="URL slug" name="slug" %}
         {% include "components/form_text.html" with field=form.number label="Project number" name="number" extra_attributes=extra_field_attributes %}
 
         <div class="form-group">

--- a/staff/templates/staff/project_edit.html
+++ b/staff/templates/staff/project_edit.html
@@ -45,13 +45,8 @@
       <form class="mb-3" method="POST">
         {% csrf_token %}
 
-        <div class="form-group">
-          {% include "components/form_text.html" with field=form.name label="Project name" name="name" %}
-        </div>
-
-        <div class="form-group">
-          {% include "components/form_text.html" with field=form.number label="Project number" name="number" extra_attributes=extra_field_attributes %}
-        </div>
+        {% include "components/form_text.html" with field=form.name label="Project name" name="name" %}
+        {% include "components/form_text.html" with field=form.number label="Project number" name="number" extra_attributes=extra_field_attributes %}
 
         <div class="form-group">
           <label class="font-weight-bold" for="id_copilot">Co-pilot</label>

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -113,19 +113,19 @@ class ProjectEdit(UpdateView):
         # mutation self.object under us
         old = self.get_object()
 
-        form.save()
+        new = form.save()
 
         # check changed_data here instead of comparing self.object.project to
         # new.project because self.object is mutated when ModelForm._post_clean
         # updates the instance it was passed.  This is because form.instance is
         # set from the passed in self.object.
-        if "org" in form.changed_data:
-            self.object.redirects.create(
+        if {"org", "slug"} & set(form.changed_data):
+            new.redirects.create(
                 created_by=self.request.user,
                 old_url=old.get_absolute_url(),
             )
 
-        return redirect(self.object.get_staff_url())
+        return redirect(new.get_staff_url())
 
     def get_context_data(self, **kwargs):
         # we don't have a nice way to override the type of text input

--- a/staff/views/workspaces.py
+++ b/staff/views/workspaces.py
@@ -8,6 +8,8 @@ from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_role
 from jobserver.models import Workspace
 
+from ..forms import WorkspaceEditForm
+
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
 class WorkspaceDetail(DetailView):
@@ -23,7 +25,7 @@ class WorkspaceDetail(DetailView):
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
 class WorkspaceEdit(UpdateView):
-    fields = ["project", "uses_new_release_flow"]
+    form_class = WorkspaceEditForm
     model = Workspace
     slug_field = "name"
     template_name = "staff/workspace_edit.html"

--- a/tests/unit/staff/test_forms.py
+++ b/tests/unit/staff/test_forms.py
@@ -71,12 +71,16 @@ def test_projecteditform_number_is_not_required():
     org = OrgFactory()
     users = User.objects.all()
 
-    form = ProjectEditForm(data={"name": "test", "org": str(org.pk)}, users=users)
+    data = {
+        "name": "Test",
+        "slug": "test",
+        "org": str(org.pk),
+    }
+
+    form = ProjectEditForm(data=data, users=users)
     assert form.is_valid(), form.errors
 
-    form = ProjectEditForm(
-        data={"name": "test", "org": str(org.pk), "number": 123}, users=users
-    )
+    form = ProjectEditForm(data=data | {"number": 123}, users=users)
     assert form.is_valid(), form.errors
 
 


### PR DESCRIPTION
To handle #1878 I need to change several Workspace's Project, and the slug of a Project.  These changes streamline both of those.