### PR TITLE
Merge pip sections of Dependabot Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,17 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    allow:
-      - dependency-type: "production"
-    reviewers:
-
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    allow:
-      - dependency-type: "development"
-    reviewers:
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
We think this config is slightly broken and it's not clear if all dependencies are getting updated.  Since we're auto-merging Python dependabot PRs there's no benefit from having the two sections here either.

Fixes #1852 