### PR TITLE
Fix Private Repos report page

### DIFF
--- a/assets/src/js/tablesorter.js
+++ b/assets/src/js/tablesorter.js
@@ -18,7 +18,6 @@ $(() => {
         "form-control",
         "form-control",
         "form-control",
-        "form-control",
       ],
     },
   });

--- a/services/logging.py
+++ b/services/logging.py
@@ -88,6 +88,9 @@ logging_config_dict = {
             "level": "INFO",
             "propagate": False,
         },
+        "applications": {"handlers": ["console"], "level": "INFO", "propagate": False},
         "jobserver": {"handlers": ["console"], "level": "INFO", "propagate": False},
+        "services": {"handlers": ["console"], "level": "INFO", "propagate": False},
+        "staff": {"handlers": ["console"], "level": "INFO", "propagate": False},
     },
 }

--- a/staff/templates/staff/repo_list.html
+++ b/staff/templates/staff/repo_list.html
@@ -50,7 +50,12 @@
               <td class="text-nowrap">{{ repo.created_at|date:"d M Y" }}</td>
               <td class="text-nowrap">{{ repo.first_run|date:"d M Y" }}</td>
               <td><a href="{{ repo.url }}">{{ repo.name }}</a></td>
-              <td><a href="{{ repo.workspace.get_staff_url }}">{{ repo.workspace.name }}</a></td>
+              <td>
+                <a href="{{ repo.workspace.get_staff_url }}">{{ repo.workspace.name }}</a>
+                {% if repo.workspaces|length > 1 %}
+                (+{{ repo.workspaces|length }})
+                {% endif %}
+              </td>
               <td><a href="{{ repo.workspace.created_by.get_staff_url }}">{{ repo.workspace.created_by.email }}</a></td>
               {% if repo.has_releases %}
               <td class="text-danger">✓</td>

--- a/staff/templates/staff/repo_list.html
+++ b/staff/templates/staff/repo_list.html
@@ -40,7 +40,6 @@
               <th>First Run</th>
               <th>Repo</th>
               <th>Workspace</th>
-              <th>Project</th>
               <th>Contact</th>
               <th>Released to GH?</th>
             </tr>
@@ -49,12 +48,15 @@
             {% for repo in repos %}
             <tr>
               <td class="text-nowrap">{{ repo.created_at|date:"d M Y" }}</td>
-              <td class="text-nowrap">{{ repo.workspace.first_run|date:"d M Y" }}</td>
+              <td class="text-nowrap">{{ repo.first_run|date:"d M Y" }}</td>
               <td><a href="{{ repo.url }}">{{ repo.name }}</a></td>
               <td><a href="{{ repo.workspace.get_staff_url }}">{{ repo.workspace.name }}</a></td>
-              <td><a href="{{ repo.workspace.project.get_staff_url }}">{{ repo.workspace.project.title }}</a></td>
               <td><a href="{{ repo.workspace.created_by.get_staff_url }}">{{ repo.workspace.created_by.email }}</a></td>
-              <td>{% if repo.has_releases %}✓{% else %}❌{% endif %}</td>
+              {% if repo.has_releases %}
+              <td class="text-danger">✓</td>
+              {% else %}
+              <td class="text-success">✘</td>
+              {% endif %}
             </tr>
             {% endfor %}
           </tbody>

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -1,7 +1,7 @@
-import operator
-from datetime import datetime, timedelta
+from datetime import timedelta
 
-from django.db.models import Count
+import structlog
+from django.db.models import Count, Min
 from django.db.models.functions import Least
 from django.template.response import TemplateResponse
 from django.utils import timezone
@@ -15,11 +15,23 @@ from jobserver.github import _get_github_api
 from jobserver.models import Workspace
 
 
+logger = structlog.get_logger(__name__)
+
+
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
 class RepoList(View):
     get_github_api = staticmethod(_get_github_api)
 
     def get(self, request, *args, **kwargs):
+        """
+        List private repos which are in need of converting to public
+
+        Repos should be:
+         * Private
+         * first job was run > 11 months ago
+           OR
+         * no workspaces/jobs AND has github-releases topic
+        """
         all_repos = list(self.get_github_api().get_repos_with_dates("opensafely"))
 
         # remove repos with the non-research topic
@@ -27,83 +39,90 @@ class RepoList(View):
 
         private_repos = [repo for repo in all_repos if repo["is_private"]]
 
+        all_workspaces = list(
+            Workspace.objects.exclude(project__slug="opensafely-testing")
+            .select_related("created_by", "project")
+            .annotate(num_jobs=Count("job_requests__jobs"))
+            .annotate(
+                first_run=Min(
+                    Least(
+                        "job_requests__jobs__started_at",
+                        "job_requests__jobs__created_at",
+                    )
+                ),
+            )
+        )
+
+        def enhance(repo):
+            """
+            Enhance the repo dict from get_repos_with_dates() with workspace data
+
+            We need to filter repos, not workspaces, so this gives us all the
+            information we need when filtering further down.
+            """
+            # get workspaces just for this repo
+            workspaces = [
+                w for w in all_workspaces if repo["url"].lower() == w.repo.lower()
+            ]
+
+            # get workspaces which have run jobs
+            with_jobs = [w for w in workspaces if w.first_run]
+
+            # sorting by a datetime puts the workspaces into oldest job first
+            with_jobs = sorted(with_jobs, key=lambda w: w.first_run)
+
+            # get the first workspace to have run a job
+            workspace = first(with_jobs, key=lambda w: w.first_run)
+
+            # get first_run as either None or a datetime
+            first_run = workspace.first_run if workspace else None
+
+            # has this repo ever had jobs run with it?
+            has_jobs = sum(w.num_jobs for w in workspaces) > 0
+
+            return repo | {
+                "first_run": first_run,
+                "has_jobs": has_jobs,
+                "has_releases": "github-releases" in repo["topics"],
+                "workspace": workspace,
+                "workspaces": workspaces,
+            }
+
+        # add workspace (and related object) data to repos
+        repos = [enhance(r) for r in private_repos]
+
         eleven_months_ago = timezone.now() - timedelta(days=30 * 11)
 
-        # get workspaces with the first run job started_at annotated on
-        workspaces = (
-            Workspace.objects.exclude(project__slug="opensafely-testing")
-            .annotate(num_jobs=Count("job_requests__jobs"))
-            .filter(num_jobs__gt=0)
-            .select_related("created_by", "project")
-            .annotate(
-                first_run=Least(
-                    "job_requests__jobs__started_at", "job_requests__jobs__created_at"
-                )
-            )
-            .filter(first_run__lt=eleven_months_ago)
-        )
-
-        # build up a list of dicts with repo URL and the first started_at date
-        # as keys alongside the workspace.  This allows us to order by
-        # first_run below.
-        workspaces = [
-            {
-                "first_run": w.first_run,
-                "repo": w.repo,
-                "workspace": w,
-            }
-            for w in workspaces
-        ]
-        workspaces = sorted(workspaces, key=operator.itemgetter("first_run"))
-
-        def merge_data(repo):
+        def select(repo):
             """
-            Merge our workspace and first run data with the data from GitHub
+            Select a repo based on various predicates below.
 
-            Repos aren't unique to a workspace.  At the time of writing ~2/3 of
-            repo URLs were duplicates, but we only care about the first time
-            repo code was executed against patient data.
+            We're already working with private repos here so we check
 
-            Since the workspaces list has been ordered by the first started_at
-            date of any Job in the Workspace we can use first() to find the
-            first occurance of a repo URL based on Job.started_at.
+            * Has the `github-releases` topic
+            * Has jobs or a workspace
+            * First job to run happened over 11 months ago
             """
-            workspace = first(workspaces, key=lambda w: w["repo"] == repo["url"])
+            if repo["has_releases"]:
+                # it has outputs released to it so assume code has been run to
+                # make those
+                return True
 
-            if workspace is not None:
-                # extract the workspace object from our wrapper dictionary
-                workspace = workspace["workspace"]
+            if not (repo["workspaces"] and repo["has_jobs"]):
+                logger.info("No workspaces/jobs", url=repo["url"])
+                return False
 
-            # merge GitHub and our Workspace
-            return repo | {"workspace": workspace}
+            # because we know we have at least one job and first_run looks at
+            # either started_at OR created_at we know we will always have a
+            # value for first_run at this point
+            first_ran_over_11_months_ago = repo["first_run"] < eleven_months_ago
+            if not first_ran_over_11_months_ago:
+                logger.info("First run <11mo ago", url=repo["url"])
+                return False
 
-        repos = list(merge_data(r) for r in private_repos)
-        repos = list(
-            r | {"has_releases": "github-releases" in r["topics"]} for r in repos
-        )
+            return True
 
-        def exclude_never_run_repos(repos):
-            """
-            Exclude repos which we think can't have run a job
-
-            Repos created after 2021-01-01 will almost certainly have used the
-            job-server and thus if they have no workspace or jobs they haven't
-            executed code on a backend and can be excluded.
-            """
-            for repo in repos:
-                before_job_server = repo["created_at"] < datetime(
-                    2021, 1, 1, tzinfo=timezone.utc
-                )
-
-                has_run_jobs = repo["workspace"] and repo["workspace"].first_run
-
-                if before_job_server and not has_run_jobs:
-                    continue
-
-                yield repo
-
-        repos = list(exclude_never_run_repos(repos))
-
-        repos = sorted(repos, key=lambda r: r["created_at"])
+        # select only repos we care about
+        repos = [r for r in repos if select(r)]
 
         return TemplateResponse(request, "staff/repo_list.html", {"repos": repos})

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -53,31 +53,45 @@ class FakeGitHubAPI:
     def get_repos_with_dates(self, org):
         return [
             {
-                "name": "job-runner",
-                "url": "https://github.com/opensafely-core/job-runner",
-                "is_private": True,
-                "created_at": timezone.now(),
-                "topics": ["test"],
-            },
-            {
-                "name": "job-server",
-                "url": "https://github.com/opensafely-core/job-server",
-                "is_private": True,
-                "created_at": timezone.now(),
-                "topics": ["test"],
-            },
-            {
-                "name": "test",
-                "url": "test",
-                "is_private": True,
-                "created_at": timezone.now(),
-                "topics": ["test"],
-            },
-            {
                 "name": "predates-job-server",
-                "url": "test-url",
+                "url": "https://github.com/opensafely/predates-job-server",
                 "is_private": True,
                 "created_at": datetime(2020, 7, 31, tzinfo=timezone.utc),
+                "topics": ["github-releases"],
+            },
+            {
+                "name": "research-repo-1",
+                "url": "https://github.com/opensafely/research-repo-1",
+                "is_private": True,
+                "created_at": timezone.now(),
+                "topics": ["github-releases"],
+            },
+            {
+                "name": "research-repo-2",
+                "url": "https://github.com/opensafely/research-repo-2",
+                "is_private": True,
+                "created_at": timezone.now(),
+                "topics": [],
+            },
+            {
+                "name": "research-repo-3",
+                "url": "https://github.com/opensafely/research-repo-3",
+                "is_private": False,
+                "created_at": timezone.now(),
+                "topics": ["github-releases"],
+            },
+            {
+                "name": "no workspaces or jobs",
+                "url": "https://github.com/opensafely/research-repo-4",
+                "is_private": True,
+                "created_at": timezone.now(),
+                "topics": [],
+            },
+            {
+                "name": "jobs haven't run",
+                "url": "https://github.com/opensafely/research-repo-5",
+                "is_private": True,
+                "created_at": timezone.now(),
                 "topics": [],
             },
         ]


### PR DESCRIPTION
This reworks the logic for the view, keeping repos as the object we get and filter, but enhancing them with workspaces and related derived data (first job run etc).

h/t to @bloodearnest for helping me get the Workspace query to work without massively duplicating the number of Workspaces!