### PR TITLE
Always fallback to / on login page redirect

### DIFF
--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -11,7 +11,7 @@ from ..utils import is_safe_path
 
 
 def login_view(request):
-    next_url = request.GET.get("next", "/")
+    next_url = request.GET.get("next") or "/"
     if not is_safe_path(next_url):
         return bad_request(request, SuspiciousOperation)
 

--- a/tests/unit/jobserver/views/test_users.py
+++ b/tests/unit/jobserver/views/test_users.py
@@ -6,6 +6,16 @@ from jobserver.views.users import Settings, login_view
 from ....factories import UserFactory
 
 
+def test_login_empty_next(rf):
+    request = rf.get("/?next=")
+    request.user = UserFactory()
+
+    response = login_view(request)
+
+    assert response.status_code == 302
+    assert response.url == "/"
+
+
 def test_login_no_path(rf):
     request = rf.get("/")
     request.user = AnonymousUser()


### PR DESCRIPTION
When the `next` (or any) query arg is present but empty then then
`request.GET.get(<key>)` returns an empty string, even if we define a
default.  However, since the empty string is falsey we can set a default
using `or`.

Fixes [this event](https://sentry.io/organizations/ebm-datalab/issues/3142131236/events/864eab235b1d47e9965a7d593341cd22/?project=5443358).