### PR TITLE
fix: do not consider legacy pre-jobrunner repos in repos page

### DIFF
--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -28,9 +28,8 @@ class RepoList(View):
 
         Repos should be:
          * Private
+         * not have `non-research` topic
          * first job was run > 11 months ago
-           OR
-         * no workspaces/jobs AND has github-releases topic
         """
         all_repos = list(self.get_github_api().get_repos_with_dates("opensafely"))
 
@@ -99,15 +98,9 @@ class RepoList(View):
 
             We're already working with private repos here so we check
 
-            * Has the `github-releases` topic
             * Has jobs or a workspace
             * First job to run happened over 11 months ago
             """
-            if repo["has_releases"]:
-                # it has outputs released to it so assume code has been run to
-                # make those
-                return True
-
             if not (repo["workspaces"] and repo["has_jobs"]):
                 logger.info("No workspaces/jobs", url=repo["url"])
                 return False

--- a/tests/unit/staff/views/test_repos.py
+++ b/tests/unit/staff/views/test_repos.py
@@ -77,13 +77,7 @@ def test_repolist_success(rf, django_assert_num_queries, core_developer):
 
     assert response.status_code == 200
 
-    predates_job_server, research_repo_1, research_repo_2 = response.context_data[
-        "repos"
-    ]
-
-    assert predates_job_server["first_run"] is None
-    assert predates_job_server["has_releases"]
-    assert predates_job_server["workspace"] is None
+    research_repo_1, research_repo_2 = response.context_data["repos"]
 
     assert research_repo_1["first_run"] == minutes_ago(eleven_months_ago, 10)
     assert research_repo_1["has_releases"]


### PR DESCRIPTION
These are being tracked separately
