### PR TITLE
Filter out non research repos

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -267,6 +267,13 @@ class GitHubAPI:
                     name
                   }
                 }
+                repositoryTopics(first: 100) {
+                  nodes {
+                    topic {
+                      name
+                    }
+                  }
+                }
               }
               pageInfo {
                   endCursor
@@ -279,6 +286,13 @@ class GitHubAPI:
         results = list(self._iter_query_results(query, org_name=org))
         for repo in results:
             branches = [b["name"] for b in repo["refs"]["nodes"]]
+
+            topics = []
+            if repo["repositoryTopics"]["nodes"]:
+                topics = [n["topic"]["name"] for n in repo["repositoryTopics"]["nodes"]]
+
+            if "non-research" in topics:
+                continue  # ignore non-research repos
 
             yield {
                 "name": repo["name"],

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -117,7 +117,7 @@ class GitHubAPI:
         wraps the actual API calls done in _get_query_page and tracks the cursor.
         one.
         """
-        cursor = ""
+        cursor = None
         while True:
             data = self._get_query_page(
                 query=query,

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -102,7 +102,7 @@ class GitHubAPI:
                 f"graphql query failed\n\nquery:\n{query}\n\nresponse:\n{json.dumps(results, indent=2)}"
             )
 
-        return results["data"]["organization"]["team"]["repositories"]
+        return results["data"]["organization"]["repositories"]
 
     def _iter_query_results(self, query, **kwargs):
         """
@@ -258,21 +258,19 @@ class GitHubAPI:
         query = """
         query reposAndBranches($cursor: String, $org_name: String!) {
           organization(login: $org_name) {
-            team(slug: "researchers") {
-              repositories(first: 100, after: $cursor) {
-                nodes {
-                  name
-                  url
-                  refs(refPrefix: "refs/heads/", first: 100) {
-                    nodes {
-                      name
-                    }
+            repositories(first: 100, after: $cursor) {
+              nodes {
+                name
+                url
+                refs(refPrefix: "refs/heads/", first: 100) {
+                  nodes {
+                    name
                   }
                 }
-                pageInfo {
-                    endCursor
-                    hasNextPage
-                }
+              }
+              pageInfo {
+                  endCursor
+                  hasNextPage
               }
             }
           }
@@ -292,25 +290,23 @@ class GitHubAPI:
         query = """
         query reposAndBranches($cursor: String, $org_name: String!) {
           organization(login: $org_name) {
-            team(slug: "researchers") {
-              repositories(first: 100, after: $cursor) {
-                nodes {
-                  name
-                  url
-                  isPrivate
-                  createdAt
-                  repositoryTopics(first: 100) {
-                    nodes {
-                      topic {
-                        name
-                      }
+            repositories(first: 100, after: $cursor) {
+              nodes {
+                name
+                url
+                isPrivate
+                createdAt
+                repositoryTopics(first: 100) {
+                  nodes {
+                    topic {
+                      name
                     }
                   }
                 }
-                pageInfo {
-                    endCursor
-                    hasNextPage
-                }
+              }
+              pageInfo {
+                  endCursor
+                  hasNextPage
               }
             }
           }


### PR DESCRIPTION
This flips the way in which we filter repos to present to the User when creating a Workspace.

We currently get repos from the `researchers` team  relying on our permissions script to ensure repos are in that.  There's a lag time for that script running (every 15 minutes) and it causes some amount of support overhead to ask Users to wait for that to update.

This change removes the team check in favour of relying on our recent use of tagging non-research repos with the `non-research` topic.