### PR TITLE
Switch to contextvars based structlog usage

### DIFF
--- a/services/logging.py
+++ b/services/logging.py
@@ -24,15 +24,17 @@ def timestamper(logger, log_method, event_dict):
 
 
 pre_chain = [
-    # Add the log level and a timestamp to the event_dict if the log entry
-    # is not from structlog.
+    structlog.contextvars.merge_contextvars,
     structlog.stdlib.add_log_level,
     structlog.stdlib.add_logger_name,
+    # Add the log level and a timestamp to the event_dict if the log entry
+    # is not from structlog.
     timestamper,
 ]
 
 structlog.configure(
     processors=[
+        structlog.contextvars.merge_contextvars,
         structlog.stdlib.filter_by_level,
         timestamper,
         structlog.stdlib.add_logger_name,
@@ -44,7 +46,6 @@ structlog.configure(
         structlog.processors.ExceptionPrettyPrinter(),
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
     ],
-    context_class=structlog.threadlocal.wrap_dict(dict),
     logger_factory=structlog.stdlib.LoggerFactory(),
     wrapper_class=structlog.stdlib.BoundLogger,
 )


### PR DESCRIPTION
The threadlocal bind() function has been deprecated.

I followed this guide to do the upgrade:

https://github.com/jrobichaud/django-structlog/#upgrading-to-30