### PR TITLE
Add badges for number of jobs and released files for a given workspace

### DIFF
--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -25,6 +25,7 @@ from jobserver.api.releases import (
     WorkspaceStatusAPI,
 )
 
+from .views.badges import WorkspaceNumJobs, WorkspaceNumPublished, WorkspaceNumReleased
 from .views.index import Index
 from .views.job_requests import (
     JobRequestCancel,
@@ -68,7 +69,6 @@ from .views.workspaces import (
     WorkspaceLog,
     WorkspaceNotificationsToggle,
     WorkspaceOutputList,
-    WorkspaceOutputsBadge,
 )
 
 
@@ -151,7 +151,6 @@ outputs_urls = [
         WorkspaceLatestOutputsDetail.as_view(),
         name="workspace-latest-outputs-detail",
     ),
-    path("badge/", WorkspaceOutputsBadge.as_view(), name="workspace-outputs-badge"),
     path(
         "<int:pk>/",
         SnapshotDetail.as_view(),
@@ -204,6 +203,28 @@ workspace_urls = [
         "",
         WorkspaceDetail.as_view(),
         name="workspace-detail",
+    ),
+    path(
+        "badges/",
+        include(
+            [
+                path(
+                    "num-jobs/",
+                    WorkspaceNumJobs.as_view(),
+                    name="workspace-badge-num-jobs",
+                ),
+                path(
+                    "num-published/",
+                    WorkspaceNumPublished.as_view(),
+                    name="workspace-badge-num-published",
+                ),
+                path(
+                    "num-released/",
+                    WorkspaceNumReleased.as_view(),
+                    name="workspace-badge-num-released",
+                ),
+            ]
+        ),
     ),
     path(
         "run-jobs/",

--- a/jobserver/views/badges.py
+++ b/jobserver/views/badges.py
@@ -1,0 +1,67 @@
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
+from django.views.generic import View
+from pybadges import badge
+
+from ..models import Job, ReleaseFile, Workspace
+
+
+class WorkspaceNumJobs(View):
+    def get(self, request, *args, **kwargs):
+        workspace = get_object_or_404(
+            Workspace,
+            project__org__slug=self.kwargs["org_slug"],
+            project__slug=self.kwargs["project_slug"],
+            name=self.kwargs["workspace_slug"],
+        )
+
+        num_jobs = Job.objects.filter(job_request__workspace=workspace).count()
+
+        s = badge(
+            left_text="Jobs run",
+            right_text=str(num_jobs),
+            right_color="#0058be",
+        )
+        return HttpResponse(s, headers={"Content-Type": "image/svg+xml"})
+
+
+class WorkspaceNumPublished(View):
+    def get(self, request, *args, **kwargs):
+        workspace = get_object_or_404(
+            Workspace,
+            project__org__slug=self.kwargs["org_slug"],
+            project__slug=self.kwargs["project_slug"],
+            name=self.kwargs["workspace_slug"],
+        )
+
+        num_published = (
+            ReleaseFile.objects.filter(snapshots__workspace=workspace)
+            .distinct()
+            .count()
+        )
+
+        s = badge(
+            left_text="Published outputs",
+            right_text=str(num_published),
+            right_color="#0058be",
+        )
+        return HttpResponse(s, headers={"Content-Type": "image/svg+xml"})
+
+
+class WorkspaceNumReleased(View):
+    def get(self, request, *args, **kwargs):
+        workspace = get_object_or_404(
+            Workspace,
+            project__org__slug=self.kwargs["org_slug"],
+            project__slug=self.kwargs["project_slug"],
+            name=self.kwargs["workspace_slug"],
+        )
+
+        num_released = ReleaseFile.objects.filter(release__workspace=workspace).count()
+
+        s = badge(
+            left_text="Released outputs",
+            right_text=str(num_released),
+            right_color="#0058be",
+        )
+        return HttpResponse(s, headers={"Content-Type": "image/svg+xml"})

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -1,14 +1,13 @@
 import requests
 from django.contrib import messages
 from django.db.models import Q
-from django.http import FileResponse, Http404, HttpResponse
+from django.http import FileResponse, Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.views.generic import CreateView, ListView, View
 from first import first
 from furl import furl
 from opentelemetry import trace
-from pybadges import badge
 
 from ..authorization import has_permission
 from ..forms import (
@@ -496,22 +495,3 @@ class WorkspaceOutputList(ListView):
             "workspace_output_list.html",
             context=context,
         )
-
-
-class WorkspaceOutputsBadge(View):
-    def get(self, request, *args, **kwargs):
-        workspace = get_object_or_404(
-            Workspace,
-            project__org__slug=self.kwargs["org_slug"],
-            project__slug=self.kwargs["project_slug"],
-            name=self.kwargs["workspace_slug"],
-        )
-
-        published_snapshots = workspace.snapshots.exclude(published_at=None).count()
-
-        s = badge(
-            left_text="Published outputs",
-            right_text=str(published_snapshots),
-            right_color="#0058be",
-        )
-        return HttpResponse(s, headers={"Content-Type": "image/svg+xml"})

--- a/tests/unit/jobserver/test_urls.py
+++ b/tests/unit/jobserver/test_urls.py
@@ -25,6 +25,7 @@ from jobserver.api.releases import (
 )
 from jobserver.utils import dotted_path
 from jobserver.views import (
+    badges,
     index,
     job_requests,
     jobs,
@@ -133,6 +134,9 @@ def test_url_redirects(client, url, redirect):
         ("/o/p/w/", workspaces.WorkspaceDetail),
         ("/o/p/w/run-jobs/", job_requests.JobRequestCreate),
         ("/o/p/w/archive-toggle/", workspaces.WorkspaceArchiveToggle),
+        ("/o/p/w/badges/num-published/", badges.WorkspaceNumPublished),
+        ("/o/p/w/badges/num-jobs/", badges.WorkspaceNumJobs),
+        ("/o/p/w/badges/num-released/", badges.WorkspaceNumReleased),
         ("/o/p/w/files/", workspaces.WorkspaceFileList),
         ("/o/p/w/files/tpp/", workspaces.WorkspaceBackendFiles),
         ("/o/p/w/files/tpp/file.txt", workspaces.WorkspaceBackendFiles),
@@ -142,7 +146,6 @@ def test_url_redirects(client, url, redirect):
         ("/o/p/w/outputs/latest/", workspaces.WorkspaceLatestOutputsDetail),
         ("/o/p/w/outputs/latest/download/", workspaces.WorkspaceLatestOutputsDownload),
         ("/o/p/w/outputs/latest/file.txt", workspaces.WorkspaceLatestOutputsDetail),
-        ("/o/p/w/outputs/badge/", workspaces.WorkspaceOutputsBadge),
         ("/o/p/w/outputs/42/", releases.SnapshotDetail),
         ("/o/p/w/outputs/42/download/", releases.SnapshotDownload),
         ("/o/p/w/outputs/42/file.txt", releases.SnapshotDetail),

--- a/tests/unit/jobserver/views/test_badges.py
+++ b/tests/unit/jobserver/views/test_badges.py
@@ -1,0 +1,166 @@
+import pytest
+from django.http import Http404
+from django.utils import timezone
+
+from jobserver.views.badges import (
+    WorkspaceNumJobs,
+    WorkspaceNumPublished,
+    WorkspaceNumReleased,
+)
+
+from ....factories import (
+    JobFactory,
+    JobRequestFactory,
+    ProjectFactory,
+    ReleaseFactory,
+    ReleaseUploadsFactory,
+    SnapshotFactory,
+    WorkspaceFactory,
+)
+
+
+def test_worksapcenumjobs_some_jobs(rf):
+    workspace = WorkspaceFactory()
+    job_request = JobRequestFactory(workspace=workspace)
+    JobFactory.create_batch(5, job_request=job_request)
+
+    request = rf.get("/")
+
+    response = WorkspaceNumJobs.as_view()(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+
+
+def test_workspacenumjobs_no_jobs(rf):
+    workspace = WorkspaceFactory()
+    JobRequestFactory(workspace=workspace)
+
+    request = rf.get("/")
+
+    response = WorkspaceNumJobs.as_view()(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+
+
+def test_workspacenumjobs_unknown_workspace(rf):
+    project = ProjectFactory()
+
+    request = rf.get("/")
+
+    with pytest.raises(Http404):
+        WorkspaceNumJobs.as_view()(
+            request,
+            org_slug=project.org.slug,
+            project_slug=project.slug,
+            workspace_slug="",
+        )
+
+
+def test_workspacenumpublished_with_published_outputs(rf):
+    workspace = WorkspaceFactory()
+
+    ReleaseFactory(
+        ReleaseUploadsFactory({"file1.txt": b"text", "file2.txt": b"text"}),
+        workspace=workspace,
+    )
+    snapshot = SnapshotFactory(workspace=workspace, published_at=timezone.now())
+    snapshot.files.set(workspace.files.all())
+
+    request = rf.get("/")
+
+    response = WorkspaceNumPublished.as_view()(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+
+
+def test_workspacenumpublished_without_published_outputs(rf):
+    workspace = WorkspaceFactory()
+
+    request = rf.get("/")
+
+    response = WorkspaceNumPublished.as_view()(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+
+
+def test_workspacenumpublished_unknown_workspace(rf):
+    project = ProjectFactory()
+
+    request = rf.get("/")
+
+    with pytest.raises(Http404):
+        WorkspaceNumPublished.as_view()(
+            request,
+            org_slug=project.org.slug,
+            project_slug=project.slug,
+            workspace_slug="",
+        )
+
+
+def test_workspacenumreleased_no_released_files(rf):
+    workspace = WorkspaceFactory()
+
+    request = rf.get("/")
+
+    response = WorkspaceNumReleased.as_view()(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+
+
+def test_workspacenumreleased_some_released_files(rf):
+    workspace = WorkspaceFactory()
+
+    ReleaseFactory(
+        ReleaseUploadsFactory({"file1.txt": b"text", "file2.txt": b"text"}),
+        workspace=workspace,
+    )
+
+    request = rf.get("/")
+
+    response = WorkspaceNumReleased.as_view()(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+
+
+def test_workspacenumreleased_unknown_workspace(rf):
+    project = ProjectFactory()
+
+    request = rf.get("/")
+
+    with pytest.raises(Http404):
+        WorkspaceNumReleased.as_view()(
+            request,
+            org_slug=project.org.slug,
+            project_slug=project.slug,
+            workspace_slug="",
+        )

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -24,7 +24,6 @@ from jobserver.views.workspaces import (
     WorkspaceLog,
     WorkspaceNotificationsToggle,
     WorkspaceOutputList,
-    WorkspaceOutputsBadge,
 )
 
 from ....factories import (
@@ -1181,57 +1180,6 @@ def test_workspaceoutputlist_unknown_workspace(rf):
 
     with pytest.raises(Http404):
         WorkspaceOutputList.as_view()(
-            request,
-            org_slug=project.org.slug,
-            project_slug=project.slug,
-            workspace_slug="",
-        )
-
-
-def test_workspaceoutputsbadge_with_published_outputs(rf):
-    workspace = WorkspaceFactory()
-
-    ReleaseFactory(
-        ReleaseUploadsFactory({"file1.txt": b"text", "file2.txt": b"text"}),
-        workspace=workspace,
-    )
-    snapshot = SnapshotFactory(workspace=workspace, published_at=timezone.now())
-    snapshot.files.set(workspace.files.all())
-
-    request = rf.get("/")
-
-    response = WorkspaceOutputsBadge.as_view()(
-        request,
-        org_slug=workspace.project.org.slug,
-        project_slug=workspace.project.slug,
-        workspace_slug=workspace.name,
-    )
-
-    assert response.status_code == 200
-
-
-def test_workspaceoutputsbadge_without_published_outputs(rf):
-    workspace = WorkspaceFactory()
-
-    request = rf.get("/")
-
-    response = WorkspaceOutputsBadge.as_view()(
-        request,
-        org_slug=workspace.project.org.slug,
-        project_slug=workspace.project.slug,
-        workspace_slug=workspace.name,
-    )
-
-    assert response.status_code == 200
-
-
-def test_workspaceoutputsbadge_unknown_workspace(rf):
-    project = ProjectFactory()
-
-    request = rf.get("/")
-
-    with pytest.raises(Http404):
-        WorkspaceOutputsBadge.as_view()(
             request,
             org_slug=project.org.slug,
             project_slug=project.slug,


### PR DESCRIPTION
This adds a couple of extra badges and reorganises the badge views into their own module.

Refs #1968 