### PR TITLE
Wrap up asset creation in skipable just targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: extractions/setup-just@v1
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -18,7 +19,7 @@ jobs:
           cache: 'npm'
 
       - name: Install node_modules
-        run: npm ci
+        run: just assets-install
 
       - name: Lint assets
         run: npm run lint
@@ -27,7 +28,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Build assets
-        run: npm run build
+        run: just assets-build
 
       - name: Store assets
         uses: actions/upload-artifact@v3

--- a/justfile
+++ b/justfile
@@ -150,8 +150,56 @@ run: devenv
     $BIN/python manage.py runserver
 
 
-# update npm deps, build payload, and collect for Django
-rebuild-static:
+# Remove built assets and collected static files
+assets-clean:
+    rm -rf assets/dist
+    rm -rf staticfiles
+
+
+# Install the Node.js dependencies
+assets-install:
+    #!/usr/bin/env bash
+    set -eu
+
+    # exit if lock file has not changed since we installed them. -nt == "newer than",
+    # but we negate with || to avoid error exit code
+    test package-lock.json -nt node_modules/.written || exit 0
+
     npm ci
+    touch node_modules/.written
+
+
+# Build the Node.js assets
+assets-build:
+    #!/usr/bin/env bash
+    set -eu
+
+    # find files which are newer than dist/.written in the src directory. grep
+    # will exit with 1 if there are no files in the result.  We negate this
+    # with || to avoid error exit code
+    # we wrap the find in an if in case dist/.written is missing so we don't
+    # trigger a failure prematurely
+    if test -f assets/dist/.written; then
+        find assets/src -type f -newer assets/dist/.written | grep -q . || exit 0
+    fi
+
     npm run build
+    touch assets/dist/.written
+
+
+# Collect the static files
+assets-collect:
+    #!/usr/bin/env bash
+    set -eu
+
+    # exit if nothing has changed in the built assets since we last collected staticfiles.
+    # -nt == "newer than", but we negate with || to avoid error exit code
+    test assets/dist/.written -nt staticfiles/.written || exit 0
+
     $BIN/python manage.py collectstatic --no-input
+    touch staticfiles/.written
+
+
+assets: assets-install assets-build assets-collect
+
+assets-rebuild: assets-clean assets


### PR DESCRIPTION
This copies our python stack in flow, where each target compares some
file modification times, and only runs the target if the check file is
older than the source.