### PR TITLE
extend base exclude with various project and tool directories

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .direnv,.venv,venv
+extend-exclude = .direnv,.github,.ipynb_checkpoints,.pytest_cache,.venv,assets,coverage,doc,htmlcov,node_modules,releases,snippets,static,staticfiles,uploads,venv
 extend-select = \
     W504  # match black&PEP8 putting binary operators after new lines
 ignore = \


### PR DESCRIPTION
This switches us to `extend-exclude` so we get the base flake8 excludes for free and adds various project and tooling-related directories to the ignore.  Locally this dropped flake8 runtime from ~6.5 to ~4.5s for me.