### PR TITLE
dynamically look up workspace names in tests

### DIFF
--- a/tests/unit/jobserver/views/test_jobs.py
+++ b/tests/unit/jobserver/views/test_jobs.py
@@ -177,7 +177,7 @@ def test_jobdetail_with_core_developer(rf):
     assert "Honeycomb" in response.rendered_content
     assert "%22end_time%22%3A1655380800%2C" in response.rendered_content
     assert (
-        "workspace_name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22workspace-246"
+        f"workspace_name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{job.job_request.workspace.name}"
         in response.rendered_content
     )
 

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -504,7 +504,7 @@ def test_workspacedetail_authorized_honeycomb(rf):
     assert response.status_code == 200
     assert "Honeycomb" in response.rendered_content
     assert (
-        "workspace_name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22workspace-329"
+        f"workspace_name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{workspace.name}"
         in response.rendered_content
     )
 


### PR DESCRIPTION
Workspace.name is a factory boy sequence so we can't rely on a hardcoded
value since other tests will change this value.