### PR TITLE
Create GitHub issue on release

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -144,6 +144,30 @@ class GitHubAPI:
 
         return f.url
 
+    def create_issue(self, org, repo, title, body, labels):
+        path_segments = [
+            "repos",
+            org,
+            repo,
+            "issues",
+        ]
+        url = self._url(path_segments)
+
+        payload = {
+            "title": title,
+            "body": body,
+            "labels": labels,
+        }
+
+        headers = {
+            "Accept": "application/vnd.github.v3+json",
+        }
+        r = self._post(url, headers=headers, json=payload)
+
+        r.raise_for_status()
+
+        return r.json()
+
     def get_branch(self, org, repo, branch):
         path_segments = [
             "repos",

--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -1,9 +1,11 @@
 import hashlib
 import io
+import textwrap
 import zipfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from django.conf import settings
 from django.db import transaction
 from django.http import FileResponse
 from django.utils.http import http_date
@@ -19,6 +21,24 @@ from .signing import AuthToken
 
 class ReleaseFileAlreadyExists(Exception):
     pass
+
+
+def size_formatter(value):
+    """
+    Format the value, in bytes, with a size suffix
+
+    Kilobytes (Kb) and Megabytes (Mb) will be automatically selected if the
+    values is large enough.
+    """
+    if value < 1024:
+        return f"{value}b"
+
+    if value < 1024**2:
+        value = round(value / 1024, 2)
+        return f"{value}Kb"
+
+    value = round(value / 1024**2, 2)
+    return f"{value}Mb"
 
 
 def _build_paths(release, filename, data):
@@ -151,6 +171,58 @@ def create_release(workspace, backend, created_by, requested_files, **kwargs):
             )
 
     return release
+
+
+def create_github_issue(
+    release, github_api, org="ebmdatalab", repo="opensafely-output-review"
+):
+    template = """
+    Requested by: {requested_by}
+    Release: {release}
+    GitHub repo: {github_repo}
+    Workspace: {workspace}
+
+    {number} files have been selected for review, with a total size of {size}.{review_form}
+
+    **When you start a review please react to this message with :eyes:. When you have completed your review add a :thumbsup:. Once two reviews have been completed and a response has been sent to the requester, please close the issue.**
+    """
+
+    is_internal = release.created_by.orgs.filter(slug="datalab").exists()
+
+    base_url = furl(settings.BASE_URL)
+
+    def link(title, url):
+        return f"[{title}]({url})"
+
+    github_repo = link(release.workspace.repo_name, release.workspace.repo)
+    requested_by = link(release.created_by.name, release.created_by.get_staff_url())
+    release_url = link(release.id, base_url / release.get_absolute_url())
+    workspace_url = link(
+        release.workspace.name, base_url / release.workspace.get_absolute_url()
+    )
+
+    files = release.files.all()
+    number = len(files)
+    size = size_formatter(sum(f.size for f in files))
+    review_form = "" if is_internal else "\n\n[Review request form]()"
+
+    content = textwrap.dedent(template).format(
+        github_repo=github_repo,
+        number=number,
+        release=release_url,
+        requested_by=requested_by,
+        review_form=review_form,
+        size=size,
+        workspace=workspace_url,
+    )
+
+    github_api.create_issue(
+        org,
+        repo,
+        title=release.workspace.name,
+        body=content,
+        labels=["internal" if is_internal else "external"],
+    )
 
 
 @transaction.atomic

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -5,6 +5,9 @@ from django.utils import timezone
 
 
 class FakeGitHubAPI:
+    def create_issue(self, org, repo, title, body, labels):
+        return {}
+
     def get_branch(self, org, repo, branch):
         return {
             "commit": {

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -39,6 +39,7 @@ from tests.factories import (
     UserFactory,
     WorkspaceFactory,
 )
+from tests.fakes import FakeGitHubAPI
 
 
 def test_releaseapi_get_unknown_release(api_rf):
@@ -338,7 +339,9 @@ def test_releasenotificationapicreate_success_with_files(api_rf, slack_messages)
 def test_releaseworkspaceapi_get_unknown_workspace(api_rf):
     request = api_rf.get("/")
 
-    response = ReleaseWorkspaceAPI.as_view()(request, workspace_name="")
+    response = ReleaseWorkspaceAPI.as_view(get_github_api=FakeGitHubAPI)(
+        request, workspace_name=""
+    )
 
     assert response.status_code == 404
 
@@ -348,7 +351,9 @@ def test_releaseworkspaceapi_get_with_anonymous_user(api_rf):
 
     request = api_rf.get("/")
 
-    response = ReleaseWorkspaceAPI.as_view()(request, workspace_name=workspace.name)
+    response = ReleaseWorkspaceAPI.as_view(get_github_api=FakeGitHubAPI)(
+        request, workspace_name=workspace.name
+    )
 
     assert response.status_code == 403
 
@@ -375,7 +380,9 @@ def test_releaseworkspaceapi_get_with_permission(api_rf, build_release_with_file
     request = api_rf.get("/")
     request.user = user
 
-    response = ReleaseWorkspaceAPI.as_view()(request, workspace_name=workspace.name)
+    response = ReleaseWorkspaceAPI.as_view(get_github_api=FakeGitHubAPI)(
+        request, workspace_name=workspace.name
+    )
 
     assert response.status_code == 200
     assert response.data == {
@@ -416,7 +423,9 @@ def test_releaseworkspaceapi_get_without_permission(api_rf):
     request = api_rf.get("/")
     request.user = UserFactory()
 
-    response = ReleaseWorkspaceAPI.as_view()(request, workspace_name=workspace.name)
+    response = ReleaseWorkspaceAPI.as_view(get_github_api=FakeGitHubAPI)(
+        request, workspace_name=workspace.name
+    )
 
     assert response.status_code == 403
 
@@ -454,7 +463,9 @@ def test_releaseworkspaceapi_post_create_release(api_rf, slack_messages):
         HTTP_OS_USER=user.username,
     )
 
-    response = ReleaseWorkspaceAPI.as_view()(request, workspace_name=workspace.name)
+    response = ReleaseWorkspaceAPI.as_view(get_github_api=FakeGitHubAPI)(
+        request, workspace_name=workspace.name
+    )
 
     assert response.status_code == 201, response.data
     assert Release.objects.count() == 1
@@ -510,7 +521,7 @@ def test_releaseworkspaceapi_post_release_already_exists(api_rf):
         HTTP_OS_USER=user.username,
     )
 
-    response = ReleaseWorkspaceAPI.as_view()(
+    response = ReleaseWorkspaceAPI.as_view(get_github_api=FakeGitHubAPI)(
         request, workspace_name=release.workspace.name
     )
 
@@ -522,7 +533,9 @@ def test_releaseworkspaceapi_post_release_already_exists(api_rf):
 def test_releaseworkspaceapi_post_unknown_workspace(api_rf):
     request = api_rf.post("/")
 
-    response = ReleaseWorkspaceAPI.as_view()(request, workspace_name="")
+    response = ReleaseWorkspaceAPI.as_view(get_github_api=FakeGitHubAPI)(
+        request, workspace_name=""
+    )
 
     assert response.status_code == 404
 
@@ -533,7 +546,9 @@ def test_releaseworkspaceapi_post_with_bad_backend_token(api_rf):
 
     request = api_rf.post("/", HTTP_AUTHORIZATION="invalid")
 
-    response = ReleaseWorkspaceAPI.as_view()(request, workspace_name=workspace.name)
+    response = ReleaseWorkspaceAPI.as_view(get_github_api=FakeGitHubAPI)(
+        request, workspace_name=workspace.name
+    )
 
     assert response.status_code == 403
 
@@ -555,7 +570,9 @@ def test_releaseworkspaceapi_post_with_bad_json(api_rf):
         HTTP_OS_USER=user.username,
     )
 
-    response = ReleaseWorkspaceAPI.as_view()(request, workspace_name=workspace.name)
+    response = ReleaseWorkspaceAPI.as_view(get_github_api=FakeGitHubAPI)(
+        request, workspace_name=workspace.name
+    )
 
     assert response.status_code == 400
 
@@ -570,7 +587,9 @@ def test_releaseworkspaceapi_post_with_bad_user(api_rf):
         HTTP_OS_USER="baduser",
     )
 
-    response = ReleaseWorkspaceAPI.as_view()(request, workspace_name=workspace.name)
+    response = ReleaseWorkspaceAPI.as_view(get_github_api=FakeGitHubAPI)(
+        request, workspace_name=workspace.name
+    )
 
     assert response.status_code == 403
 
@@ -580,7 +599,9 @@ def test_releaseworkspaceapi_post_without_backend_token(api_rf):
 
     request = api_rf.post("/")
 
-    response = ReleaseWorkspaceAPI.as_view()(request, workspace_name=workspace.name)
+    response = ReleaseWorkspaceAPI.as_view(get_github_api=FakeGitHubAPI)(
+        request, workspace_name=workspace.name
+    )
 
     assert response.status_code == 403
 
@@ -594,7 +615,9 @@ def test_releaseworkspaceapi_post_without_user(api_rf):
         HTTP_AUTHORIZATION="test",
     )
 
-    response = ReleaseWorkspaceAPI.as_view()(request, workspace_name=workspace.name)
+    response = ReleaseWorkspaceAPI.as_view(get_github_api=FakeGitHubAPI)(
+        request, workspace_name=workspace.name
+    )
 
     assert response.status_code == 403
 

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -46,6 +46,25 @@ def compare(fake, real):
             compare(fake[key], real[key])
 
 
+def test_create_issue(enable_network, github_api):
+    # use a private repo to test here so we can mirror what the output checkers
+    # are doing
+    args = [
+        "opensafely-testing",
+        "github-api-testing-private",
+        "Test Issue",
+        "test content",
+        ["testing"],
+    ]
+
+    real = github_api.create_issue(*args)
+    fake = FakeGitHubAPI().create_issue(*args)
+
+    compare(fake, real)
+
+    assert real is not None
+
+
 def test_get_branch(enable_network, github_api):
     args = ["opensafely-testing", "github-api-testing", "main"]
 


### PR DESCRIPTION
This creates an issue on GitHub for the release when it's created via the API.  It uses the templates from the output reviewing repo.

There's one open question around how we decide if a user is considered internal but the rest can be reviewed now.

Fixes #2027 