### PR TITLE
Set Release.review & ReleaseFile.review (via FileSerializer) as nullable

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -53,13 +53,13 @@ class FileSerializer(serializers.Serializer):
     sha256 = serializers.CharField()
     date = serializers.DateTimeField()
     metadata = serializers.DictField()
-    review = ReviewSerializer(required=False)
+    review = ReviewSerializer(allow_null=True)
 
 
 class ReleaseSerializer(serializers.Serializer):
     files = FileSerializer(many=True)
     metadata = serializers.DictField()
-    review = serializers.DictField()
+    review = serializers.DictField(allow_null=True)
 
 
 class ReleaseNotificationAPICreate(CreateAPIView):

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -443,10 +443,11 @@ def test_releaseworkspaceapi_post_create_release(api_rf, slack_messages):
                 "sha256": "hash",
                 "date": timezone.now(),
                 "metadata": {},
+                "review": None,
             }
         ],
         "metadata": {},
-        "review": {},
+        "review": None,
     }
     request = api_rf.post(
         "/",
@@ -498,6 +499,7 @@ def test_releaseworkspaceapi_post_release_already_exists(api_rf):
                 "sha256": rfile.filehash,
                 "date": timezone.now(),
                 "metadata": {},
+                "review": None,
             }
         ],
         "metadata": {},


### PR DESCRIPTION
We want to be explicit that both review fields are None | dict where the
dict is either free form (in Release) or specified for ReleaseFile
(because we generate ReleaseFileReviews from it).