### PR TITLE
Build releases with the new format of requested_files

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -267,7 +267,7 @@ class ReleaseAPI(APIView):
         _, params = cgi.parse_header(request.headers["Content-Disposition"])
         filename = params["filename"]
 
-        if filename not in release.requested_files:
+        if filename not in {f["name"] for f in release.requested_files}:
             raise ValidationError(
                 {"detail": f"File {filename} not requested in release {release.id}"}
             )


### PR DESCRIPTION
The tests changes here are quite clunky.  They've mostly been ripped from the `new-style-release-factories` branch where I'm abstracting them away from most tests and my hope is to get that landed very quickly after this.