### PR TITLE
check for existance of files using uploaded_at

### DIFF
--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -210,7 +210,8 @@ def handle_file_upload(release, backend, user, upload, filename, **kwargs):
     # the uploaded files hash matches what was sent to us when the ReleaseFile
     # and Release were created.
     if rfile.filehash != calculated_hash:
-        raise Exception
+        msg = "Contents of uploaded file does not match the file which a review was requested for"
+        raise Exception(msg)
 
     absolute_path.write_bytes(data)
     rfile.path = str(relative_path)

--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -199,7 +199,7 @@ def handle_file_upload(release, backend, user, upload, filename, **kwargs):
     # New flow
 
     # _is_ on disk
-    if rfile.absolute_path().exists():
+    if rfile.uploaded_at:
         # existence of a ReleaseFile isn't an error case now but a file-on-disk
         # having already been uploaded is
         raise ReleaseFileAlreadyExists(

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -120,6 +120,7 @@ def test_releaseapi_post_already_uploaded(api_rf, tmp_path):
         release=release,
         name="file.txt",
         path=Path(release.workspace.name) / "releases" / str(release.id) / "file.txt",
+        uploaded_at=timezone.now(),
     )
     content = "".join(random.choice(string.ascii_letters) for i in range(10))
     content = content.encode("utf8")

--- a/tests/unit/jobserver/test_releases.py
+++ b/tests/unit/jobserver/test_releases.py
@@ -202,7 +202,8 @@ def test_handle_release_upload_file_created():
 def test_handle_release_upload_exists_in_db_and_not_on_disk():
     uploads = ReleaseUploadsFactory({"file1.txt": b"test"})
     existing = ReleaseFileFactory(uploads[0])
-    existing.absolute_path().unlink()
+    existing.uploaded_at = None
+    existing.save()
 
     # check out test setup is correct
     assert existing.filehash == uploads[0].filehash

--- a/tests/unit/jobserver/test_releases.py
+++ b/tests/unit/jobserver/test_releases.py
@@ -246,11 +246,12 @@ def test_handle_release_upload_exists_with_incorrect_filehash():
     existing = ReleaseFileFactory(uploads[0])
 
     existing.absolute_path().unlink()
+    existing.uploaded_at = None
     existing.filehash = "test"
-    existing.save(update_fields=["filehash"])
+    existing.save(update_fields=["filehash", "uploaded_at"])
     existing.refresh_from_db()
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="^Contents of uploaded"):
         releases.handle_file_upload(
             existing.release,
             existing.release.backend,


### PR DESCRIPTION
When a ReleaseFile has been created but no file uploaded we don't have a
path for it, so ReleaseFile.absolute_path() will return a valid path to
the releases directory, which will exist.  However a file being on disk
isn't the most correct check here since a file could have also been
deleted from disk, so lets check to see if we think we've uploaded it
previously.