### PR TITLE
Build a testing onion for Release[File]s

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -308,7 +308,9 @@ class ReleaseFileAPI(APIView):
 
     def get(self, request, file_id):
         """Return the content of a specific ReleaseFile"""
-        rfile = get_object_or_404(ReleaseFile, id=file_id)
+        # treat a deleted file as missing
+        release_files = ReleaseFile.objects.filter(deleted_at=None, deleted_by=None)
+        rfile = get_object_or_404(release_files, id=file_id)
         validate_release_access(request, rfile.workspace)
         return serve_file(request, rfile)
 

--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -227,10 +227,11 @@ def serve_file(request, rfile):
     If Releases-Redirect header is set, use nginx's X-Accel-Redirect to serve
     response. Else just serve the bytes directly (for dev).
     """
-    path = rfile.absolute_path()
-    # check the file actually exists on disk
-    if not path.exists():
+    # check the file has been uploaded
+    if not rfile.uploaded_at:
         raise NotFound
+
+    path = rfile.absolute_path()
 
     internal_redirect = request.headers.get("Releases-Redirect")
     if internal_redirect:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,14 @@
+import hashlib
 import os
+import random
+import string
 import textwrap
+from pathlib import Path
 
 import pytest
 import structlog
 from django.conf import settings
+from django.utils import timezone
 from structlog.testing import LogCapture
 
 import services.slack
@@ -12,6 +17,7 @@ from jobserver.authorization.roles import CoreDeveloper
 
 from .factories import OrgFactory, OrgMembershipFactory, UserFactory
 from .factories import applications as application_factories
+from .factories.releases import ReleaseFactory, ReleaseFileFactory
 
 
 @pytest.fixture(autouse=True)
@@ -81,6 +87,97 @@ def incomplete_application():
         factory = getattr(application_factories, factory_name)
         factory(application=application)
     return application
+
+
+@pytest.fixture
+def build_release(build_release_path):
+    def func(names, **kwargs):
+        requested_files = [{"name": n} for n in names]
+        release = ReleaseFactory(requested_files=requested_files, **kwargs)
+
+        build_release_path(release)
+
+        return release
+
+    return func
+
+
+@pytest.fixture
+def build_release_with_files(build_release, build_release_file):
+    """Build a Release and generate some files for the given names"""
+
+    def func(names, **kwargs):
+        release = build_release(names, **kwargs)
+
+        for name in names:
+            build_release_file(release, name)
+
+        return release
+
+    return func
+
+
+@pytest.fixture
+def build_release_file(file_content):
+    """
+    Build a ReleaseFile
+
+    Given a Release instance and a filename create both the ReleaseFile object
+    and the on-disk file with random content from the file_content fixture.
+    """
+
+    def func(release, name):
+        # build a relative path for the file
+        path = Path(release.workspace.name) / "releases" / str(release.id) / name
+
+        rfile = ReleaseFileFactory(
+            release=release,
+            workspace=release.workspace,
+            name=name,
+            path=path,
+            filehash=hashlib.sha256(file_content).hexdigest(),
+            size=len(file_content),
+            uploaded_at=timezone.now(),
+        )
+
+        # write the file to disk
+        rfile.absolute_path().write_bytes(file_content)
+
+        return rfile
+
+    return func
+
+
+@pytest.fixture
+def build_release_path(tmp_path):
+    """Build the path and directories for a Release directory"""
+
+    def func(release):
+        path = (
+            tmp_path
+            / "releases"
+            / release.workspace.name
+            / "releases"
+            / str(release.id)
+        )
+        path.mkdir(parents=True)
+
+        return path
+
+    return func
+
+
+@pytest.fixture
+def file_content():
+    """Generate random file content ready for writing to disk"""
+    content = "".join(random.choice(string.ascii_letters) for i in range(10))
+    return content.encode("utf-8")
+
+
+@pytest.fixture
+def release(build_release_with_files):
+    """Generate a Release instance with both a ReleaseFile and on-disk file"""
+    return build_release_with_files(["file1.txt"])
 
 
 slack_token = os.environ.get("SLACK_BOT_TOKEN")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,14 @@ import services.slack
 from applications.form_specs import form_specs
 from jobserver.authorization.roles import CoreDeveloper
 
-from .factories import OrgFactory, OrgMembershipFactory, UserFactory
+from .factories import (
+    OrgFactory,
+    OrgMembershipFactory,
+    ReleaseFactory,
+    ReleaseFileFactory,
+    UserFactory,
+)
 from .factories import applications as application_factories
-from .factories.releases import ReleaseFactory, ReleaseFileFactory
 
 
 @pytest.fixture(autouse=True)

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,3 +1,4 @@
 from .applications import *  # noqa: F401, F403
 from .jobserver import *  # noqa: F401, F403
 from .redirects import *  # noqa: F401, F403
+from .releases import *  # noqa: F401, F403

--- a/tests/factories/releases.py
+++ b/tests/factories/releases.py
@@ -21,7 +21,7 @@ class ReleaseFileFactory(factory.django.DjangoModelFactory):
         model = ReleaseFile
 
     created_by = factory.SubFactory("tests.factories.UserFactory")
-    release = factory.SubFactory("tests.factories.releases.ReleaseFactory")
+    release = factory.SubFactory("tests.factories.ReleaseFactory")
     workspace = factory.SubFactory("tests.factories.WorkspaceFactory")
 
     mtime = factory.Faker("date_time", tzinfo=timezone.utc)

--- a/tests/factories/releases.py
+++ b/tests/factories/releases.py
@@ -21,7 +21,7 @@ class ReleaseFileFactory(factory.django.DjangoModelFactory):
         model = ReleaseFile
 
     created_by = factory.SubFactory("tests.factories.UserFactory")
-    release = factory.SubFactory("tests.factories.ReleaseFactory")
+    release = factory.SubFactory("tests.factories.releases.ReleaseFactory")
     workspace = factory.SubFactory("tests.factories.WorkspaceFactory")
 
     mtime = factory.Faker("date_time", tzinfo=timezone.utc)

--- a/tests/integration/test_release_api_access.py
+++ b/tests/integration/test_release_api_access.py
@@ -1,20 +1,12 @@
 from django.urls import reverse
 from django.utils import timezone
 
-from ..factories import (
-    ReleaseFactory,
-    ReleaseUploadsFactory,
-    SnapshotFactory,
-    UserFactory,
-    WorkspaceFactory,
-)
+from ..factories import SnapshotFactory, UserFactory, WorkspaceFactory
 
 
-def test_published_output_access(client):
+def test_published_output_access(client, release):
     user = UserFactory()
     workspace = WorkspaceFactory()
-    uploads = ReleaseUploadsFactory({"file1.txt": b"test1"})
-    release = ReleaseFactory(uploads, workspace=workspace)
     snapshot = SnapshotFactory(
         workspace=workspace, published_by=user, published_at=timezone.now()
     )
@@ -33,10 +25,8 @@ def test_published_output_access(client):
     assert response.status_code == 200
 
 
-def test_unpublished_output_access(client):
+def test_unpublished_output_access(client, release):
     workspace = WorkspaceFactory()
-    uploads = ReleaseUploadsFactory({"file1.txt": b"test1"})
-    release = ReleaseFactory(uploads, workspace=workspace)
     snapshot = SnapshotFactory(workspace=workspace)
     snapshot.files.set(release.files.all())
 

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -33,11 +33,12 @@ from tests.factories import (
     BackendMembershipFactory,
     ProjectFactory,
     ProjectMembershipFactory,
+    ReleaseFactory,
+    ReleaseFileFactory,
     SnapshotFactory,
     UserFactory,
     WorkspaceFactory,
 )
-from tests.factories.releases import ReleaseFactory, ReleaseFileFactory
 
 
 def test_releaseapi_get_unknown_release(api_rf):

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1,8 +1,6 @@
-import hashlib
 import json
 import random
 import string
-from pathlib import Path
 
 import pytest
 from django.contrib.auth.models import AnonymousUser
@@ -35,13 +33,11 @@ from tests.factories import (
     BackendMembershipFactory,
     ProjectFactory,
     ProjectMembershipFactory,
-    ReleaseFactory,
-    ReleaseUploadsFactory,
     SnapshotFactory,
     UserFactory,
     WorkspaceFactory,
 )
-from tests.factories import releases as new_style
+from tests.factories.releases import ReleaseFactory, ReleaseFileFactory
 
 
 def test_releaseapi_get_unknown_release(api_rf):
@@ -53,7 +49,7 @@ def test_releaseapi_get_unknown_release(api_rf):
 
 
 def test_releaseapi_get_with_anonymous_user(api_rf):
-    release = ReleaseFactory(ReleaseUploadsFactory(["file.txt"]))
+    release = ReleaseFactory()
 
     request = api_rf.get("/")
 
@@ -62,8 +58,8 @@ def test_releaseapi_get_with_anonymous_user(api_rf):
     assert response.status_code == 403
 
 
-def test_releaseapi_get_with_permission(api_rf):
-    release = ReleaseFactory(ReleaseUploadsFactory(["file.txt"]))
+def test_releaseapi_get_with_permission(api_rf, build_release_with_files):
+    release = build_release_with_files(["file.txt"])
     rfile = release.files.first()
 
     ProjectMembershipFactory(
@@ -88,7 +84,7 @@ def test_releaseapi_get_with_permission(api_rf):
                 "url": f"/api/v2/releases/file/{rfile.id}",
                 "user": rfile.created_by.username,
                 "date": rfile.created_at.isoformat(),
-                "size": 8,
+                "size": rfile.size,
                 "sha256": rfile.filehash,
                 "is_deleted": False,
                 "backend": release.backend.name,
@@ -98,7 +94,7 @@ def test_releaseapi_get_with_permission(api_rf):
 
 
 def test_releaseapi_get_without_permission(api_rf):
-    release = ReleaseFactory(ReleaseUploadsFactory(["file.txt"]))
+    release = ReleaseFactory()
 
     request = api_rf.get("/")
     request.user = UserFactory()
@@ -108,23 +104,9 @@ def test_releaseapi_get_without_permission(api_rf):
     assert response.status_code == 403
 
 
-def test_releaseapi_post_already_uploaded(api_rf, tmp_path):
+def test_releaseapi_post_already_uploaded(api_rf, build_release_with_files):
     user = UserFactory(roles=[OutputChecker])
-
-    release = new_style.ReleaseFactory(requested_files=[{"name": "file.txt"}])
-    # mirror path building until we can abstract this into a fixture
-    path = tmp_path / "releases" / release.workspace.name / "releases" / str(release.id)
-    path.mkdir(parents=True)
-
-    rfile = new_style.ReleaseFileFactory(
-        release=release,
-        name="file.txt",
-        path=Path(release.workspace.name) / "releases" / str(release.id) / "file.txt",
-        uploaded_at=timezone.now(),
-    )
-    content = "".join(random.choice(string.ascii_letters) for i in range(10))
-    content = content.encode("utf8")
-    rfile.absolute_path().write_bytes(content)
+    release = build_release_with_files(["file.txt"])
 
     BackendMembershipFactory(backend=release.backend, user=user)
 
@@ -133,7 +115,7 @@ def test_releaseapi_post_already_uploaded(api_rf, tmp_path):
     request = api_rf.post(
         "/",
         content_type="application/octet-stream",
-        data=content,
+        data="test",
         HTTP_CONTENT_DISPOSITION="attachment; filename=file.txt",
         HTTP_AUTHORIZATION=release.backend.auth_token,
         HTTP_OS_USER=user.username,
@@ -147,9 +129,9 @@ def test_releaseapi_post_already_uploaded(api_rf, tmp_path):
     assert release.files.count() == count_before
 
 
-def test_releaseapi_post_bad_backend(api_rf):
+def test_releaseapi_post_bad_backend(api_rf, build_release, file_content):
     user = UserFactory(roles=[OutputChecker])
-    release = new_style.ReleaseFactory(requested_files=[{"name": "file.txt"}])
+    release = build_release(["output/file.txt"])
 
     bad_backend = BackendFactory()
     BackendMembershipFactory(backend=bad_backend, user=user)
@@ -159,8 +141,8 @@ def test_releaseapi_post_bad_backend(api_rf):
     request = api_rf.post(
         "/",
         content_type="application/octet-stream",
-        data=content,
-        HTTP_CONTENT_DISPOSITION="attachment; filename=file.txt",
+        data=file_content,
+        HTTP_CONTENT_DISPOSITION="attachment; filename=output/file.txt",
         HTTP_AUTHORIZATION=bad_backend.auth_token,
         HTTP_OS_USER=user.username,
     )
@@ -172,8 +154,7 @@ def test_releaseapi_post_bad_backend(api_rf):
 
 
 def test_releaseapi_post_bad_backend_token(api_rf):
-    uploads = ReleaseUploadsFactory(["file.txt"])
-    release = ReleaseFactory(uploads, uploaded=False)
+    release = ReleaseFactory()
 
     request = api_rf.post("/", HTTP_AUTHORIZATION="invalid")
 
@@ -182,9 +163,9 @@ def test_releaseapi_post_bad_backend_token(api_rf):
     assert response.status_code == 403
 
 
-def test_releaseapi_post_bad_filename(api_rf):
+def test_releaseapi_post_bad_filename(api_rf, build_release, file_content):
     user = UserFactory(roles=[OutputChecker])
-    release = new_style.ReleaseFactory()
+    release = build_release(["file.txt"])
 
     BackendMembershipFactory(backend=release.backend, user=user)
 
@@ -193,7 +174,7 @@ def test_releaseapi_post_bad_filename(api_rf):
     request = api_rf.post(
         "/",
         content_type="application/octet-stream",
-        data=content,
+        data=file_content,
         HTTP_CONTENT_DISPOSITION="attachment; filename=wrongname.txt",
         HTTP_AUTHORIZATION=release.backend.auth_token,
         HTTP_OS_USER=user.username,
@@ -206,8 +187,7 @@ def test_releaseapi_post_bad_filename(api_rf):
 
 
 def test_releaseapi_post_bad_user(api_rf):
-    uploads = ReleaseUploadsFactory(["file.txt"])
-    release = ReleaseFactory(uploads, uploaded=False)
+    release = ReleaseFactory()
 
     request = api_rf.post(
         "/",
@@ -222,14 +202,13 @@ def test_releaseapi_post_bad_user(api_rf):
 
 def test_releaseapi_post_no_files(api_rf):
     user = UserFactory(roles=[OutputChecker])
-    uploads = ReleaseUploadsFactory(["file.txt"])
-    release = ReleaseFactory(uploads, uploaded=False)
+    release = ReleaseFactory()
 
     BackendMembershipFactory(backend=release.backend, user=user)
 
     request = api_rf.post(
         "/",
-        HTTP_CONTENT_DISPOSITION=f"attachment; filename={uploads[0].filename}",
+        HTTP_CONTENT_DISPOSITION="attachment; filename=file1.txt",
         HTTP_AUTHORIZATION=release.backend.auth_token,
         HTTP_OS_USER=user.username,
     )
@@ -241,8 +220,7 @@ def test_releaseapi_post_no_files(api_rf):
 
 
 def test_releaseapi_post_no_user(api_rf):
-    uploads = ReleaseUploadsFactory(["file.txt"])
-    release = ReleaseFactory(uploads, uploaded=False)
+    release = ReleaseFactory()
 
     request = api_rf.post(
         "/",
@@ -254,26 +232,12 @@ def test_releaseapi_post_no_user(api_rf):
     assert response.status_code == 403
 
 
-def test_releaseapi_post_success(api_rf, slack_messages):
+def test_releaseapi_post_success(api_rf, slack_messages, build_release, file_content):
     creating_user = UserFactory()
     uploading_user = UserFactory(roles=[OutputChecker])
-
     backend = BackendFactory(name="test-backend")
-    release = new_style.ReleaseFactory(
-        backend=backend,
-        created_by=creating_user,
-        requested_files=[{"name": "file.txt"}],
-    )
-    content = "".join(random.choice(string.ascii_letters) for i in range(10))
-    content = content.encode("utf8")
-    filehash = hashlib.sha256(content).hexdigest()
-    rfile = new_style.ReleaseFileFactory(
-        release=release,
-        created_by=uploading_user,
-        name="file.txt",
-        path="test/file.txt",
-        filehash=filehash,
-    )
+
+    release = build_release(["file.txt"], backend=backend, created_by=creating_user)
 
     BackendMembershipFactory(backend=release.backend, user=creating_user)
     BackendMembershipFactory(backend=release.backend, user=uploading_user)
@@ -281,7 +245,7 @@ def test_releaseapi_post_success(api_rf, slack_messages):
     request = api_rf.post(
         "/",
         content_type="application/octet-stream",
-        data=content,
+        data=file_content,
         HTTP_CONTENT_DISPOSITION="attachment; filename=file.txt",
         HTTP_AUTHORIZATION=release.backend.auth_token,
         HTTP_OS_USER=uploading_user.username,
@@ -312,8 +276,7 @@ def test_releaseapi_post_unknown_release(api_rf):
 
 
 def test_releaseapi_post_with_no_backend_token(api_rf):
-    uploads = ReleaseUploadsFactory(["file.txt"])
-    release = ReleaseFactory(uploads, uploaded=False)
+    release = ReleaseFactory()
 
     request = api_rf.post("/")
 
@@ -387,7 +350,7 @@ def test_releaseworkspaceapi_get_with_anonymous_user(api_rf):
     assert response.status_code == 403
 
 
-def test_releaseworkspaceapi_get_with_permission(api_rf):
+def test_releaseworkspaceapi_get_with_permission(api_rf, build_release_with_files):
     workspace = WorkspaceFactory()
     backend1 = BackendFactory(slug="backend1")
     backend2 = BackendFactory(slug="backend2")
@@ -397,18 +360,14 @@ def test_releaseworkspaceapi_get_with_permission(api_rf):
     )
 
     # two release for same filename but different content
-    release1 = ReleaseFactory(
-        ReleaseUploadsFactory({"file1.txt": b"backend1"}),
-        workspace=workspace,
-        backend=backend1,
-        created_by=user,
+    release1 = build_release_with_files(
+        ["file1.txt"], workspace=workspace, backend=backend1, created_by=user
     )
-    release2 = ReleaseFactory(
-        ReleaseUploadsFactory({"file1.txt": b"backend2"}),
-        workspace=workspace,
-        backend=backend2,
-        created_by=user,
+    rfile1 = release1.files.first()
+    release2 = build_release_with_files(
+        ["file1.txt"], workspace=workspace, backend=backend2, created_by=user
     )
+    rfile2 = release2.files.first()
 
     request = api_rf.get("/")
     request.user = user
@@ -420,23 +379,23 @@ def test_releaseworkspaceapi_get_with_permission(api_rf):
         "files": [
             {
                 "name": "backend2/file1.txt",
-                "id": release2.files.first().pk,
-                "url": f"/api/v2/releases/file/{release2.files.first().id}",
-                "user": user.username,
-                "date": release2.files.first().created_at.isoformat(),
-                "size": 8,
-                "sha256": release2.files.first().filehash,
+                "id": rfile2.pk,
+                "url": f"/api/v2/releases/file/{rfile2.id}",
+                "user": rfile2.created_by.username,
+                "date": rfile2.created_at.isoformat(),
+                "size": rfile2.size,
+                "sha256": rfile2.filehash,
                 "is_deleted": False,
                 "backend": release2.backend.name,
             },
             {
                 "name": "backend1/file1.txt",
-                "id": release1.files.first().pk,
-                "url": f"/api/v2/releases/file/{release1.files.first().id}",
-                "user": user.username,
-                "date": release1.files.first().created_at.isoformat(),
-                "size": 8,
-                "sha256": release1.files.first().filehash,
+                "id": rfile1.pk,
+                "url": f"/api/v2/releases/file/{rfile1.id}",
+                "user": rfile1.created_by.username,
+                "date": rfile1.created_at.isoformat(),
+                "size": rfile1.size,
+                "sha256": rfile1.filehash,
                 "is_deleted": False,
                 "backend": release1.backend.name,
             },
@@ -510,8 +469,8 @@ def test_releaseworkspaceapi_post_create_release(api_rf, slack_messages):
 def test_releaseworkspaceapi_post_release_already_exists(api_rf):
     user = UserFactory(roles=[OutputChecker])
 
-    release = new_style.ReleaseFactory()
-    rfile = new_style.ReleaseFileFactory(
+    release = ReleaseFactory()
+    rfile = ReleaseFileFactory(
         release=release,
         created_by=user,
         name="file.txt",
@@ -642,8 +601,7 @@ def test_releasefileapi_get_unknown_file(api_rf):
 
 
 def test_releasefileapi_with_anonymous_user(api_rf):
-    release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
-    rfile = release.files.first()
+    rfile = ReleaseFileFactory()
 
     request = api_rf.get("/")
 
@@ -653,31 +611,25 @@ def test_releasefileapi_with_anonymous_user(api_rf):
 
 
 def test_releasefileapi_with_deleted_file(api_rf):
-    uploads = ReleaseUploadsFactory({"file.txt": b"test"})
-    release = ReleaseFactory(uploads)
-    rfile = release.files.first()
+    rfile = ReleaseFileFactory(deleted_at=timezone.now(), deleted_by=UserFactory())
     user = UserFactory()
 
     ProjectMembershipFactory(
         user=user,
-        project=release.workspace.project,
+        project=rfile.release.workspace.project,
         roles=[ProjectCollaborator],
     )
-
-    # delete file
-    rfile.absolute_path().unlink()
 
     request = api_rf.get("/")
     request.user = user
 
     response = ReleaseFileAPI.as_view()(request, file_id=rfile.id)
 
-    assert response.status_code == 404
+    assert response.status_code == 404, response.data
 
 
-def test_releasefileapi_with_nginx_redirect(api_rf):
-    uploads = ReleaseUploadsFactory({"file.txt": b"test"})
-    release = ReleaseFactory(uploads)
+def test_releasefileapi_with_nginx_redirect(api_rf, build_release_with_files):
+    release = build_release_with_files(["file.txt"])
     rfile = release.files.first()
     user = UserFactory()
 
@@ -700,9 +652,8 @@ def test_releasefileapi_with_nginx_redirect(api_rf):
     )
 
 
-def test_releasefileapi_with_permission(api_rf):
-    uploads = ReleaseUploadsFactory({"file.txt": b"test"})
-    release = ReleaseFactory(uploads)
+def test_releasefileapi_with_permission(api_rf, build_release_with_files):
+    release = build_release_with_files(["file1.txt"])
     rfile = release.files.first()
     user = UserFactory()
 
@@ -719,13 +670,12 @@ def test_releasefileapi_with_permission(api_rf):
     response = ReleaseFileAPI.as_view()(request, file_id=rfile.id)
 
     assert response.status_code == 200
-    assert b"".join(response.streaming_content) == b"test"
+    assert b"".join(response.streaming_content) == rfile.absolute_path().read_bytes()
     assert response.headers["Content-Type"] == "text/plain"
 
 
 def test_releasefileapi_without_permission(api_rf):
-    release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
-    rfile = release.files.first()
+    rfile = ReleaseFileFactory()
 
     request = api_rf.get("/")
     request.user = UserFactory()  # logged in, but no permission
@@ -736,7 +686,7 @@ def test_releasefileapi_without_permission(api_rf):
 
 
 def test_reviewapi_without_permission(api_rf):
-    release = new_style.ReleaseFactory()
+    release = ReleaseFactory()
 
     data = {
         "files": [],
@@ -751,9 +701,9 @@ def test_reviewapi_without_permission(api_rf):
 
 
 def test_reviewapi_unknown_filename_or_content(api_rf):
-    release = new_style.ReleaseFactory()
-    new_style.ReleaseFileFactory(release=release, name="test1", filehash="test1")
-    new_style.ReleaseFileFactory(release=release, name="test2", filehash="test2")
+    release = ReleaseFactory()
+    ReleaseFileFactory(release=release, name="test1", filehash="test1")
+    ReleaseFileFactory(release=release, name="test2", filehash="test2")
 
     data = {
         "files": [
@@ -795,9 +745,9 @@ def test_reviewapi_unknown_filename_or_content(api_rf):
 
 
 def test_reviewapi_success(api_rf):
-    release = new_style.ReleaseFactory()
-    new_style.ReleaseFileFactory(release=release, name="test1", filehash="test1")
-    new_style.ReleaseFileFactory(release=release, name="test2", filehash="test2")
+    release = ReleaseFactory()
+    ReleaseFileFactory(release=release, name="test1", filehash="test1")
+    ReleaseFileFactory(release=release, name="test2", filehash="test2")
 
     data = {
         "files": [
@@ -960,10 +910,9 @@ def test_snapshotcreate_unknown_files(api_rf):
     assert "Unknown file IDs" in response.data["detail"], response.data
 
 
-def test_snapshotcreate_with_existing_snapshot(api_rf):
+def test_snapshotcreate_with_existing_snapshot(api_rf, build_release_with_files):
     workspace = WorkspaceFactory()
-    uploads = ReleaseUploadsFactory({"file1.txt": b"test1"})
-    release = ReleaseFactory(uploads, workspace=workspace)
+    release = build_release_with_files(["file1.txt"])
     snapshot = SnapshotFactory(workspace=workspace)
     snapshot.files.set(release.files.all())
 
@@ -983,18 +932,18 @@ def test_snapshotcreate_with_existing_snapshot(api_rf):
     assert msg in response.data["detail"], response.data
 
 
-def test_snapshotcreate_with_permission(api_rf):
+def test_snapshotcreate_with_permission(api_rf, build_release_with_files):
     workspace = WorkspaceFactory()
-    uploads = ReleaseUploadsFactory(
-        {
-            "file1.txt": b"test1",
-            "file2.txt": b"test2",
-            "file3.txt": b"test3",
-            "file4.txt": b"test4",
-            "file5.txt": b"test5",
-        }
+    release = build_release_with_files(
+        [
+            "file1.txt",
+            "file2.txt",
+            "file3.txt",
+            "file4.txt",
+            "file5.txt",
+        ],
+        workspace=workspace,
     )
-    release = ReleaseFactory(uploads, workspace=workspace)
 
     user = UserFactory()
     ProjectMembershipFactory(

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -628,6 +628,30 @@ def test_releasefileapi_with_deleted_file(api_rf):
     assert response.status_code == 404, response.data
 
 
+def test_releasefileapi_with_no_file_on_disk(api_rf, build_release):
+    release = build_release(["file1.txt"])
+    rfile = ReleaseFileFactory(
+        release=release,
+        workspace=release.workspace,
+        name="file1.txt",
+        uploaded_at=None,
+    )
+    user = UserFactory()
+
+    ProjectMembershipFactory(
+        user=user,
+        project=release.workspace.project,
+        roles=[ProjectCollaborator],
+    )
+
+    request = api_rf.get("/")
+    request.user = user
+
+    response = ReleaseFileAPI.as_view()(request, file_id=rfile.id)
+
+    assert response.status_code == 404, response.data
+
+
 def test_releasefileapi_with_nginx_redirect(api_rf, build_release_with_files):
     release = build_release_with_files(["file.txt"])
     rfile = release.files.first()

--- a/tests/unit/jobserver/models/test_outputs.py
+++ b/tests/unit/jobserver/models/test_outputs.py
@@ -4,17 +4,12 @@ from django.db import IntegrityError
 from django.urls import reverse
 from django.utils import timezone
 
-from tests.factories import (
-    ReleaseFactory,
-    ReleaseFileFactory,
-    ReleaseUploadsFactory,
-    SnapshotFactory,
-    UserFactory,
-)
+from tests.factories import SnapshotFactory, UserFactory
+from tests.factories.releases import ReleaseFactory, ReleaseFileFactory
 
 
 def test_release_get_absolute_url():
-    release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
+    release = ReleaseFactory()
 
     url = release.get_absolute_url()
 
@@ -30,12 +25,13 @@ def test_release_get_absolute_url():
 
 
 def test_release_get_api_url():
-    release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
+    release = ReleaseFactory()
+
     assert release.get_api_url() == f"/api/v2/releases/release/{release.id}"
 
 
 def test_release_get_download_url():
-    release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
+    release = ReleaseFactory()
 
     url = release.get_download_url()
 
@@ -51,147 +47,124 @@ def test_release_get_download_url():
 
 
 def test_release_ulid():
-    release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
-    assert release.ulid.timestamp
+    assert ReleaseFactory().ulid.timestamp
 
 
-def test_release_file_absolute_path():
-    files = {"file.txt": b"test_absolute_path"}
-    release = ReleaseFactory(ReleaseUploadsFactory(files))
-    rfile = release.files.get(name="file.txt")
+def test_releasefile_absolute_path(release):
+    rfile = release.files.first()
 
     expected = (
         settings.RELEASE_STORAGE
-        / f"{release.workspace.name}/releases/{release.id}/file.txt"
+        / release.workspace.name
+        / "releases"
+        / release.id
+        / "file1.txt"
     )
     path = rfile.absolute_path()
     assert path == expected
-    assert path.read_text() == "test_absolute_path"
+    assert path.read_text()
 
 
 def test_releasefile_constraints_deleted_at_and_deleted_by_both_set():
-    upload = ReleaseUploadsFactory({"file1.txt": b"test"})[0]
-    ReleaseFileFactory(upload, deleted_at=timezone.now(), deleted_by=UserFactory())
+    ReleaseFileFactory(deleted_at=timezone.now(), deleted_by=UserFactory())
 
 
 def test_releasefile_constraints_deleted_at_and_deleted_by_neither_set():
-    upload = ReleaseUploadsFactory({"file1.txt": b"test"})[0]
-    ReleaseFileFactory(upload, deleted_at=None, deleted_by=None)
+    ReleaseFileFactory(deleted_at=None, deleted_by=None)
 
 
 @pytest.mark.django_db(transaction=True)
 def test_releasefile_constraints_missing_deleted_at_or_deleted_by():
-    upload = ReleaseUploadsFactory({"file1.txt": b"test"})[0]
+    with pytest.raises(IntegrityError):
+        ReleaseFileFactory(deleted_at=None, deleted_by=UserFactory())
 
     with pytest.raises(IntegrityError):
-        ReleaseFileFactory(upload, deleted_at=None, deleted_by=UserFactory())
-
-    with pytest.raises(IntegrityError):
-        ReleaseFileFactory(upload, deleted_at=timezone.now(), deleted_by=None)
+        ReleaseFileFactory(deleted_at=timezone.now(), deleted_by=None)
 
 
 def test_releasefile_get_absolute_url():
-    files = {"file.txt": b"contents"}
-    release = ReleaseFactory(ReleaseUploadsFactory(files))
+    rfile = ReleaseFileFactory(name="file1.txt")
 
-    file = release.files.first()
-
-    url = file.get_absolute_url()
+    url = rfile.get_absolute_url()
 
     assert url == reverse(
         "release-detail",
         kwargs={
-            "org_slug": release.workspace.project.org.slug,
-            "project_slug": release.workspace.project.slug,
-            "workspace_slug": release.workspace.name,
-            "pk": release.id,
-            "path": file.name,
+            "org_slug": rfile.release.workspace.project.org.slug,
+            "project_slug": rfile.release.workspace.project.slug,
+            "workspace_slug": rfile.release.workspace.name,
+            "pk": rfile.release.id,
+            "path": rfile.name,
         },
     )
 
 
 def test_releasefile_get_delete_url():
-    files = {"file.txt": b"contents"}
-    release = ReleaseFactory(ReleaseUploadsFactory(files))
+    rfile = ReleaseFileFactory()
 
-    file = release.files.first()
-
-    url = file.get_delete_url()
+    url = rfile.get_delete_url()
 
     assert url == reverse(
         "release-file-delete",
         kwargs={
-            "org_slug": release.workspace.project.org.slug,
-            "project_slug": release.workspace.project.slug,
-            "workspace_slug": release.workspace.name,
-            "pk": release.id,
-            "release_file_id": file.pk,
+            "org_slug": rfile.release.workspace.project.org.slug,
+            "project_slug": rfile.release.workspace.project.slug,
+            "workspace_slug": rfile.release.workspace.name,
+            "pk": rfile.release.id,
+            "release_file_id": rfile.pk,
         },
     )
 
 
 def test_releasefile_get_latest_url():
-    files = {"file.txt": b"contents"}
-    release = ReleaseFactory(ReleaseUploadsFactory(files))
+    rfile = ReleaseFileFactory(name="file1.txt")
 
-    file = release.files.first()
-
-    url = file.get_latest_url()
+    url = rfile.get_latest_url()
 
     assert url == reverse(
         "workspace-latest-outputs-detail",
         kwargs={
-            "org_slug": release.workspace.project.org.slug,
-            "project_slug": release.workspace.project.slug,
-            "workspace_slug": release.workspace.name,
-            "path": f"{release.backend.slug}/{file.name}",
+            "org_slug": rfile.release.workspace.project.org.slug,
+            "project_slug": rfile.release.workspace.project.slug,
+            "workspace_slug": rfile.release.workspace.name,
+            "path": f"{rfile.release.backend.slug}/{rfile.name}",
         },
     )
 
 
 def test_releasefile_get_api_url_without_is_published():
-    files = {"file.txt": b"contents"}
-    release = ReleaseFactory(ReleaseUploadsFactory(files))
+    rfile = ReleaseFileFactory()
 
-    file = release.files.first()
+    url = rfile.get_api_url()
 
-    url = file.get_api_url()
-
-    assert url == reverse("api:release-file", kwargs={"file_id": file.id})
+    assert url == reverse("api:release-file", kwargs={"file_id": rfile.id})
 
 
 def test_releasefile_get_api_url_with_is_published():
-    files = {"file.txt": b"contents"}
-    release = ReleaseFactory(ReleaseUploadsFactory(files))
-
-    file = release.files.first()
+    rfile = ReleaseFileFactory()
 
     # mirror the SnapshotAPI view setting this value on the ReleaseFile object.
-    setattr(file, "is_published", True)
+    setattr(rfile, "is_published", True)
 
-    url = file.get_api_url()
+    url = rfile.get_api_url()
 
     assert url == reverse(
         "published-file",
         kwargs={
-            "org_slug": release.workspace.project.org.slug,
-            "project_slug": release.workspace.project.slug,
-            "workspace_slug": release.workspace.name,
-            "file_id": file.id,
+            "org_slug": rfile.workspace.project.org.slug,
+            "project_slug": rfile.workspace.project.slug,
+            "workspace_slug": rfile.workspace.name,
+            "file_id": rfile.id,
         },
     )
 
 
 def test_releasefile_ulid():
-    release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
-    rfile = release.files.first()
-    assert rfile.ulid.timestamp
+    assert ReleaseFileFactory().ulid.timestamp
 
 
 def test_releasefile_format():
-    release = ReleaseFactory(ReleaseUploadsFactory({"file1.txt": b"a"}))
-
-    rfile = release.files.first()
+    rfile = ReleaseFileFactory()
     rfile.size = 3.2 * 1024 * 1024  # 3.2Mb
     rfile.save()
 

--- a/tests/unit/jobserver/models/test_outputs.py
+++ b/tests/unit/jobserver/models/test_outputs.py
@@ -4,8 +4,12 @@ from django.db import IntegrityError
 from django.urls import reverse
 from django.utils import timezone
 
-from tests.factories import SnapshotFactory, UserFactory
-from tests.factories.releases import ReleaseFactory, ReleaseFileFactory
+from tests.factories import (
+    ReleaseFactory,
+    ReleaseFileFactory,
+    SnapshotFactory,
+    UserFactory,
+)
 
 
 def test_release_get_absolute_url():

--- a/tests/unit/jobserver/test_releases.py
+++ b/tests/unit/jobserver/test_releases.py
@@ -10,8 +10,12 @@ from django.utils import timezone
 from jobserver import releases
 from jobserver.models import ReleaseFile
 from jobserver.models.outputs import absolute_file_path
-from tests.factories import BackendFactory, UserFactory, WorkspaceFactory
-from tests.factories.releases import ReleaseFileFactory
+from tests.factories import (
+    BackendFactory,
+    ReleaseFileFactory,
+    UserFactory,
+    WorkspaceFactory,
+)
 
 from ...utils import minutes_ago
 

--- a/tests/unit/jobserver/views/test_releases.py
+++ b/tests/unit/jobserver/views/test_releases.py
@@ -19,11 +19,12 @@ from jobserver.views.releases import (
 from ....factories import (
     OrgFactory,
     ProjectFactory,
+    ReleaseFactory,
+    ReleaseFileFactory,
     SnapshotFactory,
     UserFactory,
     WorkspaceFactory,
 )
-from ....factories.releases import ReleaseFactory, ReleaseFileFactory
 
 
 def test_projectreleaselist_no_releases(rf):

--- a/tests/unit/jobserver/views/test_releases.py
+++ b/tests/unit/jobserver/views/test_releases.py
@@ -19,12 +19,11 @@ from jobserver.views.releases import (
 from ....factories import (
     OrgFactory,
     ProjectFactory,
-    ReleaseFactory,
-    ReleaseUploadsFactory,
     SnapshotFactory,
     UserFactory,
     WorkspaceFactory,
 )
+from ....factories.releases import ReleaseFactory, ReleaseFileFactory
 
 
 def test_projectreleaselist_no_releases(rf):
@@ -42,19 +41,13 @@ def test_projectreleaselist_no_releases(rf):
         )
 
 
-def test_projectreleaselist_success(rf):
+def test_projectreleaselist_success(rf, build_release):
     project = ProjectFactory()
     workspace1 = WorkspaceFactory(project=project)
     workspace2 = WorkspaceFactory(project=project)
 
-    r1 = ReleaseFactory(
-        ReleaseUploadsFactory(["test1", "test2"]),
-        workspace=workspace1,
-    )
-    ReleaseFactory(
-        ReleaseUploadsFactory(["test3", "test4"]),
-        workspace=workspace2,
-    )
+    r1 = build_release(["test1", "test2"], workspace=workspace1)
+    build_release(["test3", "test4"], workspace=workspace2)
 
     request = rf.get("/")
     request.user = UserFactory()
@@ -88,19 +81,13 @@ def test_projectreleaselist_unknown_workspace(rf):
         )
 
 
-def test_projectreleaselist_with_delete_permission(rf):
+def test_projectreleaselist_with_delete_permission(rf, build_release_with_files):
     project = ProjectFactory()
     workspace1 = WorkspaceFactory(project=project)
     workspace2 = WorkspaceFactory(project=project)
 
-    ReleaseFactory(
-        ReleaseUploadsFactory(["test1", "test2"]),
-        workspace=workspace1,
-    )
-    ReleaseFactory(
-        ReleaseUploadsFactory(["test3", "test4"]),
-        workspace=workspace2,
-    )
+    build_release_with_files(("test1", "test2"), workspace=workspace1)
+    build_release_with_files(["test3", "test4"], workspace=workspace2)
 
     request = rf.get("/")
     request.user = UserFactory(roles=[OutputChecker, ProjectCollaborator])
@@ -120,10 +107,10 @@ def test_projectreleaselist_with_delete_permission(rf):
     assert "Delete" in response.rendered_content
 
 
-def test_publishedsnapshotfile_success(rf):
-    release = ReleaseFactory(ReleaseUploadsFactory({"file1.txt": b"test"}))
+def test_publishedsnapshotfile_success(rf, release):
+    rfile = release.files.first()
     snapshot = SnapshotFactory(published_at=timezone.now())
-    snapshot.files.set(release.files.all())
+    snapshot.files.add(rfile)
 
     rfile = release.files.first()
 
@@ -139,7 +126,7 @@ def test_publishedsnapshotfile_success(rf):
     )
 
     assert response.status_code == 200
-    assert b"".join(response.streaming_content) == b"test"
+    assert b"".join(response.streaming_content) == rfile.absolute_path().read_bytes()
     assert response.headers["Content-Type"] == "text/plain"
     assert response.headers["Last-Modified"]
 
@@ -160,8 +147,7 @@ def test_publishedsnapshotfile_with_unknown_release_file(rf):
         )
 
 
-def test_publishedsnapshotfile_with_unpublished_release_file(rf):
-    release = ReleaseFactory(ReleaseUploadsFactory(["test1"]))
+def test_publishedsnapshotfile_with_unpublished_release_file(rf, release):
     snapshot = SnapshotFactory(published_at=None)
     snapshot.files.set(release.files.all())
 
@@ -194,9 +180,7 @@ def test_releasedetail_unknown_release(rf):
         )
 
 
-def test_releasedetail_with_path_success(rf):
-    release = ReleaseFactory(ReleaseUploadsFactory(["test1"]))
-
+def test_releasedetail_with_path_success(rf, release):
     request = rf.get("/")
     request.user = UserFactory(roles=[ProjectCollaborator])
 
@@ -212,9 +196,7 @@ def test_releasedetail_with_path_success(rf):
     assert response.status_code == 200
 
 
-def test_releasedetail_without_permission(rf):
-    release = ReleaseFactory(ReleaseUploadsFactory(["test1"]))
-
+def test_releasedetail_without_permission(rf, release):
     request = rf.get("/")
     request.user = UserFactory()
 
@@ -229,7 +211,7 @@ def test_releasedetail_without_permission(rf):
 
 
 def test_releasedetail_without_files(rf):
-    release = ReleaseFactory(uploads=[], uploaded=False)
+    release = ReleaseFactory()
 
     request = rf.get("/")
     request.user = UserFactory(roles=[ProjectCollaborator])
@@ -245,7 +227,7 @@ def test_releasedetail_without_files(rf):
 
 
 def test_releasedownload_release_with_no_files(rf):
-    release = ReleaseFactory(uploads=[], uploaded=False)
+    release = ReleaseFactory()
 
     request = rf.get("/")
     request.user = UserFactory(roles=[ProjectCollaborator])
@@ -260,9 +242,7 @@ def test_releasedownload_release_with_no_files(rf):
         )
 
 
-def test_releasedownload_success(rf):
-    release = ReleaseFactory(ReleaseUploadsFactory(["test1"]))
-
+def test_releasedownload_success(rf, release):
     request = rf.get("/")
     request.user = UserFactory(roles=[ProjectCollaborator])
 
@@ -293,9 +273,7 @@ def test_releasedownload_unknown_release(rf):
         )
 
 
-def test_releasedownload_without_permission(rf):
-    release = ReleaseFactory(ReleaseUploadsFactory(["test1"]))
-
+def test_releasedownload_without_permission(rf, release):
     request = rf.get("/")
     request.user = UserFactory()
 
@@ -310,12 +288,7 @@ def test_releasedownload_without_permission(rf):
 
 
 def test_releasefiledelete_no_file_on_disk(rf):
-    release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
-    rfile = release.files.first()
-
-    assert rfile.absolute_path().exists()
-    rfile.absolute_path().unlink()
-    assert not rfile.absolute_path().exists()
+    rfile = ReleaseFileFactory()
 
     request = rf.post("/")
     request.user = UserFactory(roles=[OutputChecker])
@@ -323,20 +296,17 @@ def test_releasefiledelete_no_file_on_disk(rf):
     with pytest.raises(Http404):
         ReleaseFileDelete.as_view()(
             request,
-            org_slug=release.workspace.project.org.slug,
-            project_slug=release.workspace.project.slug,
-            workspace_slug=release.workspace.name,
-            pk=release.pk,
+            org_slug=rfile.release.workspace.project.org.slug,
+            project_slug=rfile.release.workspace.project.slug,
+            workspace_slug=rfile.release.workspace.name,
+            pk=rfile.release.pk,
             release_file_id=rfile.pk,
         )
 
 
-def test_releasefiledelete_success(rf, freezer):
-    release = ReleaseFactory(ReleaseUploadsFactory({"file1.txt": b"test"}))
+def test_releasefiledelete_success(rf, freezer, release):
     rfile = release.files.first()
     user = UserFactory(roles=[OutputChecker])
-
-    assert rfile.absolute_path().exists()
 
     request = rf.post("/")
     request.user = user
@@ -360,7 +330,7 @@ def test_releasefiledelete_success(rf, freezer):
 
 
 def test_releasefiledelete_unknown_release_file(rf):
-    release = ReleaseFactory([], uploaded=False)
+    release = ReleaseFactory()
 
     request = rf.post("/")
     request.user = UserFactory()
@@ -376,11 +346,8 @@ def test_releasefiledelete_unknown_release_file(rf):
         )
 
 
-def test_releasefiledelete_without_permission(rf):
-    release = ReleaseFactory(ReleaseUploadsFactory(["file1.txt"]))
+def test_releasefiledelete_without_permission(rf, release):
     rfile = release.files.first()
-
-    assert rfile.absolute_path().exists()
 
     request = rf.post("/")
     request.user = UserFactory()
@@ -531,11 +498,10 @@ def test_snapshotdetail_unknown_snapshot(rf):
         )
 
 
-def test_snapshotdownload_published_with_permission(rf):
+def test_snapshotdownload_published_with_permission(rf, release):
     workspace = WorkspaceFactory()
-    ReleaseFactory(ReleaseUploadsFactory(["test1"]), workspace=workspace)
     snapshot = SnapshotFactory(workspace=workspace, published_at=timezone.now())
-    snapshot.files.set(workspace.files.all())
+    snapshot.files.set(release.files.all())
 
     request = rf.get("/")
     request.user = UserFactory(roles=[ProjectCollaborator])
@@ -551,11 +517,10 @@ def test_snapshotdownload_published_with_permission(rf):
     assert response.status_code == 200
 
 
-def test_snapshotdownload_published_without_permission(rf):
+def test_snapshotdownload_published_without_permission(rf, release):
     workspace = WorkspaceFactory()
-    ReleaseFactory(ReleaseUploadsFactory(["test1"]), workspace=workspace)
     snapshot = SnapshotFactory(workspace=workspace, published_at=timezone.now())
-    snapshot.files.set(workspace.files.all())
+    snapshot.files.set(release.files.all())
 
     request = rf.get("/")
     request.user = UserFactory()
@@ -587,11 +552,10 @@ def test_snapshotdownload_unknown_snapshot(rf):
         )
 
 
-def test_snapshotdownload_unpublished_with_permission(rf):
+def test_snapshotdownload_unpublished_with_permission(rf, release):
     workspace = WorkspaceFactory()
-    ReleaseFactory(ReleaseUploadsFactory(["test1"]), workspace=workspace)
     snapshot = SnapshotFactory(workspace=workspace, published_at=None)
-    snapshot.files.set(workspace.files.all())
+    snapshot.files.set(release.files.all())
 
     request = rf.get("/")
     request.user = UserFactory(roles=[ProjectCollaborator])
@@ -607,11 +571,10 @@ def test_snapshotdownload_unpublished_with_permission(rf):
     assert response.status_code == 200
 
 
-def test_snapshotdownload_unpublished_without_permission(rf):
+def test_snapshotdownload_unpublished_without_permission(rf, release):
     workspace = WorkspaceFactory()
-    ReleaseFactory(ReleaseUploadsFactory(["test1"]), workspace=workspace)
     snapshot = SnapshotFactory(workspace=workspace, published_at=None)
-    snapshot.files.set(workspace.files.all())
+    snapshot.files.set(release.files.all())
 
     request = rf.get("/")
     request.user = UserFactory()
@@ -642,9 +605,11 @@ def test_snapshotdownload_with_no_files(rf):
         )
 
 
-def test_workspacereleaselist_authenticated_to_view_not_delete(rf):
+def test_workspacereleaselist_authenticated_to_view_not_delete(
+    rf, build_release_with_files
+):
     workspace = WorkspaceFactory()
-    release = ReleaseFactory(ReleaseUploadsFactory(["test1"]), workspace=workspace)
+    release = build_release_with_files(["test1"], workspace=workspace)
 
     request = rf.get("/")
     request.user = UserFactory(roles=[ProjectCollaborator])
@@ -671,9 +636,11 @@ def test_workspacereleaselist_authenticated_to_view_not_delete(rf):
     )
 
 
-def test_workspacereleaselist_authenticated_to_view_and_delete(rf):
+def test_workspacereleaselist_authenticated_to_view_and_delete(
+    rf, build_release_with_files
+):
     workspace = WorkspaceFactory()
-    ReleaseFactory(ReleaseUploadsFactory(["test1"]), workspace=workspace)
+    build_release_with_files(["test1"], workspace=workspace)
 
     request = rf.get("/")
     request.user = UserFactory(roles=[OutputChecker, ProjectCollaborator])
@@ -710,9 +677,9 @@ def test_workspacereleaselist_no_releases(rf):
         )
 
 
-def test_workspacereleaselist_unauthenticated(rf):
+def test_workspacereleaselist_unauthenticated(rf, build_release):
     workspace = WorkspaceFactory()
-    ReleaseFactory(ReleaseUploadsFactory(["test1"]), workspace=workspace)
+    build_release(["test1"], workspace=workspace)
 
     request = rf.get("/")
     request.user = AnonymousUser()
@@ -745,9 +712,9 @@ def test_workspacereleaselist_unknown_workspace(rf):
         )
 
 
-def test_workspacereleaselist_build_files_for_latest(rf):
+def test_workspacereleaselist_build_files_for_latest(rf, build_release):
     workspace = WorkspaceFactory()
-    ReleaseFactory(ReleaseUploadsFactory(["test1"]), workspace=workspace)
+    build_release(["test1"], workspace=workspace)
 
     request = rf.get("/")
     request.user = UserFactory(roles=[OutputChecker, ProjectCollaborator])
@@ -765,9 +732,9 @@ def test_workspacereleaselist_build_files_for_latest(rf):
     assert all(f["detail_url"].__func__ == ReleaseFile.get_latest_url for f in files)
 
 
-def test_workspacereleaselist_build_files_for_releases(rf):
+def test_workspacereleaselist_build_files_for_releases(rf, build_release):
     workspace = WorkspaceFactory()
-    ReleaseFactory(ReleaseUploadsFactory(["test1"]), workspace=workspace)
+    build_release(["test1"], workspace=workspace)
 
     request = rf.get("/")
     request.user = UserFactory(roles=[OutputChecker, ProjectCollaborator])

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -37,11 +37,12 @@ from ....factories import (
     OrgMembershipFactory,
     ProjectFactory,
     ProjectMembershipFactory,
+    ReleaseFactory,
+    ReleaseFileFactory,
     SnapshotFactory,
     UserFactory,
     WorkspaceFactory,
 )
-from ....factories.releases import ReleaseFactory, ReleaseFileFactory
 from ....fakes import FakeGitHubAPI
 from ....utils import minutes_ago
 


### PR DESCRIPTION
This switches all our tests which touch Release and/or ReleaseFile objects to use some combination of FactoryBoy factories and fixtures which wrap up the logic necessary for combining them.

The goal here was to support our recent full use of the two-legged upload process whereby we can have ReleaseFiles without files on disk.  This means many of our tests can have greatly reduced setup (as little as a bare factory invocation) or have the creation of the appropriate objects abstracted to a fixture.

The fixtures are made up of a few layers of functions with low level ones like `file_content` generating random byte strings and high level ones like `release` which generates all the pieces required to have a Release, a related ReleaseFile, and a file on-disk.

I've laid out how this all works in TESTING.md, which I hope is clear enough to fully explain it!

Reviewing this is going to be a bit of a pig I'm afraid.  I've pulled everything I can into separate commits but there's still one very meaty commit where I move all the tests over.

Fixes #2038