### PR TITLE
feat: serve helpful content to SPA for missing files

### DIFF
--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -650,7 +650,8 @@ def test_releasefileapi_with_no_file_on_disk(api_rf, build_release):
 
     response = ReleaseFileAPI.as_view()(request, file_id=rfile.id)
 
-    assert response.status_code == 404, response.data
+    assert response.status_code == 200
+    assert "not yet been uploaded" in response.data
 
 
 def test_releasefileapi_with_nginx_redirect(api_rf, build_release_with_files):


### PR DESCRIPTION
ReleaseFiles might not be able to be served: if they have been redacted,
if they have not yet been uploaded, and if the file is simply not there.

Currently, all the above cases, the API returns a 404, for which the SPA
displays a generic page and pop up error. This doesn't give the user
much clue as to why the file cannot be served.

This change serves place holder content, specific to each of the above
cases, which informs the user why they cannot view the file contents.

 - it returns these as 200s, rather than the more correct 404, as I am
   not sure if the SPA can handle 404s with content.
 - it returns a plain text message. This might be prettier as a html
   template with links, perhaps.
 - it assumes the SPA displays the content-type in the response, rather
   than based on filename.
