### PR TITLE
Display review data

### DIFF
--- a/assets/src/scripts/outputs-viewer/App.jsx
+++ b/assets/src/scripts/outputs-viewer/App.jsx
@@ -141,6 +141,7 @@ function App({
                   fileName={selectedFile.name}
                   fileSize={selectedFile.size}
                   fileUrl={selectedFile.url}
+                  metadata={selectedFile.metadata}
                 />
                 <Card.Body>
                   <Viewer

--- a/assets/src/scripts/outputs-viewer/components/Metadata/Metadata.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Metadata/Metadata.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import prettyFileSize from "../../utils/pretty-file-size";
 import { selectedFileProps } from "../../utils/props";
 
-function Metadata({ fileDate, fileName, fileSize, fileUrl }) {
+function Metadata({ fileDate, fileName, fileSize, fileUrl, metadata }) {
   const fileDateValue = () => {
     if (Date.parse(fileDate)) {
       const getDate = new Date(fileDate);
@@ -18,6 +18,13 @@ function Metadata({ fileDate, fileName, fileSize, fileUrl }) {
     }
     return false;
   };
+
+  const derp = Object.keys(metadata).map((key) => (
+    <div key={key} className="mt-3">
+      <strong>{key}</strong>
+      <div>{metadata[key]}</div>
+    </div>
+  ));
 
   return (
     <div className="card-header">
@@ -46,6 +53,7 @@ function Metadata({ fileDate, fileName, fileSize, fileUrl }) {
         )}
         <li className="list-inline-item spacer">{prettyFileSize(fileSize)}</li>
       </ul>
+      <div>{derp}</div>
     </div>
   );
 }
@@ -57,4 +65,5 @@ Metadata.propTypes = {
   fileName: selectedFileProps.name.isRequired,
   fileSize: selectedFileProps.size.isRequired,
   fileUrl: selectedFileProps.url.isRequired,
+  metadata: selectedFileProps.metadata.isRequired,
 };

--- a/assets/src/scripts/outputs-viewer/utils/props.js
+++ b/assets/src/scripts/outputs-viewer/utils/props.js
@@ -20,4 +20,5 @@ export const selectedFileProps = {
   size: PropTypes.number,
   url: PropTypes.string,
   user: PropTypes.string,
+  metadata: PropTypes.object,
 };

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -200,6 +200,7 @@ def generate_index(files):
                 size=get_size(rfile),
                 is_deleted=rfile.deleted_at or not rfile.absolute_path().exists(),
                 backend=rfile.release.backend.name,
+                metadata=rfile.metadata,
             )
             for name, rfile in files.items()
         ],

--- a/jobserver/templates/release_detail.html
+++ b/jobserver/templates/release_detail.html
@@ -59,5 +59,13 @@
 {% endblock jumbotron %}
 
 {% block content %}
+<div class="container-fluid">
+  <div class="row">
+    <div class="col">
+      <pre>{{ release.metadata }}</pre>
+    </div>
+  </div>
+</div>
+
 {% include "outputs-spa.html" %}
 {% endblock %}

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -89,6 +89,7 @@ def test_releaseapi_get_with_permission(api_rf, build_release_with_files):
                 "sha256": rfile.filehash,
                 "is_deleted": False,
                 "backend": release.backend.name,
+                "metadata": None,
             }
         ],
     }
@@ -388,6 +389,7 @@ def test_releaseworkspaceapi_get_with_permission(api_rf, build_release_with_file
                 "sha256": rfile2.filehash,
                 "is_deleted": False,
                 "backend": release2.backend.name,
+                "metadata": None,
             },
             {
                 "name": "backend1/file1.txt",
@@ -399,6 +401,7 @@ def test_releaseworkspaceapi_get_with_permission(api_rf, build_release_with_file
                 "sha256": rfile1.filehash,
                 "is_deleted": False,
                 "backend": release1.backend.name,
+                "metadata": None,
             },
         ],
     }


### PR DESCRIPTION
Add per-Release and per-ReleaseFile metadata

**Release**
We're just saving raw data to the metadata for Release currently so this isn't the most useful but we can at least show that we've captured parts of it?
![](https://p198.p4.n0.cdn.getcloudapp.com/items/4gueYlmP/09af33cb-0094-436b-be97-c079c0846b61.jpg?v=15d6d900f2b55dbaf681a933ffbc10f0)

**ReleaseFile**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/wbuQAl2j/2dc2d262-ed2f-404b-89b1-e1c9cc52c7b7.jpg?v=cc5fddf79bcd17a83a699157b9730bd4)