### PR TITLE
Use deleted_at to drive is_deleted

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -198,7 +198,7 @@ def generate_index(files):
                 date=rfile.created_at.isoformat(),
                 sha256=rfile.filehash,
                 size=get_size(rfile),
-                is_deleted=rfile.deleted_at or not rfile.absolute_path().exists(),
+                is_deleted=rfile.is_deleted,
                 backend=rfile.release.backend.name,
             )
             for name, rfile in files.items()
@@ -411,7 +411,7 @@ class SnapshotCreateAPI(APIView):
             raise ParseError(f"Unknown file IDs: {', '.join(missing)}")
 
         # only look at files which haven't been deleted (redacted)
-        files = [f for f in files if f.absolute_path().exists()]
+        files = [f for f in files if not f.is_deleted]
 
         rfile_ids = {f.pk for f in files}
         snapshot_ids = [set_from_qs(s.files.all()) for s in workspace.snapshots.all()]

--- a/jobserver/models/outputs.py
+++ b/jobserver/models/outputs.py
@@ -224,7 +224,7 @@ class ReleaseFile(models.Model):
     @property
     def is_deleted(self):
         """Has the file on disk been deleted?"""
-        return not self.absolute_path().exists()
+        return self.deleted_at is not None
 
 
 class ReleaseFileReview(models.Model):

--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -228,7 +228,7 @@ def serve_file(request, rfile):
     response. Else just serve the bytes directly (for dev).
     """
     # check the file has been uploaded
-    if not rfile.uploaded_at:
+    if not rfile.uploaded_at or rfile.is_deleted:
         raise NotFound
 
     path = rfile.absolute_path()

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -180,7 +180,7 @@ class ReleaseFileDelete(View):
             pk=self.kwargs["release_file_id"],
         )
 
-        if not rfile.absolute_path().exists():
+        if rfile.is_deleted or not rfile.absolute_path().exists():
             raise Http404
 
         if not has_permission(

--- a/tests/unit/jobserver/views/test_releases.py
+++ b/tests/unit/jobserver/views/test_releases.py
@@ -288,6 +288,23 @@ def test_releasedownload_without_permission(rf, release):
         )
 
 
+def test_releasefiledelete_deleted_file(rf):
+    rfile = ReleaseFileFactory(deleted_at=timezone.now(), deleted_by=UserFactory())
+
+    request = rf.post("/")
+    request.user = UserFactory(roles=[OutputChecker])
+
+    with pytest.raises(Http404):
+        ReleaseFileDelete.as_view()(
+            request,
+            org_slug=rfile.release.workspace.project.org.slug,
+            project_slug=rfile.release.workspace.project.slug,
+            workspace_slug=rfile.release.workspace.name,
+            pk=rfile.release.pk,
+            release_file_id=rfile.pk,
+        )
+
+
 def test_releasefiledelete_no_file_on_disk(rf):
     rfile = ReleaseFileFactory()
 


### PR DESCRIPTION
Now that ReleaseFiles are created without a file on-disk we want ReleaseFile.is_deleted to use one of the two deleted_* fields we explicity set when deleting.  Since those fields are required to both be filled _or_ empty by the db check constraint I've picked `deleted_at` since it's a cheaper field to look up.