### PR TITLE
Validate file list apis

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -182,12 +182,6 @@ def validate_snapshot_access(request, snapshot):
 def generate_index(files):
     """Generate a JSON list of files as expected by the SPA."""
 
-    def get_size(rfile):
-        try:
-            return rfile.absolute_path().stat().st_size
-        except FileNotFoundError:  # pragma: no cover
-            return None
-
     return dict(
         files=[
             dict(
@@ -197,7 +191,7 @@ def generate_index(files):
                 user=rfile.created_by.username,
                 date=rfile.created_at.isoformat(),
                 sha256=rfile.filehash,
-                size=get_size(rfile),
+                size=rfile.size,
                 is_deleted=rfile.is_deleted,
                 backend=rfile.release.backend.name,
             )

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -182,7 +182,7 @@ def validate_snapshot_access(request, snapshot):
 def generate_index(files):
     """Generate a JSON list of files as expected by the SPA."""
 
-    return dict(
+    output = dict(
         files=[
             dict(
                 name=name,
@@ -194,10 +194,18 @@ def generate_index(files):
                 size=rfile.size,
                 is_deleted=rfile.is_deleted,
                 backend=rfile.release.backend.name,
+                metadata=rfile.metadata,
+                review=None,
             )
             for name, rfile in files.items()
         ],
     )
+
+    # validate our output data with the serializer, without having to encode
+    # all the source lookups into the serializer itself
+    FileSerializer(data=output, many=True).is_valid()
+
+    return output
 
 
 class ReleaseWorkspaceAPI(APIView):

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -89,6 +89,8 @@ def test_releaseapi_get_with_permission(api_rf, build_release_with_files):
                 "sha256": rfile.filehash,
                 "is_deleted": False,
                 "backend": release.backend.name,
+                "metadata": None,
+                "review": None,
             }
         ],
     }
@@ -388,6 +390,8 @@ def test_releaseworkspaceapi_get_with_permission(api_rf, build_release_with_file
                 "sha256": rfile2.filehash,
                 "is_deleted": False,
                 "backend": release2.backend.name,
+                "metadata": None,
+                "review": None,
             },
             {
                 "name": "backend1/file1.txt",
@@ -399,6 +403,8 @@ def test_releaseworkspaceapi_get_with_permission(api_rf, build_release_with_file
                 "sha256": rfile1.filehash,
                 "is_deleted": False,
                 "backend": release1.backend.name,
+                "metadata": None,
+                "review": None,
             },
         ],
     }


### PR DESCRIPTION
Use FileSerializer to validate the output of generate_index to ensure we match the incoming payloads for various APIs.

I've avoided using the serializer to pull the field data since this feels a lot more readable.

Small drive-by fix on getting file size from the db as I was there too.

Fixes #2049 