### PR TITLE
chore: add tooling to run local release-hatch for testing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-extend-exclude = .direnv,.github,.ipynb_checkpoints,.pytest_cache,.venv,assets,coverage,doc,htmlcov,node_modules,releases,snippets,static,staticfiles,uploads,venv
+extend-exclude = .direnv,.github,.ipynb_checkpoints,.pytest_cache,.venv,assets,coverage,doc,htmlcov,node_modules,releases,snippets,static,staticfiles,uploads,venv,release-hatch
 extend-select = \
     W504  # match black&PEP8 putting binary operators after new lines
 ignore = \

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules/
 releases
 staticfiles
 uploads
+/release-hatch

--- a/justfile
+++ b/justfile
@@ -203,3 +203,8 @@ assets-collect: devenv
 assets: assets-install assets-build assets-collect
 
 assets-rebuild: assets-clean assets
+
+
+
+release-hatch:
+    ./scripts/local-release-hatch.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ exclude = '''
     | static
     | staticfiles
     | venv
+    | release-hatch
   )/
 )
 '''

--- a/scripts/local-release-hatch.sh
+++ b/scripts/local-release-hatch.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -eu -o pipefail
+
+RELEASE_HATCH_REPO=${RELEASE_HATCH_REPO:-./release-hatch}
+RELEASE_HATCH_URL=${RELEASE_HATCH_URL:-http://localhost:8001}
+WORKSPACE_DIR=${WORKSPACE_DIR:-./workspaces}
+
+mkdir -p "$WORKSPACE_DIR"
+
+if test -d "$RELEASE_HATCH_REPO"; then
+    git -C "$RELEASE_HATCH_REPO" pull
+else
+    git clone https://github.com/opensafely-core/release-hatch "$RELEASE_HATCH_REPO"
+fi
+env -C "$RELEASE_HATCH_REPO" VIRTUAL_ENV="$RELEASE_HATCH_REPO/.venv" just devenv
+
+JOB_SERVER_TOKEN="$("$VIRTUAL_ENV/bin/python" manage.py shell << EOF
+from jobserver.models.backends import Backend
+
+backend, created = Backend.objects.get_or_create(
+    slug="local-dev",
+    name="Local Dev"
+)
+backend.level_4_url = "$RELEASE_HATCH_URL"
+backend.save()
+print(backend.auth_token)
+EOF
+)"
+
+JOB_SERVER_ENDPOINT="$("$VIRTUAL_ENV/bin/python" manage.py shell -c 'from django.conf import settings; print(settings.BASE_URL)')"
+
+cat > "$RELEASE_HATCH_REPO/.env" << EOF
+JOB_SERVER_TOKEN=$JOB_SERVER_TOKEN
+JOB_SERVER_ENDPOINT=$JOB_SERVER_ENDPOINT
+RELEASE_HOST=$RELEASE_HATCH_URL
+WORKSPACES=$WORKSPACE_DIR
+EOF
+cat "$RELEASE_HATCH_REPO/.env"
+
+env -C "$RELEASE_HATCH_REPO" VIRTUAL_ENV="$RELEASE_HATCH_REPO/.venv" just run


### PR DESCRIPTION
`just release-hatch` will ensure a local-dev backend exists, and set up
a local checkout of release-hatch to use it, and run the release-hatch
server. Its purpose is to ease development against the release-hatch api
