### PR TITLE
use auth token to talk to release-hatch

### DIFF
--- a/assets/src/scripts/outputs-viewer/components/Review/Modal.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Review/Modal.jsx
@@ -19,8 +19,8 @@ function ReviewModal() {
     state.hideModal,
     state.isModalOpen,
   ]);
-  const [csrfToken, reviewUrl] = useAppStore((state) => [
-    state.csrfToken,
+  const [authToken, reviewUrl] = useAppStore((state) => [
+    state.authToken,
     state.reviewUrl,
   ]);
   const { formData, getFormDataMeta, setFormDataFiles, setFormDataMeta } =
@@ -36,8 +36,8 @@ function ReviewModal() {
       const response = await fetch(reviewUrl, {
         method: "POST",
         headers: {
+          Authorization: authToken,
           "Content-Type": "application/json",
-          "X-CSRFToken": csrfToken,
         },
         body: JSON.stringify({ ...formData }),
       });


### PR DESCRIPTION
The review portion of the SPA talks to release-hatch, which is done via an auth token.  We were testing this locally with a job-server endpoint during development so it was easy to miss this.