### PR TITLE
fix: re add the release-id header that was accidentally removed.

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -233,10 +233,15 @@ class ReleaseWorkspaceAPI(APIView):
             raise ValidationError({"detail": str(exc)})
 
         slacks.notify_release_created(release)
-        # TODO: test this with only a subset of users
-        releases.create_github_issue(release, self.get_github_api())
+
+        # Current osrelease workflow should not create a Github issues, so allow that to be supressed
+        if request.headers.get("Suppress-Github-Issue") is None:  # pragma: no cover
+            releases.create_github_issue(release, self.get_github_api())
 
         response = Response(status=201)
+        # this is required for osrelease
+        response["Release-Id"] = str(release.id)
+        # this is required for the SPA to redirect
         response["Release-Location"] = request.build_absolute_uri(
             release.get_absolute_url()
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ skip_glob = [".direnv", "venv", ".venv"]
 use_parentheses = true
 
 [tool.pytest.ini_options]
-addopts = "--disable-network --tb=native --no-migrations"
+addopts = "--disable-network --tb=native --no-migrations --ignore=./release-hatch"
 DJANGO_SETTINGS_MODULE = "jobserver.settings"
 env = [
   "GITHUB_TOKEN=empty",

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -471,6 +471,7 @@ def test_releaseworkspaceapi_post_create_release(api_rf, slack_messages):
     assert Release.objects.count() == 1
 
     release = Release.objects.first()
+    assert response["Release-Id"] == str(release.id)
     assert (
         response["Release-Location"] == f"http://testserver{release.get_absolute_url()}"
     )


### PR DESCRIPTION
osrelease requires it.

Also, allow github issue creation to be skipped if needed, as osrelease
does not want one to be created.

There doesn't seem to be a fixture for github messages, so I'm going to add that and a test in a follow up PR, but this fix need to get out quickly
