### PR TITLE
fix: return data via json from the create release rather than headers

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -238,13 +238,14 @@ class ReleaseWorkspaceAPI(APIView):
         if request.headers.get("Suppress-Github-Issue") is None:  # pragma: no cover
             releases.create_github_issue(release, self.get_github_api())
 
-        response = Response(status=201)
-        # this is required for osrelease
+        body = {
+            "release_id": str(release.id),
+            "release_url": request.build_absolute_uri(release.get_absolute_url()),
+        }
+
+        response = Response(body, status=201)
+        # this is required for osrelease currently
         response["Release-Id"] = str(release.id)
-        # this is required for the SPA to redirect
-        response["Release-Location"] = request.build_absolute_uri(
-            release.get_absolute_url()
-        )
         return response
 
     def get(self, request, workspace_name):

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -472,9 +472,9 @@ def test_releaseworkspaceapi_post_create_release(api_rf, slack_messages):
 
     release = Release.objects.first()
     assert response["Release-Id"] == str(release.id)
-    assert (
-        response["Release-Location"] == f"http://testserver{release.get_absolute_url()}"
-    )
+    assert response.data["release_id"] == str(release.id)
+    assert response.data["release_url"].startswith("http://testserver/")
+    assert response.data["release_url"].endswith(f"/releases/{release.id}/")
 
     assert len(slack_messages) == 1
     text, channel = slack_messages[0]


### PR DESCRIPTION
Headers were proving problematic with CORS requests
