### PR TITLE
fix: view not-yet-uploaded files for a release

### DIFF
--- a/assets/src/scripts/outputs-viewer/components/Viewer/Viewer.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Viewer/Viewer.jsx
@@ -41,13 +41,26 @@ function Viewer({
       // Combine file URL with UUID
       const fileURL = `${fileUrl}?${uuid}`;
 
-      const response = await fetch(fileURL, {
+      let response = await fetch(fileURL, {
         headers: {
           Authorization: authToken,
         },
       });
 
       if (!response.ok) throw new Error();
+
+      // check if reidrected to release-hatch for an un-uploaded file
+      if (
+        response.headers.has("Location") &&
+        response.headers.has("Authorization")
+      ) {
+        response = await fetch(response.headers.get("Location"), {
+          headers: {
+            Authorization: response.headers.get("Authorization"),
+          },
+        });
+        if (!response.ok) throw new Error();
+      }
 
       // If the file is an image
       // grab the blob and create a URL for the blob

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -134,11 +134,14 @@ class ReleaseDetail(View):
             "files_url": reverse("api:release", kwargs={"release_id": release.id}),
             "release": release,
         }
-        return TemplateResponse(
+        response = TemplateResponse(
             request,
             "release_detail.html",
             context=context,
         )
+        # we may view level 4 for un-uploaded files
+        response._csp_update = {"connect-src": release.backend.level_4_url}
+        return response
 
 
 class ReleaseDownload(View):

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -681,7 +681,12 @@ def test_releasefileapi_with_no_file_on_disk(api_rf, build_release):
 
     response = ReleaseFileAPI.as_view()(request, file_id=rfile.id)
 
-    assert response.status_code == 404, response.data
+    assert response.status_code == 200, response.data
+    assert response.headers["Authorization"]
+    assert (
+        response.headers["Location"]
+        == f"{release.backend.level_4_url}/workspace/{release.workspace.name}/release/{release.id}/{rfile.name}"
+    )
 
 
 def test_releasefileapi_with_nginx_redirect(api_rf, build_release_with_files):


### PR DESCRIPTION
Currently, there is no way to via a release with files from
release-hatch. All the release metadata is stored in jobserver, but the
contents are stored in release-hatch, so the SPA really needs data from
both sources.

This change is a quick hack to redirect to release-hatch for the file
contents if the file has not been uploaded. This will only work on level
4, but provides a basic view of the pending release for an OutputChecker
to look at.

It works by returning an empty 200 with some headers, including auth,
which the output-viewer manually fetches.

It would be better to add support for this mode of viewing to the
output-viewer itself, and launched in a specific manner different to the
current method. But this will work for the purposes of a demo.
