### PR TITLE
Rename maintenance mode url

### DIFF
--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -48,7 +48,7 @@ from .views.releases import (
     SnapshotDownload,
     WorkspaceReleaseList,
 )
-from .views.status import DBAvailability, PerBackendStatus, Status
+from .views.status import MaintenanceMode, PerBackendStatus, Status
 from .views.users import Settings, login_view
 from .views.workspaces import (
     WorkspaceArchiveToggle,
@@ -191,9 +191,9 @@ status_urls = [
     path("", Status.as_view(), name="status"),
     path("<slug:backend>/", PerBackendStatus.as_view(), name="status-backend"),
     path(
-        "<slug:backend>/db-availability/",
-        DBAvailability.as_view(),
-        name="status-db-availability",
+        "<slug:backend>/maintenance-mode/",
+        MaintenanceMode.as_view(),
+        name="status-maintenance-mode",
     ),
 ]
 

--- a/jobserver/views/status.py
+++ b/jobserver/views/status.py
@@ -10,7 +10,7 @@ from ..backends import show_warning
 from ..models import Backend
 
 
-class DBAvailability(View):
+class MaintenanceMode(View):
     def get(self, request, *args, **kwargs):
         backend = get_object_or_404(Backend, slug=self.kwargs["backend"])
 

--- a/tests/unit/jobserver/views/test_status.py
+++ b/tests/unit/jobserver/views/test_status.py
@@ -6,7 +6,7 @@ import pytest
 from django.utils import timezone
 from first import first
 
-from jobserver.views.status import DBAvailability, PerBackendStatus, Status
+from jobserver.views.status import MaintenanceMode, PerBackendStatus, Status
 
 from ....factories import BackendFactory, JobFactory, JobRequestFactory, StatsFactory
 from ....utils import minutes_ago
@@ -23,7 +23,7 @@ def test_dbavailability_in_db_maintenance(rf):
 
     request = rf.get("/")
 
-    response = DBAvailability.as_view()(request, backend=backend.slug)
+    response = MaintenanceMode.as_view()(request, backend=backend.slug)
 
     assert response.status_code == 503
 
@@ -33,7 +33,7 @@ def test_dbavailability_non_tpp(rf):
 
     request = rf.get("/")
 
-    response = DBAvailability.as_view()(request, backend=backend.slug)
+    response = MaintenanceMode.as_view()(request, backend=backend.slug)
 
     assert response.status_code == 200
 
@@ -43,7 +43,7 @@ def test_dbavailability_out_of_db_maintenance(rf):
 
     request = rf.get("/")
 
-    response = DBAvailability.as_view()(request, backend=backend.slug)
+    response = MaintenanceMode.as_view()(request, backend=backend.slug)
 
     assert response.status_code == 200
 


### PR DESCRIPTION
This endpoint shows up in the alert/message when maintenance mode is switched
on. We hope to make that message clearer by renaming the endpoint.

Note: fresh ping will need to be updated when this is merged.

Fixes #2081