### PR TITLE
fix: expose project and org name in JobRequest API

### DIFF
--- a/tests/unit/jobserver/api/test_jobs.py
+++ b/tests/unit/jobserver/api/test_jobs.py
@@ -697,6 +697,11 @@ def test_jobrequestapilist_success(api_rf):
         job_request4.identifier,
     }
 
+    job_request_data = response.data["results"][0]
+    assert job_request_data["identifier"] == job_request4.identifier
+    assert job_request_data["project"] == workspace.project.slug
+    assert job_request_data["orgs"] == [workspace.project.org.slug]
+
 
 def test_userapidetail_success(api_rf):
     backend = BackendFactory()


### PR DESCRIPTION
The purpose of this is to allow metrics emitted by job-runner to be
tagged by org/project so we can aggregate by them by those values. e.g.
how much CPU has this org used in the last month?
