### PR TITLE
Handle uploaded file's hash not matching the requested ReleaseFile

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -302,7 +302,10 @@ class ReleaseAPI(APIView):
             rfile = releases.handle_file_upload(
                 release, backend, user, upload, filename
             )
-        except releases.ReleaseFileAlreadyExists as exc:
+        except (
+            releases.ReleaseFileAlreadyExists,
+            releases.ReleaseFileHashMismatch,
+        ) as exc:
             raise ValidationError({"detail": str(exc)})
 
         slacks.notify_release_file_uploaded(rfile)

--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -23,6 +23,10 @@ class ReleaseFileAlreadyExists(Exception):
     pass
 
 
+class ReleaseFileHashMismatch(Exception):
+    pass
+
+
 def size_formatter(value):
     """
     Format the value, in bytes, with a size suffix
@@ -284,7 +288,7 @@ def handle_file_upload(release, backend, user, upload, filename, **kwargs):
     # and Release were created.
     if rfile.filehash != calculated_hash:
         msg = "Contents of uploaded file does not match the file which a review was requested for"
-        raise Exception(msg)
+        raise ReleaseFileHashMismatch(msg)
 
     absolute_path.write_bytes(data)
     rfile.path = str(relative_path)


### PR DESCRIPTION
We want to feed this back to the user and raising a ValidationError is the correct way to do this in a DRF world.  We don't want to couple the releases module to DRF though so as with ReleaseFileAlreadyExists we're using a custom exception and capturing it outside that module.