### PR TITLE
Add orgs to the JobRequest API endpoint

### DIFF
--- a/jobserver/api/jobs.py
+++ b/jobserver/api/jobs.py
@@ -320,6 +320,7 @@ class JobRequestAPIList(ListAPIView):
         backend = serializers.CharField(source="backend.slug")
         created_by = serializers.CharField(source="created_by.username")
         workspace = WorkspaceSerializer()
+        orgs = serializers.SerializerMethodField()
 
         class Meta:
             fields = [
@@ -332,8 +333,12 @@ class JobRequestAPIList(ListAPIView):
                 "created_by",
                 "created_at",
                 "workspace",
+                "orgs",
             ]
             model = JobRequest
+
+        def get_orgs(self, obj):
+            return [obj.workspace.project.org.slug]
 
     def initial(self, request, *args, **kwargs):
         token = request.headers.get("Authorization")


### PR DESCRIPTION
This adds the `orgs` field to the JobRequest API endpoint so we can pass it through to job-runner to enhance our metrics with.

We're using a `SerializerMethodField` here because a JobRequest only has one Org currently (via it's Workspace then Project) but in the future we expect that to change so we're adding a little future proofing.