### PR TITLE
Update wording around private repos

### DIFF
--- a/jobserver/templates/index.html
+++ b/jobserver/templates/index.html
@@ -15,13 +15,6 @@
       that was run.
     </p>
     <p>
-      In accordance with the <a href="https://www.opensafely.org/about/#transparency-and-public-logs">Principles of
-      OpenSAFELY</a> some Github repositories are kept private until the results are
-      shared publicly - at which point we require the entire repository to be made public.
-      If the repository is currently private, any links to it from this site will return
-      a "404 Not Found" error unless you are logged in and have the relevant permissions.
-    </p>
-    <p>
       Pick a Workspace below to get started running your research on the OpenSAFELY
       platform or look at some of the existing research tasks that have been created to
       run on it.

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -94,24 +94,26 @@
             <h2 class="card-header h5">
               Repos
             </h2>
-            <ul class="list-unstyled card-body">
+            <ul class="list-group list-group-flush">
               {% for repo in repos %}
-                <li class="d-flex align-items-center">
-                  <a class="mr-2" href="{{ repo.url }}">{{ repo.name }}</a>
-                  {% if repo.is_private != None %}
-                    <span
-                      class="
-                        badge badge-pill
-                        badge-{% if repo.is_private %}warning{% else %}success{% endif %}
-                    ">
-                      {% if repo.is_private %}Private{% else %}Public{% endif %}
-                    </span>
-                  {% endif %}
-                </li>
                 {% if repo.is_private %}
-                  <li><details>In accordance with the <a href='https://www.opensafely.org/about/#transparency-and-public-logs'>Principles of OpenSAFELY</a> we expect all code from all users to be made public.
-                    However, some GitHub repositories may be private during the development stage of a project, which means any links to them from this site will return a '404 Not Found' error unless you are logged in and have the relevant permissions.
-                  </details></li>
+                  <li class="list-group-item">
+                    <a href="{{ repo.url }}">
+                      {{ repo.name }}
+                    </a>
+                    <p class="mt-1 mb-1">This repo is not publicly viewable.</p>
+                    <details class="small">
+                      <summary class="font-weight-bold text-primary">Why is this repo private?</summary>
+                      <div class="pl-3">
+                        <p class="my-1">In accordance with the <a href="https://www.opensafely.org/about/#transparency-and-public-logs">Principles of OpenSAFELY</a> we expect all code from all users to be made public.</p>
+                        <p class="mb-0">However, some GitHub repositories may be private during the development stage of a project, which means any links to them from this site will return a '404 Not Found' error unless you are logged in and have the relevant permissions.</p>
+                      </div>
+                    </details>
+                  </li>
+                {% else %}
+                  <a href="{{ repo.url }}" class="list-group-item list-group-item-action">
+                    {{ repo.name }}
+                  </a>
                 {% endif %}
               {% endfor %}
             </ul>

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -108,6 +108,11 @@
                     </span>
                   {% endif %}
                 </li>
+                {% if repo.is_private %}
+                  <li><details>In accordance with the <a href='https://www.opensafely.org/about/#transparency-and-public-logs'>Principles of OpenSAFELY</a> we expect all code from all users to be made public.
+                    However, some GitHub repositories may be private during the development stage of a project, which means any links to them from this site will return a '404 Not Found' error unless you are logged in and have the relevant permissions.
+                  </details></li>
+                {% endif %}
               {% endfor %}
             </ul>
           </li>

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -123,31 +123,15 @@
               <dd class="d-inline-flex mb-0 align-items-center">
                 <a class="mr-1" href="{{ workspace.repo }}/tree/{{ workspace.branch }}/">{{ workspace.repo_name }}</a>
               </dd>
-              <dd class="d-inline-flex mb-0 align-items-center">
-                {% if repo_is_private %}
-                <span
-                  class="
-                    badge badge-pill
-                    badge-warning
-                  ">
-                  Private
-                </span>
-                {% elif repo_is_private is not None %}
-                <span
-                  class="
-                    badge badge-pill
-                    badge-success
-                  ">
-                  Public
-                </span>
-                {% endif %}
-              </dd>
               {% if repo_is_private %}
-              <dd class="d-inline-block mb-0">
-                <details>In accordance with the <a href='https://www.opensafely.org/about/#transparency-and-public-logs'>Principles of OpenSAFELY</a> we expect all code from all users to be made public.
-                  However, some GitHub repositories may be private during the development stage of a project, which means any links to them from this site will return a '404 Not Found' error unless you are logged in and have the relevant permissions.
-                </details>
-              </dd>
+              <p class="mt-2 mb-1">This repo is not publicly viewable.</p>
+              <details class="small">
+                <summary class="font-weight-bold text-primary">Why is this repo private?</summary>
+                <div class="pl-3">
+                  <p class="my-1">In accordance with the <a href="https://www.opensafely.org/about/#transparency-and-public-logs">Principles of OpenSAFELY</a> we expect all code from all users to be made public.</p>
+                  <p class="mb-0">However, some GitHub repositories may be private during the development stage of a project, which means any links to them from this site will return a '404 Not Found' error unless you are logged in and have the relevant permissions.</p>
+                </div>
+              </details>
               {% endif %}
             </dl>
           </li>

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -122,16 +122,33 @@
               <dt class="d-inline-block">Repo:</dt>
               <dd class="d-inline-flex mb-0 align-items-center">
                 <a class="mr-1" href="{{ workspace.repo }}/tree/{{ workspace.branch }}/">{{ workspace.repo_name }}</a>
-                {% if repo_is_private is not None %}
+              </dd>
+              <dd class="d-inline-flex mb-0 align-items-center">
+                {% if repo_is_private %}
                 <span
                   class="
                     badge badge-pill
-                    badge-{% if repo_is_private %}warning{% else %}success{% endif %}
-                ">
-                  {% if repo_is_private %}Private{% else %}Public{% endif %}
+                    badge-warning
+                  ">
+                  Private
+                </span>
+                {% elif repo_is_private is not None %}
+                <span
+                  class="
+                    badge badge-pill
+                    badge-success
+                  ">
+                  Public
                 </span>
                 {% endif %}
               </dd>
+              {% if repo_is_private %}
+              <dd class="d-inline-block mb-0">
+                <details>In accordance with the <a href='https://www.opensafely.org/about/#transparency-and-public-logs'>Principles of OpenSAFELY</a> we expect all code from all users to be made public.
+                  However, some GitHub repositories may be private during the development stage of a project, which means any links to them from this site will return a '404 Not Found' error unless you are logged in and have the relevant permissions.
+                </details>
+              </dd>
+              {% endif %}
             </dl>
           </li>
           <li class="list-group-item">


### PR DESCRIPTION
The wording around why a repository may be private is being updated in the Principles of OpenSAFELY. This change keeps job-server up-to-date with that, while moving the text to the most relevant place for users of the site.

Refs: https://github.com/opensafely/documentation/issues/892