### PR TITLE
fix: remove the GH issue creation trigger for releases

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -238,8 +238,9 @@ class ReleaseWorkspaceAPI(APIView):
         slacks.notify_release_created(release)
 
         # Current osrelease workflow should not create a Github issues, so allow that to be supressed
-        if request.headers.get("Suppress-Github-Issue") is None:  # pragma: no cover
-            releases.create_github_issue(release, self.get_github_api())
+        # Note: this is broken and spamming issues, so comment out for now
+        # if request.headers.get("Suppress-Github-Issue") is None:  # pragma: no cover
+        #   releases.create_github_issue(release, self.get_github_api())
 
         body = {
             "release_id": str(release.id),

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 class FakeGitHubAPI:
     def create_issue(self, org, repo, title, body, labels):
-        return {}
+        return {}  # pragma: no cover
 
     def get_branch(self, org, repo, branch):
         return {


### PR DESCRIPTION
The supression isn't working, and it's spaming users with issues
