### PR TITLE
Add RepoDetail page to Staff Area

### DIFF
--- a/staff/templates/staff/repo_detail.html
+++ b/staff/templates/staff/repo_detail.html
@@ -1,0 +1,138 @@
+{% extends "staff/base.html" %}
+
+{% load humanize %}
+{% load static %}
+
+{% block metatitle %}{{ repo.name }}: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:index' %}">Staff area</a>
+      </li>
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:repo-list' %}">Repos</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        {{ repo.name }}
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
+  <div class="container">
+    <h1 class="display-4">{{ repo.name }}</h1>
+
+    <ul class="list-unstyled lead">
+      <li>
+        <strong>GitHub Org:</strong>
+        {{ repo.owner.login }}
+      </li>
+      <li>
+        <strong>Status:</strong>
+        <span>
+          {% if repo.is_private %}Private{% else %}Public{% endif %}
+        </span>
+      </li>
+    </ul>
+
+    <div class="d-flex">
+      <a class="btn btn-primary mr-1" href="{{ repo.url }}">Open on GitHub</a>
+    </div>
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block staff_content %}
+<div class="container">
+  <div class="row">
+    <div class="col col-lg-9 col-xl-8">
+
+      <h2>Workspaces</h2>
+
+      {% for workspace in workspaces %}
+      <div class="card mb-3">
+
+        <h2 class="card-header h5 d-flex justify-content-between">
+          <a href="{{ workspace.get_staff_url }}">{{ workspace.name }}</a>
+          {% if workspace.is_archived %}
+          <span class="badge badge-secondary">Archived</span>
+          {% endif %}
+        </h2>
+
+        <div class="card-body mb-0">
+
+          <div>
+            <h6>Users</h6>
+            <ul class="list-unstyled">
+              {% for user in workspace.job_requesting_users %}
+              <li>
+                <a href="{{ user.get_staff_url }}">{{ user.name }}</a>
+                {% if workspace.created_by.pk == user.pk %}
+                <span class="badge badge-sm badge-secondary">Creator</span>
+                {% endif %}
+              </li>
+              {% endfor %}
+            </ul>
+          </div>
+
+        </div>
+      </div>
+      {% endfor %}
+
+    </div>
+
+    <div class="col col-lg-3 col-xl-4">
+
+      <div class="card mb-3">
+        <h2 class="card-header h5">
+          Dates
+        </h2>
+        <div class="card-body mb-0">
+          <p>
+            <strong>Created:</strong>
+            <span title="{{ repo.created_at.isoformat }}">{{ repo.created_at }}</span>
+          </p>
+          <p>
+            <strong>First job run:</strong>
+            <span title="{{ first_job_ran_at.isoformat }}">{{ first_job_ran_at }}</span>
+          </p>
+          <p>
+            <strong>Last job run:</strong>
+            <span title="{{ last_job_ran_at.isoformat }}">{{ last_job_ran_at }}</span>
+          </p>
+          <p>
+            <strong>12 month limit:</strong>
+            <span title="{{ twelve_month_limit.isoformat }}">
+              {{ twelve_month_limit|naturalday }}
+            </span>
+          </p>
+        </div>
+      </div>
+
+      <div class="card mb-3">
+        <h2 class="card-header h5">
+          Info
+        </h2>
+        <div class="card-body mb-0">
+          <p>
+            <strong>Has outputs on GitHub:</strong>
+            {% if has_releases %}
+            <strong class="text-danger">YES</strong>
+            {% else %}
+            <span class="text-success">NO</span>
+            {% endif %}
+          </p>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</div>
+{% endblock staff_content %}

--- a/staff/templates/staff/repo_list.html
+++ b/staff/templates/staff/repo_list.html
@@ -52,11 +52,7 @@
           <tbody>
             {% for repo in repos %}
             <tr>
-              <td>
-                <a href="{{ repo.url }}">
-                  {{ repo.name }}
-                </a>
-              </td>
+              <td><a href="{% url 'staff:repo-detail' repo_url=repo.quoted_url %}">{{ repo.name }}</a></td>
 
               <td>
                 {% if repo.workspaces|length > 1 %}

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -39,7 +39,7 @@ from .views.projects import (
     ProjectMembershipRemove,
 )
 from .views.redirects import RedirectDelete, RedirectDetail, RedirectList
-from .views.repos import RepoList
+from .views.repos import RepoDetail, RepoList
 from .views.researchers import ResearcherEdit
 from .views.users import UserDetail, UserList, UserSetOrgs
 from .views.workspaces import WorkspaceDetail, WorkspaceEdit, WorkspaceList
@@ -131,6 +131,11 @@ redirect_urls = [
     path("<int:pk>/delete/", RedirectDelete.as_view(), name="redirect-delete"),
 ]
 
+repo_urls = [
+    path("", RepoList.as_view(), name="repo-list"),
+    path("<repo_url>/", RepoDetail.as_view(), name="repo-detail"),
+]
+
 researcher_urls = [
     path("<int:pk>/edit/", ResearcherEdit.as_view(), name="researcher-edit"),
 ]
@@ -154,8 +159,8 @@ urlpatterns = [
     path("orgs/", include(org_urls)),
     path("projects/", include(project_urls)),
     path("redirects/", include(redirect_urls)),
+    path("repos/", include(repo_urls)),
     path("researchers/", include(researcher_urls)),
-    path("repos/", RepoList.as_view(), name="repo-list"),
     path("users/", include(user_urls)),
     path("workspaces/", include(workspace_urls)),
 ]

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -1,21 +1,100 @@
 from datetime import timedelta
+from urllib.parse import quote, unquote
 
 import structlog
 from django.db.models import Count, Min
-from django.db.models.functions import Least
+from django.db.models.functions import Least, Lower
 from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.generic import View
 from first import first
+from furl import furl
 
 from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_role
 from jobserver.github import _get_github_api
-from jobserver.models import Workspace
+from jobserver.models import Job, User, Workspace
 
 
 logger = structlog.get_logger(__name__)
+
+
+def ran_at(job):
+    return job.started_at or job.created_at
+
+
+@method_decorator(require_role(CoreDeveloper), name="dispatch")
+class RepoDetail(View):
+    get_github_api = staticmethod(_get_github_api)
+
+    def get(self, request, *args, **kwargs):
+        url = unquote(self.kwargs["repo_url"])
+
+        org, name = furl(url).path.segments
+        repo = self.get_github_api().get_repo(org, name)
+
+        workspaces = (
+            Workspace.objects.filter(repo=url)
+            .select_related("created_by", "project", "project__org")
+            .order_by("name")
+        )
+        users = User.objects.filter(job_requests__workspace__in=workspaces).distinct()
+
+        jobs = Job.objects.filter(job_request__workspace__in=workspaces).annotate(
+            first_run=Min(Least("started_at", "created_at"))
+        )
+        first_job_ran_at = ran_at(jobs.order_by("first_run").first())
+        last_job_ran_at = ran_at(jobs.order_by("-first_run").first())
+
+        twelve_month_limit = first_job_ran_at + timedelta(days=365)
+
+        def build_workspace(workspace, all_users):
+            """
+            Build a dictionary representation of the Workspace data for the template
+
+            We want to show a list of users-who-created-jobs-in-this-workspace
+            in the template.  Getting this as part of the Workspace QuerySet
+            doesn't appear to be possible (we tried Subquery and Prefetch to no
+            avail).  Instead we've looked up the users who created jobs for
+            each workspace used in this view and are pairing them up here.
+            """
+
+            # get the users who created jobs in this workspace or created it,
+            # just in case the creator has not run any jobs.
+            users = list(
+                all_users.filter(job_requests__workspace=workspace)
+                .distinct()
+                .order_by(Lower("username"), Lower("fullname"))
+            )
+            if workspace.created_by not in users:
+                users = [workspace.created_by, *users]
+
+            return {
+                "created_by": workspace.created_by,
+                "get_staff_url": workspace.get_staff_url,
+                "is_archived": workspace.is_archived,
+                "job_requesting_users": users,
+                "name": workspace.name,
+            }
+
+        workspaces = [build_workspace(w, users) for w in workspaces]
+
+        context = {
+            "first_job_ran_at": first_job_ran_at,
+            "has_releases": "github-releases" in repo["topics"],
+            "last_job_ran_at": last_job_ran_at,
+            "repo": repo,
+            "repo_url": url,
+            "twelve_month_limit": twelve_month_limit,
+            "workspaces": workspaces,
+        }
+
+        return TemplateResponse(
+            request,
+            "staff/repo_detail.html",
+            context=context,
+        )
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
@@ -84,6 +163,7 @@ class RepoList(View):
                 "first_run": first_run,
                 "has_jobs": has_jobs,
                 "has_releases": "github-releases" in repo["topics"],
+                "quoted_url": quote(repo["url"], safe=""),
                 "workspace": workspace,
                 "workspaces": workspaces,
             }

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -38,6 +38,7 @@ class FakeGitHubAPI:
 
     def get_repo(self, org, repo):
         return {
+            "topics": ["github-releases"],
             "private": True,
         }
 


### PR DESCRIPTION
This adds a detail page for Repos to the Staff Area so we can display more info about repos without compressing it into the list page.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/p9uQKowy/535b0f2c-a0dc-4efa-b6e6-094e1bedb5a8.jpg?v=63598cef5dc0f00ba8d7d49936dd4842)