### PR TITLE
Remove CSP from Outputs SPA view

### DIFF
--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -1,3 +1,4 @@
+from csp.decorators import csp_exempt
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.db import transaction
 from django.db.models import Prefetch
@@ -102,6 +103,7 @@ class PublishedSnapshotFile(View):
 
 
 class ReleaseDetail(View):
+    @csp_exempt
     def get(self, request, *args, **kwargs):
         """
         Orchestrate viewing of a Release in the SPA
@@ -205,6 +207,7 @@ class ReleaseFileDelete(View):
 
 
 class SnapshotDetail(View):
+    @csp_exempt
     def get(self, request, *args, **kwargs):
         snapshot = get_object_or_404(
             Snapshot,

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -59,6 +59,7 @@ class WorkspaceBackendFiles(View):
     Workspace.
     """
 
+    @csp_exempt
     def get(self, request, *args, **kwargs):
         workspace = get_object_or_404(
             Workspace,

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -1,4 +1,5 @@
 import requests
+from csp.decorators import csp_exempt
 from django.contrib import messages
 from django.db.models import Q
 from django.http import FileResponse, Http404, HttpResponse
@@ -320,6 +321,7 @@ class WorkspaceLatestOutputsDetail(View):
     Workspace.
     """
 
+    @csp_exempt
     def get(self, request, *args, **kwargs):
         workspace = get_object_or_404(
             Workspace,


### PR DESCRIPTION
Modify CSP rules for the SPA, due to the number of errors coming through to Sentry.

#2004