### PR TITLE
Display number of running and queued jobs

### DIFF
--- a/jobserver/templates/status.html
+++ b/jobserver/templates/status.html
@@ -74,6 +74,18 @@
                 <dd class="d-inline-block mb-0 text-capitalize">{{ backend.queue.acked }}</dd>
               </dl>
             </li>
+            <li class="list-group-item">
+              <dl class="mb-0">
+                <dt class="d-inline-block">Running:</dt>
+                <dd class="d-inline-block mb-0 text-capitalize">{{ backend.queue.running }}</dd>
+              </dl>
+            </li>
+            <li class="list-group-item">
+              <dl class="mb-0">
+                <dt class="d-inline-block">Pending:</dt>
+                <dd class="d-inline-block mb-0 text-capitalize">{{ backend.queue.pending }}</dd>
+              </dl>
+            </li>
           </ul>
         </div>
       </div>

--- a/jobserver/views/status.py
+++ b/jobserver/views/status.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from django.views.generic import View
 
 from ..backends import show_warning
-from ..models import Backend
+from ..models import Backend, Job
 
 
 class DBAvailability(View):
@@ -68,6 +68,12 @@ class Status(View):
                 .filter(num_jobs=0)
                 .count()
             )
+            running = Job.objects.filter(
+                job_request__backend=backend, status="running"
+            ).count()
+            pending = Job.objects.filter(
+                job_request__backend=backend, status="pending"
+            ).count()
 
             try:
                 last_seen = (
@@ -83,6 +89,8 @@ class Status(View):
                 "queue": {
                     "acked": acked,
                     "unacked": unacked,
+                    "running": running,
+                    "pending": pending,
                 },
                 "show_warning": show_warning(last_seen, backend.alert_timeout),
             }


### PR DESCRIPTION
Display the number of running and queued jobs on the job-server [status page](https://jobs.opensafely.org/status/) for each backend. This should allow us to set researchers' expectations around how long their jobs might be queued for and allow anyone on tech support to more easily identify if there are potential problems with a particular backend.

Fixes #2090


![Screenshot from 2022-09-26 17-17-13](https://user-images.githubusercontent.com/3889554/192329421-410ceccc-5cdf-45d0-af92-9aadebd46dc4.png)
