### PR TITLE
Use our User.name property for string representations of a User

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -682,6 +682,9 @@ class User(AbstractBaseUser):
             ),
         ]
 
+    def __str__(self):
+        return self.name
+
     def clean(self):
         super().clean()
         self.email = self.__class__.objects.normalize_email(self.email)


### PR DESCRIPTION
We use the string repr in the Staff Area's search so it's useful to be consistent with how Users are displayed in various other places.