### PR TITLE
Handle longer backend names on log pages

### DIFF
--- a/assets/src/styles/main.scss
+++ b/assets/src/styles/main.scss
@@ -69,7 +69,7 @@ nav {
   }
   .backend {
     margin-right: 0.5rem;
-    width: 90px;
+    width: 110px;
   }
   .job-count {
     margin-right: 0.5rem;


### PR DESCRIPTION
This expands the backend column to account for the graphnet-test backend:

**before:**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/6quGY1K9/92de19fb-b149-4bfc-a4dc-c6b2d21967f5.jpg?v=53d32972f367d4d129302d447b8f217f)

**after:**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/nOubv7A4/403b7fd2-9107-4633-8188-31f581f9099c.jpg?v=17ac74b534e17ee88358ae718411196d)