### PR TITLE
Fix all uses of workspace.repo to use attributes of the Repo instance

### DIFF
--- a/jobserver/templates/index.html
+++ b/jobserver/templates/index.html
@@ -44,7 +44,7 @@
             <span class="mr-2 name">{{ workspace.name }}</span>
             <code class="d-none d-md-block text-right font-weight-normal">
               {% spaceless %}
-              <span class="repo">{{ workspace.repo_name }}</span>
+              <span class="repo">{{ workspace.repo.name }}</span>
               <span>|</span>
               <span class="branch">{{ workspace.branch }}</span>
               {% endspaceless %}

--- a/jobserver/templates/job_request_create.html
+++ b/jobserver/templates/job_request_create.html
@@ -7,7 +7,7 @@
 <meta property="og:title" content="{{ workspace.name }}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ request.build_absolute_uri }}" />
-<meta property="og:description" content="Repo: {{ workspace.repo_name }} ({{ workspace.branch }})" />
+<meta property="og:description" content="Repo: {{ workspace.repo.name }} ({{ workspace.branch }})" />
 {% endblock extra_meta %}
 
 {% block content %}
@@ -63,7 +63,7 @@
       <a href="{{ workspace.project.get_absolute_url }}">{{ workspace.project.title }}</a>
       project on all of the secure services ("backends") supported by
       OpenSAFELY.  On each backend, the directory includes code from the
-      <a href="{{ workspace.repo }}">repository</a>,
+      <a href="{{ workspace.repo.url }}">repository</a>,
       and the results of running it against real data ("jobs"). Researchers can
       request jobs are run from this page.
     </p>

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -8,7 +8,7 @@
 <meta property="og:title" content="{{ workspace.name }}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ request.build_absolute_uri }}" />
-<meta property="og:description" content="Repo: {{ workspace.repo_name }} ({{ workspace.branch }})" />
+<meta property="og:description" content="Repo: {{ workspace.repo.name }} ({{ workspace.branch }})" />
 {% endblock extra_meta %}
 
 {% block breadcrumbs %}
@@ -121,7 +121,7 @@
             <dl class="mb-0">
               <dt class="d-inline-block">Repo:</dt>
               <dd class="d-inline-flex mb-0 align-items-center">
-                <a class="mr-1" href="{{ workspace.repo }}/tree/{{ workspace.branch }}/">{{ workspace.repo_name }}</a>
+                <a class="mr-1" href="{{ workspace.repo.url }}/tree/{{ workspace.branch }}/">{{ workspace.repo.name }}</a>
               </dd>
               {% if repo_is_private %}
               <p class="mt-2 mb-1">This repo is not publicly viewable.</p>
@@ -176,7 +176,7 @@
         <a href="{{ workspace.project.get_absolute_url }}">{{ workspace.project.title }}</a>
         project on all of the secure services ("backends") supported by
         OpenSAFELY.  On each backend, the directory includes code from the
-        <a href="{{ workspace.repo }}/tree/{{ workspace.branch }}/">repository</a>,
+        <a href="{{ workspace.repo.url }}/tree/{{ workspace.branch }}/">repository</a>,
         and the results of running it against real data ("jobs"). Researchers can
         request jobs are run from this page.
       </p>

--- a/staff/templates/staff/workspace_detail.html
+++ b/staff/templates/staff/workspace_detail.html
@@ -117,7 +117,7 @@
             Repo
           </h2>
           <p class="card-body mb-0">
-            <a href="{{ workspace.repo }}/tree/{{ workspace.branch }}">{{ workspace.repo_owner }}/{{ workspace.repo_name }}</a>
+            <a href="{{ workspace.repo.url }}/tree/{{ workspace.branch }}">{{ workspace.repo.owner }}/{{ workspace.repo.name }}</a>
           </p>
         </li>
         <li class="card mb-3">


### PR DESCRIPTION
This fixes all the missed used of `workspace.repo`, `workspace.repo_name`, and `workspace.repo_owner` to use the equivalent on the Repo object.