### PR TITLE
Exempt entire API from CSP

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -2,7 +2,6 @@ import cgi
 
 import sentry_sdk
 import structlog
-from csp.decorators import csp_exempt
 from django.db import transaction
 from django.db.models import Value
 from django.shortcuts import get_object_or_404
@@ -328,7 +327,6 @@ class ReleaseAPI(APIView):
 class ReleaseFileAPI(APIView):
     authentication_classes = [SessionAuthentication]
 
-    @csp_exempt
     def get(self, request, file_id):
         """Return the content of a specific ReleaseFile"""
         # treat a deleted file as missing

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -268,6 +268,7 @@ X_FRAME_OPTIONS = "SAMEORIGIN"
 # CSP
 # https://django-csp.readthedocs.io/en/latest/configuration.html
 CSP_REPORT_ONLY = False
+CSP_EXCLUDE_URL_PREFIXES = ("/api/",)
 CSP_REPORT_URI = [env.str("CSP_REPORT_URI", default="")]
 CSP_DEFAULT_SRC = ["'none'"]
 CSP_CONNECT_SRC = ["'self'", "https://plausible.io", "https://sentry.io"]


### PR DESCRIPTION
This exempts the API from our CSP via a URL prefix match.  Having found DRF adds in more violations we felt that the API shouldn't need to deal with the CSP at all.