### PR TITLE
Add a normal ReposList page

### DIFF
--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -64,6 +64,11 @@ def staff_nav(request):
             "url": reverse("staff:backend-list"),
         },
         {
+            "name": "Dashboards",
+            "is_active": _active(reverse("staff:dashboard:index")),
+            "url": reverse("staff:dashboard:index"),
+        },
+        {
             "name": "Orgs",
             "is_active": _active(reverse("staff:org-list")),
             "url": reverse("staff:org-list"),

--- a/staff/templates/staff/dashboards/index.html
+++ b/staff/templates/staff/dashboards/index.html
@@ -1,0 +1,47 @@
+{% extends "staff/base.html" %}
+
+{% block metatitle %}Dashboards: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:index' %}">Staff area</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        Dashboards
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
+  <div class="container">
+    <h1 class="display-4">Dashboards</h1>
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block staff_content %}
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8 col-xl-9">
+
+      <div class="card">
+        <div class="card-body">
+          <h5 class="card-title">Repos</h5>
+          <p class="card-text">
+            All private repos attached to one or more workspaces, where code
+            was first run more than 11 months ago.
+          </p>
+          <a href="{% url 'staff:dashboards:repos' %}" class="btn btn-primary">View</a>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+{% endblock staff_content %}

--- a/staff/templates/staff/dashboards/repos.html
+++ b/staff/templates/staff/dashboards/repos.html
@@ -1,0 +1,123 @@
+{% extends "staff/base.html" %}
+
+{% load static %}
+
+{% block metatitle %}Repos: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:index' %}">Staff area</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        OpenSAFELY Private Repos
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
+  <div class="container">
+    <h1 class="display-4">OpenSAFELY Private Repos</h1>
+    <div class="row">
+      <p class="lead col-lg-9">
+        This table contains all private repos attached to one or more workspaces, where code was first run more than 11 months ago.
+      </p>
+    </div>
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block staff_content %}
+<div class="container-fluid">
+  <div class="row">
+    <div class="col">
+      <button type="button" class="reset btn btn-outline-primary mb-3" data-column="0" data-filter="">Reset filters</button>
+      <div class="table-responsive">
+        <table class="table table-striped table-sm table--repo">
+          <thead>
+            <tr>
+              <th>Repo</th>
+              <th>Workspaces</th>
+              <th>Contact</th>
+              <th>Created on</th>
+              <th class="text-nowrap">Job first run on</th>
+              <th class="text-nowrap">Files released to GitHub</th>
+              <th>Sign-offs</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for repo in repos %}
+            <tr>
+              <td><a href="{% url 'staff:repo-detail' repo_url=repo.quoted_url %}">{{ repo.name }}</a></td>
+
+              <td>
+                {% if repo.workspaces|length > 1 %}
+                  <details>
+                    <summary>
+                      <span class="summary--show">Show</span>
+                      <span class="summary--hide">Hide</span>
+                      {{ repo.workspaces|length }} workspaces
+                    </summary>
+                    <ul class="mt-1 mb-0 pl-2 ml-2">
+                      {% for workspace in repo.workspaces %}
+                      <li>
+                        <a href="{{ workspace.get_staff_url }}">
+                          {{ workspace.name }}
+                        </a>
+                      </li>
+                      {% endfor %}
+                    </ul>
+                  </details>
+                {% else %}
+                  {% for workspace in repo.workspaces %}
+                    <a href="{{ workspace.get_staff_url }}">
+                      {{ workspace.name }}
+                    </a>
+                  {% endfor %}
+                {% endif %}
+              </td>
+
+              <td>
+                <a href="{{ repo.workspace.created_by.get_staff_url }}">
+                  {{ repo.workspace.created_by.name }}
+                </a>
+              </td>
+
+              <td class="text-nowrap text-monospace">
+                <span class="pr-3">{{ repo.created_at|date:"d M Y" }}</span>
+              </td>
+
+              <td class="text-nowrap text-monospace">
+                <span class="pr-3">{{ repo.first_run|date:"d M Y" }}</span>
+              </td>
+
+              {% if repo.has_releases %}
+                <td class="text-center text-danger font-weight-bold">YES</td>
+              {% else %}
+                <td class="text-center text-success">No</td>
+              {% endif %}
+              <td class="text-center">{{ repo.signed_off }}/{{ repo.workspaces|length }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock staff_content %}
+
+{% block extra_styles %}
+<link rel="stylesheet" href="{% static 'vendor/tablesorter/theme.bootstrap_4.min.css' %}">
+{% endblock %}
+
+{% block extra_js %}
+<script src="{% static 'vendor/tablesorter/jquery.tablesorter.min.js' %}"></script>
+<script src="{% static 'vendor/tablesorter/jquery.tablesorter.widgets.min.js' %}"></script>
+<script src="{% static 'js/tablesorter.js' %}"></script>
+{% endblock %}

--- a/staff/templates/staff/index.html
+++ b/staff/templates/staff/index.html
@@ -44,6 +44,7 @@
       <div class="list-group">
         <a href="{% url 'staff:application-list' %}" class="list-group-item list-group-item-action">Applications</a>
         <a href="{% url 'staff:backend-list' %}" class="list-group-item list-group-item-action">Backends</a>
+        <a href="{% url 'staff:dashboard:index' %}" class="list-group-item list-group-item-action">Dashboards</a>
         <a href="{% url 'staff:org-list' %}" class="list-group-item list-group-item-action">Organisations</a>
         <a href="{% url 'staff:project-list' %}" class="list-group-item list-group-item-action">Projects</a>
         <a href="{% url 'staff:redirect-list' %}" class="list-group-item list-group-item-action">Redirects</a>

--- a/staff/templates/staff/repo_list.html
+++ b/staff/templates/staff/repo_list.html
@@ -1,6 +1,7 @@
 {% extends "staff/base.html" %}
 
-{% load static %}
+{% load querystring_tools %}
+{% load selected_filter %}
 
 {% block metatitle %}Repos: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
 
@@ -12,7 +13,7 @@
         <a href="{% url 'staff:index' %}">Staff area</a>
       </li>
       <li class="breadcrumb-item active" aria-current="page">
-        OpenSAFELY Private Repos
+        Repos
       </li>
     </ol>
   </div>
@@ -22,102 +23,71 @@
 {% block jumbotron %}
 <div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
   <div class="container">
-    <h1 class="display-4">OpenSAFELY Private Repos</h1>
-    <div class="row">
-      <p class="lead col-lg-9">
-        This table contains all private repos attached to one or more workspaces, where code was first run more than 11 months ago.
-      </p>
-    </div>
+    <h1 class="display-4">Repos</h1>
   </div>
 </div>
 {% endblock jumbotron %}
 
 {% block staff_content %}
-<div class="container-fluid">
+<div class="container">
   <div class="row">
-    <div class="col">
-      <button type="button" class="reset btn btn-outline-primary mb-3" data-column="0" data-filter="">Reset filters</button>
-      <div class="table-responsive">
-        <table class="table table-striped table-sm table--repo">
-          <thead>
-            <tr>
-              <th>Repo</th>
-              <th>Workspaces</th>
-              <th>Contact</th>
-              <th>Created on</th>
-              <th class="text-nowrap">Job first run on</th>
-              <th class="text-nowrap">Files released to GitHub</th>
-              <th>Sign-offs</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for repo in repos %}
-            <tr>
-              <td><a href="{% url 'staff:repo-detail' repo_url=repo.quoted_url %}">{{ repo.name }}</a></td>
+    <div class="col col-lg-3 col-xl-4">
+      <h2 class="h3">Filters</h2>
 
-              <td>
-                {% if repo.workspaces|length > 1 %}
-                  <details>
-                    <summary>
-                      <span class="summary--show">Show</span>
-                      <span class="summary--hide">Hide</span>
-                      {{ repo.workspaces|length }} workspaces
-                    </summary>
-                    <ul class="mt-1 mb-0 pl-2 ml-2">
-                      {% for workspace in repo.workspaces %}
-                      <li>
-                        <a href="{{ workspace.get_staff_url }}">
-                          {{ workspace.name }}
-                        </a>
-                      </li>
-                      {% endfor %}
-                    </ul>
-                  </details>
-                {% else %}
-                  {% for workspace in repo.workspaces %}
-                    <a href="{{ workspace.get_staff_url }}">
-                      {{ workspace.name }}
-                    </a>
-                  {% endfor %}
-                {% endif %}
-              </td>
-
-              <td>
-                <a href="{{ repo.workspace.created_by.get_staff_url }}">
-                  {{ repo.workspace.created_by.name }}
-                </a>
-              </td>
-
-              <td class="text-nowrap text-monospace">
-                <span class="pr-3">{{ repo.created_at|date:"d M Y" }}</span>
-              </td>
-
-              <td class="text-nowrap text-monospace">
-                <span class="pr-3">{{ repo.first_run|date:"d M Y" }}</span>
-              </td>
-
-              {% if repo.has_releases %}
-                <td class="text-center text-danger font-weight-bold">YES</td>
-              {% else %}
-                <td class="text-center text-success">No</td>
-              {% endif %}
-              <td class="text-center">{{ repo.signed_off }}/{{ repo.workspaces|length }}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+      {% if request.GET %}
+      <div class="mb-3">
+        <a href="{% url 'staff:repo-list' %}">Clear All</a>
       </div>
+      {% endif %}
+
+      <h3 class="h4">Orgs</h3>
+      <div class="btn-group-vertical w-100 mb-4" role="group" aria-label="Filter by org">
+        {% for org in orgs %}
+        {% is_filter_selected key="org" value=org.slug as is_active %}
+        <a
+          {% if is_active %}aria-pressed="true"{% endif %}
+          class="btn btn-outline-primary btn-block text-left {% if is_active %}active{% endif %}"
+          href="
+            {% if is_active %}
+              {% url_without_querystring org=org.slug %}
+            {% else %}
+              {% url_with_querystring org=org.slug %}
+            {% endif %}
+          "
+        >
+            {{ org.name }}
+        </a>
+        {% endfor %}
+      </div>
+
+    </div>
+
+    <div class="col col-lg-9 col-xl-8">
+      <form class="form d-flex align-items-center mb-4" method="GET">
+      <input
+        class="form-control mr-2"
+        type="search"
+        placeholder="Search by repo name"
+        aria-label="Search"
+        {% if q %}
+        value="{{ q }}"
+        {% endif %}
+        name="q" />
+        <button class="btn btn-outline-primary my-2 my-sm-0" type="submit">Search</button>
+      </form>
+
+      {% if object_list %}
+      <div class="list-group list-unstyled">
+        {% for repo in object_list %}
+        <a href="{{ repo.get_staff_url }}" class="d-flex align-items-center list-group-item list-group-item-action">
+          {{ repo.name }}
+        </a>
+        {% endfor %}
+      </div>
+      {% else %}
+      <p class="text-center">No repos found for this filter.</p>
+      {% endif %}
     </div>
   </div>
 </div>
 {% endblock staff_content %}
-
-{% block extra_styles %}
-<link rel="stylesheet" href="{% static 'vendor/tablesorter/theme.bootstrap_4.min.css' %}">
-{% endblock %}
-
-{% block extra_js %}
-<script src="{% static 'vendor/tablesorter/jquery.tablesorter.min.js' %}"></script>
-<script src="{% static 'vendor/tablesorter/jquery.tablesorter.widgets.min.js' %}"></script>
-<script src="{% static 'js/tablesorter.js' %}"></script>
-{% endblock %}

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -16,6 +16,7 @@ from .views.backends import (
     BackendList,
     BackendRotateToken,
 )
+from .views.dashboards import DashboardIndex
 from .views.index import Index
 from .views.orgs import (
     OrgCreate,
@@ -39,7 +40,13 @@ from .views.projects import (
     ProjectMembershipRemove,
 )
 from .views.redirects import RedirectDelete, RedirectDetail, RedirectList
-from .views.repos import RepoDetail, RepoFeatureFlags, RepoList, RepoSignOff
+from .views.repos import (
+    PrivateReposDashboard,
+    RepoDetail,
+    RepoFeatureFlags,
+    RepoList,
+    RepoSignOff,
+)
 from .views.researchers import ResearcherEdit
 from .views.users import UserDetail, UserList, UserSetOrgs
 from .views.workspaces import WorkspaceDetail, WorkspaceEdit, WorkspaceList
@@ -81,6 +88,11 @@ backend_urls = [
         BackendRotateToken.as_view(),
         name="backend-rotate-token",
     ),
+]
+
+dashboard_urls = [
+    path("", DashboardIndex.as_view(), name="index"),
+    path("repos", PrivateReposDashboard.as_view(), name="repos"),
 ]
 
 org_urls = [
@@ -162,6 +174,7 @@ urlpatterns = [
     path("", Index.as_view(), name="index"),
     path("applications/", include(application_urls)),
     path("backends/", include(backend_urls)),
+    path("dashboards/", include((dashboard_urls, "dashboards"), namespace="dashboard")),
     path("orgs/", include(org_urls)),
     path("projects/", include(project_urls)),
     path("redirects/", include(redirect_urls)),

--- a/staff/views/dashboards.py
+++ b/staff/views/dashboards.py
@@ -1,0 +1,5 @@
+from django.views.generic import TemplateView
+
+
+class DashboardIndex(TemplateView):
+    template_name = "staff/dashboards/index.html"

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -12,14 +12,14 @@ from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
-from django.views.generic import UpdateView, View
+from django.views.generic import ListView, UpdateView, View
 from first import first
 from furl import furl
 
 from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_role
 from jobserver.github import _get_github_api
-from jobserver.models import Job, Project, Repo, User, Workspace
+from jobserver.models import Job, Org, Project, Repo, User, Workspace
 
 from ..forms import RepoFeatureFlagsForm
 
@@ -29,6 +29,118 @@ logger = structlog.get_logger(__name__)
 
 def ran_at(job):
     return job.started_at or job.created_at
+
+
+@method_decorator(require_role(CoreDeveloper), name="dispatch")
+class PrivateReposDashboard(View):
+    get_github_api = staticmethod(_get_github_api)
+
+    @csp_exempt
+    def get(self, request, *args, **kwargs):
+        """
+        List private repos which are in need of converting to public
+
+        Repos should be:
+         * Private
+         * not have `non-research` topic
+         * first job was run > 11 months ago
+        """
+        all_repos = list(self.get_github_api().get_repos_with_dates("opensafely"))
+
+        # remove repos with the non-research topic
+        all_repos = [r for r in all_repos if "non-research" not in r["topics"]]
+
+        private_repos = [repo for repo in all_repos if repo["is_private"]]
+
+        all_workspaces = list(
+            Workspace.objects.exclude(project__slug="opensafely-testing")
+            .select_related("created_by", "project", "repo")
+            .annotate(num_jobs=Count("job_requests__jobs"))
+            .annotate(
+                first_run=Min(
+                    Least(
+                        "job_requests__jobs__started_at",
+                        "job_requests__jobs__created_at",
+                    )
+                ),
+            )
+        )
+
+        def enhance(repo):
+            """
+            Enhance the repo dict from get_repos_with_dates() with workspace data
+
+            We need to filter repos, not workspaces, so this gives us all the
+            information we need when filtering further down.
+            """
+            # get workspaces just for this repo
+            workspaces = [
+                w for w in all_workspaces if repo["url"].lower() == w.repo.url.lower()
+            ]
+            workspaces = sorted(workspaces, key=lambda w: w.name.lower())
+
+            # get workspaces which have run jobs
+            with_jobs = [w for w in workspaces if w.first_run]
+
+            # sorting by a datetime puts the workspaces into oldest job first
+            with_jobs = sorted(with_jobs, key=lambda w: w.first_run)
+
+            # get the first workspace to have run a job
+            workspace = first(with_jobs, key=lambda w: w.first_run)
+
+            # get first_run as either None or a datetime
+            first_run = workspace.first_run if workspace else None
+
+            # has this repo ever had jobs run with it?
+            has_jobs = sum(w.num_jobs for w in workspaces) > 0
+
+            # how many of the workspaces have been signed-off for being published?
+            signed_off = sum(1 for w in workspaces if w.signed_off_at)
+
+            return repo | {
+                "first_run": first_run,
+                "has_jobs": has_jobs,
+                "has_releases": "github-releases" in repo["topics"],
+                "quoted_url": quote(repo["url"], safe=""),
+                "signed_off": signed_off,
+                "workspace": workspace,
+                "workspaces": workspaces,
+            }
+
+        # add workspace (and related object) data to repos
+        repos = [enhance(r) for r in private_repos]
+
+        eleven_months_ago = timezone.now() - timedelta(days=30 * 11)
+
+        def select(repo):
+            """
+            Select a repo based on various predicates below.
+
+            We're already working with private repos here so we check
+
+            * Has jobs or a workspace
+            * First job to run happened over 11 months ago
+            """
+            if not (repo["workspaces"] and repo["has_jobs"]):
+                logger.info("No workspaces/jobs", url=repo["url"])
+                return False
+
+            # because we know we have at least one job and first_run looks at
+            # either started_at OR created_at we know we will always have a
+            # value for first_run at this point
+            first_ran_over_11_months_ago = repo["first_run"] < eleven_months_ago
+            if not first_ran_over_11_months_ago:
+                logger.info("First run <11mo ago", url=repo["url"])
+                return False
+
+            return True
+
+        # select only repos we care about
+        repos = [r for r in repos if select(r)]
+
+        return TemplateResponse(
+            request, "staff/dashboards/repos.html", {"repos": repos}
+        )
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
@@ -147,113 +259,27 @@ class RepoFeatureFlags(UpdateView):
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
-class RepoList(View):
-    get_github_api = staticmethod(_get_github_api)
+class RepoList(ListView):
+    model = Repo
+    template_name = "staff/repo_list.html"
 
-    @csp_exempt
-    def get(self, request, *args, **kwargs):
-        """
-        List private repos which are in need of converting to public
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(**kwargs) | {
+            "orgs": Org.objects.order_by(Lower("name")),
+            "q": self.request.GET.get("q", ""),
+        }
 
-        Repos should be:
-         * Private
-         * not have `non-research` topic
-         * first job was run > 11 months ago
-        """
-        all_repos = list(self.get_github_api().get_repos_with_dates("opensafely"))
+    def get_queryset(self):
+        qs = Repo.objects.order_by(Lower("url"))
 
-        # remove repos with the non-research topic
-        all_repos = [r for r in all_repos if "non-research" not in r["topics"]]
+        # filter on the search query
+        if q := self.request.GET.get("q"):
+            qs = qs.filter(url__icontains=q)
 
-        private_repos = [repo for repo in all_repos if repo["is_private"]]
+        if org := self.request.GET.get("org"):
+            qs = qs.filter(workspaces__project__org__slug=org)
 
-        all_workspaces = list(
-            Workspace.objects.exclude(project__slug="opensafely-testing")
-            .select_related("created_by", "project", "repo")
-            .annotate(num_jobs=Count("job_requests__jobs"))
-            .annotate(
-                first_run=Min(
-                    Least(
-                        "job_requests__jobs__started_at",
-                        "job_requests__jobs__created_at",
-                    )
-                ),
-            )
-        )
-
-        def enhance(repo):
-            """
-            Enhance the repo dict from get_repos_with_dates() with workspace data
-
-            We need to filter repos, not workspaces, so this gives us all the
-            information we need when filtering further down.
-            """
-            # get workspaces just for this repo
-            workspaces = [
-                w for w in all_workspaces if repo["url"].lower() == w.repo.url.lower()
-            ]
-            workspaces = sorted(workspaces, key=lambda w: w.name.lower())
-
-            # get workspaces which have run jobs
-            with_jobs = [w for w in workspaces if w.first_run]
-
-            # sorting by a datetime puts the workspaces into oldest job first
-            with_jobs = sorted(with_jobs, key=lambda w: w.first_run)
-
-            # get the first workspace to have run a job
-            workspace = first(with_jobs, key=lambda w: w.first_run)
-
-            # get first_run as either None or a datetime
-            first_run = workspace.first_run if workspace else None
-
-            # has this repo ever had jobs run with it?
-            has_jobs = sum(w.num_jobs for w in workspaces) > 0
-
-            # how many of the workspaces have been signed-off for being published?
-            signed_off = sum(1 for w in workspaces if w.signed_off_at)
-
-            return repo | {
-                "first_run": first_run,
-                "has_jobs": has_jobs,
-                "has_releases": "github-releases" in repo["topics"],
-                "quoted_url": quote(repo["url"], safe=""),
-                "signed_off": signed_off,
-                "workspace": workspace,
-                "workspaces": workspaces,
-            }
-
-        # add workspace (and related object) data to repos
-        repos = [enhance(r) for r in private_repos]
-
-        eleven_months_ago = timezone.now() - timedelta(days=30 * 11)
-
-        def select(repo):
-            """
-            Select a repo based on various predicates below.
-
-            We're already working with private repos here so we check
-
-            * Has jobs or a workspace
-            * First job to run happened over 11 months ago
-            """
-            if not (repo["workspaces"] and repo["has_jobs"]):
-                logger.info("No workspaces/jobs", url=repo["url"])
-                return False
-
-            # because we know we have at least one job and first_run looks at
-            # either started_at OR created_at we know we will always have a
-            # value for first_run at this point
-            first_ran_over_11_months_ago = repo["first_run"] < eleven_months_ago
-            if not first_ran_over_11_months_ago:
-                logger.info("First run <11mo ago", url=repo["url"])
-                return False
-
-            return True
-
-        # select only repos we care about
-        repos = [r for r in repos if select(r)]
-
-        return TemplateResponse(request, "staff/repo_list.html", {"repos": repos})
+        return qs.distinct()
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
@@ -288,5 +314,4 @@ class RepoSignOff(View):
             repo.internal_signed_off_at = timezone.now()
             repo.internal_signed_off_by = request.user
             repo.save()
-
         return redirect(repo.get_staff_url())

--- a/tests/unit/staff/views/test_repos.py
+++ b/tests/unit/staff/views/test_repos.py
@@ -8,6 +8,7 @@ from django.http import Http404
 from django.utils import timezone
 
 from staff.views.repos import (
+    PrivateReposDashboard,
     RepoDetail,
     RepoFeatureFlags,
     RepoList,
@@ -32,6 +33,85 @@ def test_ran_at():
 
     assert ran_at(JobFactory(created_at=created, started_at=None)) == created
     assert ran_at(JobFactory(created_at=created, started_at=started)) == started
+
+
+def test_privatereposdashboard_success(rf, django_assert_num_queries, core_developer):
+    eleven_months_ago = timezone.now() - timedelta(days=30 * 11)
+
+    # 3 private repos
+    # 1 public repo
+    # 3, 2, 1 workspaces respectively for 3 private repos
+
+    # research-repo-1
+    repo1 = RepoFactory(url="https://github.com/opensafely/research-repo-1")
+    rr1_workspace_1 = WorkspaceFactory(repo=repo1)
+    rr1_jr_1 = JobRequestFactory(workspace=rr1_workspace_1)
+    JobFactory(job_request=rr1_jr_1, started_at=minutes_ago(eleven_months_ago, 3))
+    JobFactory(job_request=rr1_jr_1, started_at=minutes_ago(eleven_months_ago, 2))
+    JobFactory(job_request=rr1_jr_1, started_at=minutes_ago(eleven_months_ago, 1))
+
+    rr1_workspace_2 = WorkspaceFactory(repo=repo1)
+    rr1_jr_2 = JobRequestFactory(workspace=rr1_workspace_2)
+    JobFactory(job_request=rr1_jr_2, started_at=minutes_ago(eleven_months_ago, 4))
+    JobFactory(job_request=rr1_jr_2, started_at=minutes_ago(eleven_months_ago, 5))
+
+    rr1_workspace_3 = WorkspaceFactory(repo=repo1)
+    rr1_jr_3 = JobRequestFactory(workspace=rr1_workspace_3)
+    JobFactory(job_request=rr1_jr_3, started_at=minutes_ago(eleven_months_ago, 10))
+
+    # research-repo-2
+    repo2 = RepoFactory(url="https://github.com/opensafely/research-repo-2")
+    rr2_workspace_1 = WorkspaceFactory(repo=repo2)
+    rr2_jr_1 = JobRequestFactory(workspace=rr2_workspace_1)
+    JobFactory(job_request=rr2_jr_1, started_at=minutes_ago(eleven_months_ago, 30))
+    JobFactory(job_request=rr2_jr_1, started_at=minutes_ago(eleven_months_ago, 20))
+    JobFactory(job_request=rr2_jr_1, started_at=None)
+
+    rr2_workspace_2 = WorkspaceFactory(repo=repo2)
+    rr2_jr_2 = JobRequestFactory(workspace=rr2_workspace_2)
+    JobFactory(job_request=rr2_jr_2, started_at=minutes_ago(eleven_months_ago, 17))
+    JobFactory(job_request=rr2_jr_2, started_at=minutes_ago(eleven_months_ago, 13))
+
+    # research-repo-3
+    rr3_workspace_1 = WorkspaceFactory(
+        repo=RepoFactory(url="https://github.com/opensafely/research-repo-3")
+    )
+    rr3_jr_1 = JobRequestFactory(workspace=rr3_workspace_1)
+    JobFactory(job_request=rr3_jr_1, started_at=minutes_ago(eleven_months_ago, 42))
+    JobFactory(job_request=rr3_jr_1, started_at=minutes_ago(eleven_months_ago, 38))
+
+    # research-repo-5
+    rr5_workspace_1 = WorkspaceFactory(
+        repo=RepoFactory(url="https://github.com/opensafely/research-repo-5")
+    )
+    rr5_jr_1 = JobRequestFactory(workspace=rr5_workspace_1)
+    JobFactory(job_request=rr5_jr_1, started_at=None)
+
+    request = rf.get("/")
+    request.user = core_developer
+
+    with django_assert_num_queries(1):
+        response = PrivateReposDashboard.as_view(get_github_api=FakeGitHubAPI)(request)
+
+    assert response.status_code == 200
+
+    research_repo_1, research_repo_2 = response.context_data["repos"]
+
+    assert research_repo_1["first_run"] == minutes_ago(eleven_months_ago, 10)
+    assert research_repo_1["has_releases"]
+    assert research_repo_1["workspace"] == rr1_workspace_3
+
+    assert research_repo_2["first_run"] == minutes_ago(eleven_months_ago, 30)
+    assert not research_repo_2["has_releases"]
+    assert research_repo_2["workspace"] == rr2_workspace_1
+
+
+def test_privatereposdashboard_unauthorized(rf):
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    with pytest.raises(PermissionDenied):
+        PrivateReposDashboard.as_view()(request)
 
 
 def test_repodetail_success(rf, core_developer):
@@ -147,75 +227,43 @@ def test_repofeatureflags_unknown_repo(rf, core_developer):
         RepoFeatureFlags.as_view()(request, repo_url="")
 
 
-def test_repolist_success(rf, django_assert_num_queries, core_developer):
-    eleven_months_ago = timezone.now() - timedelta(days=30 * 11)
+def test_projectlist_filter_by_org(rf, core_developer):
+    repo = RepoFactory()
+    RepoFactory.create_batch(2)
+    WorkspaceFactory(repo=repo)
 
-    # 3 private repos
-    # 1 public repo
-    # 3, 2, 1 workspaces respectively for 3 private repos
+    request = rf.get(f"/?org={repo.workspaces.first().project.org.slug}")
+    request.user = core_developer
 
-    # research-repo-1
-    repo1 = RepoFactory(url="https://github.com/opensafely/research-repo-1")
-    rr1_workspace_1 = WorkspaceFactory(repo=repo1)
-    rr1_jr_1 = JobRequestFactory(workspace=rr1_workspace_1)
-    JobFactory(job_request=rr1_jr_1, started_at=minutes_ago(eleven_months_ago, 3))
-    JobFactory(job_request=rr1_jr_1, started_at=minutes_ago(eleven_months_ago, 2))
-    JobFactory(job_request=rr1_jr_1, started_at=minutes_ago(eleven_months_ago, 1))
+    response = RepoList.as_view()(request)
 
-    rr1_workspace_2 = WorkspaceFactory(repo=repo1)
-    rr1_jr_2 = JobRequestFactory(workspace=rr1_workspace_2)
-    JobFactory(job_request=rr1_jr_2, started_at=minutes_ago(eleven_months_ago, 4))
-    JobFactory(job_request=rr1_jr_2, started_at=minutes_ago(eleven_months_ago, 5))
+    assert len(response.context_data["object_list"]) == 1
 
-    rr1_workspace_3 = WorkspaceFactory(repo=repo1)
-    rr1_jr_3 = JobRequestFactory(workspace=rr1_workspace_3)
-    JobFactory(job_request=rr1_jr_3, started_at=minutes_ago(eleven_months_ago, 10))
 
-    # research-repo-2
-    repo2 = RepoFactory(url="https://github.com/opensafely/research-repo-2")
-    rr2_workspace_1 = WorkspaceFactory(repo=repo2)
-    rr2_jr_1 = JobRequestFactory(workspace=rr2_workspace_1)
-    JobFactory(job_request=rr2_jr_1, started_at=minutes_ago(eleven_months_ago, 30))
-    JobFactory(job_request=rr2_jr_1, started_at=minutes_ago(eleven_months_ago, 20))
-    JobFactory(job_request=rr2_jr_1, started_at=None)
+def test_projectlist_find_by_name(rf, core_developer):
+    repo1 = RepoFactory(url="age-test-distribution")
+    repo2 = RepoFactory(url="ghickman-testing")
+    RepoFactory(url="sro-measures")
 
-    rr2_workspace_2 = WorkspaceFactory(repo=repo2)
-    rr2_jr_2 = JobRequestFactory(workspace=rr2_workspace_2)
-    JobFactory(job_request=rr2_jr_2, started_at=minutes_ago(eleven_months_ago, 17))
-    JobFactory(job_request=rr2_jr_2, started_at=minutes_ago(eleven_months_ago, 13))
+    request = rf.get("/?q=test")
+    request.user = core_developer
 
-    # research-repo-3
-    rr3_workspace_1 = WorkspaceFactory(
-        repo=RepoFactory(url="https://github.com/opensafely/research-repo-3")
-    )
-    rr3_jr_1 = JobRequestFactory(workspace=rr3_workspace_1)
-    JobFactory(job_request=rr3_jr_1, started_at=minutes_ago(eleven_months_ago, 42))
-    JobFactory(job_request=rr3_jr_1, started_at=minutes_ago(eleven_months_ago, 38))
+    response = RepoList.as_view()(request)
 
-    # research-repo-5
-    rr5_workspace_1 = WorkspaceFactory(
-        repo=RepoFactory(url="https://github.com/opensafely/research-repo-5")
-    )
-    rr5_jr_1 = JobRequestFactory(workspace=rr5_workspace_1)
-    JobFactory(job_request=rr5_jr_1, started_at=None)
+    assert response.status_code == 200
+    assert set(response.context_data["object_list"]) == {repo1, repo2}
+
+
+def test_repolist_success(rf, core_developer):
+    RepoFactory.create_batch(5)
 
     request = rf.get("/")
     request.user = core_developer
 
-    with django_assert_num_queries(1):
-        response = RepoList.as_view(get_github_api=FakeGitHubAPI)(request)
+    response = RepoList.as_view()(request)
 
     assert response.status_code == 200
-
-    research_repo_1, research_repo_2 = response.context_data["repos"]
-
-    assert research_repo_1["first_run"] == minutes_ago(eleven_months_ago, 10)
-    assert research_repo_1["has_releases"]
-    assert research_repo_1["workspace"] == rr1_workspace_3
-
-    assert research_repo_2["first_run"] == minutes_ago(eleven_months_ago, 30)
-    assert not research_repo_2["has_releases"]
-    assert research_repo_2["workspace"] == rr2_workspace_1
+    assert len(response.context_data["object_list"])
 
 
 def test_repolist_unauthorized(rf):
@@ -223,7 +271,7 @@ def test_repolist_unauthorized(rf):
     request.user = AnonymousUser()
 
     with pytest.raises(PermissionDenied):
-        RepoList.as_view(get_github_api=FakeGitHubAPI)(request)
+        RepoList.as_view()(request)
 
 
 def test_reposignoff_success(rf, core_developer):


### PR DESCRIPTION
This pulls the existing repos page into a new dashboards menu and adds a "normal" repos page, which only lists repos that job-server knows about.

I've added orgs as a filter in leiu of anything more obvious.

Fixes #2156 