### PR TITLE
Explain disabled release buttons

### DIFF
--- a/jobserver/templates/project_release_list.html
+++ b/jobserver/templates/project_release_list.html
@@ -36,6 +36,15 @@
 <div class="jumbotron jumbotron-fluid">
   <div class="container">
     <h1>Releases for the {{ project.name }} project</h1>
+    <p class="lead">
+      Each release listed below contains one or more files released from a
+      secure research backend to the Jobs site. Some releases have been
+      redacted for privacy reasons.
+    </p>
+    <p class="lead">
+      The buttons below will be disabled if a release has been redacted or if
+      you do not have permission to view them.
+    </p>
   </div>
 </div>
 {% endblock jumbotron %}

--- a/jobserver/templates/project_release_list.html
+++ b/jobserver/templates/project_release_list.html
@@ -2,46 +2,50 @@
 
 {% load humanize %}
 
-{% block content %}
+{% block metatitle %}Releases: {{ workspace.name }} | OpenSAFELY Jobs{% endblock metatitle %}
 
-<nav aria-label="breadcrumb">
-  <ol class="breadcrumb">
+{% block breadcrumbs %}
+<nav class="breadcrumb-container" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="/">Home</a>
+      </li>
 
-    <li class="breadcrumb-item"><a href="/">Home</a></li>
+      <li class="breadcrumb-item">
+        <a href="{{ project.org.get_absolute_url }}">
+          {{ project.org.name }}
+        </a>
+      </li>
 
-    <li class="breadcrumb-item">
-      <a href="{{ project.org.get_absolute_url }}">
-        {{ project.org.name }}
-      </a>
-    </li>
+      <li class="breadcrumb-item">
+        <a href="{{ project.get_absolute_url }}">
+          {{ project.title }}
+        </a>
+      </li>
 
-    <li class="breadcrumb-item">
-      <a href="{{ project.get_absolute_url }}">
-        {{ project.title }}
-      </a>
-    </li>
-
-    <li class="breadcrumb-item active" aria-current="page">Releases</li>
-
-  </ol>
+      <li class="breadcrumb-item active" aria-current="page">
+        Releases
+      </li>
+    </ol>
+  </div>
 </nav>
+{% endblock breadcrumbs %}
 
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid">
+  <div class="container">
+    <h1>Releases for the {{ project.name }} project</h1>
+  </div>
+</div>
+{% endblock jumbotron %}
 
-<div class="row">
-  <div class="col-lg-8 offset-lg-2">
-
-    <h4>Releases for the {{ project.title }} project</h4>
-
-    <p>
-      Below are all released files for the {{ project.title }} project across
-      all of its workspaces.
-    </p>
-
+{% block content %}
+<div class="container">
+  <div class="list-group">
     {% for release in releases %}
     {% include "_release_list.html" with org_slug=project.org.slug project_slug=project.slug workspace_slug=release.workspace.name r=release %}
     {% endfor %}
-
   </div>
-
 </div>
 {% endblock %}

--- a/jobserver/templates/workspace_release_list.html
+++ b/jobserver/templates/workspace_release_list.html
@@ -42,6 +42,15 @@
 <div class="jumbotron jumbotron-fluid">
   <div class="container">
     <h1>Releases for the {{ workspace.name }} workspace</h1>
+    <p class="lead">
+      Each release listed below contains one or more files released from a
+      secure research backend to the website. Some releases have been
+      redacted for privacy reasons.
+    </p>
+    <p class="lead">
+      The buttons below are disabled if a release has been redacted or if you
+      do not have permission to view them.
+    </p>
   </div>
 </div>
 {% endblock jumbotron %}


### PR DESCRIPTION
This adds explainer text to both the project and workspace release list pages.  While we don't link to the project releases page (which I think might just be a bug?) I've updated it since it's still live.

The workspace releases page looks like this:
![](https://p198.p4.n0.cdn.getcloudapp.com/items/jkuWXbqn/576a5bf0-b644-4960-879f-a346aa74583a.jpg?v=575fc33249b769fad50f8c002dc69817)

Fixes #2162 