### PR TITLE
Show case sensitive Job ID

### DIFF
--- a/jobserver/templates/job_detail_tw.html
+++ b/jobserver/templates/job_detail_tw.html
@@ -134,7 +134,7 @@
 
         {% #description_item title="Job identifier" %}
           <code class="font-mono font-semibold text-oxford-800 tracking-widest">
-            {{ job.identifier|upper }}
+            {{ job.identifier }}
           </code>
         {% /description_item %}
 


### PR DESCRIPTION
Don't convert the identifier to uppercase.