### PR TITLE
Django management command to delete empty projects

### DIFF
--- a/jobserver/management/commands/delete_project.py
+++ b/jobserver/management/commands/delete_project.py
@@ -1,0 +1,30 @@
+import sys
+
+from django.core.management.base import BaseCommand
+
+from jobserver.models import Project
+
+
+def delete_project(name):
+    project = Project.objects.get(name=name)
+    if project.workspaces.exists() or project.members.exists():
+        raise Exception("Unable to delete a project with workspaces or members")
+    project.delete()
+    print(f"Project {name} deleted")
+
+
+class Command(BaseCommand):
+    help = "Delete an empty project"  # noqa: A003
+
+    def add_arguments(self, parser):
+        parser.add_argument("project_name")
+
+    def handle(self, *args, **options):
+        project_name = options["project_name"]
+
+        try:
+            delete_project(project_name)
+        except Project.DoesNotExist:
+            sys.exit("Project does not exist")
+        except Exception as e:
+            sys.exit(str(e))

--- a/tests/unit/jobserver/management/commands/test_delete_project.py
+++ b/tests/unit/jobserver/management/commands/test_delete_project.py
@@ -1,0 +1,59 @@
+import pytest
+from django.core.management import CommandError, call_command
+
+from tests.factories import (
+    ProjectFactory,
+    ProjectMembershipFactory,
+    UserFactory,
+    WorkspaceFactory,
+)
+
+
+def test_delete_project_missing_project_name():
+    msg = "Error: the following arguments are required: project_name"
+
+    with pytest.raises(CommandError, match=msg):
+        call_command("delete_project")
+
+
+def test_delete_project_success(capsys):
+    ProjectFactory(name="test-project")
+
+    call_command("delete_project", "test-project")
+
+    captured = capsys.readouterr()
+    assert captured.out == "Project test-project deleted\n"
+
+
+def test_delete_project_doesnt_exist(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        call_command("delete_project", "no-project")
+
+    assert exc_info.value.args[0] == "Project does not exist"
+
+
+def test_delete_project_with_members(capsys):
+    project = ProjectFactory(name="test-project")
+    user = UserFactory()
+    ProjectMembershipFactory(project=project, user=user)
+
+    with pytest.raises(SystemExit) as exc_info:
+        call_command("delete_project", "test-project")
+
+    assert (
+        exc_info.value.args[0]
+        == "Unable to delete a project with workspaces or members"
+    )
+
+
+def test_delete_project_with_workspaces(capsys):
+    project = ProjectFactory(name="test-project")
+    WorkspaceFactory(project=project)
+
+    with pytest.raises(SystemExit) as exc_info:
+        call_command("delete_project", "test-project")
+
+    assert (
+        exc_info.value.args[0]
+        == "Unable to delete a project with workspaces or members"
+    )


### PR DESCRIPTION
We've been asked to [delete a project](https://github.com/opensafely-core/job-server/issues/1991) that no longer has any workspaces associated with it, as part of a data tidying exercise for older work in job server.

There is currently no way to do this in the UI (e.g via the staff area), so this management command adds a quick way for admins to do this without manually editing the database.