### PR TITLE
Remove bot access to the event log page

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -3,6 +3,7 @@ Disallow: /api/
 Disallow: /applications/
 Disallow: /complete/
 Disallow: /disconnect/
+Disallow: /event-log/
 Disallow: /login/
 Disallow: /logout/
 Disallow: /settings/


### PR DESCRIPTION
This is an ever growing list of jobs which have run on the platform, all of which have detail pages which are still crawled.  We're seeing a lot of bot traffic to the page which isn't ideal so this aims to stop that.