### PR TITLE
feat: add link to honeycomb concurrency visualisation for a job_request

### DIFF
--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -213,23 +213,12 @@
           <p class="card-subtitle small mb-0">Honeycomb login required</p>
         </div>
         <div class="card-body">
-          <h3 class="h6">Events count for:</h3>
           <ul class="pl-3 mb-0">
-            <li>
-              <a href="https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production/datasets/job-server?query=%7B%22start_time%22%3A{{ honeycomb_context_starttime|date:'U'|default_if_none:'1646312416' }}%2C%22end_time%22%3A{{ honeycomb_context_endtime|date:'U' }}%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22status%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D,%7B%22column%22%3A%22job_request_identifier%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ job_request.identifier }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D">
-                This job request
-              </a>
-            </li>
-            <li>
-              <a href="https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production/datasets/job-server?query=%7B%22start_time%22%3A1658222043%2C%22end_time%22%3A1659015327%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22action%22%2C%22status%22%2C%22job_identifier%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D%2C%7B%22column%22%3A%22job_request_identifier%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22xglmbwz5iy6ojuzo%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22job_identifier%22%2C%22order%22%3A%22ascending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D">
-                This job request, grouped by job
-              </a>
-            </li>
-            <li>
-              <a href="https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production/datasets/job-server?query=%7B%22start_time%22%3A{{ honeycomb_context_starttime|date:'U'|default_if_none:'1646312416' }}%2C%22end_time%22%3A{{ honeycomb_context_endtime|date:'U' }}%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22status%22,%22action%22,%22job_identifier%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D,%7B%22column%22%3A%22status%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22running%22%7D,%7B%22column%22%3A%22job_request_identifier%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ job_request.identifier }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D">
-                Running jobs from this job request
-              </a>
-            </li>
+            {% for name, link in honeycomb_links.items %}
+                <li>
+                    <a href="{{ link }}">{{ name }}</a>
+                </li>
+            {% endfor %}
           </ul>
         </div>
       </div>

--- a/tests/unit/jobserver/test_honeycomb.py
+++ b/tests/unit/jobserver/test_honeycomb.py
@@ -1,13 +1,16 @@
+from urllib.parse import unquote
+
 import pytest
 from django.utils import timezone
 
 from jobserver.honeycomb import (
     format_honeycomb_timestamps,
+    format_jobrequest_concurrency_link,
     format_trace_id,
     format_trace_link,
 )
 
-from ...factories import JobFactory
+from ...factories import JobFactory, JobRequestFactory
 
 
 def test_format_trace_id_hexadecimal():
@@ -36,3 +39,13 @@ def test_format_trace_link():
     url = format_trace_link(job)
     assert "trace_start_ts=1655297940&trace_end_ts=1655298060" in url
     assert "bennett-institute-for-applied-data-science" in url
+
+
+@pytest.mark.freeze_time("2022-10-12 17:00")
+def test_format_jobrequest_concurrency_link():
+    job_request = JobRequestFactory(identifier="jpbaeldzjqqiaolg")
+
+    url = format_jobrequest_concurrency_link(job_request)
+    expected_url = "https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production/datasets/jobrunner?query=%7B%22start_time%22%3A1665593940%2C%22end_time%22%3A1665594000%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22CONCURRENCY%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22enter_state%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22true%22%7D%2C%7B%22column%22%3A%22name%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22RUN%22%7D%2C%7B%22column%22%3A%22name%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22JOB%22%7D%2C%7B%22column%22%3A%22name%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22job%22%7D%2C%7B%22column%22%3A%22job_request%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22jpbaeldzjqqiaolg%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22CONCURRENCY%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D"
+
+    assert unquote(url) == unquote(expected_url)


### PR DESCRIPTION
* [example visualisation](https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production/datasets/jobrunner?query=%7B%22start_time%22%3A1665410183%2C%22end_time%22%3A1665492336%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22CONCURRENCY%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22enter_state%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3Atrue%7D%2C%7B%22column%22%3A%22name%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22RUN%22%7D%2C%7B%22column%22%3A%22name%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22JOB%22%7D%2C%7B%22column%22%3A%22name%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22job%22%7D%2C%7B%22column%22%3A%22job_request%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22rfhiav5zj4bizh2v%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22CONCURRENCY%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D)
* unfortunately I don't think the template link includes whether the graph is formatted as a "stacked graph" ([docs](https://docs.honeycomb.io/api/query-specification/#fields-on-a-query-specification) )
* remove the old job-server visualisations while we're here
