### PR TITLE
Add the repo handler view

### DIFF
--- a/jobserver/templates/project_repo_list.html
+++ b/jobserver/templates/project_repo_list.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+
+{% block metatitle %}Repo: {{ repo.owner }}/{{ repo.name }} | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="/">Home</a>
+      </li>
+
+      <li class="breadcrumb-item active" aria-current="page">
+        {{ repo.owner }}/{{ repo.name }}
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid">
+  <div class="container">
+    <h1>Projects for the {{ repo.name }} repo</h1>
+    {% if projects %}
+    <p class="lead">
+      Each project listed below has one or more workspaces using the
+      <a href="{{ repo.url }}">{{ repo.name }}</a> repository.
+    </p>
+    {% endif %}
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block content %}
+<div class="container">
+
+  {% if projects %}
+  <div class="list-group">
+    {% for project in projects %}
+    <a href="{{ project.get_absolute_url }}" class="list-group-item list-group-item-action">
+      {{ project.name }}
+    </a>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p>
+    This code in the <a href="{{ repo.url }}">{{ repo.owner }}/{{ repo.name }}</a>
+    repository has not yet been run on the OpenSAFELY platform.
+  </p>
+
+  <p>
+    Once its code has been run on the platform you can reload this page and you
+    will get redirected to the relevant project.
+  </p>
+  {% endif %}
+
+</div>
+{% endblock %}

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -49,7 +49,7 @@ from .views.releases import (
     SnapshotDownload,
     WorkspaceReleaseList,
 )
-from .views.repos import SignOffRepo
+from .views.repos import RepoHandler, SignOffRepo
 from .views.status import DBAvailability, PerBackendStatus, Status
 from .views.users import Settings, login_view
 from .views.workspaces import (
@@ -273,6 +273,7 @@ urlpatterns = [
     path("logout/", LogoutView.as_view(), name="logout"),
     path("orgs/", OrgList.as_view(), name="org-list"),
     path("publish-repo/<repo_url>/", SignOffRepo.as_view(), name="repo-sign-off"),
+    path("repo/<repo_url>/", RepoHandler.as_view(), name="repo-handler"),
     path("settings/", Settings.as_view(), name="settings"),
     path("staff/", include("staff.urls", namespace="staff")),
     path("status/", include(status_urls)),


### PR DESCRIPTION
This adds a view to handle incoming requests of the form `/repo/<quoted GitHub repo URL>/`.

Fixes #2194 