### PR TITLE
Remove deprecations from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183
+      - uses: hadolint/hadolint-action@bc289f2eaa84c94cc5686b19f6e9d69696dcee46  # v2.1.0
 
   deploy:
     needs: [check, test, lint-dockerfile]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: "actions/setup-python@v4"
         with:
           python-version: "3.10"
@@ -76,7 +76,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: "actions/setup-python@v4"
         with:
           python-version: "3.10"
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183
 
   deploy:
@@ -118,7 +118,7 @@ jobs:
     concurrency: deploy-production
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
I'm not sure why dependabot hasn't caught the checkout upgrades yet.

This should fix the deprecations flagged in #2204, except the `set-output` one in the `tests` job because it comes from `actions/download-artifact` which hasn't fixed this yet.