### PR TITLE
Add a User's email address to their staff area page

### DIFF
--- a/staff/templates/staff/user_detail.html
+++ b/staff/templates/staff/user_detail.html
@@ -33,6 +33,15 @@
         {{ user.get_full_name }}
       </li>
       {% endif %}
+
+      <li>
+        {% if user.notifications_email %}
+        {{ user.notifications_email }}
+        {% else %}
+        {{ user.email }}
+        {% endif %}
+      </li>
+
       <li>
         <strong>Created at:</strong> {{ user.date_joined }}
       </li>


### PR DESCRIPTION
This adds an email address to the UserDetail page in the staff area.  It picks their manually set notifications address if they've set one (since their GitHub address might not be ideal), and falls back to the email we get from GitHub if not.

Fixes #2205 