### PR TITLE
Add first job run datetime to Project pages

### DIFF
--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -122,13 +122,39 @@
 
         <li class="card mb-3">
           <h2 class="card-header h5">
-            Created
+            Timeline
           </h2>
-          <p class="card-body mb-0">
-            <time datetime="{{ project.created_at|date:"Y-m-d H:i:sO" }}" title="{{ project.created_at|date:"Y-m-d H:i:sO" }}">
-              {{ project.created_at|naturaltime }}
-            </time>
-          </p>
+          <div class="card-body mb-0">
+            <div class="mb-3">
+              <strong>Created:</strong>
+              <time datetime="{{ project.created_at|date:"Y-m-d H:i:sO" }}" title="{{ project.created_at|date:"Y-m-d H:i:sO" }}">
+                {{ project.created_at|naturaltime }}
+              </time>
+            </div>
+
+            <div class="mb-0">
+              <strong>Code first run:</strong>
+
+              {% if first_job_ran_at %}
+              <time datetime="{{ first_job_ran_at|date:"Y-m-d H:i:sO" }}" title="{{ first_job_ran_at|date:"Y-m-d H:i:sO" }}">
+                {{ first_job_ran_at|naturaltime }}
+              </time>
+              {% if first_job_ran_at < project.created_at %}
+              <details class="small mt-1">
+                <summary class="font-weight-bold text-primary">Why is this job older than the project?</summary>
+                <div class="pl-3">
+                  <p class="mb-0">
+                    The concept of projects were added to this site after
+                    workspaces, so some workspaces predate their projects.
+                  </p>
+                </div>
+              </details>
+              {% endif %}
+              {% else %}
+              No code has run yet.
+              {% endif %}
+            </div>
+          </div>
         </li>
 
         <li class="card mb-3">


### PR DESCRIPTION
This switches the Created card to "Timeline" (matching the idea of the timeline in the revamped JobDetail page), adding in the date and time the first job for a project was run.

I've added a details section to explain why a Project might be younger than its first job:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/wbuQx4OW/b5ead171-c285-46fc-ac1c-167593e2a4e0.jpg?v=a7f12c41b80198f301749e401fd0f558)

And for projects without any jobs yet kept it succinct:
![](https://p198.p4.n0.cdn.getcloudapp.com/items/p9uQ2JoW/d254d411-57f1-4d0b-b63a-5614174df7eb.jpg?v=db33063d2473570b1923efbbab655427)

Fixes #2145 