### PR TITLE
Fix Honeycomb link styling

### DIFF
--- a/jobserver/templates/job_detail_tw.html
+++ b/jobserver/templates/job_detail_tw.html
@@ -164,12 +164,12 @@
 
     {% if honeycomb_links %}
       {% #card title="Monitoring" subtitle="Honeycomb login required" container %}
-        <ul class="flow-root list-disc text-sm">
-            {% for name, link in honeycomb_links.items %}
-                <li class="ml-4">
-                    <a href="{{ link }}">{{ name }}</a>
-                </li>
-            {% endfor %}
+        <ul class="flex flex-col gap-y-1.5 list-disc text-sm">
+          {% for name, link in honeycomb_links.items %}
+            <li class="ml-4">
+              {% link href=link text=name new_tab=True %}
+            </li>
+          {% endfor %}
         </ul>
       {% /card %}
     {% endif %}


### PR DESCRIPTION
Closes #2213 

## Before

<img width="653" alt="CleanShot 2022-10-20 at 14 57 27@2x" src="https://user-images.githubusercontent.com/24863179/196969136-004cff61-f985-498e-89f6-1ad1b19b3f21.png">

## After

<img width="655" alt="CleanShot 2022-10-20 at 14 57 38@2x" src="https://user-images.githubusercontent.com/24863179/196969142-e2d5a0fd-6cc7-41e2-a7eb-e70889032b07.png">