### PR TITLE
Remove our custom uses of response._csp_update

### DIFF
--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -136,14 +136,12 @@ class ReleaseDetail(View):
             "files_url": reverse("api:release", kwargs={"release_id": release.id}),
             "release": release,
         }
-        response = TemplateResponse(
+
+        return TemplateResponse(
             request,
             "release_detail.html",
             context=context,
         )
-        # we may view level 4 for un-uploaded files
-        response._csp_update = {"connect-src": release.backend.level_4_url}
-        return response
 
 
 class ReleaseDownload(View):

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -104,19 +104,12 @@ class WorkspaceBackendFiles(View):
             "review_url": review_url,
             "workspace": workspace,
         }
-        response = TemplateResponse(
+
+        return TemplateResponse(
             request,
             "workspace_backend_files.html",
             context=context,
         )
-
-        # dynamically set the the connect-src CSP directive for the current
-        # backend.  CSPMiddleware will pick this up (it's what the package's
-        # @csp_update decorator does) and merge it into the headers for this
-        # response.
-        response._csp_update = {"connect-src": backend.level_4_url}
-
-        return response
 
 
 class WorkspaceCreate(CreateView):

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -124,7 +124,6 @@ def test_workspacebackendfiles_success(rf):
     )
 
     assert response.status_code == 200
-    assert response._csp_update == {"connect-src": backend.level_4_url}
 
 
 def test_workspacebackendfiles_unknown_backend(rf):


### PR DESCRIPTION
We've moved all the views which use this method of header update to be CSP exempt so we no longer need this code.