### PR TITLE
Display contacts for workspaces as email addresses

### DIFF
--- a/staff/templates/staff/repo_detail.html
+++ b/staff/templates/staff/repo_detail.html
@@ -64,6 +64,14 @@
   <div class="row">
     <div class="col col-lg-9 col-xl-8">
 
+      <div class="card mb-3">
+        <h2 class="card-header">Contacts</h2>
+
+        <div class="card-body mb-0 d-flex justify-content-between align-items-center">
+          <code id="contacts" class="mb-0 mr-2">{{ contacts }}</code>
+        </div>
+      </div>
+
       <h2>Workspaces</h2>
 
       {% for workspace in workspaces %}

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -204,7 +204,17 @@ class RepoDetail(View):
         )
         workspaces = [build_workspace(w, users) for w in workspaces]
 
+        def build_contact(user):
+            return (
+                f"{user.fullname} <{user.notifications_email}>"
+                if user.fullname
+                else user.notifications_email
+            )
+
+        contacts = ", ".join({build_contact(w["created_by"]) for w in workspaces})
+
         context = {
+            "contacts": contacts,
             "first_job_ran_at": first_job_ran_at,
             "has_releases": "github-releases" in api_repo["topics"],
             "last_job_ran_at": last_job_ran_at,


### PR DESCRIPTION
This displays the email addresses of workspace contacts on a RepoDetail page.  It uses the format `name <email>` for users with email addresses.

Fixes #2245