### PR TITLE
Fix link to publishing repos guidance

### DIFF
--- a/jobserver/templates/sign_off_repo.html
+++ b/jobserver/templates/sign_off_repo.html
@@ -94,7 +94,10 @@
             </li>
             <li class="d-flex align-items-center mb-2">
               {% icon_check_outline class="text-success mr-2" %}
-              <span>Updated README's on each branch to match the <a href="#">OpenSAFELY guidance</a></span>
+              <span>
+                Updated READMEs on each branch to match the
+                <a href="https://docs.opensafely.org/publishing-repo/">OpenSAFELY guidance</a>
+              </span>
             </li>
             <li class="d-flex align-items-center mb-2">
               {% icon_check_outline class="text-success mr-2" %}


### PR DESCRIPTION
This doesn't change any text on the page since we still need to double check READMEs until the majority of them have been updated, so I've left the changes at just setting the docs link now that we know it.

Fixes #2238