### PR TITLE
Email workspace creators after final researcher sign off

### DIFF
--- a/jobserver/emails.py
+++ b/jobserver/emails.py
@@ -2,6 +2,8 @@ from django.conf import settings
 from furl import furl
 from incuna_mail import send
 
+from .models import User
+
 
 def send_finished_notification(email, job):
     f = furl(settings.BASE_URL)
@@ -23,5 +25,25 @@ def send_finished_notification(email, job):
         sender="notifications@jobs.opensafely.org",
         subject=f"{job.status}: [os {workspace_name}] {job.action}",
         template_name="emails/notify_finished.txt",
+        context=context,
+    )
+
+
+def send_researcher_repo_signed_off_notification(repo):
+    creators = User.objects.filter(workspaces__repo=repo)
+    emails = [
+        u.notifications_email if u.notifications_email else u.email for u in creators
+    ]
+
+    context = {
+        "repo": repo,
+    }
+
+    send(
+        to=[],
+        bcc=emails,
+        sender="notifications@jobs.opensafely.org",
+        subject=f"Repo {repo.owner}/{repo.name} was signed off by {repo.researcher_signed_off_by.name}",
+        template_name="emails/notify_repo_signed_off.txt",
         context=context,
     )

--- a/jobserver/templates/emails/notify_repo_signed_off.txt
+++ b/jobserver/templates/emails/notify_repo_signed_off.txt
@@ -1,0 +1,8 @@
+Hello workspace creator,
+
+The repository, {{ repo.owner }}/{{ repo.name }}, has been signed off by {{ repo.researcher_signed_off_by.name }}.
+It will now be reviewed by the OpenSAFELY team and if everything is in order we will mark the repo as public.
+
+If you think this has been done in error, please email publications@opensafely.org
+
+The OpenSAFELY team

--- a/jobserver/views/repos.py
+++ b/jobserver/views/repos.py
@@ -12,6 +12,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView, View
 from furl import furl
 
+from ..emails import send_researcher_repo_signed_off_notification
 from ..github import _get_github_api
 from ..models import Org, Project, ProjectMembership, Repo
 
@@ -127,6 +128,11 @@ class SignOffRepo(TemplateView):
             self.repo.researcher_signed_off_at = timezone.now()
             self.repo.researcher_signed_off_by = request.user
             self.repo.save()
+
+            # notify the workspace creators this has happened so they get a
+            # chance to contact us if there is an error
+            send_researcher_repo_signed_off_notification(self.repo)
+
             return redirect("/")
 
         # we have a name in the form which means we're looking at an action for

--- a/tests/unit/jobserver/views/test_repos.py
+++ b/tests/unit/jobserver/views/test_repos.py
@@ -219,7 +219,7 @@ def test_signoffrepo_post_all_workspaces_signed_off_and_name(rf):
     assert not repo.researcher_signed_off_at
 
 
-def test_signoffrepo_post_all_workspaces_signed_off_and_no_name(rf):
+def test_signoffrepo_post_all_workspaces_signed_off_and_no_name(rf, mailoutbox):
     user = UserFactory()
     project = ProjectFactory()
     ProjectMembershipFactory(project=project, user=user)
@@ -250,6 +250,8 @@ def test_signoffrepo_post_all_workspaces_signed_off_and_no_name(rf):
     repo.refresh_from_db()
     assert repo.researcher_signed_off_at
     assert repo.researcher_signed_off_by
+
+    assert len(mailoutbox) == 1
 
 
 def test_signoffrepo_post_no_signed_off_workspaces_and_no_name(rf):


### PR DESCRIPTION
This adds an email for workspace creators once a repo has been completely signed off, notifying them of the change in repo state.  I've used `bcc` here so as not to leak email addresses between workspace creators.

Fixes #2261 