### PR TITLE
Remind researchers that outputs hosted on GitHub will also be published

### DIFF
--- a/jobserver/templates/sign_off_repo.html
+++ b/jobserver/templates/sign_off_repo.html
@@ -210,6 +210,17 @@
               </ul>
             {% endfor %}
           {% endif %}
+
+          {% if repo.has_github_outputs %}
+          <div class="alert alert-secondary mt-5" role="alert">
+            <h2>Outputs</h2>
+            <p class="mb-4">
+              This repository has outputs released to GitHub.  By agreeing to
+              make this repository public you are also agreeing the repo has
+              appropriate data released (i.e. had disclosure controls applied).
+            </p>
+          </div>
+          {% endif %}
         </div>
       </div>
     </section>

--- a/jobserver/views/repos.py
+++ b/jobserver/views/repos.py
@@ -170,6 +170,7 @@ class SignOffRepo(TemplateView):
             is_private = None
 
         repo = {
+            "has_github_outputs": self.repo.has_github_outputs,
             "is_private": is_private,
             "name": f"{self.repo.owner}/{self.repo.name}",
             "researcher_signed_off_at": self.repo.researcher_signed_off_at,


### PR DESCRIPTION
This adds a section to the repo sign-off page for researchers explaining that outputs will be made public too.  This is only displayed for repos with outputs on GitHub.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/P8u7oQ75/82b066b4-8739-4f4b-a835-090fec037d1d.jpg?v=f7d9bce350da84544ae03aca69a8dd7c)

Fixes #2144 