### PR TITLE
Styling tweaks for Project Details

### DIFF
--- a/jobserver/templates/_components/pill.html
+++ b/jobserver/templates/_components/pill.html
@@ -8,10 +8,14 @@
     bg-red-200 text-red-900
   {% elif variant == "success" %}
     bg-green-200 text-green-900
+  {% elif variant == "info" %}
+    bg-white text-slate-600
   {% endif %}
+  {{ class }}
 ">
   {% if sr_only %}
     <span class="sr-only">{{ sr_only }}</span>
   {% endif %}
   {{ text }}
+  {{ children }}
 </span>

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -60,6 +60,11 @@
         {% elif project.status == "completed" %}
           {% pill sr_only="Status:" variant="success" text=project.get_status_display %}
         {% endif %}
+        {% if request.user.is_authenticated and project.number %}
+          {% #pill sr_only="Project number:" class="mt-2" variant="info" %}
+            #{{ project.number }}
+          {% /pill %}
+        {% endif %}
       </div>
 
       <div class="flex-grow flex flex-col gap-y-4 sm:gap-y-2">

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -119,7 +119,7 @@
           {% for workspace in workspaces %}
             <li class="relative transition-colors hover:bg-oxford-50 group">
               <dl class="flex flex-col gap-2 px-4 py-4 sm:px-6">
-                <div class="flex">
+                <div class="flex gap-x-2">
                   <dt class="sr-only">Workspace:</dt>
                   <dd class="
                     text-base font-semibold text-oxford-600 transition-colors truncate
@@ -135,9 +135,8 @@
                       {{ workspace.name }}
                     </a>
                   </dd>
-                  <div class="ml-auto">
                     <dt class="sr-only">Status:</dt>
-                    <dd class="ml-2 flex-shrink-0">
+                  <dd class="ml-auto flex-shrink-0">
                       {% if workspace.is_archived %}
                         {% pill variant="warning" text="Archived" %}
                       {% else %}

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -2,7 +2,7 @@
 
 {% load humanize %}
 
-{% block metatitle %}{{ project.title }} | OpenSAFELY Jobs{% endblock metatitle %}
+{% block metatitle %}{{ project.name }} | OpenSAFELY Jobs{% endblock metatitle %}
 
 {% block breadcrumbs %}
   {% url "home" as home_url %}
@@ -10,7 +10,7 @@
   {% #breadcrumbs %}
     {% breadcrumb title="Home" url=home_url %}
     {% breadcrumb title=project.org.name url=project.org.get_absolute_url location="Organisation" %}
-    {% breadcrumb title=project.title active=True location="Project" %}
+    {% breadcrumb title=project.name active=True location="Project" %}
   {% /breadcrumbs %}
 {% endblock breadcrumbs %}
 

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -135,29 +135,28 @@
                       {{ workspace.name }}
                     </a>
                   </dd>
-                    <dt class="sr-only">Status:</dt>
+                  <dt class="sr-only">Status:</dt>
                   <dd class="ml-auto flex-shrink-0">
-                      {% if workspace.is_archived %}
-                        {% pill variant="warning" text="Archived" %}
-                      {% else %}
-                        {% pill variant="primary" text="Active" %}
-                      {% endif %}
-                    </dd>
-                  </div>
+                    {% if workspace.is_archived %}
+                      {% pill variant="warning" text="Archived" %}
+                    {% else %}
+                      {% pill variant="primary" text="Active" %}
+                    {% endif %}
+                  </dd>
                 </div>
                 <div class="flex flex-col gap-2 text-sm text-slate-600 sm:flex-row sm:gap-x-4">
                   <dt class="sr-only">GitHub repository:</dt>
-                  <dd class="flex flex-row items-start">
+                  <dd class="flex flex-row items-start overflow-hidden max-w-[50%]">
                     {% icon_github_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
-                    {{ workspace.repo.name }}
+                    <span class="truncate">{{ workspace.repo.name }}</span>
                   </dd>
                   <dt class="sr-only">Git branch:</dt>
-                  <dd class="flex flex-row items-start">
+                  <dd class="flex flex-row items-start overflow-hidden max-w-[50%]">
                     {% icon_branches_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
-                    {{ workspace.branch }}
+                    <span class="truncate">{{ workspace.branch }}</span>
                   </dd>
                   <dt class="sr-only">Created at:</dt>
-                  <dd class="flex flex-row items-start sm:ml-auto">
+                  <dd class="flex flex-row flex-shrink-0 items-start sm:ml-auto">
                     {% icon_calendar_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
                     <time datetime="{{ workspace.created_at|date:"Y-m-d H:i:sO" }}">
                       {{ workspace.created_at|date:"d M Y" }}

--- a/jobserver/templates/project_detail.html
+++ b/jobserver/templates/project_detail.html
@@ -3,6 +3,9 @@
 {% load humanize %}
 
 {% block metatitle %}{{ project.name }} | OpenSAFELY Jobs{% endblock metatitle %}
+{% block extra_meta %}
+<meta name="description" content="{{ project.name }} is an OpenSAFELY project from {{ project.org.name }}. Every time a researcher runs their analytic code against patient data, it is audited in public here.">
+{% endblock %}
 
 {% block breadcrumbs %}
   {% url "home" as home_url %}


### PR DESCRIPTION
After checking all the projects, the following styling changes were required.

## Use project name

`project.title` contains the _"Project Number"_ which is used for internal communication. For this reason, we should only display the `project.name` in the meta title and breadcrumbs.

> ![](https://user-images.githubusercontent.com/24863179/199524104-6d7adf5c-7fbd-49b8-861e-dccb919f7fd2.png)

## Display Project Number to logged in users

As we have removed the _"Project Number"_ from the breadcrumbs and meta title, we should display this Project Number to logged in users on the Project Detail page.

> ![](https://user-images.githubusercontent.com/24863179/199531199-65d0dfeb-b10e-44bb-91f3-b2ecd020a30a.png)

## Fix `<dl>` nesting

Google Lighthouse was (correctly) complaining about the nesting of the definition list items.

> ![](https://user-images.githubusercontent.com/24863179/199524058-7a848611-b471-420d-8b8c-06877240adcd.png)

## Truncate long repo and branch names

As they were overflowing to multiple lines in the `list_group_item` component.

> ![](https://user-images.githubusercontent.com/24863179/199524343-d4d4ea91-8011-4606-ac63-68fb577ae241.png)