### PR TITLE
Only set fullname from GitHub if not already set

### DIFF
--- a/jobserver/auth_pipeline.py
+++ b/jobserver/auth_pipeline.py
@@ -7,6 +7,24 @@ def notify_on_new_user(user, is_new, *args, **kwargs):
     notify_new_user(user)
 
 
+def set_fullname(user, details, *args, **kwargs):
+    """
+    Set a User's fullname from GitHub if it's not already set
+
+    By default social_core.pipeline.user.user_details takes the values from
+    the social backend, GitHub for us, and overwrites the data in a given User
+    instance.  We want to let users update (or set) their name on our service
+    without involving GitHub and not have it overwritten each time they log in.
+
+    We've added the fullname field to the SOCIAL_AUTH_PROTECTED_USER_FIELDS
+    setting which stops social_core's user_details function from overwriting
+    our version, and this function fills it if it's not already set.
+    """
+    if not user.fullname:
+        user.fullname = details.get("fullname", "")
+        user.save()
+
+
 def set_notifications_email(user, *args, **kwargs):
     """
     Set a User's notifications_email if it's not already set

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -357,9 +357,11 @@ SOCIAL_AUTH_PIPELINE = [
     "social_core.pipeline.social_auth.associate_user",
     "social_core.pipeline.social_auth.load_extra_data",
     "social_core.pipeline.user.user_details",
+    "jobserver.auth_pipeline.set_fullname",
     "jobserver.auth_pipeline.set_notifications_email",
     "jobserver.auth_pipeline.notify_on_new_user",
 ]
+SOCIAL_AUTH_PROTECTED_USER_FIELDS = ["fullname"]
 
 # Sentry
 initialise_sentry()

--- a/tests/unit/jobserver/test_auth_pipeline.py
+++ b/tests/unit/jobserver/test_auth_pipeline.py
@@ -1,4 +1,8 @@
-from jobserver.auth_pipeline import notify_on_new_user, set_notifications_email
+from jobserver.auth_pipeline import (
+    notify_on_new_user,
+    set_fullname,
+    set_notifications_email,
+)
 
 from ...factories import UserFactory
 
@@ -20,6 +24,33 @@ def test_notify_on_new_user_with_new_user(slack_messages):
     text, channel = slack_messages[0]
     assert channel == "job-server-registrations"
     assert text == f"New user ({user.username}) registered: <{url}>"
+
+
+def test_set_fullname_already_set():
+    user = UserFactory(fullname="Testy Mctesterson")
+
+    set_fullname(user, details={"fullname": "test"})
+
+    user.refresh_from_db()
+    assert user.fullname == "Testy Mctesterson"
+
+
+def test_set_fullname_empty():
+    user = UserFactory()
+
+    set_fullname(user, details={"fullname": "test"})
+
+    user.refresh_from_db()
+    assert user.fullname == "test"
+
+
+def test_set_fullname_empty_fullname_in_details():
+    user = UserFactory()
+
+    set_fullname(user, details={"fullname": ""})
+
+    user.refresh_from_db()
+    assert user.fullname == ""
 
 
 def test_set_notifications_email_already_set():


### PR DESCRIPTION
This fixes the issue where changing/setting your name on job-server got overwritten with the data from GitHub the next time you logged into job-server.  This was particularly annoying when a user had no name set on GitHub, set one on job-server, then was prompted to set it again the next time they logged into job-server.

Ref #1962