### PR TITLE
Separate emails with semi-colons instead of commas

### DIFF
--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -211,7 +211,7 @@ class RepoDetail(View):
                 else user.notifications_email
             )
 
-        contacts = ", ".join({build_contact(w["created_by"]) for w in workspaces})
+        contacts = "; ".join({build_contact(w["created_by"]) for w in workspaces})
 
         context = {
             "contacts": contacts,


### PR DESCRIPTION
In testing with Catherine we found the comma form ended up malformed in Windows Mail.  Some googling suggests that semi-colon is the correct form.

Ref #2245 