### PR TITLE
Look up file counts for copilot dashboard in a second query

### DIFF
--- a/staff/views/dashboards/copiloting.py
+++ b/staff/views/dashboards/copiloting.py
@@ -1,3 +1,6 @@
+import itertools
+
+from csp.decorators import csp_exempt
 from django.db.models import Count, Min
 from django.db.models.functions import Least
 from django.utils.decorators import method_decorator
@@ -5,10 +8,11 @@ from django.views.generic import TemplateView
 
 from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_role
-from jobserver.models import Project
+from jobserver.models import Project, ReleaseFile
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
+@method_decorator(csp_exempt, name="dispatch")
 class Copiloting(TemplateView):
     template_name = "staff/dashboards/copiloting.html"
 
@@ -18,7 +22,6 @@ class Copiloting(TemplateView):
             .annotate(
                 workspace_count=Count("workspaces", distinct=True),
                 job_request_count=Count("workspaces__job_requests", distinct=True),
-                files_released_count=Count("workspaces__files", distinct=True),
                 date_first_run=Min(
                     Least(
                         "workspaces__job_requests__jobs__started_at",
@@ -27,7 +30,47 @@ class Copiloting(TemplateView):
                 ),
             )
             .order_by("name")
+            .iterator()
         )
+
+        release_files_by_project = itertools.groupby(
+            ReleaseFile.objects.select_related("workspace__project")
+            .order_by("workspace__project__pk")
+            .iterator(),
+            key=lambda f: f.workspace.project.pk,
+        )
+        file_counts_by_project = {
+            p: len(list(files)) for p, files in release_files_by_project
+        }
+
+        def iter_projects(projects, file_counts_by_project):
+            """
+            Build a project representation
+
+            Looking up a number of files released for a project as an annotation
+            on the main `projects` query makes Postgres very unhappy and it's
+            not obvious how to fix that from the query planner.  This function
+            combines the ReleaseFile data (which we've grouped by Project PK) and
+            the general project representation.
+
+            Note: we could handle all stats this way but at the time of writing
+            the current annotations were performant.
+            """
+            for project in projects:
+                files_released_count = file_counts_by_project.get(project.pk, 0)
+
+                yield {
+                    "copilot": project.copilot,
+                    "date_first_run": project.date_first_run,
+                    "files_released_count": files_released_count,
+                    "get_staff_url": project.get_staff_url(),
+                    "job_request_count": project.job_request_count,
+                    "name": project.name,
+                    "org": project.org,
+                    "workspace_count": project.workspace_count,
+                }
+
+        projects = list(iter_projects(projects, file_counts_by_project))
 
         return super().get_context_data(**kwargs) | {
             "projects": projects,

--- a/tests/unit/staff/views/dashboards/test_copiloting.py
+++ b/tests/unit/staff/views/dashboards/test_copiloting.py
@@ -1,18 +1,50 @@
+from datetime import datetime, timezone
+
 import pytest
 from django.core.exceptions import PermissionDenied
 
 from staff.views.dashboards.copiloting import Copiloting
 
-from .....factories import UserFactory
+from .....factories import (
+    JobFactory,
+    JobRequestFactory,
+    ProjectFactory,
+    ReleaseFileFactory,
+    UserFactory,
+    WorkspaceFactory,
+)
 
 
 def test_copiloting_success(rf, core_developer):
+    project = ProjectFactory()
+    workspace = WorkspaceFactory(project=project)
+    ReleaseFileFactory.create_batch(15, workspace=workspace)
+
+    job_request1 = JobRequestFactory(workspace=workspace)
+    JobFactory(
+        job_request=job_request1, started_at=datetime(2020, 7, 31, tzinfo=timezone.utc)
+    )
+    job_request2 = JobRequestFactory(workspace=workspace)
+    JobFactory(
+        job_request=job_request2, started_at=datetime(2021, 9, 3, tzinfo=timezone.utc)
+    )
+
     request = rf.get("/")
     request.user = core_developer
 
     response = Copiloting.as_view()(request)
 
     assert response.status_code == 200
+
+    assert len(response.context_data["projects"])
+
+    project = response.context_data["projects"][0]
+    assert project["date_first_run"] == datetime(
+        2020, 7, 31, 0, 0, 0, tzinfo=timezone.utc
+    )
+    assert project["files_released_count"] == 15
+    assert project["job_request_count"] == 2
+    assert project["workspace_count"] == 1
 
 
 def test_copiloting_unauthorized(rf):


### PR DESCRIPTION
In production this page is hitting the 30s timeout for gunicorn and the worker is being killed.

When annotating the number of files for a project the query projects query jumps from ~120ms to ~20s locally.  I can't see anything obviously wrong from the query planner and it seems to specifically be the files annotation causing this slow down.  So instead this does a separate query, grouping in memory by project and coverting to a dict of
project_pk: number_of_files, which is merged with the project data.

With this change I'm seeing page load times of ~160ms.

Refs #2256 