### PR TITLE
Merge ignored directories into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 .env
 .envrc
 .idea/
+.ipynb_checkpoints
+.pytest_cache
 .venv/
 /assets/dist
 /assets/stats.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,11 @@
 [tool.black]
-exclude = '''
+extend-exclude = '''
 (
   /(
-      \.direnv
-    | \.git
-    | \.github
-    | \.ipynb_checkpoints
-    | \.pytest_cache
-    | \.venv
-    | assets
-    | coverage
-    | htmlcov
-    | node_modules
+      assets
     | outputs
-    | releases
     | snippets
     | static
-    | staticfiles
-    | venv
-    | release-hatch
   )/
 )
 '''


### PR DESCRIPTION
By default (according to --help as of v22.8.0) black is already ignoring this list of directories:

/(\.direnv|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|venv|\.svn|_build|buck-out|build|dist|__pypackages__)/

We were using --exclude which overwrote this list.  Black supports --extend-exclude which builds upon this list and also makes use of the repos .gitignore [1].  Since we we want both git and black to ignore the files for this repo can drop all black config here.

1: https://black.readthedocs.io/en/stable/usage_and_configuration/file_collection_and_discovery.html#gitignore