### PR TITLE
Add a projects dashboard

### DIFF
--- a/assets/src/js/projects-tablesorter.js
+++ b/assets/src/js/projects-tablesorter.js
@@ -1,0 +1,25 @@
+/* global $ */
+$(() => {
+  $("table").tablesorter({
+    theme: "bootstrap",
+    widthFixed: true,
+    sortReset: true,
+    widgets: ["filter", "columns"],
+    headers: {
+      0: { sortInitialOrder: "desc" },
+    },
+    widgetOptions: {
+      columns: ["table-info"],
+      filter_reset: ".reset",
+      filter_cssFilter: [
+        "form-control",
+        "form-control",
+        "form-control",
+        "form-control",
+        "form-control",
+        "form-control",
+        "form-control",
+      ],
+    },
+  });
+});

--- a/staff/templates/staff/dashboards/index.html
+++ b/staff/templates/staff/dashboards/index.html
@@ -34,9 +34,19 @@
         <div class="card-body">
           <h5 class="card-title">Copiloting</h5>
           <p class="card-text">
-            Projects with various counts useful to copilots
+            Projects with various counts useful to copilots.
           </p>
           <a href="{% url 'staff:dashboards:copiloting' %}" class="btn btn-primary">View</a>
+        </div>
+      </div>
+
+      <div class="card mb-3">
+        <div class="card-body">
+          <h5 class="card-title">Projects</h5>
+          <p class="card-text">
+            All projects on the platform.
+          </p>
+          <a href="{% url 'staff:dashboards:projects' %}" class="btn btn-primary">View</a>
         </div>
       </div>
 

--- a/staff/templates/staff/dashboards/projects.html
+++ b/staff/templates/staff/dashboards/projects.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-{% block metatitle %}Copiloting Dashboard: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+{% block metatitle %}Projects Dashboard: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
 
 {% block breadcrumbs %}
 <nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
@@ -15,7 +15,7 @@
         <a href="{% url 'staff:dashboards:index' %}">Dashboards</a>
       </li>
       <li class="breadcrumb-item active" aria-current="page">
-        Copiloting
+        Projects
       </li>
     </ol>
   </div>
@@ -25,10 +25,10 @@
 {% block jumbotron %}
 <div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
   <div class="container">
-    <h1 class="display-4">Copiloting</h1>
+    <h1 class="display-4">Projects</h1>
     <div class="row">
       <p class="lead col-lg-9">
-        Projects with various counts useful to copilots.
+        A list of all projects on OpenSAFELY
       </p>
     </div>
   </div>
@@ -87,5 +87,5 @@
 {% block extra_js %}
 <script src="{% static 'vendor/tablesorter/jquery.tablesorter.min.js' %}"></script>
 <script src="{% static 'vendor/tablesorter/jquery.tablesorter.widgets.min.js' %}"></script>
-<script src="{% static 'js/copiloting-tablesorter.js' %}"></script>
+<script src="{% static 'js/projects-tablesorter.js' %}"></script>
 {% endblock %}

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -18,6 +18,7 @@ from .views.backends import (
 )
 from .views.dashboards.copiloting import Copiloting
 from .views.dashboards.index import DashboardIndex
+from .views.dashboards.projects import ProjectsDashboard
 from .views.index import Index
 from .views.orgs import (
     OrgCreate,
@@ -94,6 +95,7 @@ backend_urls = [
 dashboard_urls = [
     path("", DashboardIndex.as_view(), name="index"),
     path("copiloting/", Copiloting.as_view(), name="copiloting"),
+    path("project/", ProjectsDashboard.as_view(), name="projects"),
     path("repos", PrivateReposDashboard.as_view(), name="repos"),
 ]
 

--- a/staff/views/dashboards/projects.py
+++ b/staff/views/dashboards/projects.py
@@ -1,0 +1,77 @@
+import itertools
+
+from csp.decorators import csp_exempt
+from django.db.models import Count, Min
+from django.db.models.functions import Least
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
+
+from jobserver.authorization import CoreDeveloper
+from jobserver.authorization.decorators import require_role
+from jobserver.models import Project, ReleaseFile
+
+
+@method_decorator(require_role(CoreDeveloper), name="dispatch")
+@method_decorator(csp_exempt, name="dispatch")
+class ProjectsDashboard(TemplateView):
+    template_name = "staff/dashboards/projects.html"
+
+    def get_context_data(self, **kwargs):
+        projects = (
+            Project.objects.select_related("copilot", "org")
+            .annotate(
+                workspace_count=Count("workspaces", distinct=True),
+                job_request_count=Count("workspaces__job_requests", distinct=True),
+                date_first_run=Min(
+                    Least(
+                        "workspaces__job_requests__jobs__started_at",
+                        "workspaces__job_requests__jobs__created_at",
+                    )
+                ),
+            )
+            .order_by("name")
+            .iterator()
+        )
+
+        release_files_by_project = itertools.groupby(
+            ReleaseFile.objects.select_related("workspace__project")
+            .order_by("workspace__project__pk")
+            .iterator(),
+            key=lambda f: f.workspace.project.pk,
+        )
+        file_counts_by_project = {
+            p: len(list(files)) for p, files in release_files_by_project
+        }
+
+        def iter_projects(projects, file_counts_by_project):
+            """
+            Build a project representation
+
+            Looking up a number of files released for a project as an annotation
+            on the main `projects` query makes Postgres very unhappy and it's
+            not obvious how to fix that from the query planner.  This function
+            combines the ReleaseFile data (which we've grouped by Project PK) and
+            the general project representation.
+
+            Note: we could handle all stats this way but at the time of writing
+            the current annotations were performant.
+            """
+            for project in projects:
+                files_released_count = file_counts_by_project.get(project.pk, 0)
+
+                yield {
+                    "copilot": project.copilot,
+                    "date_first_run": project.date_first_run,
+                    "files_released_count": files_released_count,
+                    "get_staff_url": project.get_staff_url(),
+                    "job_request_count": project.job_request_count,
+                    "name": project.name,
+                    "org": project.org,
+                    "workspace_count": project.workspace_count,
+                }
+
+        projects = list(iter_projects(projects, file_counts_by_project))
+
+        return super().get_context_data(**kwargs) | {
+            "projects": projects,
+        }

--- a/tests/unit/staff/views/dashboards/test_projects.py
+++ b/tests/unit/staff/views/dashboards/test_projects.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timezone
+
+import pytest
+from django.core.exceptions import PermissionDenied
+
+from staff.views.dashboards.projects import ProjectsDashboard
+
+from .....factories import (
+    JobFactory,
+    JobRequestFactory,
+    ProjectFactory,
+    ReleaseFileFactory,
+    UserFactory,
+    WorkspaceFactory,
+)
+
+
+def test_projects_success(rf, core_developer):
+    project = ProjectFactory()
+    workspace = WorkspaceFactory(project=project)
+    ReleaseFileFactory.create_batch(15, workspace=workspace)
+
+    job_request1 = JobRequestFactory(workspace=workspace)
+    JobFactory(
+        job_request=job_request1, started_at=datetime(2020, 7, 31, tzinfo=timezone.utc)
+    )
+    job_request2 = JobRequestFactory(workspace=workspace)
+    JobFactory(
+        job_request=job_request2, started_at=datetime(2021, 9, 3, tzinfo=timezone.utc)
+    )
+
+    request = rf.get("/")
+    request.user = core_developer
+
+    response = ProjectsDashboard.as_view()(request)
+
+    assert response.status_code == 200
+
+    assert len(response.context_data["projects"])
+
+    project = response.context_data["projects"][0]
+    assert project["date_first_run"] == datetime(
+        2020, 7, 31, 0, 0, 0, tzinfo=timezone.utc
+    )
+    assert project["files_released_count"] == 15
+    assert project["job_request_count"] == 2
+    assert project["workspace_count"] == 1
+
+
+def test_projects_unauthorized(rf):
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    with pytest.raises(PermissionDenied):
+        ProjectsDashboard.as_view()(request)


### PR DESCRIPTION
This is ostensibly identical to the copilots dashboard but doesn't exclude the Datalab or LSHTM orgs.  We expect these dashboards to diverge over time, hence putting them on separate pages.