### PR TITLE
Link to both our repo page and GitHub on the staff's WorkspaceDetail

### DIFF
--- a/staff/templates/staff/workspace_detail.html
+++ b/staff/templates/staff/workspace_detail.html
@@ -116,9 +116,16 @@
           <h2 class="card-header h5">
             Repo
           </h2>
-          <p class="card-body mb-0">
-            <a href="{{ workspace.repo.url }}/tree/{{ workspace.branch }}">{{ workspace.repo.owner }}/{{ workspace.repo.name }}</a>
-          </p>
+          <div class="card-body">
+            <p>
+              <a href="{{ workspace.repo.get_staff_url }}">{{ workspace.repo.owner }}/{{ workspace.repo.name }}</a>
+            </p>
+            <p class="mb-0">
+            <a class="btn btn-sm btn-primary" href="{{ workspace.repo.url }}/tree/{{ workspace.branch }}">
+              View branch on GitHub
+            </a>
+            </p>
+          </div>
         </li>
         <li class="card mb-3">
           <h2 class="card-header h5">


### PR DESCRIPTION
The repo link on the WorkspaceDetail page of the staff area linked to the branch of a workspace on GitHub.  This changes that to our internal RepoDetail page but keeps the GitHub link as a button so it's clear where on GitHub it's going to.