### PR TITLE
Sign off projects section

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -611,6 +611,9 @@ class Repo(models.Model):
     def __str__(self):
         return self.url
 
+    def get_handler_url(self):
+        return reverse("repo-handler", kwargs={"repo_url": self.quoted_url})
+
     def get_sign_off_url(self):
         return reverse("repo-sign-off", kwargs={"repo_url": self.quoted_url})
 

--- a/jobserver/templates/sign_off_repo.html
+++ b/jobserver/templates/sign_off_repo.html
@@ -101,6 +101,10 @@
             </li>
             <li class="d-flex align-items-center mb-2">
               {% icon_check_outline class="text-success mr-2" %}
+              <span>Added or updated the purpose</span>
+            </li>
+            <li class="d-flex align-items-center mb-2">
+              {% icon_check_outline class="text-success mr-2" %}
               <span>Permission to make the workspace public</span>
             </li>
           </ul>

--- a/jobserver/templates/sign_off_repo.html
+++ b/jobserver/templates/sign_off_repo.html
@@ -214,6 +214,25 @@
       </div>
     </section>
 
+    <section class="border-top pt-4 mt-4">
+      <div class="row">
+        <div class="col-lg-8">
+          <h2>Project</h2>
+          <p>
+            By signing off the repository below you are confirming you have
+            updated the status of the project. You can read how to do this on
+            <a href="https://docs.opensafely.org/jobs-site/#updating-project-status">
+              the OpenSAFELY documentation site
+            </a>.
+          </p>
+
+          <p>
+            <a class="btn btn-outline-success" href="{{ project_url }}">View project</a>
+          </p>
+        </div>
+      </div>
+    </section>
+
     {% if workspaces_signed_off %}
 
     <section class="border-top pt-4 mt-4">

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -149,4 +149,4 @@ class ProjectEdit(UpdateView):
         return project
 
     def get_success_url(self):
-        return self.object.get_absolute_url()
+        return self.request.GET.get("next") or self.object.get_absolute_url()

--- a/jobserver/views/repos.py
+++ b/jobserver/views/repos.py
@@ -184,10 +184,21 @@ class SignOffRepo(TemplateView):
 
         workspaces_signed_off = not self.workspaces.filter(signed_off_at=None).exists()
 
+        # TODO: when we have dealt with all the cross-project repos and are
+        # enforcing repos can't be used acrosss projects this check can be
+        # skipped.
+        projects = Project.objects.filter(workspaces__repo=self.repo).distinct()
+        if projects.count() == 1:
+            sign_off_url = self.repo.get_sign_off_url()
+            project_url = projects.first().get_edit_url() + f"?next={sign_off_url}"
+        else:
+            project_url = self.repo.get_handler_url()
+
         context = super().get_context_data() | {
             "workspaces_signed_off": workspaces_signed_off,
             "branches": branches,
             "repo": repo,
+            "project_url": project_url,
             "workspaces": workspaces,
         }
 

--- a/tests/unit/jobserver/models/test_core.py
+++ b/tests/unit/jobserver/models/test_core.py
@@ -637,6 +637,14 @@ def test_projectmembership_str():
     assert str(membership) == "ben | DataLab"
 
 
+def test_repo_get_handler_url():
+    repo = RepoFactory()
+
+    url = repo.get_handler_url()
+
+    assert url == reverse("repo-handler", kwargs={"repo_url": repo.quoted_url})
+
+
 def test_repo_get_sign_off_url():
     repo = RepoFactory()
 

--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -220,6 +220,31 @@ def test_projectedit_post_success(rf):
     assert project.status_description == "test"
 
 
+def test_projectedit_post_success_with_next(rf):
+    project = ProjectFactory(status=Project.Statuses.POSTPONED)
+
+    user = UserFactory()
+    ProjectMembershipFactory(project=project, user=user)
+
+    data = {
+        "status": Project.Statuses.ONGOING,
+        "status_description": "test",
+    }
+    request = rf.post("/?next=foo", data=data)
+    request.user = user
+
+    response = ProjectEdit.as_view()(
+        request, org_slug=project.org.slug, project_slug=project.slug
+    )
+
+    assert response.status_code == 302
+    assert response.url == "foo"
+
+    project.refresh_from_db()
+    assert project.status == Project.Statuses.ONGOING
+    assert project.status_description == "test"
+
+
 def test_projectedit_unknown_org(rf):
     project = ProjectFactory()
 

--- a/tests/unit/jobserver/views/test_repos.py
+++ b/tests/unit/jobserver/views/test_repos.py
@@ -101,7 +101,7 @@ def test_signoffrepo_get_success(rf):
     request.user = user
 
     response = SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(
-        request, repo_url=quote(repo.url)
+        request, repo_url=repo.quoted_url
     )
 
     assert response.status_code == 200
@@ -139,7 +139,7 @@ def test_signoffrepo_get_success_with_broken_github(rf):
             raise requests.HTTPError()
 
     response = SignOffRepo.as_view(get_github_api=BrokenGitHubAPI)(
-        request, repo_url=quote(repo.url)
+        request, repo_url=repo.quoted_url
     )
 
     assert response.status_code == 200
@@ -165,7 +165,9 @@ def test_signoffrepo_member_with_no_workspaces(rf):
     request.user = user
 
     with pytest.raises(Http404):
-        SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(request, repo_url=repo.url)
+        SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(
+            request, repo_url=repo.quoted_url
+        )
 
 
 def test_signoffrepo_sign_offs_disabled(rf):
@@ -175,7 +177,9 @@ def test_signoffrepo_sign_offs_disabled(rf):
     request.user = UserFactory()
 
     with pytest.raises(Http404):
-        SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(request, repo_url=repo.url)
+        SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(
+            request, repo_url=repo.quoted_url
+        )
 
 
 def test_signoffrepo_not_a_project_member(rf):
@@ -185,7 +189,9 @@ def test_signoffrepo_not_a_project_member(rf):
     request.user = UserFactory()
 
     with pytest.raises(Http404):
-        SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(request, repo_url=repo.url)
+        SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(
+            request, repo_url=repo.quoted_url
+        )
 
 
 def test_signoffrepo_post_all_workspaces_signed_off_and_name(rf):
@@ -210,7 +216,7 @@ def test_signoffrepo_post_all_workspaces_signed_off_and_name(rf):
     request.user = user
 
     response = SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(
-        request, repo_url=repo.url
+        request, repo_url=repo.quoted_url
     )
 
     assert response.status_code == 200
@@ -244,7 +250,7 @@ def test_signoffrepo_post_all_workspaces_signed_off_and_no_name_with_github_outp
     request.user = user
 
     response = SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(
-        request, repo_url=repo.url
+        request, repo_url=repo.quoted_url
     )
 
     assert response.status_code == 302
@@ -283,7 +289,7 @@ def test_signoffrepo_post_all_workspaces_signed_off_and_no_name_without_github_o
     request.user = user
 
     response = SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(
-        request, repo_url=repo.url
+        request, repo_url=repo.quoted_url
     )
 
     assert response.status_code == 302
@@ -315,7 +321,7 @@ def test_signoffrepo_post_no_signed_off_workspaces_and_no_name(rf):
     request._messages = messages
 
     response = SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(
-        request, repo_url=repo.url
+        request, repo_url=repo.quoted_url
     )
     assert response.status_code == 200
 
@@ -339,7 +345,7 @@ def test_signoffrepo_post_partially_signed_off_workspaces_and_name(rf):
     request.user = user
 
     response = SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(
-        request, repo_url=repo.url
+        request, repo_url=repo.quoted_url
     )
 
     assert response.status_code == 302
@@ -369,7 +375,7 @@ def test_signoffrepo_post_partially_signed_off_workspaces_and_no_name(rf):
     request._messages = messages
 
     response = SignOffRepo.as_view(get_github_api=FakeGitHubAPI)(
-        request, repo_url=repo.url
+        request, repo_url=repo.quoted_url
     )
 
     assert response.status_code == 200


### PR DESCRIPTION
This adds a line to the workspaces checklist for updating the purpose (which nearly everyone will have to do for a while), and links out to the repo's project at the bottom, explaining that they need to update its status.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/P8u7BnOX/4a527e9d-50a0-45f2-b4a6-51361db3b742.jpg?v=d93751ee0d3a44e21dccb97bcaf19d8c)

I'm conditionally linking to the RepoHandler view for repos with >1 project, but as the comment says, this can go away when (if?) we tidy up that data.  For the happy path of 1 Project :: 1 Repo I've redirected to the Project's edit page using `?next=` so it'll redirect back on submit.

Fixes #2288 