### PR TITLE
set to address for send_repo_signed_off_notification_to_researchers

### DIFF
--- a/jobserver/emails.py
+++ b/jobserver/emails.py
@@ -36,7 +36,7 @@ def send_repo_signed_off_notification_to_researchers(repo):
     ]
 
     send(
-        to=[],
+        to="notifications@jobs.opensafely.org",
         bcc=emails,
         sender="notifications@jobs.opensafely.org",
         subject=f"Repo {repo.owner}/{repo.name} was signed off by {repo.researcher_signed_off_by.name}",

--- a/tests/unit/jobserver/test_emails.py
+++ b/tests/unit/jobserver/test_emails.py
@@ -66,5 +66,5 @@ def test_send_repo_signed_off_notification_to_researchers(mailoutbox):
 
     m = mailoutbox[0]
 
-    assert list(m.to) == []
+    assert list(m.to) == ["notifications@jobs.opensafely.org"]
     assert list(m.bcc) == [user1.email, user2.email, user3.email]


### PR DESCRIPTION
Mailgun doesn't allow emails to be sent without a to address.  However we don't want to expose email addresses to recipients so we're using the notifications address here for lack of a better option.

Fixes: #2291