### PR TITLE
Restrict new workspaces to using repos in the same project

### DIFF
--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -209,6 +209,7 @@ class WorkspaceCreate(CreateView):
         del kwargs["instance"]
 
         return kwargs | {
+            "project": self.project,
             "repos_with_branches": self.repos_with_branches,
         }
 

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -8,27 +8,6 @@ from jobserver.models import Backend
 from ...factories import BackendFactory, ProjectFactory, RepoFactory, WorkspaceFactory
 
 
-def test_jobrequestcreateform_with_duplicate_name():
-    project = ProjectFactory()
-    WorkspaceFactory(name="test")
-
-    data = {
-        "name": "test",
-        "repo": "test",
-        "branch": "test",
-        "purpose": "test",
-    }
-    repos_with_branches = [{"name": "test", "url": "test", "branches": ["test"]}]
-    form = WorkspaceCreateForm(project, repos_with_branches, data)
-    form.is_valid()
-
-    assert form.errors == {
-        "name": [
-            'A workspace with the name "test" already exists, please choose a unique one.'
-        ]
-    }
-
-
 def test_jobrequestcreateform_with_single_backend():
     backend = BackendFactory()
     choices = backends_to_choices([backend])
@@ -137,6 +116,27 @@ def test_workspacecreateform_unknown_repo():
         form.clean()
 
     assert e.value.message.startswith("Unknown repo")
+
+
+def test_workspacecreateform_with_duplicate_name():
+    project = ProjectFactory()
+    WorkspaceFactory(name="test")
+
+    data = {
+        "name": "test",
+        "repo": "test",
+        "branch": "test",
+        "purpose": "test",
+    }
+    repos_with_branches = [{"name": "test", "url": "test", "branches": ["test"]}]
+    form = WorkspaceCreateForm(project, repos_with_branches, data)
+    form.is_valid()
+
+    assert form.errors == {
+        "name": [
+            'A workspace with the name "test" already exists, please choose a unique one.'
+        ]
+    }
 
 
 def test_workspacecreateform_repo_used_in_another_project():

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -5,10 +5,11 @@ from jobserver.backends import backends_to_choices
 from jobserver.forms import JobRequestCreateForm, WorkspaceCreateForm
 from jobserver.models import Backend
 
-from ...factories import BackendFactory, WorkspaceFactory
+from ...factories import BackendFactory, ProjectFactory, RepoFactory, WorkspaceFactory
 
 
 def test_jobrequestcreateform_with_duplicate_name():
+    project = ProjectFactory()
     WorkspaceFactory(name="test")
 
     data = {
@@ -18,7 +19,7 @@ def test_jobrequestcreateform_with_duplicate_name():
         "purpose": "test",
     }
     repos_with_branches = [{"name": "test", "url": "test", "branches": ["test"]}]
-    form = WorkspaceCreateForm(repos_with_branches, data)
+    form = WorkspaceCreateForm(project, repos_with_branches, data)
     form.is_valid()
 
     assert form.errors == {
@@ -50,6 +51,7 @@ def test_jobrequestcreateform_with_multiple_backends():
 
 
 def test_workspacecreateform_success():
+    project = ProjectFactory()
     data = {
         "name": "test",
         "db": "slice",
@@ -64,12 +66,13 @@ def test_workspacecreateform_success():
             "branches": ["test-branch"],
         }
     ]
-    form = WorkspaceCreateForm(repos_with_branches, data)
+    form = WorkspaceCreateForm(project, repos_with_branches, data)
 
     assert form.is_valid()
 
 
 def test_workspacecreateform_success_with_upper_case_names():
+    project = ProjectFactory()
     data = {
         "name": "TeSt",
         "db": "full",
@@ -84,13 +87,14 @@ def test_workspacecreateform_success_with_upper_case_names():
             "branches": ["test-branch"],
         }
     ]
-    form = WorkspaceCreateForm(repos_with_branches, data)
+    form = WorkspaceCreateForm(project, repos_with_branches, data)
 
     assert form.is_valid()
     assert form.cleaned_data["name"] == "test", form.cleaned_data["name"]
 
 
 def test_workspacecreateform_unknown_branch():
+    project = ProjectFactory()
     repos_with_branches = [
         {
             "name": "test-repo",
@@ -98,7 +102,7 @@ def test_workspacecreateform_unknown_branch():
             "branches": ["test-branch"],
         }
     ]
-    form = WorkspaceCreateForm(repos_with_branches)
+    form = WorkspaceCreateForm(project, repos_with_branches)
     form.cleaned_data = {
         "name": "test",
         "db": "slice",
@@ -113,6 +117,7 @@ def test_workspacecreateform_unknown_branch():
 
 
 def test_workspacecreateform_unknown_repo():
+    project = ProjectFactory()
     repos_with_branches = [
         {
             "name": "test-repo",
@@ -120,7 +125,7 @@ def test_workspacecreateform_unknown_repo():
             "branches": ["test-branch"],
         }
     ]
-    form = WorkspaceCreateForm(repos_with_branches)
+    form = WorkspaceCreateForm(project, repos_with_branches)
     form.cleaned_data = {
         "name": "test",
         "db": "full",
@@ -132,3 +137,91 @@ def test_workspacecreateform_unknown_repo():
         form.clean()
 
     assert e.value.message.startswith("Unknown repo")
+
+
+def test_workspacecreateform_repo_used_in_another_project():
+    project1 = ProjectFactory()
+    project2 = ProjectFactory()
+    repo = RepoFactory(url="test")
+    WorkspaceFactory(project=project1, repo=repo)
+
+    repos_with_branches = [
+        {
+            "name": "test",
+            "url": "test",
+            "branches": ["test-branch"],
+        }
+    ]
+    data = {
+        "name": "test",
+        "repo": "test",
+        "branch": "test-branch",
+        "purpose": "test",
+    }
+    form = WorkspaceCreateForm(project2, repos_with_branches, data)
+    form.is_valid()
+
+    assert form.errors == {
+        "repo": [
+            "This repo has already been used in another project, please pick a different one"
+        ]
+    }
+
+
+def test_workspacecreateform_repo_used_with_no_projects():
+    project = ProjectFactory()
+    repos_with_branches = [
+        {
+            "name": "test",
+            "url": "test",
+            "branches": ["test-branch"],
+        }
+    ]
+
+    form = WorkspaceCreateForm(project, repos_with_branches, {"repo": "test"})
+    form.cleaned_data = {"repo": "test"}
+
+    assert form.clean_repo()
+
+
+def test_workspacecreateform_repo_used_with_only_this_project():
+    project = ProjectFactory()
+    repo = RepoFactory(url="test")
+    WorkspaceFactory(project=project, repo=repo)
+    repos_with_branches = [
+        {
+            "name": "test",
+            "url": "test",
+            "branches": ["test-branch"],
+        }
+    ]
+
+    form = WorkspaceCreateForm(project, repos_with_branches, {"repo": "test"})
+    form.cleaned_data = {"repo": "test"}
+
+    assert form.clean_repo()
+
+
+def test_workspacecreateform_repo_used_with_this_and_other_projects():
+    repo = RepoFactory(url="test")
+
+    # an existing, different project
+    project1 = ProjectFactory()
+    WorkspaceFactory(project=project1, repo=repo)
+
+    # the project we're working on
+    project2 = ProjectFactory()
+    WorkspaceFactory(project=project2, repo=repo)
+
+    repos_with_branches = [
+        {
+            "name": "test",
+            "url": "test",
+            "branches": ["test-branch"],
+        }
+    ]
+
+    form = WorkspaceCreateForm(project2, repos_with_branches, {"repo": "test"})
+    form.cleaned_data = {"repo": "test"}
+
+    assert form.clean_repo()


### PR DESCRIPTION
This enforces that a repo picked in the WorkspaceCreate page isn't being used by a workspace in another project.  The caveat here is if the current project is in the list of related projects and others are too then it's still ok to use the repo.

Fixes: #2271