### PR TITLE
Use project name in breadcrumbs and workspace order

### DIFF
--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -16,7 +16,7 @@
     {% url 'home' as home_url %}
     {% breadcrumb title="Home" url=home_url %}
     {% breadcrumb location="Organisation" title=job.job_request.workspace.project.org.name url=job.job_request.workspace.project.org.get_absolute_url %}
-    {% breadcrumb location="Project" title=job.job_request.workspace.project.title url=job.job_request.workspace.project.get_absolute_url %}
+    {% breadcrumb location="Project" title=job.job_request.workspace.project.name url=job.job_request.workspace.project.get_absolute_url %}
     {% breadcrumb location="Workspace" title=job.job_request.workspace.name url=job.job_request.workspace.get_absolute_url %}
     {% breadcrumb location="Job request" title=job.job_request.id url=job.job_request.get_absolute_url %}
     {% breadcrumb location="Action" title=job.action active=True %}

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -21,7 +21,7 @@
     {% url 'home' as home_url %}
     {% breadcrumb title="Home" url=home_url %}
     {% breadcrumb location="Organisation" title=job_request.workspace.project.org.name url=job_request.workspace.project.org.get_absolute_url %}
-    {% breadcrumb location="Project" title=job_request.workspace.project.title url=job_request.workspace.project.get_absolute_url %}
+    {% breadcrumb location="Project" title=job_request.workspace.project.name url=job_request.workspace.project.get_absolute_url %}
     {% breadcrumb location="Workspace" title=job_request.workspace.name url=job_request.workspace.get_absolute_url %}
     {% breadcrumb location="Job request" title=job_request.id active=True %}
   {% /breadcrumbs %}

--- a/jobserver/templates/org_detail.html
+++ b/jobserver/templates/org_detail.html
@@ -50,7 +50,7 @@
               <div class="px-4 py-4 sm:px-6">
                 <div class="flex items-center justify-between">
                   <p class="truncate text-base font-semibold text-oxford-600">
-                    {{ project.title }}
+                    {{ project.name }}
                   </p>
                   <div class="ml-2 flex flex-shrink-0">
                     {% if project.status == "retired" %}

--- a/jobserver/views/orgs.py
+++ b/jobserver/views/orgs.py
@@ -33,7 +33,7 @@ class OrgDetail(DetailView):
             .annotate(
                 workspace_count=Count("workspaces", distinct=True),
             )
-            .order_by("number", Lower("name"))
+            .order_by(Lower("name"))
         )
 
         return TemplateResponse(


### PR DESCRIPTION
So that we are consistently using the Project name without the project number included. The project number is listed on the Project detail page, underneath the projects status.