### PR TITLE
WorkspaceCreate fixes

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -54,7 +54,7 @@ class WorkspaceArchiveToggleForm(forms.Form):
 
 
 class WorkspaceCreateForm(forms.Form):
-    name = forms.CharField(
+    name = forms.SlugField(
         help_text="Enter a descriptive name which makes this workspace easy to identify.  It will also be the name of the directory in which you will find results after jobs from this workspace are run."
     )
     purpose = forms.CharField(help_text="Describe the purpose of this workspace.")

--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from first import first
 
 from .authorization.forms import RolesForm
-from .models import JobRequest
+from .models import JobRequest, Workspace
 
 
 class JobRequestCreateForm(forms.ModelForm):
@@ -104,9 +104,14 @@ class WorkspaceCreateForm(forms.Form):
             raise forms.ValidationError(f'Unknown branch "{branch}"')
 
     def clean_name(self):
-        name = self.cleaned_data["name"]
+        name = self.cleaned_data["name"].lower()
 
-        return name.lower()
+        if Workspace.objects.filter(name=name).exists():
+            raise forms.ValidationError(
+                f'A workspace with the name "{name}" already exists, please choose a unique one.'
+            )
+
+        return name
 
 
 class WorkspaceEditForm(forms.Form):

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -5,7 +5,27 @@ from jobserver.backends import backends_to_choices
 from jobserver.forms import JobRequestCreateForm, WorkspaceCreateForm
 from jobserver.models import Backend
 
-from ...factories import BackendFactory
+from ...factories import BackendFactory, WorkspaceFactory
+
+
+def test_jobrequestcreateform_with_duplicate_name():
+    WorkspaceFactory(name="test")
+
+    data = {
+        "name": "test",
+        "repo": "test",
+        "branch": "test",
+        "purpose": "test",
+    }
+    repos_with_branches = [{"name": "test", "url": "test", "branches": ["test"]}]
+    form = WorkspaceCreateForm(repos_with_branches, data)
+    form.is_valid()
+
+    assert form.errors == {
+        "name": [
+            'A workspace with the name "test" already exists, please choose a unique one.'
+        ]
+    }
 
 
 def test_jobrequestcreateform_with_single_backend():


### PR DESCRIPTION
We weren't enforcing workspace names were slugs since the `validators` kwarg on a ModelField only applies to ModelForms, not any data serialised to a field, and WorkspaceCreateForm isn't a model form since so much of the form is created dynamically from data pulled from GitHub.

I've checked in production (by running `Workspace.objects.exclude(name__regex="^[-a-zA-Z0-9_]+\Z")`, that's the regex for `validate_slug`) that the only workspace with an incorrect name is the one mentioned in #2327.

Since this was partially related (the same user found it at least!), I've also fixed that we weren't handling the uniqueness of workspace names in the form.

Refs: #2327
Fixes: #2322