### PR TITLE
Add a UI component gallery page

### DIFF
--- a/assets/src/scripts/components.js
+++ b/assets/src/scripts/components.js
@@ -11,8 +11,7 @@ const anchors = new AnchorJS();
 document.addEventListener("DOMContentLoaded", () => {
   anchors.add('.prose :where(h2):not(:where([class~="not-prose"] *))');
 
-  const ul = document.createElement("ul");
-  document.getElementById("table-of-contents").appendChild(ul);
+  const ul = document.getElementById("table-of-contents");
 
   anchors.elements.forEach((heading) =>
     ul.insertAdjacentHTML(

--- a/assets/src/scripts/components.js
+++ b/assets/src/scripts/components.js
@@ -41,11 +41,4 @@ document.addEventListener("DOMContentLoaded", () => {
       </li>`
     );
   });
-
-  document.querySelectorAll("section").forEach((section) => {
-    section.insertAdjacentHTML(
-      "beforeend",
-      `<a class="inline-flex mt-6" href="#table-of-contents">Back to menu</a>`
-    );
-  });
 });

--- a/assets/src/scripts/components.js
+++ b/assets/src/scripts/components.js
@@ -7,38 +7,21 @@ hljs.registerLanguage("django", django);
 hljs.highlightAll();
 
 const anchors = new AnchorJS();
-anchors.add(".prose h2:not([data-anchor=ignore]");
 
-function addNavItem(ul, href, text) {
-  const listItem = document.createElement("li");
-  const anchorItem = document.createElement("a");
-  const textNode = document.createTextNode(text);
+document.addEventListener("DOMContentLoaded", () => {
+  anchors.add('.prose :where(h2):not(:where([class~="not-prose"] *))');
 
-  anchorItem.href = href;
-  ul.appendChild(listItem);
-  listItem.appendChild(anchorItem);
-  anchorItem.appendChild(textNode);
-}
-
-function generateTableOfContents(els) {
-  let anchoredElText;
-  let anchoredElHref;
   const ul = document.createElement("ul");
-
   document.getElementById("table-of-contents").appendChild(ul);
 
-  els.map((_, i) => {
-    anchoredElText = els[i].textContent;
-    anchoredElHref = els[i]
-      .querySelector(".anchorjs-link")
-      .getAttribute("href");
-    return addNavItem(
-      ul,
-      anchoredElHref,
-      anchoredElText,
-      "toc-li-".concat(els[i].tagName)
-    );
-  });
-}
-
-generateTableOfContents(anchors.elements);
+  anchors.elements.forEach((heading) =>
+    ul.insertAdjacentHTML(
+      "beforeend",
+      `<li>
+        <a href="#${heading.id}">
+          ${heading.textContent}
+        </a>
+      </li>`
+    )
+  );
+});

--- a/assets/src/scripts/components.js
+++ b/assets/src/scripts/components.js
@@ -1,19 +1,25 @@
-import AnchorJS from "anchor-js";
 import hljs from "highlight.js/lib/core";
 import django from "highlight.js/lib/languages/django";
+import slugify from "slugify";
 import "highlight.js/styles/github-dark.css";
 
 hljs.registerLanguage("django", django);
 hljs.highlightAll();
 
-const anchors = new AnchorJS();
-
 document.addEventListener("DOMContentLoaded", () => {
-  anchors.add('.prose :where(h2, h3):not(:where([class~="not-prose"] *))');
+  const anchors = document.querySelectorAll(
+    '.prose :where(h2, h3):not(:where([class~="not-prose"] *))'
+  );
 
   const ul = document.getElementById("table-of-contents");
 
-  anchors.elements.forEach((heading) => {
+  anchors.forEach((heading) => {
+    // eslint-disable-next-line no-param-reassign
+    heading.id = `${slugify(heading.textContent, {
+      lower: true,
+      strict: true,
+    })}`;
+
     if (heading.tagName === "H3") {
       return ul.querySelector("li:last-of-type ul").insertAdjacentHTML(
         "beforeend",
@@ -33,6 +39,13 @@ document.addEventListener("DOMContentLoaded", () => {
         </a>
         ${heading.parentElement.querySelector("h3") ? `<ul></ul>` : ""}
       </li>`
+    );
+  });
+
+  document.querySelectorAll("section").forEach((section) => {
+    section.insertAdjacentHTML(
+      "beforeend",
+      `<a class="inline-flex mt-6" href="#table-of-contents">Back to menu</a>`
     );
   });
 });

--- a/assets/src/scripts/components.js
+++ b/assets/src/scripts/components.js
@@ -9,18 +9,30 @@ hljs.highlightAll();
 const anchors = new AnchorJS();
 
 document.addEventListener("DOMContentLoaded", () => {
-  anchors.add('.prose :where(h2):not(:where([class~="not-prose"] *))');
+  anchors.add('.prose :where(h2, h3):not(:where([class~="not-prose"] *))');
 
   const ul = document.getElementById("table-of-contents");
 
-  anchors.elements.forEach((heading) =>
-    ul.insertAdjacentHTML(
+  anchors.elements.forEach((heading) => {
+    if (heading.tagName === "H3") {
+      return ul.querySelector("li:last-of-type ul").insertAdjacentHTML(
+        "beforeend",
+        `<li>
+          <a href="#${heading.id}">
+            ${heading.textContent}
+          </a>
+        </li>`
+      );
+    }
+
+    return ul.insertAdjacentHTML(
       "beforeend",
       `<li>
         <a href="#${heading.id}">
           ${heading.textContent}
         </a>
+        ${heading.parentElement.querySelector("h3") ? `<ul></ul>` : ""}
       </li>`
-    )
-  );
+    );
+  });
 });

--- a/assets/src/scripts/components.js
+++ b/assets/src/scripts/components.js
@@ -1,0 +1,44 @@
+import AnchorJS from "anchor-js";
+import hljs from "highlight.js/lib/core";
+import django from "highlight.js/lib/languages/django";
+import "highlight.js/styles/github-dark.css";
+
+hljs.registerLanguage("django", django);
+hljs.highlightAll();
+
+const anchors = new AnchorJS();
+anchors.add(".prose h2:not([data-anchor=ignore]");
+
+function addNavItem(ul, href, text) {
+  const listItem = document.createElement("li");
+  const anchorItem = document.createElement("a");
+  const textNode = document.createTextNode(text);
+
+  anchorItem.href = href;
+  ul.appendChild(listItem);
+  listItem.appendChild(anchorItem);
+  anchorItem.appendChild(textNode);
+}
+
+function generateTableOfContents(els) {
+  let anchoredElText;
+  let anchoredElHref;
+  const ul = document.createElement("ul");
+
+  document.getElementById("table-of-contents").appendChild(ul);
+
+  els.map((_, i) => {
+    anchoredElText = els[i].textContent;
+    anchoredElHref = els[i]
+      .querySelector(".anchorjs-link")
+      .getAttribute("href");
+    return addNavItem(
+      ul,
+      anchoredElHref,
+      anchoredElText,
+      "toc-li-".concat(els[i].tagName)
+    );
+  });
+}
+
+generateTableOfContents(anchors.elements);

--- a/assets/src/scripts/highlight.js
+++ b/assets/src/scripts/highlight.js
@@ -1,6 +1,0 @@
-import hljs from "highlight.js/lib/core";
-import django from "highlight.js/lib/languages/django";
-import "highlight.js/styles/github-dark.css";
-
-hljs.registerLanguage("django", django);
-hljs.highlightAll();

--- a/assets/src/scripts/highlight.js
+++ b/assets/src/scripts/highlight.js
@@ -1,0 +1,6 @@
+import hljs from "highlight.js/lib/core";
+import django from "highlight.js/lib/languages/django";
+import "highlight.js/styles/github-dark.css";
+
+hljs.registerLanguage("django", django);
+hljs.highlightAll();

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -7,9 +7,21 @@
     <h1>UI Components</h1>
     <p>A gallery for the available components for building OpenSAFELY Jobs pages.</p>
 
-    <div id="table-of-contents">
-      <h2 data-anchor="ignore">Components:</h2>
-    </div>
+    <details
+      class="
+        group bg-oxford-50 border border-l-4 border-oxford-700/95 overflow-hidden rounded
+        open:bg-white
+      "
+      id="table-of-contents"
+    >
+      <summary class="cursor-pointer list-none p-4 py-2 transition-colors hover:bg-oxford-100 hover:text-oxford-900">
+        <span class="text-lg font-semibold text-oxford">
+          <span class="group-open:hidden inline-flex">Show</span>
+          <span class="group-open:inline-flex hidden">Hide</span>
+          components list
+        </span>
+      </summary>
+    </details>
     <hr>
 
     <section>

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -86,6 +86,54 @@
     <hr>
 
     <section>
+      <h2>Card</h2>
+      <h3>Card</h3>
+      <ul>
+        <li><code>aria_labelled_by</code></li>
+        <li><code>children</code></li>
+        <li><code>class</code></li>
+        <li><code>container_class</code></li>
+        <li><code>container</code></li>
+        <li><code>subtitle</code></li>
+        <li><code>title</code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <pre><code class="language-django">{% verbatim %}{% #card class="bg-red-50" title="Hola mundo" subtitle="Hallo welt" %}{% endverbatim %}
+  {% filter force_escape %}<span class="text-bn-ribbon-600">Hello world</span>{% endfilter %}
+{% verbatim %}{% /card %}{% endverbatim %}</code></pre>
+      </div>
+      <h3>Card footer</h3>
+      <ul>
+        <li><code>children</code></li>
+        <li><code>no_container</code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <pre><code class="language-django">{% verbatim %}{% #card_footer no_container=False %}{% endverbatim %}
+  {% filter force_escape %}<span class="text-bn-egg-500">Hello world</span>{% endfilter %}
+{% verbatim %}{% /card %}{% endverbatim %}</code></pre>
+      </div>
+      <h3>Example</h3>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {% #card class="bg-red-50" title="Hola mundo" subtitle="Hallo welt" container=True class="w-full max-w-lg mx-auto" %}
+            <p class="text-oxford-700 text-lg font-semibold">Hello world</p>
+            {% #card_footer %}
+              <p class="text-sm text-slate-600">Bonjour le monde</p>
+            {% /card_footer %}
+          {% /card %}
+        </div>
+        <pre><code class="language-django">{% verbatim %}{% #card class="bg-red-50" title="Hola mundo" subtitle="Hallo welt" container=True class="w-full max-w-lg mx-auto" %}{% endverbatim %}
+  {% filter force_escape %}<p class="text-oxford-700 text-lg font-semibold">Hello world</p>{% endfilter %}
+  {% verbatim %}{% #card_footer %}{% endverbatim %}
+    {% filter force_escape %}<p class="text-sm text-slate-600">Bonjour le monde</p>{% endfilter %}
+  {% verbatim %}{% /card_footer %}{% endverbatim %}
+{% verbatim %}{% /card %}{% endverbatim %}</code></pre>
+      </div>
+    </section>
+
+    <hr>
+
+    <section>
       <h2>Pill</h2>
 
       <h3>Properties</h3>
@@ -97,7 +145,7 @@
       </ul>
 
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
-        <div class="flex flex-row gap-x-8 items-center mx-auto">
+        <div class="flex flex-row gap-x-8 items-center">
           {% pill variant="danger" text="Danger" %}
           {% pill variant="info" text="Info" %}
           {% pill variant="primary" text="Primary" %}
@@ -112,6 +160,20 @@
 {% pill variant="warning" text="Warning" %}{% endverbatim %}</code></pre>
       </div>
     </section>
+
+    {# Template #}
+    {# <section> #}
+      {# <h2>Title</h2> #}
+      {# <ul> #}
+        {# <li><code></code></li> #}
+      {# </ul> #}
+      {# <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded"> #}
+        {# <div class="flex flex-row gap-x-8 items-center"> #}
+          {# {% example_here %} #}
+        {# </div> #}
+        {# <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre> #}
+      {# </div> #}
+    {# </section> #}
   </div>
 {% endblock %}
 

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -44,7 +44,16 @@
       <hr>
 
       <h3>Example</h3>
-      <div class="not-prose mb-4">
+      <div class="not-prose relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">{% #breadcrumbs %}
+        {% url 'home' as home_url %}
+        {% breadcrumb title="Home" url=home_url %}
+        {% breadcrumb location="Organisation" title="Bennett Institute for Applied Data Science" url="#" %}
+        {% breadcrumb location="Project" title="UI Components" url="#" %}
+        {% breadcrumb location="Workspace" title="Slippers" url="#" %}
+        {% breadcrumb location="Job request" title="2022" url="#" %}
+        {% breadcrumb location="Action" title="create_components" active=True %}
+      {% /breadcrumbs %}</div>
+      <div class="not-prose relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
       <pre><code class="language-django">{% verbatim myblock %}{% #breadcrumbs %}
     {% url 'home' as home_url %}
     {% breadcrumb title="Home" url=home_url %}
@@ -55,19 +64,37 @@
     {% breadcrumb location="Action" title="create_components" active=True %}
   {% /breadcrumbs %}{% endverbatim myblock %}</code></pre></div>
 
-  <div class="not-prose relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-300">{% #breadcrumbs %}
-    {% url 'home' as home_url %}
-    {% breadcrumb title="Home" url=home_url %}
-    {% breadcrumb location="Organisation" title="Bennett Institute for Applied Data Science" url="#" %}
-    {% breadcrumb location="Project" title="UI Components" url="#" %}
-    {% breadcrumb location="Workspace" title="Slippers" url="#" %}
-    {% breadcrumb location="Job request" title="2022" url="#" %}
-    {% breadcrumb location="Action" title="create_components" active=True %}
-  {% /breadcrumbs %}</div>
-
     </section>
 
     <hr>
+
+    <section>
+      <h2>Pill</h2>
+
+      <h3>Properties</h3>
+      <ul>
+        <li><code>children</code></li>
+        <li><code>sr_only</code></li>
+        <li><code>text</code></li>
+        <li><code>variant</code></li>
+      </ul>
+
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center mx-auto">
+          {% pill variant="danger" text="Danger" %}
+          {% pill variant="info" text="Info" %}
+          {% pill variant="primary" text="Primary" %}
+          {% pill variant="success" text="Success" %}
+          {% pill variant="warning" text="Warning" %}
+        </div>
+
+        <pre><code class="language-django">{% verbatim %}{% pill variant="danger" text="Danger" %}
+{% pill variant="info" text="Info" %}
+{% pill variant="primary" text="Primary" %}
+{% pill variant="success" text="Success" %}
+{% pill variant="warning" text="Warning" %}{% endverbatim %}</code></pre>
+      </div>
+    </section>
   </div>
 {% endblock %}
 

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -4,6 +4,37 @@
 {% load humanize %}
 
 {% block content %}
+  <details
+    class="
+      fixed top-0 left-0 inline-flex z-50
+      group bg-oxford-50 border border-l-4 border-oxford-700/95 overflow-hidden rounded
+      open:bg-white
+    "
+    open
+  >
+    <summary
+      class="
+        cursor-pointer list-none p-4 py-2 transition-colors
+        hover:bg-oxford-100 hover:text-oxford-900
+        group-open:border-b
+      "
+    >
+      <span class="text-lg font-semibold text-oxford">
+        <span class="group-open:hidden inline-flex">Show</span>
+        <span class="group-open:inline-flex hidden">Hide</span>
+        components list
+      </span>
+    </summary>
+    <ul
+      class="
+        m-2 ml-8 px-2 list-disc
+        [&_a]:text-oxford-600 [&_a]:font-semibold [&_a:hover]:text-oxford-900 [&_a:hover]:underline
+        [&_ul_li]:list-[circle] [&_ul_li]:ml-4
+      "
+      id="table-of-contents"
+    ></ul>
+  </details>
+
   <div class="
     prose mx-auto relative flex flex-col
     [&_section+section]:mt-24 [&_section+section]:pt-24 [&_section+section]:border-t
@@ -12,35 +43,6 @@
     <h1>UI Components</h1>
     <p>A gallery for the available components for building OpenSAFELY Jobs pages.</p>
 
-    <details
-      class="
-        group bg-oxford-50 border border-l-4 border-oxford-700/95 overflow-hidden rounded not-prose
-        open:bg-white
-      "
-      open
-    >
-      <summary
-        class="
-          cursor-pointer list-none p-4 py-2 transition-colors
-          hover:bg-oxford-100 hover:text-oxford-900
-          group-open:border-b
-        "
-      >
-        <span class="text-lg font-semibold text-oxford">
-          <span class="group-open:hidden inline-flex">Show</span>
-          <span class="group-open:inline-flex hidden">Hide</span>
-          components list
-        </span>
-      </summary>
-      <ul
-        class="
-          m-2 ml-8 pl-2 list-disc
-          [&_a]:text-oxford-600 [&_a]:font-semibold [&_a:hover]:text-oxford-900 [&_a:hover]:underline
-          [&_ul_li]:list-[circle] [&_ul_li]:ml-4
-        "
-        id="table-of-contents"
-      ></ul>
-    </details>
     <hr>
 
     <section id="alert">

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -75,7 +75,7 @@
       <hr>
 
       <h3>Example</h3>
-      <div class="not-prose relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">{% #breadcrumbs %}
+      <div class="not-prose relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">{% #breadcrumbs %}
         {% url 'home' as home_url %}
         {% breadcrumb title="Home" url=home_url %}
         {% breadcrumb location="Organisation" title="Bennett Institute for Applied Data Science" url="#" %}
@@ -84,7 +84,7 @@
         {% breadcrumb location="Job request" title="2022" url="#" %}
         {% breadcrumb location="Action" title="create_components" active=True %}
       {% /breadcrumbs %}</div>
-      <div class="not-prose relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
       <pre><code class="language-django">{% verbatim myblock %}{% #breadcrumbs %}
     {% url 'home' as home_url %}
     {% breadcrumb title="Home" url=home_url %}
@@ -111,7 +111,7 @@
         <li><code>subtitle</code></li>
         <li><code>title</code></li>
       </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <pre><code class="language-django">{% verbatim %}{% #card class="bg-red-50" title="Hola mundo" subtitle="Hallo welt" %}{% endverbatim %}
   {% filter force_escape %}<span class="text-bn-ribbon-600">Hello world</span>{% endfilter %}
 {% verbatim %}{% /card %}{% endverbatim %}</code></pre>
@@ -121,13 +121,13 @@
         <li><code>children</code></li>
         <li><code>no_container</code></li>
       </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <pre><code class="language-django">{% verbatim %}{% #card_footer no_container=False %}{% endverbatim %}
   {% filter force_escape %}<span class="text-bn-egg-500">Hello world</span>{% endfilter %}
 {% verbatim %}{% /card %}{% endverbatim %}</code></pre>
       </div>
       <h3>Example</h3>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
           {% #card class="bg-red-50" title="Hola mundo" subtitle="Hallo welt" container=True class="w-full max-w-lg mx-auto" %}
             <p class="text-oxford-700 text-lg font-semibold">Hello world</p>
@@ -150,7 +150,7 @@
       <ul>
         <li><code></code></li>
       </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
           {# {% example_here %} #}
         </div>
@@ -162,7 +162,7 @@
       <ul>
         <li><code></code></li>
       </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
           {# {% example_here %} #}
         </div>
@@ -172,76 +172,127 @@
     <section>
       <h2>Alert</h2>
       <ul>
-        <li><code></code></li>
+        <li><code>children</code></li>
+        <li><code>class</code></li>
+        <li><code>no_icon</code></li>
+        <li><code>variant</code></li>
       </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
-        <div class="flex flex-row gap-x-8 items-center">
-          {# {% example_here %} #}
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+        <div class="flex flex-col gap-8 items-center">
+          {% #alert variant="warning" title="Attention needed" %}
+            This Job has not been updated for over 30 minutes, some of the data on this page could be stale.
+          {% /alert %}
+          {% #alert variant="info" title="For your information" class="mt-4" no_icon=True %}
+            This Job has not been updated for over 30 minutes, some of the data on this page could be stale.
+          {% /alert %}
         </div>
-        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+        <pre><code class="language-django">{% verbatim %}{% #alert variant="warning" title="Attention needed" %}
+  This Job has not been updated for over 30 minutes, some of the data on this page could be stale.
+{% /alert %}
+{% #alert variant="info" title="For your information" class="mt-4" no_icon=True %}
+  This Job has not been updated for over 30 minutes, some of the data on this page could be stale.
+{% /alert %}{% endverbatim %}</code></pre>
       </div>
     </section>
     <section>
       <h2>Button</h2>
       <ul>
-        <li><code></code></li>
+        <li><code>children</code></li>
+        <li><code>class</code></li>
+        <li><code>disabled</code></li>
+        <li><code>external</code></li>
+        <li><code>href</code></li>
+        <li><code>id</code></li>
+        <li><code>name</code></li>
+        <li><code>tooltip</code></li>
+        <li><code>type</code></li>
+        <li><code>variant</code></li>
       </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
-          {# {% example_here %} #}
+          {% #button type="link" href="#" variant="danger" %}Danger link{% /button %}
+          {% #button type="submit" variant="success" %}Submit success{% /button %}
+          {% #button tooltip="I am the tooltip" variant="warning" %}Warning with a tooltip{% /button %}
+          {% #button disabled=True class="hover:scale-110 transition-transform" %}Disabled button with custom class{% /button %}
         </div>
-        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+        <pre><code class="language-django">{% verbatim %}{% #button type="link" href="#" variant="danger" %}Danger link{% /button %}
+{% #button type="submit" variant="success" %}Submit success{% /button %}
+{% #button tooltip="I am the tooltip" variant="warning" %}Warning with a tooltip{% /button %}
+{% #button disabled=True class="hover:scale-110 transition-transform" %}Disabled button with custom class{% /button %}{% endverbatim %}</code></pre>
       </div>
     </section>
     <section>
       <h2>Code</h2>
       <ul>
-        <li><code></code></li>
+        <li><code>class</code></li>
+        <li><code>children</code></li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
-          {# {% example_here %} #}
+          {% #code %}
+            <h1>Hello world!</h1>
+            <p>This is a code block</p>
+          {% /code %}
         </div>
-        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+        <pre><code class="language-django">{% verbatim %}{% #code %}{% endverbatim %}
+  {% filter force_escape %}<h1>Hello world!</h1>
+  <p>This is a code block</p>{% endfilter %}
+{% verbatim %}{% /code %}{% endverbatim %}</code></pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>Description Item</h2>
+      <ul>
+        <li><code>children</code></li>
+        <li><code>details_class</code></li>
+        <li><code>title</code></li>
+        <li><code>title_class</code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {% #description_item title="This is a title" %}
+            <p>This is the child content</p>
+          {% /description_item %}
+        </div>
+        <pre><code class="language-django">{% verbatim %}{% #description_item title="This is a title" %}{% endverbatim %}
+  {% filter force_escape %}<p>This is the child content</p>{% endfilter %}
+{% verbatim %}{% /description_item %}{% endverbatim %}</code></pre>
       </div>
     </section>
 
     <section>
       <h2>Header</h2>
-      <ul>
-        <li><code></code></li>
-      </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
-        <div class="flex flex-row gap-x-8 items-center">
-          {# {% example_here %} #}
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+        <div class="block relative">
+          {% header nav=nav %}
         </div>
-        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+        <pre><code class="language-django">{% verbatim %}{% header %}{% endverbatim %}</code></pre>
       </div>
     </section>
 
     <section>
       <h2>Footer</h2>
-      <ul>
-        <li><code></code></li>
-      </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
-          {# {% example_here %} #}
+          {% footer %}
         </div>
-        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+        <pre><code class="language-django">{% verbatim %}{% footer %}{% endverbatim %}</code></pre>
       </div>
     </section>
 
     <section>
       <h2>Link</h2>
       <ul>
-        <li><code></code></li>
+        <li><code>href</code></li>
+        <li><code>new_tab</code></li>
+        <li><code>text</code></li>
       </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
-          {# {% example_here %} #}
+          {% link href="#" new_tab=True text="It's me, a link!" %}
         </div>
-        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+        <pre><code class="language-django">{% verbatim %}{% link href="#" new_tab=True text="It's me, a link!" %}{% endverbatim %}</code></pre>
       </div>
     </section>
 
@@ -256,7 +307,7 @@
         <li><code>variant</code></li>
       </ul>
 
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
           {% pill variant="danger" text="Danger" %}
           {% pill variant="info" text="Info" %}
@@ -275,14 +326,12 @@
 
     <section>
       <h2>Skip link</h2>
-      <ul>
-        <li><code></code></li>
-      </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
-          {# {% example_here %} #}
+          <p>Use the tab key to get the link to show</p>
+          {% skip_link %}
         </div>
-        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+        <pre><code class="language-django">{% verbatim %}{% skip_link %}{% endverbatim %}</code></pre>
       </div>
     </section>
 
@@ -298,17 +347,26 @@
         <li><code>time</code></li>
         <li><code>title</code></li>
       </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
           {% #card title="Timeline" class="w-full" container=True %}
             <ul class="flow-root">
-              {% #timeline_item background="blue" title="Created by the backend:" time=example_date last=True no_padding_bottom=True %}
+              {% #timeline_item background="blue" title="Created by the backend:" time=example_date %}
                 {% icon_pencil_outline class="h-5 w-5" %}
+              {% /timeline_item %}
+              {% #timeline_item background="green" title="Accepted by the backend:" time=example_date last=True no_padding_bottom=True %}
+                {% icon_check_outline class="h-5 w-5" %}
               {% /timeline_item %}
             </ul>
           {% /card %}
         </div>
-        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+        <pre><code class="language-django">{% verbatim %}{% #card title="Timeline" class="w-full" container=True %}{% endverbatim %}
+  {% filter force_escape %}<ul class="flow-root">{% endfilter %}
+    {% verbatim %}{% #timeline_item background="blue" title="Created by the backend:" time=example_date last=True no_padding_bottom=True %}
+      {% icon_pencil_outline class="h-5 w-5" %}
+    {% /timeline_item %}{% endverbatim %}
+  {% filter force_escape %}</ul>{% endfilter %}
+{% verbatim %}{% /card %}{% endverbatim %}</code></pre>
       </div>
     </section>
 
@@ -318,14 +376,17 @@
         <li><code>class</code></li>
         <li><code>content</code></li>
       </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
           <div class="relative group cursor-pointer">
             Hover here to see a tooltip
             {% tooltip content="I am the tooltip!" %}
           </div>
         </div>
-        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+        <pre><code class="language-django">{% filter force_escape %}<div class="relative group cursor-pointer">
+  Hover here to see a tooltip
+  {% verbatim %}{% tooltip content="I am the tooltip!" %}{% endverbatim %}
+</div>{% endfilter %}</code></pre>
       </div>
     </section>
 
@@ -335,7 +396,7 @@
       {# <ul> #}
         {# <li><code></code></li> #}
       {# </ul> #}
-      {# <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded"> #}
+      {# <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded"> #}
         {# <div class="flex flex-row gap-x-8 items-center"> #}
           {# {% example_here %} #}
         {# </div> #}

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -1,6 +1,7 @@
 {% extends 'base-tw.html' %}
 
 {% load django_vite %}
+{% load humanize %}
 
 {% block content %}
   <div class="prose mx-auto relative">
@@ -9,18 +10,31 @@
 
     <details
       class="
-        group bg-oxford-50 border border-l-4 border-oxford-700/95 overflow-hidden rounded
+        group bg-oxford-50 border border-l-4 border-oxford-700/95 overflow-hidden rounded not-prose
         open:bg-white
       "
-      id="table-of-contents"
+      open
     >
-      <summary class="cursor-pointer list-none p-4 py-2 transition-colors hover:bg-oxford-100 hover:text-oxford-900">
+      <summary
+        class="
+          cursor-pointer list-none p-4 py-2 transition-colors
+          hover:bg-oxford-100 hover:text-oxford-900
+          group-open:border-b
+        "
+      >
         <span class="text-lg font-semibold text-oxford">
           <span class="group-open:hidden inline-flex">Show</span>
           <span class="group-open:inline-flex hidden">Hide</span>
           components list
         </span>
       </summary>
+      <ul
+        class="
+          m-2 ml-8 pl-2 list-disc
+          [&_a]:text-oxford-600 [&_a]:font-semibold [&_a:hover]:text-oxford-900 [&_a:hover]:underline
+        "
+        id="table-of-contents"
+      ></ul>
     </details>
     <hr>
 
@@ -131,7 +145,105 @@
       </div>
     </section>
 
-    <hr>
+    <section>
+      <h2>Forms</h2>
+      <ul>
+        <li><code></code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {# {% example_here %} #}
+        </div>
+        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+      </div>
+    </section>
+    <section>
+      <h2>List group</h2>
+      <ul>
+        <li><code></code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {# {% example_here %} #}
+        </div>
+        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+      </div>
+    </section>
+    <section>
+      <h2>Alert</h2>
+      <ul>
+        <li><code></code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {# {% example_here %} #}
+        </div>
+        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+      </div>
+    </section>
+    <section>
+      <h2>Button</h2>
+      <ul>
+        <li><code></code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {# {% example_here %} #}
+        </div>
+        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+      </div>
+    </section>
+    <section>
+      <h2>Code</h2>
+      <ul>
+        <li><code></code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {# {% example_here %} #}
+        </div>
+        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>Header</h2>
+      <ul>
+        <li><code></code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {# {% example_here %} #}
+        </div>
+        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>Footer</h2>
+      <ul>
+        <li><code></code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {# {% example_here %} #}
+        </div>
+        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>Link</h2>
+      <ul>
+        <li><code></code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {# {% example_here %} #}
+        </div>
+        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+      </div>
+    </section>
 
     <section>
       <h2>Pill</h2>
@@ -158,6 +270,62 @@
 {% pill variant="primary" text="Primary" %}
 {% pill variant="success" text="Success" %}
 {% pill variant="warning" text="Warning" %}{% endverbatim %}</code></pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>Skip link</h2>
+      <ul>
+        <li><code></code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {# {% example_here %} #}
+        </div>
+        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>Timeline</h2>
+      <h3>Timeline item</h3>
+      <ul>
+        <li><code>background</code></li>
+        <li><code>children</code></li>
+        <li><code>content</code></li>
+        <li><code>last</code></li>
+        <li><code>no_padding_bottom</code></li>
+        <li><code>time</code></li>
+        <li><code>title</code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {% #card title="Timeline" class="w-full" container=True %}
+            <ul class="flow-root">
+              {% #timeline_item background="blue" title="Created by the backend:" time=example_date last=True no_padding_bottom=True %}
+                {% icon_pencil_outline class="h-5 w-5" %}
+              {% /timeline_item %}
+            </ul>
+          {% /card %}
+        </div>
+        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
+      </div>
+    </section>
+
+    <section>
+      <h2>Tooltip</h2>
+      <ul>
+        <li><code>class</code></li>
+        <li><code>content</code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          <div class="relative group cursor-pointer">
+            Hover here to see a tooltip
+            {% tooltip content="I am the tooltip!" %}
+          </div>
+        </div>
+        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
       </div>
     </section>
 

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -32,6 +32,7 @@
         class="
           m-2 ml-8 pl-2 list-disc
           [&_a]:text-oxford-600 [&_a]:font-semibold [&_a:hover]:text-oxford-900 [&_a:hover]:underline
+          [&_ul_li]:list-[circle] [&_ul_li]:ml-4
         "
         id="table-of-contents"
       ></ul>

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -4,7 +4,11 @@
 {% load humanize %}
 
 {% block content %}
-  <div class="prose mx-auto relative">
+  <div class="
+    prose mx-auto relative flex flex-col
+    [&_section+section]:mt-24 [&_section+section]:pt-24 [&_section+section]:border-t
+    [&_section>h2]:mt-0
+  ">
     <h1>UI Components</h1>
     <p>A gallery for the available components for building OpenSAFELY Jobs pages.</p>
 

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -39,138 +39,7 @@
     </details>
     <hr>
 
-    <section>
-      <h2>Breadcrumbs</h2>
-
-      <h3><code>breadcrumb.html</code></h3>
-      <h4>Properties</h4>
-      <ul>
-        <li><code>active</code>: [boolean] - true if the current page matches this breadcrumb item</li>
-        <li><code>location</code>: [string] - shows a tooltip on hvoer displaying the text</li>
-        <li><code>title</code>: [string] - the text to display for the breadcrumb</li>
-        <li><code>url</code>: [string] - the anchor href for the breadcrumb</li>
-      </ul>
-      <div class="not-prose mb-4">
-        <pre><code class="language-django">{% verbatim breadcrumbs %}{# Title is special, if it is equal to "home" then the home icon will show #}
-{% breadcrumb title="Home" url=home_url %}
-
-{# URL will make the breadcrumb contain an anchor link #}
-{% breadcrumb location="Organisation" title="Bennett Institute for Applied Data Science" url="#" %}
-
-{# Active will make the breadcrumb not contain a link #}
-{% breadcrumb location="Action" title="create_components" active=True %}
-{% endverbatim breadcrumbs %}</code></pre>
-      </div>
-      <hr>
-
-      <h3><code>breadcrumbs-container.html</code></h3>
-      <h4>Properties</h4>
-      <ul>
-        <li><code>children</code>: display the children components</li>
-      </ul>
-      <div class="not-prose mb-4">
-        <pre><code class="language-django">{% verbatim breadcrumbs_container %}{% #breadcrumbs %}
-  {# Children components go here #}
-{% /breadcrumbs %}{% endverbatim breadcrumbs_container %}</code></pre>
-      </div>
-      <hr>
-
-      <h3>Example</h3>
-      <div class="not-prose relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">{% #breadcrumbs %}
-        {% url 'home' as home_url %}
-        {% breadcrumb title="Home" url=home_url %}
-        {% breadcrumb location="Organisation" title="Bennett Institute for Applied Data Science" url="#" %}
-        {% breadcrumb location="Project" title="UI Components" url="#" %}
-        {% breadcrumb location="Workspace" title="Slippers" url="#" %}
-        {% breadcrumb location="Job request" title="2022" url="#" %}
-        {% breadcrumb location="Action" title="create_components" active=True %}
-      {% /breadcrumbs %}</div>
-      <div class="not-prose relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
-      <pre><code class="language-django">{% verbatim myblock %}{% #breadcrumbs %}
-    {% url 'home' as home_url %}
-    {% breadcrumb title="Home" url=home_url %}
-    {% breadcrumb location="Organisation" title="Bennett Institute for Applied Data Science" url="#" %}
-    {% breadcrumb location="Project" title="UI Components" url="#" %}
-    {% breadcrumb location="Workspace" title="Slippers" url="#" %}
-    {% breadcrumb location="Job request" title="2022" url="#" %}
-    {% breadcrumb location="Action" title="create_components" active=True %}
-  {% /breadcrumbs %}{% endverbatim myblock %}</code></pre></div>
-
-    </section>
-
-    <hr>
-
-    <section>
-      <h2>Card</h2>
-      <h3>Card</h3>
-      <ul>
-        <li><code>aria_labelled_by</code></li>
-        <li><code>children</code></li>
-        <li><code>class</code></li>
-        <li><code>container_class</code></li>
-        <li><code>container</code></li>
-        <li><code>subtitle</code></li>
-        <li><code>title</code></li>
-      </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
-        <pre><code class="language-django">{% verbatim %}{% #card class="bg-red-50" title="Hola mundo" subtitle="Hallo welt" %}{% endverbatim %}
-  {% filter force_escape %}<span class="text-bn-ribbon-600">Hello world</span>{% endfilter %}
-{% verbatim %}{% /card %}{% endverbatim %}</code></pre>
-      </div>
-      <h3>Card footer</h3>
-      <ul>
-        <li><code>children</code></li>
-        <li><code>no_container</code></li>
-      </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
-        <pre><code class="language-django">{% verbatim %}{% #card_footer no_container=False %}{% endverbatim %}
-  {% filter force_escape %}<span class="text-bn-egg-500">Hello world</span>{% endfilter %}
-{% verbatim %}{% /card %}{% endverbatim %}</code></pre>
-      </div>
-      <h3>Example</h3>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
-        <div class="flex flex-row gap-x-8 items-center">
-          {% #card class="bg-red-50" title="Hola mundo" subtitle="Hallo welt" container=True class="w-full max-w-lg mx-auto" %}
-            <p class="text-oxford-700 text-lg font-semibold">Hello world</p>
-            {% #card_footer %}
-              <p class="text-sm text-slate-600">Bonjour le monde</p>
-            {% /card_footer %}
-          {% /card %}
-        </div>
-        <pre><code class="language-django">{% verbatim %}{% #card class="bg-red-50" title="Hola mundo" subtitle="Hallo welt" container=True class="w-full max-w-lg mx-auto" %}{% endverbatim %}
-  {% filter force_escape %}<p class="text-oxford-700 text-lg font-semibold">Hello world</p>{% endfilter %}
-  {% verbatim %}{% #card_footer %}{% endverbatim %}
-    {% filter force_escape %}<p class="text-sm text-slate-600">Bonjour le monde</p>{% endfilter %}
-  {% verbatim %}{% /card_footer %}{% endverbatim %}
-{% verbatim %}{% /card %}{% endverbatim %}</code></pre>
-      </div>
-    </section>
-
-    <section>
-      <h2>Forms</h2>
-      <ul>
-        <li><code></code></li>
-      </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
-        <div class="flex flex-row gap-x-8 items-center">
-          {# {% example_here %} #}
-        </div>
-        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
-      </div>
-    </section>
-    <section>
-      <h2>List group</h2>
-      <ul>
-        <li><code></code></li>
-      </ul>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
-        <div class="flex flex-row gap-x-8 items-center">
-          {# {% example_here %} #}
-        </div>
-        <pre><code class="language-django">{% verbatim %}code here{% endverbatim %}</code></pre>
-      </div>
-    </section>
-    <section>
+    <section id="alert">
       <h2>Alert</h2>
       <ul>
         <li><code>children</code></li>
@@ -195,7 +64,65 @@
 {% /alert %}{% endverbatim %}</code></pre>
       </div>
     </section>
-    <section>
+
+    <section id="breadcrumbsSection">
+      <h2>Breadcrumbs</h2>
+
+      <h3><code>Breadcrumb item</code></h3>
+      <h4>Properties</h4>
+      <ul>
+        <li><code>active</code>: [boolean] - true if the current page matches this breadcrumb item</li>
+        <li><code>location</code>: [string] - shows a tooltip on hvoer displaying the text</li>
+        <li><code>title</code>: [string] - the text to display for the breadcrumb</li>
+        <li><code>url</code>: [string] - the anchor href for the breadcrumb</li>
+      </ul>
+      <div class="not-prose mb-4">
+        <pre><code class="language-django">{% verbatim breadcrumbs %}{# Title is special, if it is equal to "home" then the home icon will show #}
+{% breadcrumb title="Home" url=home_url %}
+
+{# URL will make the breadcrumb contain an anchor link #}
+{% breadcrumb location="Organisation" title="Bennett Institute for Applied Data Science" url="#" %}
+
+{# Active will make the breadcrumb not contain a link #}
+{% breadcrumb location="Action" title="create_components" active=True %}
+{% endverbatim breadcrumbs %}</code></pre>
+      </div>
+      <hr>
+
+      <h3><code>Breadcrumbs list</code></h3>
+      <h4>Properties</h4>
+      <ul>
+        <li><code>children</code>: display the children components</li>
+      </ul>
+      <div class="not-prose mb-4">
+        <pre><code class="language-django">{% verbatim breadcrumbs_container %}{% #breadcrumbs %}
+  {# Children components go here #}
+{% /breadcrumbs %}{% endverbatim breadcrumbs_container %}</code></pre>
+      </div>
+
+      <div class="not-prose relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">{% #breadcrumbs %}
+        {% url 'home' as home_url %}
+        {% breadcrumb title="Home" url=home_url %}
+        {% breadcrumb location="Organisation" title="Bennett Institute for Applied Data Science" url="#" %}
+        {% breadcrumb location="Project" title="UI Components" url="#" %}
+        {% breadcrumb location="Workspace" title="Slippers" url="#" %}
+        {% breadcrumb location="Job request" title="2022" url="#" %}
+        {% breadcrumb location="Action" title="create_components" active=True %}
+      {% /breadcrumbs %}</div>
+      <div class="not-prose relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+      <pre><code class="language-django">{% verbatim myblock %}{% #breadcrumbs %}
+    {% url 'home' as home_url %}
+    {% breadcrumb title="Home" url=home_url %}
+    {% breadcrumb location="Organisation" title="Bennett Institute for Applied Data Science" url="#" %}
+    {% breadcrumb location="Project" title="UI Components" url="#" %}
+    {% breadcrumb location="Workspace" title="Slippers" url="#" %}
+    {% breadcrumb location="Job request" title="2022" url="#" %}
+    {% breadcrumb location="Action" title="create_components" active=True %}
+  {% /breadcrumbs %}{% endverbatim myblock %}</code></pre></div>
+
+    </section>
+
+    <section id="buttonSection">
       <h2>Button</h2>
       <ul>
         <li><code>children</code></li>
@@ -222,7 +149,54 @@
 {% #button disabled=True class="hover:scale-110 transition-transform" %}Disabled button with custom class{% /button %}{% endverbatim %}</code></pre>
       </div>
     </section>
-    <section>
+
+    <section id="cardSection">
+      <h2>Card</h2>
+      <h3>Card</h3>
+      <ul>
+        <li><code>aria_labelled_by</code></li>
+        <li><code>children</code></li>
+        <li><code>class</code></li>
+        <li><code>container_class</code></li>
+        <li><code>container</code></li>
+        <li><code>subtitle</code></li>
+        <li><code>title</code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+        <pre><code class="language-django">{% verbatim %}{% #card class="bg-red-50" title="Hola mundo" subtitle="Hallo welt" %}{% endverbatim %}
+  {% filter force_escape %}<span class="text-bn-ribbon-600">Hello world</span>{% endfilter %}
+{% verbatim %}{% /card %}{% endverbatim %}</code></pre>
+      </div>
+      <h3>Card footer</h3>
+      <ul>
+        <li><code>children</code></li>
+        <li><code>no_container</code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+        <pre><code class="language-django">{% verbatim %}{% #card_footer no_container=False %}{% endverbatim %}
+  {% filter force_escape %}<span class="text-bn-egg-500">Hello world</span>{% endfilter %}
+{% verbatim %}{% /card %}{% endverbatim %}</code></pre>
+      </div>
+
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+        <div class="flex flex-row gap-x-8 items-center">
+          {% #card class="bg-red-50" title="Hola mundo" subtitle="Hallo welt" container=True class="w-full max-w-lg mx-auto" %}
+            <p class="text-oxford-700 text-lg font-semibold">Hello world</p>
+            {% #card_footer %}
+              <p class="text-sm text-slate-600">Bonjour le monde</p>
+            {% /card_footer %}
+          {% /card %}
+        </div>
+        <pre><code class="language-django">{% verbatim %}{% #card class="bg-red-50" title="Hola mundo" subtitle="Hallo welt" container=True class="w-full max-w-lg mx-auto" %}{% endverbatim %}
+  {% filter force_escape %}<p class="text-oxford-700 text-lg font-semibold">Hello world</p>{% endfilter %}
+  {% verbatim %}{% #card_footer %}{% endverbatim %}
+    {% filter force_escape %}<p class="text-sm text-slate-600">Bonjour le monde</p>{% endfilter %}
+  {% verbatim %}{% /card_footer %}{% endverbatim %}
+{% verbatim %}{% /card %}{% endverbatim %}</code></pre>
+      </div>
+    </section>
+
+    <section id="codeSection">
       <h2>Code</h2>
       <ul>
         <li><code>class</code></li>
@@ -242,7 +216,7 @@
       </div>
     </section>
 
-    <section>
+    <section id="descriptionSection">
       <h2>Description Item</h2>
       <ul>
         <li><code>children</code></li>
@@ -262,17 +236,7 @@
       </div>
     </section>
 
-    <section>
-      <h2>Header</h2>
-      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
-        <div class="block relative">
-          {% header nav=nav %}
-        </div>
-        <pre><code class="language-django">{% verbatim %}{% header %}{% endverbatim %}</code></pre>
-      </div>
-    </section>
-
-    <section>
+    <section id="footerSection">
       <h2>Footer</h2>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
@@ -282,7 +246,98 @@
       </div>
     </section>
 
-    <section>
+    <section id="formSection">
+      <h2>Forms</h2>
+      <h3>Input</h3>
+      <ul>
+        <li><code>autocapitalize</code></li>
+        <li><code>autocomplete</code></li>
+        <li><code>autocorrect</code></li>
+        <li><code>class</code></li>
+        <li><code>field</code>
+          <ul>
+            <li><code>auto_id</code></li>
+            <li><code>errors</code></li>
+            <li><code>html_name</code></li>
+            <li><code>id_for_label</code></li>
+            <li><code>label</code></li>
+            <li><code>value</code></li>
+          </ul>
+        </li>
+        <li><code>inputmode</code></li>
+        <li><code>label</code></li>
+        <li><code>required</code></li>
+        <li><code>type</code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+        <div class="flex flex-col gap-y-4 items-start max-w-xl w-full mx-auto">
+          {% form_input type="email" label="Email address" required=True field=example_form_email %}
+          {% form_input type="text" label="Phone number" inputmode="number" autocapitalize=False autocomplete=False autocorrect=False %}
+          {% form_input type="search" label="Search the site"%}
+        </div>
+        <pre><code class="language-django">{% verbatim %}{% form_input type="email" label="Email address" required=True %}
+{% form_input type="text" label="Phone number" inputmode="number" autocapitalize=False autocomplete=False autocorrect=False %}
+{% form_input type="search" label="Search the site"%}{% endverbatim %}</code></pre>
+      </div>
+      <h3>Select</h3>
+      <ul>
+        <li><code>choices</code></li>
+        <li><code>class</code></li>
+        <li><code>field</code>
+          <ul>
+            <li><code>auto_id</code></li>
+            <li><code>errors</code></li>
+            <li><code>html_name</code></li>
+            <li><code>id_for_label</code></li>
+            <li><code>label</code></li>
+          </ul>
+        </li>
+        <li><code>label</code></li>
+        <li><code>required</code></li>
+        <li><code>selected</code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+        {% form_select class="w-full max-w-lg mx-auto" label="Select a language" required=True field=example_form_select choices=example_form_select.choices selected=example_form_select.value %}
+        <pre><code class="language-django">{% verbatim %}{% form_select class="w-full max-w-lg mx-auto" label="Select a language" required=True field=example_form_select choices=example_form_select.choices selected=example_form_select.value %}{% endverbatim %}</code></pre>
+      </div>
+      <h3>Textarea</h3>
+      <ul>
+        <li><code>autocapitalize</code></li>
+        <li><code>autocomplete</code></li>
+        <li><code>autocorrect</code></li>
+        <li><code>class</code></li>
+        <li><code>field</code>
+          <ul>
+            <li><code>auto_id</code></li>
+            <li><code>errors</code></li>
+            <li><code>html_name</code></li>
+            <li><code>id_for_label</code></li>
+            <li><code>label</code></li>
+            <li><code>value</code></li>
+          </ul>
+        </li>
+        <li><code>inputmode</code></li>
+        <li><code>label</code></li>
+        <li><code>required</code></li>
+        <li><code>rows</code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+        {% form_textarea class="max-w-lg w-full mx-auto" field=example_form_textarea label="Enter a short description of the project" resize=True rows=8 %}
+        <pre><code class="language-django">{% verbatim %}{% form_textarea class="max-w-lg w-full mx-auto" field=example_form_textarea label="Enter a short description of the project" resize=True rows=8 %}{% endverbatim %}</code></pre>
+      </div>
+    </section>
+
+    <section id="headerSection">
+      <h2>Header</h2>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+        <div class="block relative">
+          {% header nav=nav %}
+        </div>
+        <pre><code class="language-django">{% verbatim %}{% header %}{% endverbatim %}</code></pre>
+      </div>
+    </section>
+
+    <section id="linkSection">
       <h2>Link</h2>
       <ul>
         <li><code>href</code></li>
@@ -297,7 +352,36 @@
       </div>
     </section>
 
-    <section>
+    <section id="listGroupSection">
+      <h2>List group</h2>
+      <h3>List group container</h3>
+      <ul>
+        <li><code>children</code></li>
+        <li><code>small</code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+        <pre><code class="language-django">{% verbatim %}{% #list_group %}content in here{% /list_group %}{% endverbatim %}</code></pre>
+      </div>
+      <h3>List group item</h3>
+      <ul>
+        <li><code>children</code></li>
+        <li><code>href</code></li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
+        {% #card %}
+          {% #list_group %}
+            {% #list_group_item href="https://www.example.com/" %}Example dot com{% /list_group_item %}
+          {% /list_group %}
+        {% /card %}
+        <pre><code class="language-django">{% verbatim %}{% #card %}
+  {% #list_group %}
+    {% #list_group_item href="https://www.example.com/" %}Example dot com{% /list_group_item %}
+  {% /list_group %}
+{% /card %}{% endverbatim %}</code></pre>
+      </div>
+    </section>
+
+    <section id="pillSection">
       <h2>Pill</h2>
 
       <h3>Properties</h3>
@@ -325,7 +409,7 @@
       </div>
     </section>
 
-    <section>
+    <section id="skipLinkSection">
       <h2>Skip link</h2>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
@@ -336,7 +420,7 @@
       </div>
     </section>
 
-    <section>
+    <section id="timelineSection">
       <h2>Timeline</h2>
       <h3>Timeline item</h3>
       <ul>
@@ -371,7 +455,7 @@
       </div>
     </section>
 
-    <section>
+    <section id="tooltipSection">
       <h2>Tooltip</h2>
       <ul>
         <li><code>class</code></li>

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -389,8 +389,6 @@
 
     <section id="pillSection">
       <h2>Pill</h2>
-
-      <h3>Properties</h3>
       <ul>
         <li><code>children</code>: [html] - display the children components</li>
         <li><code>sr_only</code>: [string] - add explainer text for screen readers</li>

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -42,10 +42,10 @@
     <section id="alert">
       <h2>Alert</h2>
       <ul>
-        <li><code>children</code></li>
-        <li><code>class</code></li>
-        <li><code>no_icon</code></li>
-        <li><code>variant</code></li>
+        <li><code>children</code>: [html] - display the children components</li>
+        <li><code>class</code>: [string] - add HTML classes to the component</li>
+        <li><code>no_icon</code>: [boolean] - if true, remove the icon</li>
+        <li><code>variant</code>: [string] - select styling colour and icon for component</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-col gap-8 items-center">
@@ -92,7 +92,7 @@
       <h3><code>Breadcrumbs list</code></h3>
       <h4>Properties</h4>
       <ul>
-        <li><code>children</code>: display the children components</li>
+        <li><code>children</code>: [html] - display the children components</li>
       </ul>
       <div class="not-prose mb-4">
         <pre><code class="language-django">{% verbatim breadcrumbs_container %}{% #breadcrumbs %}
@@ -125,16 +125,16 @@
     <section id="buttonSection">
       <h2>Button</h2>
       <ul>
-        <li><code>children</code></li>
-        <li><code>class</code></li>
-        <li><code>disabled</code></li>
-        <li><code>external</code></li>
-        <li><code>href</code></li>
-        <li><code>id</code></li>
-        <li><code>name</code></li>
-        <li><code>tooltip</code></li>
-        <li><code>type</code></li>
-        <li><code>variant</code></li>
+        <li><code>children</code>: [html] - display the children components</li>
+        <li><code>class</code>: [string] - add HTML classes to the component</li>
+        <li><code>disabled</code>: [boolean] - if true, stops users from interacting with the component</li>
+        <li><code>external</code>: [boolean] - used with `type="link"` to open link in a new tab</li>
+        <li><code>href</code>: [string] - used with `type="link"` to add href to anchor tag</li>
+        <li><code>id</code>: [string] - HTML element ID</li>
+        <li><code>name</code>: [string] - HTML element name</li>
+        <li><code>tooltip</code>: [string] - if added, will show the string on hover</li>
+        <li><code>type</code>: [string] - switch between a button or anchor element</li>
+        <li><code>variant</code>: [string] - select styling colour for component</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
@@ -154,13 +154,13 @@
       <h2>Card</h2>
       <h3>Card</h3>
       <ul>
-        <li><code>aria_labelled_by</code></li>
-        <li><code>children</code></li>
-        <li><code>class</code></li>
-        <li><code>container_class</code></li>
-        <li><code>container</code></li>
-        <li><code>subtitle</code></li>
-        <li><code>title</code></li>
+        <li><code>aria_labelled_by</code>: [string] - if using a custom heading, add aria signposting to the associated heading</li>
+        <li><code>children</code>: [html] - display the children components</li>
+        <li><code>class</code>: [string] - add HTML classes to the outer section component</li>
+        <li><code>container</code>: [boolean] - add padding and margin to the children container</li>
+        <li><code>container_class</code>: [string] - add HTML classes to the container div</li>
+        <li><code>subtitle</code>: [string] - display a title for the card</li>
+        <li><code>title</code>: [string] - display a subtitle for the card</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <pre><code class="language-django">{% verbatim %}{% #card class="bg-red-50" title="Hola mundo" subtitle="Hallo welt" %}{% endverbatim %}
@@ -169,8 +169,8 @@
       </div>
       <h3>Card footer</h3>
       <ul>
-        <li><code>children</code></li>
-        <li><code>no_container</code></li>
+        <li><code>children</code>: [html] - display the children components</li>
+        <li><code>no_container</code>: [boolean] - if true, remove all padding from the footer</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <pre><code class="language-django">{% verbatim %}{% #card_footer no_container=False %}{% endverbatim %}
@@ -199,8 +199,8 @@
     <section id="codeSection">
       <h2>Code</h2>
       <ul>
-        <li><code>class</code></li>
-        <li><code>children</code></li>
+        <li><code>class</code>: [string] - add HTML classes to the component</li>
+        <li><code>children</code>: [html] - display the children components</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-white border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
@@ -219,10 +219,10 @@
     <section id="descriptionSection">
       <h2>Description Item</h2>
       <ul>
-        <li><code>children</code></li>
-        <li><code>details_class</code></li>
-        <li><code>title</code></li>
-        <li><code>title_class</code></li>
+        <li><code>children</code>: [html] - display the children components</li>
+        <li><code>details_class</code>: [string] - add HTML classes to the dt component</li>
+        <li><code>title</code>: [string] - add title text</li>
+        <li><code>title_class</code>: [string] - add HTML classes to the dd component</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
@@ -250,24 +250,24 @@
       <h2>Forms</h2>
       <h3>Input</h3>
       <ul>
-        <li><code>autocapitalize</code></li>
-        <li><code>autocomplete</code></li>
-        <li><code>autocorrect</code></li>
-        <li><code>class</code></li>
-        <li><code>field</code>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize"><code>autocapitalize</code></a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete"><code>autocomplete</code></a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#autocorrect"><code>autocorrect</code></a></li>
+        <li><code>class</code>: [string] - add HTML classes to the component</li>
+        <li><code>field</code> - passed from Django
           <ul>
-            <li><code>auto_id</code></li>
-            <li><code>errors</code></li>
-            <li><code>html_name</code></li>
-            <li><code>id_for_label</code></li>
-            <li><code>label</code></li>
-            <li><code>value</code></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.auto_id"><code>auto_id</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.errors"><code>errors</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.html_name"><code>html_name</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.id_for_label"><code>id_for_label</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.label"><code>label</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.value"><code>value</code></a></li>
           </ul>
         </li>
-        <li><code>inputmode</code></li>
-        <li><code>label</code></li>
-        <li><code>required</code></li>
-        <li><code>type</code></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode"><code>inputmode</code></a></li>
+        <li><code>label</code>: [string] - overwrite the label passed from Django</li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required"><code>required</code></a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types"><code>type</code></a></li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-col gap-y-4 items-start max-w-xl w-full mx-auto">
@@ -281,20 +281,20 @@
       </div>
       <h3>Select</h3>
       <ul>
-        <li><code>choices</code></li>
-        <li><code>class</code></li>
+        <li><code>choices</code>: [dict] - dict of [value, label] for the options</li>
+        <li><code>class</code>: [string] - add HTML classes to the component</li>
         <li><code>field</code>
           <ul>
-            <li><code>auto_id</code></li>
-            <li><code>errors</code></li>
-            <li><code>html_name</code></li>
-            <li><code>id_for_label</code></li>
-            <li><code>label</code></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.auto_id"><code>auto_id</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.errors"><code>errors</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.html_name"><code>html_name</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.id_for_label"><code>id_for_label</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.label"><code>label</code></a></li>
           </ul>
         </li>
-        <li><code>label</code></li>
-        <li><code>required</code></li>
-        <li><code>selected</code></li>
+        <li><code>label</code>: [string] - overwrite the label passed from Django</li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required"><code>required</code></a></li>
+        <li><code>selected</code>: [string] - matches value of choice for preselected option</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         {% form_select class="w-full max-w-lg mx-auto" label="Select a language" required=True field=example_form_select choices=example_form_select.choices selected=example_form_select.value %}
@@ -302,24 +302,24 @@
       </div>
       <h3>Textarea</h3>
       <ul>
-        <li><code>autocapitalize</code></li>
-        <li><code>autocomplete</code></li>
-        <li><code>autocorrect</code></li>
-        <li><code>class</code></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize"><code>autocapitalize</code></a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete"><code>autocomplete</code></a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#autocorrect"><code>autocorrect</code></a></li>
+        <li><code>class</code>: [string] - add HTML classes to the component</li>
         <li><code>field</code>
           <ul>
-            <li><code>auto_id</code></li>
-            <li><code>errors</code></li>
-            <li><code>html_name</code></li>
-            <li><code>id_for_label</code></li>
-            <li><code>label</code></li>
-            <li><code>value</code></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.auto_id"><code>auto_id</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.errors"><code>errors</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.html_name"><code>html_name</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.id_for_label"><code>id_for_label</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.label"><code>label</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.value"><code>value</code></a></li>
           </ul>
         </li>
-        <li><code>inputmode</code></li>
-        <li><code>label</code></li>
-        <li><code>required</code></li>
-        <li><code>rows</code></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode"><code>inputmode</code></a></li>
+        <li><code>label</code>: [string] - overwrite the label passed from Django</li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required"><code>required</code></a></li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-rows"><code>rows</code></a></li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         {% form_textarea class="max-w-lg w-full mx-auto" field=example_form_textarea label="Enter a short description of the project" resize=True rows=8 %}
@@ -340,9 +340,9 @@
     <section id="linkSection">
       <h2>Link</h2>
       <ul>
-        <li><code>href</code></li>
-        <li><code>new_tab</code></li>
-        <li><code>text</code></li>
+        <li><code>href</code>: [string] - href for the anchor tag</li>
+        <li><code>new_tab</code>: [boolean] - if true, opens link in a new tab</li>
+        <li><code>text</code>: [string] - link text to display</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
@@ -356,16 +356,16 @@
       <h2>List group</h2>
       <h3>List group container</h3>
       <ul>
-        <li><code>children</code></li>
-        <li><code>small</code></li>
+        <li><code>children</code>: [html] - display the children components</li>
+        <li><code>small</code>: [boolean] - if true, reduces padding and font size</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <pre><code class="language-django">{% verbatim %}{% #list_group %}content in here{% /list_group %}{% endverbatim %}</code></pre>
       </div>
       <h3>List group item</h3>
       <ul>
-        <li><code>children</code></li>
-        <li><code>href</code></li>
+        <li><code>children</code>: [html] - display the children components</li>
+        <li><code>href</code>: [string] - href for the anchor tag</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         {% #card %}
@@ -386,10 +386,10 @@
 
       <h3>Properties</h3>
       <ul>
-        <li><code>children</code></li>
-        <li><code>sr_only</code></li>
-        <li><code>text</code></li>
-        <li><code>variant</code></li>
+        <li><code>children</code>: [html] - display the children components</li>
+        <li><code>sr_only</code>: [string] - add explainer text for screen readers</li>
+        <li><code>text</code>: [string] - text to display in the component</li>
+        <li><code>variant</code>: [string] - select styling colours for the component</li>
       </ul>
 
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
@@ -424,13 +424,13 @@
       <h2>Timeline</h2>
       <h3>Timeline item</h3>
       <ul>
-        <li><code>background</code></li>
-        <li><code>children</code></li>
-        <li><code>content</code></li>
-        <li><code>last</code></li>
-        <li><code>no_padding_bottom</code></li>
-        <li><code>time</code></li>
-        <li><code>title</code></li>
+        <li><code>background</code>: [string] - select the background color for the icon</li> {# TODO: change this to "variant" #}
+        <li><code>children</code>: [html] - display the children components</li>
+        <li><code>content</code>: [string] - text to display if not passing a time</li>
+        <li><code>last</code>: [boolean] - if true, removes line running between icons</li>
+        <li><code>no_padding_bottom</code>: [boolean] - if true, remove bottom padding</li>
+        <li><code>time</code>: [date] - provide a Django date to display natural time and tooltip for exact time stamp</li>
+        <li><code>title</code>: [string] - text to display above time or content</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">
@@ -458,8 +458,8 @@
     <section id="tooltipSection">
       <h2>Tooltip</h2>
       <ul>
-        <li><code>class</code></li>
-        <li><code>content</code></li>
+        <li><code>class</code>: [string] - add HTML classes to the component</li>
+        <li><code>content</code>: [string] - text for the tooltip to display when hovered</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">
         <div class="flex flex-row gap-x-8 items-center">

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -1,0 +1,76 @@
+{% extends 'base-tw.html' %}
+
+{% load django_vite %}
+
+{% block content %}
+  <div class="prose mx-auto relative">
+    <h1>UI Components</h1>
+    <p>A gallery for the available components for building OpenSAFELY Jobs pages.</p>
+
+    <section>
+      <h2>Breadcrumbs</h2>
+
+      <h3><code>breadcrumb.html</code></h3>
+      <h4>Properties</h4>
+      <ul>
+        <li><code>active</code>: [boolean] - true if the current page matches this breadcrumb item</li>
+        <li><code>location</code>: [string] - shows a tooltip on hvoer displaying the text</li>
+        <li><code>title</code>: [string] - the text to display for the breadcrumb</li>
+        <li><code>url</code>: [string] - the anchor href for the breadcrumb</li>
+      </ul>
+      <div class="not-prose mb-4">
+        <pre><code class="language-django">{% verbatim breadcrumbs %}{# Title is special, if it is equal to "home" then the home icon will show #}
+{% breadcrumb title="Home" url=home_url %}
+
+{# URL will make the breadcrumb contain an anchor link #}
+{% breadcrumb location="Organisation" title="Bennett Institute for Applied Data Science" url="#" %}
+
+{# Active will make the breadcrumb not contain a link #}
+{% breadcrumb location="Action" title="create_components" active=True %}
+{% endverbatim breadcrumbs %}</code></pre>
+      </div>
+      <hr>
+
+      <h3><code>breadcrumbs-container.html</code></h3>
+      <h4>Properties</h4>
+      <ul>
+        <li><code>children</code>: display the children components</li>
+      </ul>
+      <div class="not-prose mb-4">
+        <pre><code class="language-django">{% verbatim breadcrumbs_container %}{% #breadcrumbs %}
+  {# Children components go here #}
+{% /breadcrumbs %}{% endverbatim breadcrumbs_container %}</code></pre>
+      </div>
+      <hr>
+
+      <h3>Example</h3>
+      <div class="not-prose mb-4">
+      <pre><code class="language-django">{% verbatim myblock %}{% #breadcrumbs %}
+    {% url 'home' as home_url %}
+    {% breadcrumb title="Home" url=home_url %}
+    {% breadcrumb location="Organisation" title="Bennett Institute for Applied Data Science" url="#" %}
+    {% breadcrumb location="Project" title="UI Components" url="#" %}
+    {% breadcrumb location="Workspace" title="Slippers" url="#" %}
+    {% breadcrumb location="Job request" title="2022" url="#" %}
+    {% breadcrumb location="Action" title="create_components" active=True %}
+  {% /breadcrumbs %}{% endverbatim myblock %}</code></pre></div>
+
+  <div class="not-prose relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-300">{% #breadcrumbs %}
+    {% url 'home' as home_url %}
+    {% breadcrumb title="Home" url=home_url %}
+    {% breadcrumb location="Organisation" title="Bennett Institute for Applied Data Science" url="#" %}
+    {% breadcrumb location="Project" title="UI Components" url="#" %}
+    {% breadcrumb location="Workspace" title="Slippers" url="#" %}
+    {% breadcrumb location="Job request" title="2022" url="#" %}
+    {% breadcrumb location="Action" title="create_components" active=True %}
+  {% /breadcrumbs %}</div>
+
+    </section>
+
+    <hr>
+  </div>
+{% endblock %}
+
+{% block extra_js %}
+  {% vite_asset 'assets/src/scripts/highlight.js' %}
+{% endblock %}

--- a/jobserver/templates/_components/index.html
+++ b/jobserver/templates/_components/index.html
@@ -7,6 +7,11 @@
     <h1>UI Components</h1>
     <p>A gallery for the available components for building OpenSAFELY Jobs pages.</p>
 
+    <div id="table-of-contents">
+      <h2 data-anchor="ignore">Components:</h2>
+    </div>
+    <hr>
+
     <section>
       <h2>Breadcrumbs</h2>
 
@@ -99,5 +104,5 @@
 {% endblock %}
 
 {% block extra_js %}
-  {% vite_asset 'assets/src/scripts/highlight.js' %}
+  {% vite_asset 'assets/src/scripts/components.js' %}
 {% endblock %}

--- a/jobserver/templates/_components/pill.html
+++ b/jobserver/templates/_components/pill.html
@@ -1,15 +1,15 @@
 <span class="
-  inline-flex rounded-full px-2 text-xs font-semibold leading-5
+  inline-flex rounded-full px-2 text-xs font-semibold leading-5 border
   {% if variant == "warning" %}
-    bg-bn-flamenco-200 text-bn-flamenco-900
+    bg-bn-flamenco-200 text-bn-flamenco-900 border-bn-flamenco-200
   {% elif variant == "primary" %}
-    bg-blue-200 text-blue-900
+    bg-blue-200 text-blue-900 border-blue-200
   {% elif variant == "danger" %}
-    bg-red-200 text-red-900
+    bg-red-200 text-red-900 border-red-200
   {% elif variant == "success" %}
-    bg-green-200 text-green-900
+    bg-green-200 text-green-900 border-green-200
   {% elif variant == "info" %}
-    bg-white text-slate-600
+    bg-white text-slate-600 border-slate-200
   {% endif %}
   {{ class }}
 ">

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -26,7 +26,7 @@ from jobserver.api.releases import (
     WorkspaceStatusAPI,
 )
 
-from .views.components import Components
+from .views.components import components
 from .views.errors import bad_request, page_not_found, permission_denied, server_error
 from .views.index import Index
 from .views.job_requests import (
@@ -281,7 +281,7 @@ urlpatterns = [
     path("settings/", Settings.as_view(), name="settings"),
     path("staff/", include("staff.urls", namespace="staff")),
     path("status/", include(status_urls)),
-    path("ui-components/", Components),
+    path("ui-components/", components),
     path("workspaces/", RedirectView.as_view(url="/")),
     path("__debug__/", include(debug_toolbar.urls)),
     path("__reload__/", include("django_browser_reload.urls")),

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -26,6 +26,7 @@ from jobserver.api.releases import (
     WorkspaceStatusAPI,
 )
 
+from .views.components import Components
 from .views.errors import bad_request, page_not_found, permission_denied, server_error
 from .views.index import Index
 from .views.job_requests import (
@@ -280,6 +281,7 @@ urlpatterns = [
     path("settings/", Settings.as_view(), name="settings"),
     path("staff/", include("staff.urls", namespace="staff")),
     path("status/", include(status_urls)),
+    path("ui-components/", Components),
     path("workspaces/", RedirectView.as_view(url="/")),
     path("__debug__/", include(debug_toolbar.urls)),
     path("__reload__/", include("django_browser_reload.urls")),

--- a/jobserver/views/components.py
+++ b/jobserver/views/components.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 
-from django.shortcuts import render
+from django.template.response import TemplateResponse
 
 
-def Components(request):
+def components(request):
     example_date = datetime.utcfromtimestamp(1667317153)
     example_form_email = {
         "auto_id": "id_notifications_email",
@@ -39,7 +39,7 @@ def Components(request):
         "value": "",
     }
 
-    return render(
+    return TemplateResponse(
         request,
         "_components/index.html",
         context={

--- a/jobserver/views/components.py
+++ b/jobserver/views/components.py
@@ -1,0 +1,5 @@
+from django.shortcuts import render
+
+
+def Components(request):
+    return render(request, "_components/index.html")

--- a/jobserver/views/components.py
+++ b/jobserver/views/components.py
@@ -5,8 +5,47 @@ from django.shortcuts import render
 
 def Components(request):
     example_date = datetime.utcfromtimestamp(1667317153)
+    example_form_email = {
+        "auto_id": "id_notifications_email",
+        "errors": {"This email is registered to a different account"},
+        "html_name": "notifications-email",
+        "id_for_label": "id_notifications_email",
+        "label": "Notification email address",
+        "value": "you@example.com",
+    }
+
+    example_form_select = {
+        "auto_id": "id_language_select",
+        "choices": [
+            ["", "Please select a language"],
+            ["english", "English"],
+            ["french", "French"],
+            ["german", "German"],
+            ["spanish", "SPanish"],
+        ],
+        "errors": {},
+        "html_name": "language-select",
+        "id_for_label": "id_language_select",
+        "label": "Language select",
+        "value": "french",
+    }
+
+    example_form_textarea = {
+        "auto_id": "id_project_description",
+        "errors": {},
+        "html_name": "project-description",
+        "id_for_label": "id_project_description",
+        "label": "Notification email address",
+        "value": "",
+    }
+
     return render(
         request,
         "_components/index.html",
-        context={"example_date": example_date},
+        context={
+            "example_date": example_date,
+            "example_form_email": example_form_email,
+            "example_form_select": example_form_select,
+            "example_form_textarea": example_form_textarea,
+        },
     )

--- a/jobserver/views/components.py
+++ b/jobserver/views/components.py
@@ -1,5 +1,12 @@
+from datetime import datetime
+
 from django.shortcuts import render
 
 
 def Components(request):
-    return render(request, "_components/index.html")
+    example_date = datetime.utcfromtimestamp(1667317153)
+    return render(
+        request,
+        "_components/index.html",
+        context={"example_date": example_date},
+    )

--- a/jobserver/views/components.py
+++ b/jobserver/views/components.py
@@ -21,7 +21,7 @@ def components(request):
             ["english", "English"],
             ["french", "French"],
             ["german", "German"],
-            ["spanish", "SPanish"],
+            ["spanish", "Spanish"],
         ],
         "errors": {},
         "html_name": "language-select",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@tanstack/react-query-devtools": "^4.16.1",
         "@ttskch/select2-bootstrap4-theme": "^1.5.2",
         "alpinejs": "git://github.com/ebmdatalab/alpine.git#v3.10.3-csp",
-        "anchor-js": "^4.3.1",
         "bootstrap": "^4.6.2",
         "bs-custom-file-input": "^1.3.4",
         "highlight.js": "^11.6.0",
@@ -34,6 +33,7 @@
         "react-router-dom": "^6.4.3",
         "react-window": "^1.8.8",
         "select2": "^4.0.13",
+        "slugify": "^1.6.5",
         "tablesorter": "^2.31.3",
         "tailwindcss": "^3.2.4",
         "whatwg-fetch": "^3.6.2"
@@ -1409,11 +1409,6 @@
       "workspaces": [
         "packages/*"
       ]
-    },
-    "node_modules/anchor-js": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/anchor-js/-/anchor-js-4.3.1.tgz",
-      "integrity": "sha512-TziERoibspey7KSm95oIdzTxiogXonJl7inQI07Y3cI25DKQaLkUftB7RhCuSb1GcwunHL6/PcIKM4dDUb9xYQ=="
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -7464,6 +7459,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/slugify": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9638,11 +9641,6 @@
     "alpinejs": {
       "version": "git+ssh://git@github.com/ebmdatalab/alpine.git#c2c3a51f6f4f4aa40a692cfe988c0a519ce3505c",
       "from": "alpinejs@git://github.com/ebmdatalab/alpine.git#v3.10.3-csp"
-    },
-    "anchor-js": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/anchor-js/-/anchor-js-4.3.1.tgz",
-      "integrity": "sha512-TziERoibspey7KSm95oIdzTxiogXonJl7inQI07Y3cI25DKQaLkUftB7RhCuSb1GcwunHL6/PcIKM4dDUb9xYQ=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -13866,6 +13864,11 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "slugify": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "alpinejs": "git://github.com/ebmdatalab/alpine.git#v3.10.3-csp",
         "bootstrap": "^4.6.2",
         "bs-custom-file-input": "^1.3.4",
+        "highlight.js": "^11.6.0",
         "htmx.org": "^1.8.4",
         "jquery": "^3.6.1",
         "just-debounce-it": "^3.1.1",
@@ -4227,6 +4228,14 @@
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
       "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==",
       "dev": true
+    },
+    "node_modules/highlight.js": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
+      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/history": {
       "version": "5.3.0",
@@ -11579,6 +11588,11 @@
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
       "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==",
       "dev": true
+    },
+    "highlight.js": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
+      "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw=="
     },
     "history": {
       "version": "5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-query-devtools": "^4.16.1",
         "@ttskch/select2-bootstrap4-theme": "^1.5.2",
         "alpinejs": "git://github.com/ebmdatalab/alpine.git#v3.10.3-csp",
+        "anchor-js": "^4.3.1",
         "bootstrap": "^4.6.2",
         "bs-custom-file-input": "^1.3.4",
         "highlight.js": "^11.6.0",
@@ -1408,6 +1409,11 @@
       "workspaces": [
         "packages/*"
       ]
+    },
+    "node_modules/anchor-js": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/anchor-js/-/anchor-js-4.3.1.tgz",
+      "integrity": "sha512-TziERoibspey7KSm95oIdzTxiogXonJl7inQI07Y3cI25DKQaLkUftB7RhCuSb1GcwunHL6/PcIKM4dDUb9xYQ=="
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -9632,6 +9638,11 @@
     "alpinejs": {
       "version": "git+ssh://git@github.com/ebmdatalab/alpine.git#c2c3a51f6f4f4aa40a692cfe988c0a519ce3505c",
       "from": "alpinejs@git://github.com/ebmdatalab/alpine.git#v3.10.3-csp"
+    },
+    "anchor-js": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/anchor-js/-/anchor-js-4.3.1.tgz",
+      "integrity": "sha512-TziERoibspey7KSm95oIdzTxiogXonJl7inQI07Y3cI25DKQaLkUftB7RhCuSb1GcwunHL6/PcIKM4dDUb9xYQ=="
     },
     "ansi-escapes": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "alpinejs": "git://github.com/ebmdatalab/alpine.git#v3.10.3-csp",
     "bootstrap": "^4.6.2",
     "bs-custom-file-input": "^1.3.4",
+    "highlight.js": "^11.6.0",
     "htmx.org": "^1.8.4",
     "jquery": "^3.6.1",
     "just-debounce-it": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@tanstack/react-query-devtools": "^4.16.1",
     "@ttskch/select2-bootstrap4-theme": "^1.5.2",
     "alpinejs": "git://github.com/ebmdatalab/alpine.git#v3.10.3-csp",
-    "anchor-js": "^4.3.1",
     "bootstrap": "^4.6.2",
     "bs-custom-file-input": "^1.3.4",
     "highlight.js": "^11.6.0",
@@ -68,6 +67,7 @@
     "react-router-dom": "^6.4.3",
     "react-window": "^1.8.8",
     "select2": "^4.0.13",
+    "slugify": "^1.6.5",
     "tablesorter": "^2.31.3",
     "tailwindcss": "^3.2.4",
     "whatwg-fetch": "^3.6.2"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@tanstack/react-query-devtools": "^4.16.1",
     "@ttskch/select2-bootstrap4-theme": "^1.5.2",
     "alpinejs": "git://github.com/ebmdatalab/alpine.git#v3.10.3-csp",
+    "anchor-js": "^4.3.1",
     "bootstrap": "^4.6.2",
     "bs-custom-file-input": "^1.3.4",
     "highlight.js": "^11.6.0",

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -8,3 +8,4 @@ Disallow: /login/
 Disallow: /logout/
 Disallow: /settings/
 Disallow: /staff/
+Disallow: /ui-components/

--- a/tests/unit/jobserver/views/test_components.py
+++ b/tests/unit/jobserver/views/test_components.py
@@ -1,0 +1,12 @@
+from django.contrib.auth.models import AnonymousUser
+
+from jobserver.views.components import components
+
+
+def test_components_gallery(rf):
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    response = components(request)
+
+    assert response.status_code == 200

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,11 +13,12 @@ const config = {
       input: {
         index: "./assets/src/scripts/index.js",
         "application-form": "./assets/src/scripts/application-form.js",
+        highlight: "./assets/src/scripts/highlight.js",
         job_request_create: "./assets/src/scripts/job_request_create.js",
         main: "./assets/src/scripts/main.js",
-        workspace_create: "./assets/src/scripts/workspace_create.js",
         "outputs-viewer": "./assets/src/scripts/outputs-viewer/index.jsx",
         tw: "./assets/src/scripts/tw.js",
+        workspace_create: "./assets/src/scripts/workspace_create.js",
       },
     },
     outDir: "assets/dist",

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,7 @@ const config = {
       input: {
         index: "./assets/src/scripts/index.js",
         "application-form": "./assets/src/scripts/application-form.js",
-        highlight: "./assets/src/scripts/highlight.js",
+        components: "./assets/src/scripts/components.js",
         job_request_create: "./assets/src/scripts/job_request_create.js",
         main: "./assets/src/scripts/main.js",
         "outputs-viewer": "./assets/src/scripts/outputs-viewer/index.jsx",


### PR DESCRIPTION
So that devs can preview and understand what each component looks like, then utilise the demo code to add components to pages.

- New page hosted at `/ui-components/`
- Added to robots.txt
- Lists each component in a menu automatically with JS
- **Fix:** Pill component border

Closes #2337

![localhost_8000_ui-components_ (1)](https://user-images.githubusercontent.com/24863179/202479454-2b28db0f-5c01-4cb4-a004-7836010a04af.png)
