### PR TITLE
Repo sign off tweaks

### DIFF
--- a/jobserver/templates/sign_off_repo.html
+++ b/jobserver/templates/sign_off_repo.html
@@ -254,7 +254,7 @@
           {% endif %}
 
           <p>
-            <a class="btn btn-outline-success" href="{{ project_url }}">Review project</a>
+            <a class="btn btn-primary" href="{{ project_url }}">Review project</a>
           </p>
         </div>
       </div>

--- a/jobserver/templates/sign_off_repo.html
+++ b/jobserver/templates/sign_off_repo.html
@@ -238,7 +238,7 @@
           </p>
 
           <p>
-            <a class="btn btn-outline-success" href="{{ project_url }}">View project</a>
+            <a class="btn btn-outline-success" href="{{ project_url }}">Review project</a>
           </p>
         </div>
       </div>

--- a/jobserver/templates/sign_off_repo.html
+++ b/jobserver/templates/sign_off_repo.html
@@ -156,6 +156,15 @@
                       <a href="{{ workspace.get_absolute_url }}">{{ workspace.name }}</a>
                     </li>
                     <li class="list-group-item">
+                      <div class="d-flex align-items-center">
+                        <strong>Purpose:</strong>
+                        <span class="d-block flex-grow-1 text-truncate ml-1">{{ workspace.purpose|default:"-" }}</span>
+                        <a class="btn btn-sm btn-primary ml-2" href="{{ workspace.get_edit_url }}">
+                          Edit
+                        </a>
+                      </div>
+                    </li>
+                    <li class="list-group-item">
                       <strong>Project:</strong>
                       <a href="{{ workspace.project.get_absolute_url }}">{{ workspace.project.title }}</a>
                     </li>

--- a/jobserver/templates/sign_off_repo.html
+++ b/jobserver/templates/sign_off_repo.html
@@ -246,6 +246,13 @@
             </a>.
           </p>
 
+          {% if project_status %}
+          <p>
+            <strong>Current status:</strong>
+            <span>{{ project_status }}</span>
+          </p>
+          {% endif %}
+
           <p>
             <a class="btn btn-outline-success" href="{{ project_url }}">Review project</a>
           </p>

--- a/jobserver/views/repos.py
+++ b/jobserver/views/repos.py
@@ -197,15 +197,19 @@ class SignOffRepo(TemplateView):
         # skipped.
         projects = Project.objects.filter(workspaces__repo=self.repo).distinct()
         if projects.count() == 1:
+            project = projects.first()
+            project_status = project.get_status_display()
             sign_off_url = self.repo.get_sign_off_url()
-            project_url = projects.first().get_edit_url() + f"?next={sign_off_url}"
+            project_url = project.get_edit_url() + f"?next={sign_off_url}"
         else:
+            project_status = None
             project_url = self.repo.get_handler_url()
 
         context = super().get_context_data() | {
             "workspaces_signed_off": workspaces_signed_off,
             "branches": branches,
             "repo": repo,
+            "project_status": project_status,
             "project_url": project_url,
             "workspaces": workspaces,
         }

--- a/jobserver/views/repos.py
+++ b/jobserver/views/repos.py
@@ -36,10 +36,12 @@ def build_workspace(workspace, github_api):
         "branch": workspace.branch,
         "branch_exists": branch_exists,
         "get_absolute_url": workspace.get_absolute_url(),
+        "get_edit_url": workspace.get_edit_url(),
         "is_archived": workspace.is_archived,
         "name": workspace.name,
         "get_readme_url": workspace.get_readme_url(),
         "project": workspace.project,
+        "purpose": workspace.purpose,
     }
 
 


### PR DESCRIPTION
Some fixes to the repo sign off page from end-to-end testing of the whole process.

* Purpose is now displayed in each workspace, truncated to a single line with an edit button which takes the user directly to the WorkspaceEdit page.  We can't trivially use the `?next=` trick on that form unfortunately because the repo URL gets unquoted and I don't think we want to handle that in that view.
* Project section now shows the current status of a Project if there is only one project.

**Before:**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/7Kuk79KJ/242f63a1-9c93-43b5-a609-513f77988414.jpg?v=9ac6b1fc42e0547c5c25ec03dfb7e5b3)

**After:**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/geuy6XXL/84d58510-6392-42a1-83ed-28eded17b77e.jpg?v=a5ba2b39366711042c5b76d0593800b1)

Fixes: #2325 
Fixes: #2326 