### PR TITLE
Ignore jobs associated with unknown JobRequests

### DIFF
--- a/jobserver/api/jobs.py
+++ b/jobserver/api/jobs.py
@@ -82,6 +82,8 @@ class JobAPIUpdate(APIView):
         jobs_by_request = itertools.groupby(
             serializer.data, key=operator.itemgetter("job_request_id")
         )
+        created_job_ids = []
+        updated_job_ids = []
         for jr_identifier, jobs in jobs_by_request:
             jobs = list(jobs)
 
@@ -103,9 +105,6 @@ class JobAPIUpdate(APIView):
             if identifiers_to_delete:
                 job_request.jobs.filter(identifier__in=identifiers_to_delete).delete()
 
-            # grab Job IDs instead of logging for every Job in the payload (which gets very noisy)
-            created_job_ids = []
-            updated_job_ids = []
             for job_data in jobs:
                 # remove this value from the data, it's going to be set by
                 # creating/updating Job instances via the JobRequest instances

--- a/tests/unit/jobserver/api/test_jobs.py
+++ b/tests/unit/jobserver/api/test_jobs.py
@@ -551,8 +551,9 @@ def test_jobapiupdate_unknown_job_request(api_rf):
     )
     response = JobAPIUpdate.as_view()(request)
 
-    assert response.status_code == 400, response.data
-    assert "Unknown JobRequest IDs" in response.data[0]
+    # Jobs associated with unknown requests should be ignored
+    assert response.status_code == 200, response.data
+    assert not Job.objects.exists()
 
 
 def test_jobrequestapicreate_invalid_token(api_rf):


### PR DESCRIPTION
We're planning to [update][1] the job-runner sync protocol such that it syncs the state of all active jobs, where active now means those jobs which job-server thinks are active _and_ those which job-runner thinks are active. This should make the sync process even more robust against "non-standard" things happening (i.e. us fiddling with the state of jobs).

This changes means that it's no longer a protocol violation for job-runner to tell job-server about a job which job-server didn't explicitly ask about. If this happens (which I don't expect it to really) we should log it but not treat it as an error.

[1]: https://github.com/opensafely-core/job-runner/pull/519