### PR TITLE
Add project number to dashboards

### DIFF
--- a/assets/src/js/repos-tablesorter.js
+++ b/assets/src/js/repos-tablesorter.js
@@ -19,6 +19,7 @@ $(() => {
         "form-control",
         "form-control",
         "form-control",
+        "form-control",
       ],
     },
   });

--- a/staff/templates/staff/dashboards/copiloting.html
+++ b/staff/templates/staff/dashboards/copiloting.html
@@ -56,7 +56,12 @@
           <tbody>
             {% for project in projects %}
             <tr>
-              <td><a href="{{ project.get_staff_url }}">{{ project.name }}</a></td>
+              <td>
+                <a href="{{ project.get_staff_url }}">
+                  {{ project.name }}
+                  {% if project.number %} ({{ project.number }}){% endif %}
+                </a>
+              </td>
               <td><a href="{{ project.org.get_staff_url }}">{{ project.org.name }}</a></td>
               <td>
                 {% if project.copilot %}

--- a/staff/templates/staff/dashboards/projects.html
+++ b/staff/templates/staff/dashboards/projects.html
@@ -56,7 +56,12 @@
           <tbody>
             {% for project in projects %}
             <tr>
-              <td><a href="{{ project.get_staff_url }}">{{ project.name }}</a></td>
+              <td>
+                <a href="{{ project.get_staff_url }}">
+                  {{ project.name }}
+                  {% if project.number %} ({{ project.number }}){% endif %}
+                </a>
+              </td>
               <td><a href="{{ project.org.get_staff_url }}">{{ project.org.name }}</a></td>
               <td>
                 {% if project.copilot %}

--- a/staff/templates/staff/dashboards/repos.html
+++ b/staff/templates/staff/dashboards/repos.html
@@ -11,6 +11,9 @@
       <li class="breadcrumb-item">
         <a href="{% url 'staff:index' %}">Staff area</a>
       </li>
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:dashboards:index' %}">Dashboards</a>
+      </li>
       <li class="breadcrumb-item active" aria-current="page">
         OpenSAFELY Private Repos
       </li>

--- a/staff/templates/staff/dashboards/repos.html
+++ b/staff/templates/staff/dashboards/repos.html
@@ -42,6 +42,7 @@
           <thead>
             <tr>
               <th>Repo</th>
+              <th>Project(s)</th>
               <th>Workspaces</th>
               <th>Contact</th>
               <th>Created on</th>
@@ -54,6 +55,41 @@
             {% for repo in repos %}
             <tr>
               <td><a href="{% url 'staff:repo-detail' repo_url=repo.quoted_url %}">{{ repo.name }}</a></td>
+
+              <td>
+                {% if repo.projects|length > 1 %}
+                  <details>
+                    <summary>
+                      <span class="summary--show">Show</span>
+                      <span class="summary--hide">Hide</span>
+                      {{ repo.projects|length }} projects
+                    </summary>
+                    <ul class="mt-1 mb-0 pl-2 ml-2">
+                      {% for project in repo.projects %}
+                      <li>
+                        <a href="{{ project.get_staff_url }}">
+                          {% if project.number %}
+                          {{ project.number }}
+                          {% else %}
+                          {{ project.name }}
+                          {% endif %}
+                        </a>
+                      </li>
+                      {% endfor %}
+                    </ul>
+                  </details>
+                {% else %}
+                  {% for project in repo.projects %}
+                    <a href="{{ project.get_staff_url }}">
+                      {% if project.number %}
+                      {{ project.number }}
+                      {% else %}
+                      {{ project.name }}
+                      {% endif %}
+                    </a>
+                  {% endfor %}
+                {% endif %}
+              </td>
 
               <td>
                 {% if repo.workspaces|length > 1 %}

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -19,6 +19,7 @@ from .views.backends import (
 from .views.dashboards.copiloting import Copiloting
 from .views.dashboards.index import DashboardIndex
 from .views.dashboards.projects import ProjectsDashboard
+from .views.dashboards.repos import PrivateReposDashboard
 from .views.index import Index
 from .views.orgs import (
     OrgCreate,
@@ -42,7 +43,7 @@ from .views.projects import (
     ProjectMembershipRemove,
 )
 from .views.redirects import RedirectDelete, RedirectDetail, RedirectList
-from .views.repos import PrivateReposDashboard, RepoDetail, RepoList, RepoSignOff
+from .views.repos import RepoDetail, RepoList, RepoSignOff
 from .views.researchers import ResearcherEdit
 from .views.users import UserDetail, UserList, UserSetOrgs
 from .views.workspaces import WorkspaceDetail, WorkspaceEdit, WorkspaceList

--- a/staff/views/dashboards/copiloting.py
+++ b/staff/views/dashboards/copiloting.py
@@ -76,7 +76,12 @@ class Copiloting(TemplateView):
                     "workspace_count": project.workspace_count,
                 }
 
-        projects = list(iter_projects(projects, file_counts_by_project))
+        projects = list(
+            sorted(
+                iter_projects(projects, file_counts_by_project),
+                key=lambda p: p["name"].lower(),
+            )
+        )
 
         return super().get_context_data(**kwargs) | {
             "projects": projects,

--- a/staff/views/dashboards/copiloting.py
+++ b/staff/views/dashboards/copiloting.py
@@ -71,6 +71,7 @@ class Copiloting(TemplateView):
                     "get_staff_url": project.get_staff_url(),
                     "job_request_count": project.job_request_count,
                     "name": project.name,
+                    "number": project.number,
                     "org": project.org,
                     "workspace_count": project.workspace_count,
                 }

--- a/staff/views/dashboards/projects.py
+++ b/staff/views/dashboards/projects.py
@@ -66,6 +66,7 @@ class ProjectsDashboard(TemplateView):
                     "get_staff_url": project.get_staff_url(),
                     "job_request_count": project.job_request_count,
                     "name": project.name,
+                    "number": project.number,
                     "org": project.org,
                     "workspace_count": project.workspace_count,
                 }

--- a/staff/views/dashboards/projects.py
+++ b/staff/views/dashboards/projects.py
@@ -2,7 +2,7 @@ import itertools
 
 from csp.decorators import csp_exempt
 from django.db.models import Count, Min
-from django.db.models.functions import Least
+from django.db.models.functions import Least, Lower
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
@@ -29,7 +29,7 @@ class ProjectsDashboard(TemplateView):
                     )
                 ),
             )
-            .order_by("name")
+            .order_by(Lower("name"))
             .iterator()
         )
 

--- a/staff/views/dashboards/repos.py
+++ b/staff/views/dashboards/repos.py
@@ -1,0 +1,132 @@
+from datetime import timedelta
+from urllib.parse import quote
+
+import structlog
+from csp.decorators import csp_exempt
+from django.db.models import Count, Min
+from django.db.models.functions import Least
+from django.template.response import TemplateResponse
+from django.utils import timezone
+from django.utils.decorators import method_decorator
+from django.views.generic import View
+from first import first
+
+from jobserver.authorization import CoreDeveloper
+from jobserver.authorization.decorators import require_role
+from jobserver.github import _get_github_api
+from jobserver.models import Workspace
+
+
+logger = structlog.get_logger(__name__)
+
+
+@method_decorator(require_role(CoreDeveloper), name="dispatch")
+class PrivateReposDashboard(View):
+    get_github_api = staticmethod(_get_github_api)
+
+    @csp_exempt
+    def get(self, request, *args, **kwargs):
+        """
+        List private repos which are in need of converting to public
+
+        Repos should be:
+         * Private
+         * not have `non-research` topic
+         * first job was run > 11 months ago
+        """
+        all_repos = list(self.get_github_api().get_repos_with_dates("opensafely"))
+
+        # remove repos with the non-research topic
+        all_repos = [r for r in all_repos if "non-research" not in r["topics"]]
+
+        private_repos = [repo for repo in all_repos if repo["is_private"]]
+
+        all_workspaces = list(
+            Workspace.objects.exclude(project__slug="opensafely-testing")
+            .select_related("created_by", "project", "repo")
+            .annotate(num_jobs=Count("job_requests__jobs"))
+            .annotate(
+                first_run=Min(
+                    Least(
+                        "job_requests__jobs__started_at",
+                        "job_requests__jobs__created_at",
+                    )
+                ),
+            )
+        )
+
+        def enhance(repo):
+            """
+            Enhance the repo dict from get_repos_with_dates() with workspace data
+
+            We need to filter repos, not workspaces, so this gives us all the
+            information we need when filtering further down.
+            """
+            # get workspaces just for this repo
+            workspaces = [
+                w for w in all_workspaces if repo["url"].lower() == w.repo.url.lower()
+            ]
+            workspaces = sorted(workspaces, key=lambda w: w.name.lower())
+
+            # get workspaces which have run jobs
+            with_jobs = [w for w in workspaces if w.first_run]
+
+            # sorting by a datetime puts the workspaces into oldest job first
+            with_jobs = sorted(with_jobs, key=lambda w: w.first_run)
+
+            # get the first workspace to have run a job
+            workspace = first(with_jobs, key=lambda w: w.first_run)
+
+            # get first_run as either None or a datetime
+            first_run = workspace.first_run if workspace else None
+
+            # has this repo ever had jobs run with it?
+            has_jobs = sum(w.num_jobs for w in workspaces) > 0
+
+            # how many of the workspaces have been signed-off for being published?
+            signed_off = sum(1 for w in workspaces if w.signed_off_at)
+
+            return repo | {
+                "first_run": first_run,
+                "has_jobs": has_jobs,
+                "has_github_outputs": "github-releases" in repo["topics"],
+                "quoted_url": quote(repo["url"], safe=""),
+                "signed_off": signed_off,
+                "workspace": workspace,
+                "workspaces": workspaces,
+            }
+
+        # add workspace (and related object) data to repos
+        repos = [enhance(r) for r in private_repos]
+
+        eleven_months_ago = timezone.now() - timedelta(days=30 * 11)
+
+        def select(repo):
+            """
+            Select a repo based on various predicates below.
+
+            We're already working with private repos here so we check
+
+            * Has jobs or a workspace
+            * First job to run happened over 11 months ago
+            """
+            if not (repo["workspaces"] and repo["has_jobs"]):
+                logger.info("No workspaces/jobs", url=repo["url"])
+                return False
+
+            # because we know we have at least one job and first_run looks at
+            # either started_at OR created_at we know we will always have a
+            # value for first_run at this point
+            first_ran_over_11_months_ago = repo["first_run"] < eleven_months_ago
+            if not first_ran_over_11_months_ago:
+                logger.info("First run <11mo ago", url=repo["url"])
+                return False
+
+            return True
+
+        # select only repos we care about
+        repos = [r for r in repos if select(r)]
+
+        return TemplateResponse(
+            request, "staff/dashboards/repos.html", {"repos": repos}
+        )

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -1,12 +1,11 @@
 import textwrap
 from datetime import timedelta
-from urllib.parse import quote, unquote
+from urllib.parse import unquote
 
 import structlog
-from csp.decorators import csp_exempt
 from django.contrib import messages
 from django.db import transaction
-from django.db.models import Count, Min
+from django.db.models import Min
 from django.db.models.functions import Least, Lower
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
@@ -14,12 +13,11 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
 from django.views.generic import ListView, View
-from first import first
 
 from jobserver.authorization import CoreDeveloper, has_permission
 from jobserver.authorization.decorators import require_role
 from jobserver.github import _get_github_api
-from jobserver.models import Job, Org, Project, Repo, User, Workspace
+from jobserver.models import Job, Org, Project, Repo, User
 
 
 logger = structlog.get_logger(__name__)
@@ -27,118 +25,6 @@ logger = structlog.get_logger(__name__)
 
 def ran_at(job):
     return job.started_at or job.created_at
-
-
-@method_decorator(require_role(CoreDeveloper), name="dispatch")
-class PrivateReposDashboard(View):
-    get_github_api = staticmethod(_get_github_api)
-
-    @csp_exempt
-    def get(self, request, *args, **kwargs):
-        """
-        List private repos which are in need of converting to public
-
-        Repos should be:
-         * Private
-         * not have `non-research` topic
-         * first job was run > 11 months ago
-        """
-        all_repos = list(self.get_github_api().get_repos_with_dates("opensafely"))
-
-        # remove repos with the non-research topic
-        all_repos = [r for r in all_repos if "non-research" not in r["topics"]]
-
-        private_repos = [repo for repo in all_repos if repo["is_private"]]
-
-        all_workspaces = list(
-            Workspace.objects.exclude(project__slug="opensafely-testing")
-            .select_related("created_by", "project", "repo")
-            .annotate(num_jobs=Count("job_requests__jobs"))
-            .annotate(
-                first_run=Min(
-                    Least(
-                        "job_requests__jobs__started_at",
-                        "job_requests__jobs__created_at",
-                    )
-                ),
-            )
-        )
-
-        def enhance(repo):
-            """
-            Enhance the repo dict from get_repos_with_dates() with workspace data
-
-            We need to filter repos, not workspaces, so this gives us all the
-            information we need when filtering further down.
-            """
-            # get workspaces just for this repo
-            workspaces = [
-                w for w in all_workspaces if repo["url"].lower() == w.repo.url.lower()
-            ]
-            workspaces = sorted(workspaces, key=lambda w: w.name.lower())
-
-            # get workspaces which have run jobs
-            with_jobs = [w for w in workspaces if w.first_run]
-
-            # sorting by a datetime puts the workspaces into oldest job first
-            with_jobs = sorted(with_jobs, key=lambda w: w.first_run)
-
-            # get the first workspace to have run a job
-            workspace = first(with_jobs, key=lambda w: w.first_run)
-
-            # get first_run as either None or a datetime
-            first_run = workspace.first_run if workspace else None
-
-            # has this repo ever had jobs run with it?
-            has_jobs = sum(w.num_jobs for w in workspaces) > 0
-
-            # how many of the workspaces have been signed-off for being published?
-            signed_off = sum(1 for w in workspaces if w.signed_off_at)
-
-            return repo | {
-                "first_run": first_run,
-                "has_jobs": has_jobs,
-                "has_github_outputs": "github-releases" in repo["topics"],
-                "quoted_url": quote(repo["url"], safe=""),
-                "signed_off": signed_off,
-                "workspace": workspace,
-                "workspaces": workspaces,
-            }
-
-        # add workspace (and related object) data to repos
-        repos = [enhance(r) for r in private_repos]
-
-        eleven_months_ago = timezone.now() - timedelta(days=30 * 11)
-
-        def select(repo):
-            """
-            Select a repo based on various predicates below.
-
-            We're already working with private repos here so we check
-
-            * Has jobs or a workspace
-            * First job to run happened over 11 months ago
-            """
-            if not (repo["workspaces"] and repo["has_jobs"]):
-                logger.info("No workspaces/jobs", url=repo["url"])
-                return False
-
-            # because we know we have at least one job and first_run looks at
-            # either started_at OR created_at we know we will always have a
-            # value for first_run at this point
-            first_ran_over_11_months_ago = repo["first_run"] < eleven_months_ago
-            if not first_ran_over_11_months_ago:
-                logger.info("First run <11mo ago", url=repo["url"])
-                return False
-
-            return True
-
-        # select only repos we care about
-        repos = [r for r in repos if select(r)]
-
-        return TemplateResponse(
-            request, "staff/dashboards/repos.html", {"repos": repos}
-        )
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")

--- a/tests/unit/staff/views/dashboards/test_repos.py
+++ b/tests/unit/staff/views/dashboards/test_repos.py
@@ -1,0 +1,91 @@
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import PermissionDenied
+from django.utils import timezone
+
+from staff.views.dashboards.repos import PrivateReposDashboard
+
+from .....factories import JobFactory, JobRequestFactory, RepoFactory, WorkspaceFactory
+from .....fakes import FakeGitHubAPI
+from .....utils import minutes_ago
+
+
+def test_privatereposdashboard_success(rf, django_assert_num_queries, core_developer):
+    eleven_months_ago = timezone.now() - timedelta(days=30 * 11)
+
+    # 3 private repos
+    # 1 public repo
+    # 3, 2, 1 workspaces respectively for 3 private repos
+
+    # research-repo-1
+    repo1 = RepoFactory(url="https://github.com/opensafely/research-repo-1")
+    rr1_workspace_1 = WorkspaceFactory(repo=repo1)
+    rr1_jr_1 = JobRequestFactory(workspace=rr1_workspace_1)
+    JobFactory(job_request=rr1_jr_1, started_at=minutes_ago(eleven_months_ago, 3))
+    JobFactory(job_request=rr1_jr_1, started_at=minutes_ago(eleven_months_ago, 2))
+    JobFactory(job_request=rr1_jr_1, started_at=minutes_ago(eleven_months_ago, 1))
+
+    rr1_workspace_2 = WorkspaceFactory(repo=repo1)
+    rr1_jr_2 = JobRequestFactory(workspace=rr1_workspace_2)
+    JobFactory(job_request=rr1_jr_2, started_at=minutes_ago(eleven_months_ago, 4))
+    JobFactory(job_request=rr1_jr_2, started_at=minutes_ago(eleven_months_ago, 5))
+
+    rr1_workspace_3 = WorkspaceFactory(repo=repo1)
+    rr1_jr_3 = JobRequestFactory(workspace=rr1_workspace_3)
+    JobFactory(job_request=rr1_jr_3, started_at=minutes_ago(eleven_months_ago, 10))
+
+    # research-repo-2
+    repo2 = RepoFactory(url="https://github.com/opensafely/research-repo-2")
+    rr2_workspace_1 = WorkspaceFactory(repo=repo2)
+    rr2_jr_1 = JobRequestFactory(workspace=rr2_workspace_1)
+    JobFactory(job_request=rr2_jr_1, started_at=minutes_ago(eleven_months_ago, 30))
+    JobFactory(job_request=rr2_jr_1, started_at=minutes_ago(eleven_months_ago, 20))
+    JobFactory(job_request=rr2_jr_1, started_at=None)
+
+    rr2_workspace_2 = WorkspaceFactory(repo=repo2)
+    rr2_jr_2 = JobRequestFactory(workspace=rr2_workspace_2)
+    JobFactory(job_request=rr2_jr_2, started_at=minutes_ago(eleven_months_ago, 17))
+    JobFactory(job_request=rr2_jr_2, started_at=minutes_ago(eleven_months_ago, 13))
+
+    # research-repo-3
+    rr3_workspace_1 = WorkspaceFactory(
+        repo=RepoFactory(url="https://github.com/opensafely/research-repo-3")
+    )
+    rr3_jr_1 = JobRequestFactory(workspace=rr3_workspace_1)
+    JobFactory(job_request=rr3_jr_1, started_at=minutes_ago(eleven_months_ago, 42))
+    JobFactory(job_request=rr3_jr_1, started_at=minutes_ago(eleven_months_ago, 38))
+
+    # research-repo-5
+    rr5_workspace_1 = WorkspaceFactory(
+        repo=RepoFactory(url="https://github.com/opensafely/research-repo-5")
+    )
+    rr5_jr_1 = JobRequestFactory(workspace=rr5_workspace_1)
+    JobFactory(job_request=rr5_jr_1, started_at=None)
+
+    request = rf.get("/")
+    request.user = core_developer
+
+    with django_assert_num_queries(1):
+        response = PrivateReposDashboard.as_view(get_github_api=FakeGitHubAPI)(request)
+
+    assert response.status_code == 200
+
+    research_repo_1, research_repo_2 = response.context_data["repos"]
+
+    assert research_repo_1["first_run"] == minutes_ago(eleven_months_ago, 10)
+    assert research_repo_1["has_github_outputs"]
+    assert research_repo_1["workspace"] == rr1_workspace_3
+
+    assert research_repo_2["first_run"] == minutes_ago(eleven_months_ago, 30)
+    assert not research_repo_2["has_github_outputs"]
+    assert research_repo_2["workspace"] == rr2_workspace_1
+
+
+def test_privatereposdashboard_unauthorized(rf):
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    with pytest.raises(PermissionDenied):
+        PrivateReposDashboard.as_view()(request)

--- a/tests/unit/staff/views/dashboards/test_repos.py
+++ b/tests/unit/staff/views/dashboards/test_repos.py
@@ -67,7 +67,7 @@ def test_privatereposdashboard_success(rf, django_assert_num_queries, core_devel
     request = rf.get("/")
     request.user = core_developer
 
-    with django_assert_num_queries(1):
+    with django_assert_num_queries(2):
         response = PrivateReposDashboard.as_view(get_github_api=FakeGitHubAPI)(request)
 
     assert response.status_code == 200

--- a/tests/unit/staff/views/test_repos.py
+++ b/tests/unit/staff/views/test_repos.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from urllib.parse import quote
 
 import pytest
@@ -8,13 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.utils import timezone
 
-from staff.views.repos import (
-    PrivateReposDashboard,
-    RepoDetail,
-    RepoList,
-    RepoSignOff,
-    ran_at,
-)
+from staff.views.repos import RepoDetail, RepoList, RepoSignOff, ran_at
 
 from ....factories import (
     JobFactory,
@@ -33,85 +26,6 @@ def test_ran_at():
 
     assert ran_at(JobFactory(created_at=created, started_at=None)) == created
     assert ran_at(JobFactory(created_at=created, started_at=started)) == started
-
-
-def test_privatereposdashboard_success(rf, django_assert_num_queries, core_developer):
-    eleven_months_ago = timezone.now() - timedelta(days=30 * 11)
-
-    # 3 private repos
-    # 1 public repo
-    # 3, 2, 1 workspaces respectively for 3 private repos
-
-    # research-repo-1
-    repo1 = RepoFactory(url="https://github.com/opensafely/research-repo-1")
-    rr1_workspace_1 = WorkspaceFactory(repo=repo1)
-    rr1_jr_1 = JobRequestFactory(workspace=rr1_workspace_1)
-    JobFactory(job_request=rr1_jr_1, started_at=minutes_ago(eleven_months_ago, 3))
-    JobFactory(job_request=rr1_jr_1, started_at=minutes_ago(eleven_months_ago, 2))
-    JobFactory(job_request=rr1_jr_1, started_at=minutes_ago(eleven_months_ago, 1))
-
-    rr1_workspace_2 = WorkspaceFactory(repo=repo1)
-    rr1_jr_2 = JobRequestFactory(workspace=rr1_workspace_2)
-    JobFactory(job_request=rr1_jr_2, started_at=minutes_ago(eleven_months_ago, 4))
-    JobFactory(job_request=rr1_jr_2, started_at=minutes_ago(eleven_months_ago, 5))
-
-    rr1_workspace_3 = WorkspaceFactory(repo=repo1)
-    rr1_jr_3 = JobRequestFactory(workspace=rr1_workspace_3)
-    JobFactory(job_request=rr1_jr_3, started_at=minutes_ago(eleven_months_ago, 10))
-
-    # research-repo-2
-    repo2 = RepoFactory(url="https://github.com/opensafely/research-repo-2")
-    rr2_workspace_1 = WorkspaceFactory(repo=repo2)
-    rr2_jr_1 = JobRequestFactory(workspace=rr2_workspace_1)
-    JobFactory(job_request=rr2_jr_1, started_at=minutes_ago(eleven_months_ago, 30))
-    JobFactory(job_request=rr2_jr_1, started_at=minutes_ago(eleven_months_ago, 20))
-    JobFactory(job_request=rr2_jr_1, started_at=None)
-
-    rr2_workspace_2 = WorkspaceFactory(repo=repo2)
-    rr2_jr_2 = JobRequestFactory(workspace=rr2_workspace_2)
-    JobFactory(job_request=rr2_jr_2, started_at=minutes_ago(eleven_months_ago, 17))
-    JobFactory(job_request=rr2_jr_2, started_at=minutes_ago(eleven_months_ago, 13))
-
-    # research-repo-3
-    rr3_workspace_1 = WorkspaceFactory(
-        repo=RepoFactory(url="https://github.com/opensafely/research-repo-3")
-    )
-    rr3_jr_1 = JobRequestFactory(workspace=rr3_workspace_1)
-    JobFactory(job_request=rr3_jr_1, started_at=minutes_ago(eleven_months_ago, 42))
-    JobFactory(job_request=rr3_jr_1, started_at=minutes_ago(eleven_months_ago, 38))
-
-    # research-repo-5
-    rr5_workspace_1 = WorkspaceFactory(
-        repo=RepoFactory(url="https://github.com/opensafely/research-repo-5")
-    )
-    rr5_jr_1 = JobRequestFactory(workspace=rr5_workspace_1)
-    JobFactory(job_request=rr5_jr_1, started_at=None)
-
-    request = rf.get("/")
-    request.user = core_developer
-
-    with django_assert_num_queries(1):
-        response = PrivateReposDashboard.as_view(get_github_api=FakeGitHubAPI)(request)
-
-    assert response.status_code == 200
-
-    research_repo_1, research_repo_2 = response.context_data["repos"]
-
-    assert research_repo_1["first_run"] == minutes_ago(eleven_months_ago, 10)
-    assert research_repo_1["has_github_outputs"]
-    assert research_repo_1["workspace"] == rr1_workspace_3
-
-    assert research_repo_2["first_run"] == minutes_ago(eleven_months_ago, 30)
-    assert not research_repo_2["has_github_outputs"]
-    assert research_repo_2["workspace"] == rr2_workspace_1
-
-
-def test_privatereposdashboard_unauthorized(rf):
-    request = rf.get("/")
-    request.user = AnonymousUser()
-
-    with pytest.raises(PermissionDenied):
-        PrivateReposDashboard.as_view()(request)
 
 
 def test_repodetail_success(rf, core_developer):


### PR DESCRIPTION
This adds project number to our dashboards so we can easily reference them elsewhere.

The private repos dashboard uses them instead of names when we have them since it's quite a dense UI at this point.

Both the copiloting and projects dashboards have them as parenthesed suffixes since we don't currently have them for most projects so a prefix made the list harder to read.

Fixes: #2362 