### PR TITLE
Scope "first time code was run" to the project level

### DIFF
--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -226,7 +226,7 @@ class WorkspaceDetail(View):
 
         # get the first job for this workspace's repo
         first_job = (
-            Job.objects.filter(job_request__workspace__repo=workspace.repo)
+            Job.objects.filter(job_request__workspace__project=workspace.project)
             .annotate(run_at=Least("started_at", "created_at"))
             .order_by("run_at")
             .first()

--- a/templates/staff/dashboards/repos.html
+++ b/templates/staff/dashboards/repos.html
@@ -122,8 +122,8 @@
               </td>
 
               <td>
-                <a href="{{ repo.workspace.created_by.get_staff_url }}">
-                  {{ repo.workspace.created_by.name }}
+                <a href="{{ repo.contact.get_staff_url }}">
+                  {{ repo.contact.name }}
                 </a>
               </td>
 

--- a/tests/unit/staff/views/dashboards/test_repos.py
+++ b/tests/unit/staff/views/dashboards/test_repos.py
@@ -76,11 +76,9 @@ def test_privatereposdashboard_success(rf, django_assert_num_queries, core_devel
 
     assert research_repo_1["first_run"] == minutes_ago(eleven_months_ago, 10)
     assert research_repo_1["has_github_outputs"]
-    assert research_repo_1["workspace"] == rr1_workspace_3
 
     assert research_repo_2["first_run"] == minutes_ago(eleven_months_ago, 30)
     assert not research_repo_2["has_github_outputs"]
-    assert research_repo_2["workspace"] == rr2_workspace_1
 
 
 def test_privatereposdashboard_unauthorized(rf):


### PR DESCRIPTION
This means that for a given repo, we have to look at any project connected to it, at least until we can confine all repos to only having one project.

Fixes: #2365 