### PR TITLE
Add link to project purpose

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -497,6 +497,14 @@ class Project(models.Model):
             kwargs={"org_slug": self.org.slug, "project_slug": self.slug},
         )
 
+    def get_approved_url(self):
+        f = furl("https://www.opensafely.org/approved-projects")
+
+        if self.number:
+            f.fragment = f"project-{self.number}"
+
+        return f.url
+
     def get_edit_url(self):
         return reverse(
             "project-edit",

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -79,6 +79,9 @@
             {% endspaceless %}. Every time a researcher runs their analytic
             code against patient data, it is audited in public here.
           </p>
+          <p class="mt-4">
+          {% link href=project.get_approved_url text="View project purpose" %}
+          </p>
         </div>
         {% if project.status_description %}
           {% #alert variant="info" title="Project "|add:project.status class="mt-3 !shadow-none border" no_icon %}

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -72,17 +72,13 @@
           {{ project.name }}
         </h1>
         <div class="max-w-prose font-lg text-slate-600">
-          {% if project.description %}
-            {{ project.description }}
-          {% else %}
-            <p>
-              {{ project.name }} is an OpenSAFELY project from
-              {% spaceless %}
-                {% link href=project.org.get_absolute_url text=project.org.name %}
-              {% endspaceless %}. Every time a researcher runs their analytic
-              code against patient data, it is audited in public here.
-            </p>
-          {% endif %}
+          <p>
+            {{ project.name }} is an OpenSAFELY project from
+            {% spaceless %}
+              {% link href=project.org.get_absolute_url text=project.org.name %}
+            {% endspaceless %}. Every time a researcher runs their analytic
+            code against patient data, it is audited in public here.
+          </p>
         </div>
         {% if project.status_description %}
           {% #alert variant="info" title="Project "|add:project.status class="mt-3 !shadow-none border" no_icon %}

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -83,7 +83,6 @@
               code against patient data, it is audited in public here.
             </p>
           {% endif %}
-          </p>
         </div>
         {% if project.status_description %}
           {% #alert variant="info" title="Project "|add:project.status class="mt-3 !shadow-none border" no_icon %}

--- a/tests/unit/jobserver/models/test_core.py
+++ b/tests/unit/jobserver/models/test_core.py
@@ -529,6 +529,21 @@ def test_project_get_absolute_url():
     )
 
 
+def test_project_get_approved_url_with_number():
+    project = ProjectFactory(number=42)
+
+    assert (
+        project.get_approved_url()
+        == "https://www.opensafely.org/approved-projects#project-42"
+    )
+
+
+def test_project_get_approved_url_without_number():
+    project = ProjectFactory()
+
+    assert project.get_approved_url() == "https://www.opensafely.org/approved-projects"
+
+
 def test_project_get_edit_url():
     project = ProjectFactory()
 


### PR DESCRIPTION
This adds a link from ProjectDetail to the approve projects page on opensafely.org, appending the anchor fragment if we have a number to put in there.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/v1uEvL7d/37b34913-4573-47fd-9f61-618e28787c10.jpg?v=375cf681ce62dd0dfb627c964b0f6f27)

Fixes: #2366