### PR TITLE
Improve the status page layout and content

### DIFF
--- a/templates/_components/card/card-footer.html
+++ b/templates/_components/card/card-footer.html
@@ -2,11 +2,11 @@
   class="
     bg-slate-50 px-4 py-2
     md:px-6 md:py-5
-
     {% if not no_container %}
       -mx-4 mt-6
       md:-mb-5 md:-mx-6
     {% endif %}
+    {{ class }}
   "
 >
   {{ children }}

--- a/templates/_components/index.html
+++ b/templates/_components/index.html
@@ -175,6 +175,7 @@
       <h3>Card footer</h3>
       <ul>
         <li><code>children</code>: [html] - display the children components</li>
+        <li><code>class</code>: [string] - add HTML classes to the component</li>
         <li><code>no_container</code>: [boolean] - if true, remove all padding from the footer</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border boder-slate-500 rounded">

--- a/templates/status.html
+++ b/templates/status.html
@@ -31,33 +31,38 @@
         </div>
       </div>
       <div>
-        {% #description_item title="Runner last seen" stacked=True %}
+        {% #description_item title="Last contact with "|add:backend.name|add:" backend" stacked=True %}
           <time
             class="
-              font-medium text-slate-900 group relative cursor-pointer
-              {% if backend.last_seen %}text-bn-ribbon-900{% endif %}
+              text-slate-900 group relative cursor-pointer
+              {% if not backend.last_seen %}text-bn-ribbon-900{% endif %}
             "
             datetime="{{ backend.last_seen|date:"Y-m-d H:i:sO" }}">
             {{ backend.last_seen|naturaltime }}
+            {% if backend.last_seen %}
             {% tooltip class="font-mono" position="-bottom-4" content=backend.last_seen|date:"d M Y H:i:s e" %}
+            {% endif %}
           </time>
         {% /description_item %}
-        {% #description_item title="Threshold for missing" stacked=True %}
-          {{ backend.alert_timeout|duration }}
-        {% /description_item %}
-        {% #description_item title="Unacked Jobs" stacked=True %}
+        {% #description_item title="Job requests sent from OpenSAFELY Jobs" stacked=True %}
           {{ backend.queue.unacked }}
         {% /description_item %}
-        {% #description_item title="Acked Jobs" stacked=True %}
+        {% #description_item title="Job requests received by "|add:backend.name|add:" backend" stacked=True %}
           {{ backend.queue.acked }}
         {% /description_item %}
-        {% #description_item title="Running" stacked=True %}
-          {{ backend.queue.running }}
-        {% /description_item %}
-        {% #description_item title="Pending" stacked=True %}
+        {% #description_item title="Pending jobs" stacked=True %}
           {{ backend.queue.pending }}
         {% /description_item %}
+        {% #description_item title="Running jobs" stacked=True %}
+          {{ backend.queue.running }}
+        {% /description_item %}
       </div>
+      {% #card_footer no_container class="border-t border-t-slate-200" %}
+        <p class="text-sm font-medium text-slate-600">
+          {{ backend.name }} backend is unavailable if OpenSAFELY Jobs does
+          not receive a response for {{ backend.alert_timeout|duration }}.
+        </p>
+      {% /card_footer %}
     {% /card %}
   {% endfor %}
 </div>

--- a/templates/status.html
+++ b/templates/status.html
@@ -59,7 +59,7 @@
       </div>
       {% #card_footer no_container class="border-t border-t-slate-200" %}
         <p class="text-sm font-medium text-slate-600">
-          {{ backend.name }} backend is unavailable if OpenSAFELY Jobs does
+          {{ backend.name }} backend is missing if OpenSAFELY Jobs does
           not receive a response for {{ backend.alert_timeout|duration }}.
         </p>
       {% /card_footer %}


### PR DESCRIPTION
So that it makes more sense to users and developers.

## Before

<img width="401" alt="CleanShot 2022-11-25 at 09 59 45@2x" src="https://user-images.githubusercontent.com/24863179/203958447-689fa130-9026-4a85-8a79-b0b8a6ebec1c.png">

## After

<img width="396" alt="CleanShot 2022-11-25 at 09 59 52@2x" src="https://user-images.githubusercontent.com/24863179/203958437-ff6e7d69-f436-4f68-bdaa-858c29501ec0.png">
