### PR TITLE
Simplify coverage config

### DIFF
--- a/justfile
+++ b/justfile
@@ -103,7 +103,6 @@ run-telemetry: devenv
 
 test-base *args: assets
     $BIN/coverage run \
-        --branch \
         --source=applications,jobserver,services,staff,tests \
         --module pytest \
         {{ args }}

--- a/justfile
+++ b/justfile
@@ -102,10 +102,7 @@ run-telemetry: devenv
 
 
 test-base *args: assets
-    $BIN/coverage run \
-        --source=applications,jobserver,services,staff,tests \
-        --module pytest \
-        {{ args }}
+    $BIN/coverage run --module pytest {{ args }}
 
 
 test-dev *args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,13 @@ omit = [
   "jobserver/wsgi.py",
   "services/sentry.py",
 ]
+source = [
+  "applications",
+  "jobserver",
+  "services",
+  "staff",
+  "tests",
+]
 
 [tool.coverage.report]
 fail_under = 100


### PR DESCRIPTION
While migrating this site to our ✨ New and Improved Docker Stack™ ✨ @bloodearnest identified that we had some duplicate/odd placement of coverage config in the justfile.  This puts everything into pyproject.toml, removing the `branch` duplication.