### PR TITLE
Run tests in parallel with pytest-xdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 __pycache__/
-.coverage
+.coverage*
 .env
 .envrc
 .idea/

--- a/docker/justfile
+++ b/docker/justfile
@@ -16,7 +16,7 @@ build env="dev":
 
 # run tests in dev container
 test *args="": build
-    docker-compose run --rm test bash -c "coverage run --branch --source=applications,interactive,jobserver,services,staff,tests --module pytest && coverage report || coverage html"
+    docker-compose run --rm test bash -c "coverage erase && coverage run --branch --source=applications,interactive,jobserver,redirects,services,staff,tests --module pytest {{ args }} && coverage combine && coverage report || coverage html"
 
 
 # run server in dev|prod container

--- a/justfile
+++ b/justfile
@@ -8,6 +8,9 @@ export VIRTUAL_ENV  := `echo ${VIRTUAL_ENV:-.venv}`
 export BIN := VIRTUAL_ENV + "/bin"
 export PIP := BIN + "/python -m pip"
 
+export COVERAGE_PROCESS_START := "pyproject.toml"
+
+
 # list available commands
 default:
     @{{ just_executable() }} --list
@@ -129,6 +132,7 @@ run-telemetry: devenv
 
 
 test-base *args: assets
+    $BIN/coverage erase
     $BIN/coverage run --module pytest {{ args }}
 
 
@@ -136,6 +140,8 @@ test-dev *args:
     {{ just_executable() }} test-base \
         '-m "not verification and not slow_test"' \
         {{ args }}
+
+    $BIN/coverage combine
 
     # run with || so they both run regardless of failures
     $BIN/coverage report --omit=interactive/opencodelists.py,jobserver/github.py,tests/integration/test_interactive.py,"tests/verification/*" \
@@ -145,6 +151,7 @@ test-dev *args:
 test *args:
     {{ just_executable() }} test-base {{ args }}
 
+    $BIN/coverage combine
     $BIN/coverage report || $BIN/coverage html
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ omit = [
   "jobserver/settings.py",
   "jobserver/wsgi.py",
 ]
+parallel = true
 source = [
   "applications",
   "interactive",
@@ -136,3 +137,4 @@ lines-after-imports = 2
 [tool.ruff.per-file-ignores]
 "gunicorn.conf.py" = ["INP001"]
 "manage.py" = ["INP001"]
+"sitecustomize.py" = ["INP001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ skip_covered = true
 show_contexts = true
 
 [tool.pytest.ini_options]
-addopts = "--disable-network --tb=native --no-migrations --ignore=./release-hatch"
+addopts = "--disable-network --tb=native --no-migrations --ignore=./release-hatch --maxprocesses=6"
 DJANGO_SETTINGS_MODULE = "jobserver.settings"
 env = [
   "GITHUB_TOKEN=empty",

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -6,6 +6,7 @@
 
 black
 coverage[toml]
+coverage-enable-subprocess
 django-upgrade
 factory_boy
 opensafely

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -17,5 +17,6 @@ pytest-freezegun
 pytest-mock
 pytest-network
 pytest-subtests
+pytest-xdist[psutil]
 responses
 ruff

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -110,6 +110,10 @@ django-upgrade==1.14.1 \
     --hash=sha256:23813464e94713e1c660ba46b0fe53b2f490fdd6263da9f22a4ae5402a4d5d31 \
     --hash=sha256:8972e2aaa4be81da629dcabc2a784ad436a82a761f9a0ffd46e5ed6b9d155dfa
     # via -r requirements.dev.in
+execnet==1.9.0 \
+    --hash=sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5 \
+    --hash=sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142
+    # via pytest-xdist
 factory-boy==3.3.0 \
     --hash=sha256:a2cdbdb63228177aa4f1c52f4b6d83fab2b8623bf602c7dedd7eb83c0f69c04c \
     --hash=sha256:bc76d97d1a65bbd9842a6d722882098eb549ec8ee1081f9fb2e8ff29f0c300f1
@@ -185,6 +189,22 @@ pre-commit==3.3.3 \
     --hash=sha256:10badb65d6a38caff29703362271d7dca483d01da88f9d7e05d0b97171c136cb \
     --hash=sha256:a2256f489cd913d575c145132ae196fe335da32d91a8294b7afe6622335dd023
     # via -r requirements.dev.in
+psutil==5.9.5 \
+    --hash=sha256:104a5cc0e31baa2bcf67900be36acde157756b9c44017b86b2c049f11957887d \
+    --hash=sha256:3c6f686f4225553615612f6d9bc21f1c0e305f75d7d8454f9b46e901778e7217 \
+    --hash=sha256:4aef137f3345082a3d3232187aeb4ac4ef959ba3d7c10c33dd73763fbc063da4 \
+    --hash=sha256:5410638e4df39c54d957fc51ce03048acd8e6d60abc0f5107af51e5fb566eb3c \
+    --hash=sha256:5b9b8cb93f507e8dbaf22af6a2fd0ccbe8244bf30b1baad6b3954e935157ae3f \
+    --hash=sha256:7a7dd9997128a0d928ed4fb2c2d57e5102bb6089027939f3b722f3a210f9a8da \
+    --hash=sha256:89518112647f1276b03ca97b65cc7f64ca587b1eb0278383017c2a0dcc26cbe4 \
+    --hash=sha256:8c5f7c5a052d1d567db4ddd231a9d27a74e8e4a9c3f44b1032762bd7b9fdcd42 \
+    --hash=sha256:ab8ed1a1d77c95453db1ae00a3f9c50227ebd955437bcf2a574ba8adbf6a74d5 \
+    --hash=sha256:acf2aef9391710afded549ff602b5887d7a2349831ae4c26be7c807c0a39fac4 \
+    --hash=sha256:b258c0c1c9d145a1d5ceffab1134441c4c5113b2417fafff7315a917a026c3c9 \
+    --hash=sha256:be8929ce4313f9f8146caad4272f6abb8bf99fc6cf59344a3167ecd74f4f203f \
+    --hash=sha256:c607bb3b57dc779d55e1554846352b4e358c10fff3abf3514a7a6601beebdb30 \
+    --hash=sha256:ea8518d152174e1249c4f2a1c89e3e6065941df2fa13a1ab45327716a23c2b48
+    # via pytest-xdist
 pyparsing==3.0.7 \
     --hash=sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea \
     --hash=sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484
@@ -201,6 +221,7 @@ pytest==7.3.2 \
     #   pytest-mock
     #   pytest-network
     #   pytest-subtests
+    #   pytest-xdist
 pytest-django==4.5.2 \
     --hash=sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e \
     --hash=sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2
@@ -223,6 +244,10 @@ pytest-network==0.0.1 \
 pytest-subtests==0.11.0 \
     --hash=sha256:453389984952eec85ab0ce0c4f026337153df79587048271c7fd0f49119c07e4 \
     --hash=sha256:51865c88457545f51fb72011942f0a3c6901ee9e24cbfb6d1b9dc1348bafbe37
+    # via -r requirements.dev.in
+pytest-xdist==3.0.2 \
+    --hash=sha256:688da9b814370e891ba5de650c9327d1a9d861721a524eb917e620eec3e90291 \
+    --hash=sha256:9feb9a18e1790696ea23e1434fa73b325ed4998b0e9fcb221f16fd1945e6df1b
     # via -r requirements.dev.in
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -101,6 +101,11 @@ coverage==6.5.0 \
     --hash=sha256:f4f05d88d9a80ad3cac6244d36dd89a3c00abc16371769f1340101d3cb899fc3 \
     --hash=sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84 \
     --hash=sha256:fc2af30ed0d5ae0b1abdb4ebdce598eafd5b35397d4d75deb341a614d333d987
+    # via
+    #   coverage-enable-subprocess
+coverage-enable-subprocess==1.0 \
+    --hash=sha256:27982522339ec77662965e0d859da5662162962c874d54d2250426506818cbdc \
+    --hash=sha256:fdbd3dc9532007cd87ef84f38e16024c5b0ccb4ab2d1755225a7edf937acc011
     # via -r requirements.dev.in
 distlib==0.3.2 \
     --hash=sha256:106fef6dc37dd8c0e2c0a60d3fca3e77460a48907f335fa28420463a6f799736 \

--- a/tests/unit/redirects/test_models.py
+++ b/tests/unit/redirects/test_models.py
@@ -102,11 +102,6 @@ def test_redirect_each_target_object():
         RedirectFactory(**kwargs)
 
 
-def test_redirect_no_target_objects():
-    with pytest.raises(IntegrityError):
-        RedirectFactory()
-
-
 def test_redirect_get_staff_url():
     redirect = RedirectFactory(project=ProjectFactory())
 
@@ -121,6 +116,11 @@ def test_redirect_get_staff_delete_url():
     url = redirect.get_staff_delete_url()
 
     assert url == reverse("staff:redirect-delete", kwargs={"pk": redirect.pk})
+
+
+def test_redirect_no_target_objects():
+    with pytest.raises(IntegrityError):
+        RedirectFactory()
 
 
 def test_redirect_obj():
@@ -150,6 +150,12 @@ def test_redirect_str():
 def test_validate_not_empty():
     assert validate_not_empty("test") is None
 
+
+def test_validate_not_empty_with_content():
+    validate_not_empty("test")
+
+
+def test_validate_not_empty_without_content():
     with pytest.raises(ValidationError):
         validate_not_empty("")
 


### PR DESCRIPTION
This setups up the test suite for running in parallel, but doesn't run that way by default.  Users can opt into using it by suffixing test commands with `-n <number|auto>`.

Locally this takes a full test run from ~59 to ~26s.

I've not configured this for CI because we only have one vCPU there so we get no improvement.  There's also a bug where running inside of docker seems to lose 92% of our coverage.