### PR TITLE
Update researcher-server-access-rubric.md

### DIFF
--- a/snippets/researcher-server-access-rubric.md
+++ b/snippets/researcher-server-access-rubric.md
@@ -1,2 +1,2 @@
 As a security measure, this should typically be the main study author only.
-All researchers requiring results server access **must** have passed a safe researcher training course, such as one provided by the ONS or the UK Data Service.
+All researchers requiring results server access **must** have passed a safe researcher training course, provided by either the ONS or the UK Data Service.


### PR DESCRIPTION
Clarifying description of accepted safe researcher courses that we only accept, as misunderstanding previously could have represented others were accepted outside of the two listed.