### PR TITLE
Maintain redirect suffixes

### DIFF
--- a/redirects/middleware.py
+++ b/redirects/middleware.py
@@ -36,11 +36,17 @@ class RedirectsMiddleware:
             .first()
         )
 
-        if redirection:
+        if not redirection:
+            # there's no direct or indirect match so let the request continue
+            return self.get_response(request)
+
+        if redirection.old_url == request.path:
             return redirect(
                 redirection.obj.get_absolute_url(),
                 permanent=True,
             )
 
-        # there's no direct or indirect match so let the request continue
-        return self.get_response(request)
+        new_url = request.path.replace(
+            redirection.old_url, redirection.obj.get_absolute_url()
+        )
+        return redirect(new_url, permanent=True)

--- a/tests/unit/redirects/test_middleware.py
+++ b/tests/unit/redirects/test_middleware.py
@@ -17,7 +17,7 @@ def test_redirectsmiddleware_known_url_via_prefix(rf):
 
     response = RedirectsMiddleware(get_response)(request)
 
-    assert response.url == project.get_absolute_url()
+    assert response.url == project.get_absolute_url() + "test"
 
 
 def test_redirectsmiddleware_known_url_with_direct_match(rf):


### PR DESCRIPTION
We match redirects using, effectively, a startswith() call.  However on a match we were redirecting to the linked objects URL.  This works when someone is trying to view that object (eg a project), but if they're trying to look at a child object (eg a job) they were still ending up on the object page.

Fixes: #2408 