### PR TITLE
Remove CMO priority list question

### DIFF
--- a/applications/form_specs.py
+++ b/applications/form_specs.py
@@ -365,25 +365,6 @@ form_specs = [
         ),
     ),
     Form(
-        key="cmo-priority-list",
-        model=models.CmoPriorityListPage,
-        title="Chief Medical Officer priority list",
-        sub_title="",
-        rubric="",
-        fieldsets=[
-            Fieldset(
-                label="",
-                fields=[
-                    Field(
-                        name="is_on_cmo_priority_list",
-                        label="Is your research on the CMO Priority list?",
-                        help_text=snippet("is_on_cmo_priority_list_help_text"),
-                    ),
-                ],
-            ),
-        ],
-    ),
-    Form(
         key="study-funding",
         model=models.StudyFundingPage,
         title="Study funding",

--- a/applications/forms.py
+++ b/applications/forms.py
@@ -13,7 +13,6 @@ class PageFormBase(forms.ModelForm):
         radio_fields = [
             "all_applicants_completed_getting_started",
             "need_record_level_data",
-            "is_on_cmo_priority_list",
             "is_approved",
         ]
         for name in radio_fields:

--- a/snippets/9-fieldset0-is_on_cmo_priority_list-label.md
+++ b/snippets/9-fieldset0-is_on_cmo_priority_list-label.md
@@ -1,1 +1,0 @@
-If you are requesting access to record level data, is your research on the [CMO priority list](https://www.nihr.ac.uk/covid-studies/)?

--- a/tests/factories/applications.py
+++ b/tests/factories/applications.py
@@ -5,7 +5,6 @@ import factory.fuzzy
 
 from applications.models import (
     Application,
-    CmoPriorityListPage,
     ContactDetailsPage,
     DatasetsPage,
     PreviousEhrExperiencePage,
@@ -132,13 +131,6 @@ class SponsorDetailsPageFactory(AbstractPageFactory):
     sponsor_email = factory.Sequence(lambda n: f"sponsor{n}@example.com")
     sponsor_job_role = factory.Faker("job")
     institutional_rec_reference = factory.Sequence(lambda n: f"Institutional REC {n}")
-
-
-class CmoPriorityListPageFactory(AbstractPageFactory):
-    class Meta:
-        model = CmoPriorityListPage
-
-    is_on_cmo_priority_list = factory.fuzzy.FuzzyChoice([True, False])
 
 
 class StudyFundingPageFactory(AbstractPageFactory):

--- a/tests/unit/applications/test_views.py
+++ b/tests/unit/applications/test_views.py
@@ -526,7 +526,7 @@ def test_page_post_with_invalid_prerequisite(rf):
     assert response.status_code == 302
     assert response.url == reverse(
         "applications:page",
-        kwargs={"pk_hash": application.pk_hash, "key": "cmo-priority-list"},
+        kwargs={"pk_hash": application.pk_hash, "key": "study-funding"},
     )
 
 

--- a/tests/unit/applications/test_wizard.py
+++ b/tests/unit/applications/test_wizard.py
@@ -40,7 +40,7 @@ def test_get_next_page_key_for_complete_application(complete_application):
 
 def test_get_next_page_key_for_incomplete_application(incomplete_application):
     wizard = Wizard(incomplete_application, form_specs)
-    assert wizard.get_next_page_key("study-data") == "study-funding"
+    assert wizard.get_next_page_key("study-data") == "team-details"
 
 
 def test_progress_percent(complete_application, incomplete_application):


### PR DESCRIPTION
This is no longer relevant to the application, as the COVID research guidelines have been updated.

Fixes #2386

I'm not sure whether the `CmoPriorityListPage` should be removed or not. I've kept it for now because it seems like we'd want to keep a record in the database about whether previous applications were on the CMO priority list and potentially surface that in a dashboard somewhere.