### PR TITLE
use conditional on auto-merge step instead of prior step

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -31,11 +31,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fail if dependency update did not update an action or requirements file
-        if: ${{ ! startsWith(steps.check-labels.outputs.is-wanted-dependency, 'y') }}
-        run: /bin/false
-
       - name: Enable auto-merge for Dependabot PRs
+        if: ${{ startsWith(steps.check-labels.outputs.is-wanted-dependency, 'y') }}
         run: |
           set -eu
 


### PR DESCRIPTION
GHA fails a job if a step exits with a code of 1+, so /bin/false fails the whole workflow, but we want to _skip_ the workflow.  This moves the conditional to the final step where we the run section should only execute when it's true.