### PR TITLE
Update the setup-just GHA to v1.5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: "3.10"
           cache: "pip"
           cache-dependency-path: requirements.*.txt
-      - uses: extractions/setup-just@v1
+      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
       - name: Check formatting, linting and import sorting
         run: just check
 
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: extractions/setup-just@v1
+      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb  # v1.4.0
+      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
 
       - name: Build docker image for both prod and dev
         run: |
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: extractions/setup-just@aa5d15c144db4585980a44ebfdd2cf337c4f14cb  # v1.4.0
+      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
 
       - name: Download docker image
         uses: actions/download-artifact@v3


### PR DESCRIPTION
GitHub are warning that they've deprecated actions running the version of node used by setup-just v1.4.0, so this updates the action to the latest version.

Pinned to the exact version, as this is a third-party action.