### PR TITLE
feat: add Honeycomb live status link

### DIFF
--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -14,11 +14,11 @@ from django.views.generic.edit import FormMixin
 from first import first
 from pipeline import load_pipeline
 
+from .. import honeycomb
 from ..authorization import CoreDeveloper, has_permission, has_role
 from ..backends import backends_to_choices
 from ..forms import JobRequestCreateForm, JobRequestSearchForm
 from ..github import _get_github_api
-from ..honeycomb import format_jobrequest_concurrency_link
 from ..models import Backend, JobRequest, User, Workspace
 from ..pipeline_config import get_actions, get_project, render_definition
 from ..utils import raise_if_not_int
@@ -217,9 +217,9 @@ class JobRequestDetail(View):
         }
 
         if honeycomb_can_view_links:
-            context["honeycomb_links"][
-                "Job Request concurrency"
-            ] = format_jobrequest_concurrency_link(job_request)
+            context["honeycomb_links"]["Job Request"] = honeycomb.jobrequest_link(
+                job_request
+            )
 
         return TemplateResponse(request, "job_request_detail.html", context=context)
 

--- a/templates/_components/list-group/list-group-item.html
+++ b/templates/_components/list-group/list-group-item.html
@@ -10,7 +10,7 @@
       {% endif %}
       {{ class }}
     "
-    href="{{ href }}"
+    href="{% attrs href %}"
   >
     {{ children }}
   </a>

--- a/tests/unit/jobserver/test_honeycomb.py
+++ b/tests/unit/jobserver/test_honeycomb.py
@@ -1,15 +1,7 @@
-from urllib.parse import unquote
-
 import pytest
 from django.utils import timezone
 
-from jobserver.honeycomb import (
-    format_honeycomb_timestamps,
-    format_job_actions_link,
-    format_jobrequest_concurrency_link,
-    format_trace_id,
-    format_trace_link,
-)
+from jobserver import honeycomb
 from jobserver.models import JobRequest
 
 from ...factories import JobFactory, JobRequestFactory, WorkspaceFactory
@@ -18,21 +10,21 @@ from ...factories import JobFactory, JobRequestFactory, WorkspaceFactory
 def test_format_trace_id_hexadecimal():
     decimal_trace_id = 300559129712114075302075132513478005344
     hex_trace_id = "e21d953231b76bd98bf45d5e5bc85260"
-    assert format_trace_id(decimal_trace_id) == hex_trace_id
+    assert honeycomb.format_trace_id(decimal_trace_id) == hex_trace_id
 
 
 def test_format_trace_id_hexadecimal_leading_zeros():
     decimal_trace_id = 15209551489903251743569348292329094282
     hex_trace_id = "0b7140c8e6bafc8ae485e68146dc3c8a"
-    assert format_trace_id(decimal_trace_id) == hex_trace_id
+    assert honeycomb.format_trace_id(decimal_trace_id) == hex_trace_id
 
 
 @pytest.mark.freeze_time("2022-06-15 13:00")
 def test_format_honeycomb_timestamps_job():
     job = JobFactory(completed_at=timezone.now(), status="succeeded")
-    honeycomb_timestamps = format_honeycomb_timestamps(job)
-    assert honeycomb_timestamps["honeycomb_starttime_unix"] == 1655297940
-    assert honeycomb_timestamps["honeycomb_endtime_unix"] == 1655298060
+    start, end = honeycomb.format_honeycomb_timestamps(job)
+    assert start == 1655297940
+    assert end == 1655298060
 
 
 @pytest.mark.freeze_time("2022-06-15 13:00")
@@ -45,36 +37,36 @@ def test_format_honeycomb_timestamps_jobrequest():
         identifier=job_request.identifier
     ).first()
 
-    honeycomb_timestamps = format_honeycomb_timestamps(prefetched_job_request)
-    assert honeycomb_timestamps["honeycomb_starttime_unix"] == 1655297940
+    start, end = honeycomb.format_honeycomb_timestamps(prefetched_job_request)
+    assert start == 1655297940
     # 1 minute in the future
-    assert honeycomb_timestamps["honeycomb_endtime_unix"] == 1655298060
+    assert end == 1655298060
 
 
 @pytest.mark.freeze_time("2022-06-15 13:00")
-def test_format_honeycomb_timestamps_jobrequest_unfinished():
+def test_honeycomb_timestamps_jobrequest_unfinished():
     job_request = JobRequestFactory()
     job = JobFactory(job_request=job_request, status="executing")  # noqa: F841
     prefetched_job_request = JobRequest.objects.filter(
         identifier=job_request.identifier
     ).first()
 
-    honeycomb_timestamps = format_honeycomb_timestamps(prefetched_job_request)
-    assert honeycomb_timestamps["honeycomb_starttime_unix"] == 1655297940
+    start, end = honeycomb.format_honeycomb_timestamps(prefetched_job_request)
+    assert start == 1655297940
     # 1 day in the future
-    assert honeycomb_timestamps["honeycomb_endtime_unix"] == 1655301600
+    assert end == 1655301600
 
 
 @pytest.mark.freeze_time("2022-06-15 13:00")
-def test_format_trace_link():
+def test_trace_link():
     job = JobFactory(completed_at=timezone.now())
-    url = format_trace_link(job)
+    url = honeycomb.trace_link(job)
     assert "trace_start_ts=1655297940&trace_end_ts=1655298060" in url
     assert "bennett-institute-for-applied-data-science" in url
 
 
 @pytest.mark.freeze_time("2022-10-12 17:00")
-def test_format_jobrequest_concurrency_link():
+def test_jobrequest_link():
     job_request = JobRequestFactory(identifier="jpbaeldzjqqiaolg")
     job = JobFactory(  # noqa: F841
         job_request=job_request, completed_at=timezone.now(), status="succeeded"
@@ -83,17 +75,34 @@ def test_format_jobrequest_concurrency_link():
         identifier=job_request.identifier
     ).first()
 
-    url = format_jobrequest_concurrency_link(prefetched_job_request)
-    expected_url = "https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production/datasets/jobrunner?query=%7B%22start_time%22%3A1665593940%2C%22end_time%22%3A1665594060%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22CONCURRENCY%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22enter_state%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22true%22%7D%2C%7B%22column%22%3A%22name%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22RUN%22%7D%2C%7B%22column%22%3A%22name%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22JOB%22%7D%2C%7B%22column%22%3A%22name%22%2C%22op%22%3A%22!%3D%22%2C%22value%22%3A%22job%22%7D%2C%7B%22column%22%3A%22job_request%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22jpbaeldzjqqiaolg%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22CONCURRENCY%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D&useStackedGraphs"
+    url = honeycomb.jobrequest_link(prefetched_job_request)
 
-    assert "start_time%22%3A1665593940" in url
-    assert "end_time%22%3A1665594060" in url
-    assert "useStackedGraphs" in url
-    assert unquote(url) == unquote(expected_url)
+    parsed = honeycomb.TemplatedUrl.parse(url)
+
+    assert parsed.stacked
+    assert parsed.query == {
+        "breakdowns": ["name"],
+        "calculations": [{"op": "CONCURRENCY"}],
+        "end_time": 1665594060,
+        "filter_combination": "AND",
+        "filters": [
+            {"column": "scope", "op": "=", "value": "jobs"},
+            {"column": "enter_state", "op": "!=", "value": "true"},
+            {"column": "name", "op": "!=", "value": "RUN"},
+            {"column": "name", "op": "!=", "value": "JOB"},
+            {"column": "name", "op": "!=", "value": "job"},
+            {"column": "job_request", "op": "=", "value": "jpbaeldzjqqiaolg"},
+        ],
+        "granularity": 0,
+        "havings": [],
+        "limit": 1000,
+        "orders": [{"op": "CONCURRENCY", "order": "descending"}],
+        "start_time": 1665593940,
+    }
 
 
 @pytest.mark.freeze_time("2022-10-12 17:00")
-def test_format_job_actions_link():
+def test_previous_actions_link():
     workspace = WorkspaceFactory(name="my_test_workspace")
     job_request = JobRequestFactory(identifier="jpbaeldzjqqiaolg", workspace=workspace)
     job = JobFactory(  # noqa: F841
@@ -103,25 +112,37 @@ def test_format_job_actions_link():
         action="my_sample_action",
     )
 
-    url = format_job_actions_link(job)
-    expected_url = "https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production/datasets/jobrunner?query=%7B%22time_range%22%3A2419200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_minutes%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22workspace%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22my_test_workspace%22%7D%2C%7B%22column%22%3A%22action%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22my_sample_action%22%7D%2C%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22EXECUTING%22%7D%2C%7B%22column%22%3A%22tick%22%2C%22op%22%3A%22does-not-exist%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D"
+    url = honeycomb.previous_actions_link(job)
+    parsed = honeycomb.TemplatedUrl.parse(url)
 
-    assert "time_range%22%3A2419200" in url
-    assert "start_time" not in url
-    assert "end_time" not in url
-    assert '"workspace","op":"=","value":"my_test_workspace"' in unquote(url)
-    assert '"action","op":"=","value":"my_sample_action"' in unquote(url)
-    assert unquote(url) == unquote(expected_url)
+    assert parsed.query == {
+        "breakdowns": [],
+        "calculations": [{"column": "duration_minutes", "op": "HEATMAP"}],
+        "filter_combination": "AND",
+        "filters": [
+            {"column": "scope", "op": "=", "value": "jobs"},
+            {"column": "workspace", "op": "=", "value": "my_test_workspace"},
+            {"column": "action", "op": "=", "value": "my_sample_action"},
+            {"column": "name", "op": "=", "value": "EXECUTING"},
+        ],
+        "granularity": 0,
+        "havings": [],
+        "limit": 1000,
+        "orders": [],
+        "time_range": 2419200,
+    }
 
 
 @pytest.mark.freeze_time("2022-10-12 17:00")
-def test_format_jobrequest_concurrency_link_unfinished():
+def test_jobrequest_concurrency_link_unfinished():
     job_request = JobRequestFactory(identifier="jpbaeldzjqqiaolg")
     job = JobFactory(job_request=job_request, status="executing")  # noqa: F841
     prefetched_job_request = JobRequest.objects.filter(
         identifier=job_request.identifier
     ).first()
 
-    url = format_jobrequest_concurrency_link(prefetched_job_request)
-    assert "start_time%22%3A1665593940" in url
-    assert "end_time%22%3A1665597600" in url
+    url = honeycomb.jobrequest_link(prefetched_job_request)
+    parsed = honeycomb.TemplatedUrl.parse(url)
+
+    assert parsed.query["start_time"] == 1665593940
+    assert parsed.query["end_time"] == 1665597600

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -5,6 +5,7 @@ from django.core.exceptions import BadRequest
 from django.http import Http404
 from django.utils import timezone
 
+from jobserver import honeycomb
 from jobserver.authorization import (
     CoreDeveloper,
     OpensafelyInteractive,
@@ -681,7 +682,13 @@ def test_jobrequestdetail_with_permission_core_developer(rf):
 
     assert response.status_code == 200
     assert "Honeycomb" in response.rendered_content
-    assert "%22end_time%22%3A1655380860%2C" in response.rendered_content
+
+    # job_requests have prefetch restrictions on them
+    prefetched_job_request = JobRequest.objects.filter(
+        identifier=job_request.identifier
+    ).first()
+    url = honeycomb.jobrequest_link(prefetched_job_request)
+    assert url in response.rendered_content
 
 
 def test_jobrequestdetail_with_permission_with_completed_at(rf):

--- a/tests/unit/jobserver/views/test_jobs.py
+++ b/tests/unit/jobserver/views/test_jobs.py
@@ -223,10 +223,12 @@ def test_jobdetail_with_core_developer_with_completed_at(rf):
     assert "Honeycomb" in response.rendered_content
     assert "Job Trace" in response.rendered_content
     assert "trace_end_ts=1655298060" in response.rendered_content
-    assert (
-        f"%7B%22column%22%3A%22job_request%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{job_request.identifier}%22%7D"
-        in response.rendered_content
-    )
+    # job_requests have prefretch restrictions on them
+    prefetched_job_request = JobRequest.objects.filter(
+        identifier=job_request.identifier
+    ).first()
+    url = honeycomb.jobrequest_link(prefetched_job_request)
+    assert url in response.rendered_content
     assert job_request.identifier in response.rendered_content
 
 

--- a/tests/unit/jobserver/views/test_jobs.py
+++ b/tests/unit/jobserver/views/test_jobs.py
@@ -3,7 +3,9 @@ from django.contrib.auth.models import AnonymousUser
 from django.http import Http404
 from django.utils import timezone
 
+from jobserver import honeycomb
 from jobserver.authorization import CoreDeveloper, ProjectDeveloper
+from jobserver.models import JobRequest
 from jobserver.views.jobs import JobCancel, JobDetail, JobDetailRedirect
 
 from ....factories import (
@@ -157,29 +159,6 @@ def test_jobdetail_with_permission(rf):
 
 
 @pytest.mark.freeze_time("2022-06-16 12:00")
-def test_jobdetail_with_core_developer_no_trace(rf):
-    job = JobFactory(trace_context={})
-    user = UserFactory(roles=[CoreDeveloper])
-
-    request = rf.get("/")
-    request.user = user
-
-    response = JobDetail.as_view()(
-        request,
-        org_slug=job.job_request.workspace.project.org.slug,
-        project_slug=job.job_request.workspace.project.slug,
-        workspace_slug=job.job_request.workspace.name,
-        pk=job.job_request.pk,
-        identifier=job.identifier,
-    )
-
-    assert response.status_code == 200
-    assert "Cancel" not in response.rendered_content
-    assert "Honeycomb" not in response.rendered_content
-    assert "Job Trace" not in response.rendered_content
-
-
-@pytest.mark.freeze_time("2022-06-16 12:00")
 def test_jobdetail_with_core_developer(rf):
     job_request = JobRequestFactory()
     job = JobFactory(
@@ -203,12 +182,18 @@ def test_jobdetail_with_core_developer(rf):
     assert "Cancel" not in response.rendered_content
     assert "Honeycomb" in response.rendered_content
     assert "trace_end_ts=1655380800" in response.rendered_content
-    assert "Historic job runs" in response.rendered_content
+    assert "Previous runs" in response.rendered_content
     assert (
         "%22action%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22my_sample_action%22"
         in response.rendered_content
     )
-    assert "Job Request concurrency" in response.rendered_content
+
+    # job_requests have prefretch restrictions on them
+    prefetched_job_request = JobRequest.objects.filter(
+        identifier=job_request.identifier
+    ).first()
+    url = honeycomb.jobrequest_link(prefetched_job_request)
+    assert url in response.rendered_content
     assert job_request.identifier in response.rendered_content
 
 
@@ -238,7 +223,10 @@ def test_jobdetail_with_core_developer_with_completed_at(rf):
     assert "Honeycomb" in response.rendered_content
     assert "Job Trace" in response.rendered_content
     assert "trace_end_ts=1655298060" in response.rendered_content
-    assert "Job Request concurrency" in response.rendered_content
+    assert (
+        f"%7B%22column%22%3A%22job_request%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{job_request.identifier}%22%7D"
+        in response.rendered_content
+    )
     assert job_request.identifier in response.rendered_content
 
 


### PR DESCRIPTION
Also refactors the honeycomb link code to:
 - use the new `scope` filter
 - use more generic names, as the data we show at that link will change
 - be a bit less verbose naming wise
 - more robust and helpful tests
