### PR TITLE
replace setup-just with manual steps to avoid rate limits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,11 @@ jobs:
           python-version: "3.11"
           cache: "pip"
           cache-dependency-path: requirements.*.txt
-      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
+      - name: Install just
+        run: |
+          mkdir -p ~/.local/bin
+          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
+           | tar -xzf - --directory ~/.local/bin just
       - name: Check formatting, linting and import sorting
         run: just check
 
@@ -45,7 +49,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
+      - name: Install just
+        run: |
+          mkdir -p ~/.local/bin
+          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
+           | tar -xzf - --directory ~/.local/bin just
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
@@ -100,7 +108,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
+      - name: Install just
+        run: |
+          mkdir -p ~/.local/bin
+          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
+           | tar -xzf - --directory ~/.local/bin just
 
       - name: Build docker image for both prod and dev
         run: |
@@ -147,7 +159,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76  # v1.5.0
+      - name: Install just
+        run: |
+          mkdir -p ~/.local/bin
+          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
+           | tar -xzf - --directory ~/.local/bin just
 
       - name: Download docker image
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Adding this, copying from opensafely-core/databuilder#897, because we're seeing more failures than normal