### PR TITLE
Use one org creation form regardless of full or partial page load

### DIFF
--- a/staff/urls.py
+++ b/staff/urls.py
@@ -7,7 +7,6 @@ from .views.applications import (
     ApplicationList,
     ApplicationRemove,
     ApplicationRestore,
-    application_add_org,
 )
 from .views.backends import (
     BackendCreate,
@@ -58,11 +57,6 @@ application_urls = [
         "<str:pk_hash>/approve/",
         ApplicationApprove.as_view(),
         name="application-approve",
-    ),
-    path(
-        "<str:pk_hash>/approve/add-org/",
-        application_add_org,
-        name="application-add-org",
     ),
     path("<str:pk_hash>/edit/", ApplicationEdit.as_view(), name="application-edit"),
     path(

--- a/templates/staff/application_approve.html
+++ b/templates/staff/application_approve.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="{% static 'vendor/select2-bootstrap4.min.css' %}">
 {% endblock %}
 
-{% block metatitle %}Invite users: {{ project.title }} | OpenSAFELY Jobs{% endblock metatitle %}
+{% block metatitle %}Approve application: {{ project.title }} | OpenSAFELY Jobs{% endblock metatitle %}
 
 {% block breadcrumbs %}
 <nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
@@ -76,7 +76,7 @@
             <p id="orgHelpBlock" class="form-text text-muted">
               If the org doesn't exist, you can
               <button
-                hx-get="{% url 'staff:application-add-org' pk_hash=application.pk_hash %}"
+                hx-get="{% url 'staff:org-create' %}?next={{ request.path }}"
                 hx-target="#dialog"
                 hx-trigger="click"
                 class="btn btn-link m-0 p-0 border-0 font-weight-bold align-baseline"
@@ -100,9 +100,7 @@
   </div>
 </div>
 
-<div id="modal" class="modal fade" tabindex="-1">
-  <div id="dialog" class="modal-dialog" hx-target="this"></div>
-</div>
+<div id="dialog" class="modal-dialog" hx-target="this"></div>
 
 {% endblock %}
 

--- a/templates/staff/org_create.form.html
+++ b/templates/staff/org_create.form.html
@@ -1,0 +1,17 @@
+<form method="POST" hx-post="{% url 'staff:org-create' %}?next={{ next }}">
+  {% csrf_token %}
+
+  {% if form.non_field_errors %}
+    <ul>
+      {% for error in form.non_field_errors %}
+        <li class="text-danger">{{ error }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+
+  {% include "components/form_text.html" with field=form.name label="Organisation name" name="name" %}
+
+  <button class="btn btn-success" type="submit">
+    Create
+  </button>
+</form>

--- a/templates/staff/org_create.html
+++ b/templates/staff/org_create.html
@@ -32,28 +32,9 @@
 <div class="container">
   <div class="row">
     <div class="col-lg-9 col-xl-8">
-      <form method="POST">
-        {% csrf_token %}
-        <fieldset>
-          <legend class="h3 mb-3">
-            Organisation details
-          </legend>
 
-          {% if form.non_field_errors %}
-            <ul>
-              {% for error in form.non_field_errors %}
-                <li class="text-danger">{{ error }}</li>
-              {% endfor %}
-            </ul>
-          {% endif %}
+      {% include "staff/org_create.form.html" %}
 
-          {% include "components/form_text.html" with field=form.name label="Organisation name" name="name" %}
-
-        </fieldset>
-
-        <button class="btn btn-success" type="submit">Create</button>
-
-      </form>
     </div>
   </div>
 </div>

--- a/templates/staff/org_create.htmx.html
+++ b/templates/staff/org_create.htmx.html
@@ -1,11 +1,6 @@
-{% load static %}
-
-<div class="modal-dialog modal-dialog-centered" role="document">
-  <div class="modal-content">
-
-    <form method="POST" hx-post="{% url 'staff:application-add-org' pk_hash=application.pk_hash %}">
-      {% csrf_token %}
-
+<div id="modal" class="modal fade" tabindex="-1">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Create an organisation</h5>
         <button type="button" class="close" data-dismiss="modal">
@@ -14,22 +9,8 @@
       </div>
 
       <div class="modal-body">
-        {% if form.non_field_errors %}
-          <ul>
-            {% for error in form.non_field_errors %}
-              <li class="text-danger">{{ error }}</li>
-            {% endfor %}
-          </ul>
-        {% endif %}
-
-        {% include "components/form_text.html" with field=form.name label="Organisation name" name="name" %}
+        {% include "staff/org_create.form.html" %}
       </div>
-
-      <div class="modal-footer">
-        <button class="btn btn-success" type="submit">
-          Create
-        </button>
-      </div>
-
+    </div>
   </div>
 </div>


### PR DESCRIPTION
This gets rid of our custom "I would like to add an org from the application approve page" view handler and converts the OrgCreate view and its templates to handle HTMX requests alongside full page requests.

The form is now in its own template and wrapped by either the HTMX or full-page template.  The HTMX template also handles all the model markup so the calling view only has to care about a div to replace with it.

This came up because I'm building an onboarding form for Interactive users and we want to set them up with an org and project, and copying all the markup and code from the view this removes seemed non-ideal.