### PR TITLE
use internal setup-action for common actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,17 +15,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: "actions/setup-python@v4"
+      - uses: "opensafely-core/setup-action@v1"
         with:
           python-version: "3.11"
-          cache: "pip"
-          cache-dependency-path: requirements.*.txt
-      - name: Install just
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
-           | tar -xzf - --directory ~/.local/bin just
+          install-just: true
       - name: Check formatting, linting and import sorting
         run: just check
 
@@ -48,24 +41,17 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Install just
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
-           | tar -xzf - --directory ~/.local/bin just
+      - uses: "opensafely-core/setup-action@v1"
+        with:
+          python-version: "3.11"
+          install-just: true
+
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: 'npm'
           cache-dependency-path: package-lock.json
-
-      - uses: "actions/setup-python@v4"
-        with:
-          python-version: "3.11"
-          cache: "pip"
-          cache-dependency-path: requirements.*.txt
 
       - name: Install node_modules
         run: npm ci --ignore-scripts
@@ -107,12 +93,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Install just
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
-           | tar -xzf - --directory ~/.local/bin just
+      - uses: "opensafely-core/setup-action@v1"
+        with:
+          install-just: true
 
       - name: Build docker image for both prod and dev
         run: |
@@ -156,14 +139,9 @@ jobs:
     concurrency: deploy-production
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: "opensafely-core/setup-action@v1"
         with:
-          fetch-depth: 0
-      - name: Install just
-        run: |
-          mkdir -p ~/.local/bin
-          curl -L https://github.com/casey/just/releases/download/1.9.0/just-1.9.0-x86_64-unknown-linux-musl.tar.gz \
-           | tar -xzf - --directory ~/.local/bin just
+          install-just: true
 
       - name: Download docker image
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Switch to using our internal opensafely-core/setup-action to avoid manually curling just in various places.