### PR TITLE
handle invalid configs

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -4,6 +4,7 @@ import secrets
 from datetime import date, timedelta
 from urllib.parse import quote
 
+import pydantic
 import structlog
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.models import UserManager
@@ -142,7 +143,10 @@ class Job(models.Model):
 
         # load job_request's project_definition into pipeline and get the
         # command for this job
-        pipeline = load_pipeline(self.job_request.project_definition)
+        try:
+            pipeline = load_pipeline(self.job_request.project_definition)
+        except pydantic.ValidationError:
+            return  # we don't have a valid config
 
         if action := pipeline.actions.get(self.action):
             command = action.run.run

--- a/tests/unit/jobserver/models/test_core.py
+++ b/tests/unit/jobserver/models/test_core.py
@@ -111,6 +111,33 @@ def test_job_run_command_error_action():
     assert JobFactory(job_request=job_request, action="__error__").run_command is None
 
 
+def test_job_run_command_invalid_project_definition():
+    """
+    Test an invalid project definition
+    """
+    pipeline = """
+    version: 3.0
+    expectations:
+      population_size: 1000
+    actions:
+      my_action:
+        run: cowsay research!
+        outputs:
+          moderately_sensitive:
+            log: logs/cowsay.log
+      another_action:
+        needs: [my_action]
+        run: cowsay research!
+        outputs:
+          moderately_sensitive:
+            log: logs/cowsay.log
+    """
+
+    job_request = JobRequestFactory(project_definition=pipeline)
+
+    assert JobFactory(job_request=job_request).run_command is None
+
+
 def test_job_run_command_success():
     pipeline = """
     version: 3.0


### PR DESCRIPTION
We spent nearly 18mo accepting jobs with config that didn't go through validation until it was parsed by job-runner.  Errors were caught there and fed back to the user via our sync mechanism.  Now that we expose the full run command of a job to the user we're parsing configs on page load.  For those older jobs this can sometimes cause an error.  I've found ~16 workspaces where this is an issue so I think we can just not display the run command for those.

Fixes [this sentry event](https://sentry.io/organizations/ebm-datalab/issues/3833851093/?project=5443358).
Fixes [this sentry event](https://sentry.io/organizations/ebm-datalab/issues/3842629873/?project=5443358)