### PR TITLE
Don't return a 400 when the login page finds an unsafe next param

### DIFF
--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -1,10 +1,8 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.core.exceptions import SuspiciousOperation
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
-from django.views.defaults import bad_request
 from django.views.generic import UpdateView
 
 from ..utils import is_safe_path
@@ -13,7 +11,7 @@ from ..utils import is_safe_path
 def login_view(request):
     next_url = request.GET.get("next") or "/"
     if not is_safe_path(next_url):
-        return bad_request(request, SuspiciousOperation)
+        next_url = ""
 
     if request.user.is_authenticated:
         return redirect(next_url)

--- a/tests/unit/jobserver/views/test_users.py
+++ b/tests/unit/jobserver/views/test_users.py
@@ -35,9 +35,11 @@ def test_login_safe_path(rf):
 def test_login_unsafe_path(rf):
     request = rf.get("/?next=https://steal-your-bank-details.com/")
     request.user = AnonymousUser()
+
     response = login_view(request)
 
-    assert response.status_code == 400
+    assert response.status_code == 200
+    assert response.context_data["next_url"] == ""
 
 
 def test_login_already_logged_with_next_url(rf):


### PR DESCRIPTION
This mirrors Django's handling of an unsafe next URL, and is a kinder route to take for users who didn't set the URL.

Fixes: #2438 