### PR TITLE
Add a password reset flow

### DIFF
--- a/jobserver/emails.py
+++ b/jobserver/emails.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.urls import reverse
 from furl import furl
 from incuna_mail import send
 
@@ -25,6 +26,25 @@ def send_finished_notification(email, job):
         sender="notifications@jobs.opensafely.org",
         subject=f"{job.status}: [os {workspace_name}] {job.action}",
         template_name="emails/notify_finished.txt",
+        context=context,
+    )
+
+
+def send_github_login_email(user):
+    login_url = furl(settings.BASE_URL) / reverse(
+        "auth-login", kwargs={"backend": "github"}
+    )
+
+    context = {
+        "url": login_url,
+    }
+
+    send(
+        to=user.email,
+        subject="OpenSAFELY password reset request",
+        sender="notifications@jobs.opensafely.org",
+        reply_to=["OpenSAFELY Team <team@opensafely.org>"],
+        template_name="emails/login_via_github.txt",
         context=context,
     )
 
@@ -60,4 +80,21 @@ def send_repo_signed_off_notification_to_staff(repo):
         subject=subject,
         template_name="emails/notify_staff_repo_signed_off.txt",
         context={"repo": repo, "staff_url": staff_url},
+    )
+
+
+def send_reset_password_email(user):
+    reset_url = furl(settings.BASE_URL) / user.get_password_reset_url()
+
+    context = {
+        "url": reset_url,
+    }
+
+    send(
+        to=user.email,
+        subject="OpenSAFELY password reset request",
+        sender="notifications@jobs.opensafely.org",
+        reply_to=["OpenSAFELY Team <team@opensafely.org>"],
+        template_name="emails/reset_password.txt",
+        context=context,
     )

--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -49,6 +49,10 @@ class ProjectMembershipForm(RolesForm):
     pass
 
 
+class ResetPasswordForm(forms.Form):
+    email = forms.EmailField(widget=forms.EmailInput(attrs={"autocomplete": "email"}))
+
+
 class WorkspaceArchiveToggleForm(forms.Form):
     is_archived = forms.BooleanField(required=False)
 

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -9,6 +9,7 @@ import structlog
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.models import UserManager
 from django.contrib.auth.models import UserManager as BaseUserManager
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import validate_slug
@@ -16,6 +17,8 @@ from django.db import models
 from django.db.models import Min, Q
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 from django.utils.text import slugify
 from environs import Env
 from furl import furl
@@ -871,6 +874,12 @@ class User(AbstractBaseUser):
     def get_full_name(self):
         """Support Django's User contract"""
         return self.fullname
+
+    def get_password_reset_url(self):
+        uid = urlsafe_base64_encode(force_bytes(self.pk))
+        token = PasswordResetTokenGenerator().make_token(self)
+
+        return reverse("set-password", kwargs={"uidb64": uid, "token": token})
 
     def get_staff_url(self):
         return reverse("staff:user-detail", kwargs={"username": self.username})

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -2,7 +2,7 @@ import debug_toolbar
 import social_django.views as social_django_views
 from django.conf import settings
 from django.conf.urls.static import static
-from django.contrib.auth.views import LogoutView
+from django.contrib.auth.views import LogoutView, PasswordResetConfirmView
 from django.urls import include, path
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
@@ -52,7 +52,7 @@ from .views.releases import (
 )
 from .views.repos import RepoHandler, SignOffRepo
 from .views.status import DBAvailability, PerBackendStatus, Status
-from .views.users import Settings, login_view
+from .views.users import ResetPassword, Settings, login_view
 from .views.workspaces import (
     WorkspaceArchiveToggle,
     WorkspaceBackendFiles,
@@ -189,6 +189,20 @@ releases_urls = [
     path("<str:pk>/<path:path>", ReleaseDetail.as_view(), name="release-detail"),
 ]
 
+reset_password_urls = [
+    path("", ResetPassword.as_view(), name="reset-password"),
+    path(
+        "<str:uidb64>/<str:token>/",
+        PasswordResetConfirmView.as_view(
+            post_reset_login=True,
+            post_reset_login_backend="django.contrib.auth.backends.ModelBackend",
+            success_url="/",
+            template_name="set_password.html",
+        ),
+        name="set-password",
+    ),
+]
+
 status_urls = [
     path("", Status.as_view(), name="status"),
     path("<slug:backend>/", PerBackendStatus.as_view(), name="status-backend"),
@@ -276,6 +290,7 @@ urlpatterns = [
     path("orgs/", OrgList.as_view(), name="org-list"),
     path("publish-repo/<repo_url>/", SignOffRepo.as_view(), name="repo-sign-off"),
     path("repo/<repo_url>/", RepoHandler.as_view(), name="repo-handler"),
+    path("reset-password/", include(reset_password_urls)),
     path("settings/", Settings.as_view(), name="settings"),
     path("staff/", include("staff.urls", namespace="staff")),
     path("status/", include(status_urls)),

--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -3,8 +3,11 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
-from django.views.generic import UpdateView
+from django.views.generic import FormView, UpdateView
 
+from ..emails import send_github_login_email, send_reset_password_email
+from ..forms import ResetPasswordForm
+from ..models import User
 from ..utils import is_safe_path
 
 
@@ -17,6 +20,33 @@ def login_view(request):
         return redirect(next_url)
 
     return TemplateResponse(request, "login.html", {"next_url": next_url})
+
+
+class ResetPassword(FormView):
+    form_class = ResetPasswordForm
+    template_name = "reset_password.html"
+
+    def form_valid(self, form):
+        user = User.objects.filter(email=form.cleaned_data["email"]).first()
+
+        # we have three possible states for the given email:
+        # * unknown user
+        # * GitHub user
+        # * email-only user
+        # we want to show the same outcome regardless of state so a bad actor
+        # can't work out work out who uses the service by email
+        if user:
+            if user.social_auth.exists():
+                # send GitHub users a link to the PSA entrypoint and explain
+                # that they don't have a password to reset
+                send_github_login_email(user)
+            else:
+                send_reset_password_email(user)
+
+        messages.success(
+            self.request, "Your password reset request was successfully sent."
+        )
+        return redirect("/")
 
 
 @method_decorator(login_required, name="dispatch")

--- a/templates/emails/login_via_github.txt
+++ b/templates/emails/login_via_github.txt
@@ -1,0 +1,9 @@
+A request to reset your password has been made.
+
+If you did not make this request then you can safely ignore this email.
+
+You registered with OpenSAFELY by using your GitHub and as such have no password reset.
+
+Please use the link below to log into the Job site directly.  You can also do so by clicking the login button in the top right of the page.
+
+{{ url }}

--- a/templates/emails/reset_password.txt
+++ b/templates/emails/reset_password.txt
@@ -1,0 +1,7 @@
+A request to reset your password has been made.
+
+If you did not make this request then you can safely ignore this email.
+
+Otherwise, please click the link below to reset your password:
+
+{{ url }}

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -1,0 +1,36 @@
+{% extends "base-tw.html" %}
+
+{% load humanize %}
+
+{% block metatitle %}Reset your password | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+  {% url "home" as home_url %}
+
+  {% #breadcrumbs %}
+    {% breadcrumb title="Home" url=home_url %}
+    {% breadcrumb title="Reset your password" active=True %}
+  {% /breadcrumbs %}
+{% endblock breadcrumbs %}
+
+{% block content %}
+  <section class="grid md:grid-cols-3">
+    <h1 class="md:col-span-3 text-3xl break-words md:text-4xl font-bold text-slate-900">
+      Reset your password
+    </h1>
+
+    <form method="POST" class="md:col-span-2 mt-6">
+      {% csrf_token %}
+
+      {% for error in form.non_field_errors %}
+      <p class="text-red-900">{{ error }}</p>
+      {% endfor %}
+
+      {% form_input type="email" field=form.email autocomplete=True required=True %}
+
+      {% #button class="mt-2" type="submit" variant="primary" %}
+        Submit
+      {% /button %}
+    </form>
+  </section>
+{% endblock %}

--- a/templates/set_password.html
+++ b/templates/set_password.html
@@ -1,0 +1,37 @@
+{% extends "base-tw.html" %}
+
+{% load humanize %}
+
+{% block metatitle %}Set your password | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+  {% url "home" as home_url %}
+
+  {% #breadcrumbs %}
+    {% breadcrumb title="Home" url=home_url %}
+    {% breadcrumb title="Set your password" active=True %}
+  {% /breadcrumbs %}
+{% endblock breadcrumbs %}
+
+{% block content %}
+  <section class="grid md:grid-cols-3">
+    <h1 class="md:col-span-3 text-3xl break-words md:text-4xl font-bold text-slate-900">
+      Set your password
+    </h1>
+
+    <form method="POST" class="md:col-span-2 mt-6">
+      {% csrf_token %}
+
+      {% for error in form.non_field_errors %}
+      <p class="text-red-900">{{ error }}</p>
+      {% endfor %}
+
+      {% form_input type="password" label="Password" field=form.new_password1 required=True %}
+      {% form_input type="password" label="Confirm password" field=form.new_password2 required=True %}
+
+      {% #button class="mt-2" type="submit" variant="primary" %}
+        Save
+      {% /button %}
+    </form>
+  </section>
+{% endblock %}

--- a/tests/unit/jobserver/models/test_core.py
+++ b/tests/unit/jobserver/models/test_core.py
@@ -1,9 +1,12 @@
 from datetime import timedelta
 
 import pytest
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.db import IntegrityError
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 
 from jobserver.authorization.roles import (
     CoreDeveloper,
@@ -907,6 +910,19 @@ def test_user_get_all_roles_empty():
         "orgs": [],
     }
     assert output == expected
+
+
+def test_user_get_password_reset_url():
+    user = UserFactory()
+
+    url = user.get_password_reset_url()
+
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+    token = PasswordResetTokenGenerator().make_token(user)
+    assert url == reverse(
+        "set-password",
+        kwargs={"uidb64": uid, "token": token},
+    )
 
 
 def test_user_get_staff_url():


### PR DESCRIPTION
This sets up a password reset flow for users, mostly using Django's built-in password reset handlers.

For users who signed up with GitHub I've added a separate email that pops them directly into the PSA auth flow so clicking the link will take them directly to GitHub and then our homepage since there's nothing for them to currently reset.