### PR TITLE
Email new email-only users a link to set their password

### DIFF
--- a/jobserver/emails.py
+++ b/jobserver/emails.py
@@ -98,3 +98,22 @@ def send_reset_password_email(user):
         template_name="emails/reset_password.txt",
         context=context,
     )
+
+
+def send_welcome_email(user):
+    reset_url = furl(settings.BASE_URL) / user.get_password_reset_url()
+
+    context = {
+        "domain": settings.BASE_URL,
+        "name": user.name,
+        "url": reset_url,
+    }
+
+    send(
+        to=user.email,
+        subject="Welcome to OpenSAFELY",
+        sender="notifications@jobs.opensafely.org",
+        reply_to=["OpenSAFELY Team <team@opensafely.org>"],
+        template_name="emails/welcome.txt",
+        context=context,
+    )

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -12,6 +12,7 @@ from django.views.generic import FormView, ListView, UpdateView
 from jobserver.authorization import InteractiveReporter, roles
 from jobserver.authorization.decorators import require_permission
 from jobserver.authorization.utils import roles_for
+from jobserver.emails import send_welcome_email
 from jobserver.models import Backend, Job, Org, Project, ProjectMembership, User
 from jobserver.utils import raise_if_not_int
 
@@ -74,7 +75,7 @@ class UserCreate(FormView):
             project=project, user=user, roles=[InteractiveReporter]
         )
 
-        # TODO: email user with password [reset] link
+        send_welcome_email(user)
 
         return redirect(user.get_staff_url())
 

--- a/templates/emails/welcome.txt
+++ b/templates/emails/welcome.txt
@@ -1,0 +1,11 @@
+Hi {{ name }},
+
+Thank you for your interest in OpenSAFELY.
+
+Please click on the link to finish setting up your account:
+
+{{ url }}
+
+Once you've setup your account, you'll be logged into to the website, {{ domain }}, and taken to the "Request an analysis" page where you can design and request your analysis.
+
+Once your analysis has been run, we will send you an email with instructions on how to view the results.

--- a/templates/staff/user_create.html
+++ b/templates/staff/user_create.html
@@ -43,7 +43,8 @@
 
       <p>
         Creating a user here will set up an account for a user who can only use
-        the Interactive portion of the site.  Please ensure users are part of an
+        the Interactive portion of the site.  They will be emailed with a link
+        to set their password.  Please ensure users are part of an
         <strong>approved application</strong>.
       </p>
 

--- a/tests/unit/staff/views/test_users.py
+++ b/tests/unit/staff/views/test_users.py
@@ -95,7 +95,9 @@ def test_usercreate_post_success_with_application_url(rf, core_developer):
     assert user.projects.first().application_url == "http://example.com"
 
 
-def test_usercreate_post_success_without_application_url(rf, core_developer):
+def test_usercreate_post_success_without_application_url(
+    rf, mailoutbox, core_developer
+):
     org = OrgFactory()
     project = ProjectFactory()
     ApplicationFactory(project=project)
@@ -120,6 +122,9 @@ def test_usercreate_post_success_without_application_url(rf, core_developer):
     assert user.orgs.first() == org
     assert user.projects.first() == project
     assert not user.projects.first().application_url
+
+    assert len(mailoutbox) == 1
+    assert "reset-password" in mailoutbox[0].body
 
 
 def test_usercreate_unauthorized(rf):


### PR DESCRIPTION
This sends a user created in the staff area an email directing them to set their password, reusing the end of the reset password flow from #2469 