### PR TITLE
ensure project has an interactive workspace

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -530,6 +530,22 @@ class Project(models.Model):
     def __str__(self):
         return f"{self.org.name} | {self.title}"
 
+    def create_interactive_workspace(self, creator):
+        name = f"{self.slug}-interactive"
+
+        # TODO: decide on which org interactive repos will live in
+        repo, _ = Repo.objects.get_or_create(
+            url=f"https://github.com/opensafely/{name}"
+        )
+
+        return self.workspaces.create(
+            repo=repo,
+            name=name,
+            branch="main",
+            created_by=creator,
+            purpose="??",
+        )
+
     def get_absolute_url(self):
         return reverse(
             "project-detail",

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -13,7 +13,15 @@ from jobserver.authorization import InteractiveReporter, roles
 from jobserver.authorization.decorators import require_permission
 from jobserver.authorization.utils import roles_for
 from jobserver.emails import send_welcome_email
-from jobserver.models import Backend, Job, Org, Project, ProjectMembership, User
+from jobserver.models import (
+    Backend,
+    Job,
+    Org,
+    Project,
+    ProjectMembership,
+    User,
+    Workspace,
+)
 from jobserver.utils import raise_if_not_int
 
 from ..forms import UserCreateForm, UserForm, UserOrgsForm
@@ -74,6 +82,11 @@ class UserCreate(FormView):
         ProjectMembership.objects.create(
             project=project, user=user, roles=[InteractiveReporter]
         )
+
+        try:
+            project.interactive_workspace
+        except Workspace.DoesNotExist:
+            project.create_interactive_workspace(self.request.user)
 
         send_welcome_email(user)
 

--- a/templates/staff/user_create.html
+++ b/templates/staff/user_create.html
@@ -118,6 +118,15 @@
             {% endfor %}
           </div>
 
+          <div class="alert alert-warning" role="alert">
+            <p>
+              Please check whether a GitHub repository, called
+              <code>project.slug-interactive</code> exists. If it doesn't you
+              will need to create it.
+            </p>
+            <p>An Interactive workspace will be created automatically if one doesn't exist.</p>
+          </div>
+
           {% include "components/form_text.html" with field=form.name label="Name" name="name" %}
           {% include "components/form_text.html" with field=form.email label="Email address" name="email" %}
         </fieldset>


### PR DESCRIPTION
The goal with the user create page is to set up a user so that when they action the welcome email they are ready to go.  We haven't made a decision on how or where we'll create interactive repos yet so I've kept this to just creating the Workspace and Repo instances.