### PR TITLE
ignore YAMLErrors when reading the run_command for a job

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -21,7 +21,7 @@ from environs import Env
 from furl import furl
 from opentelemetry.trace import propagation
 from opentelemetry.trace.propagation import tracecontext
-from pipeline import load_pipeline
+from pipeline import YAMLError, load_pipeline
 from sentry_sdk import capture_message
 
 from ..authorization.fields import RolesField
@@ -145,7 +145,7 @@ class Job(models.Model):
         # command for this job
         try:
             pipeline = load_pipeline(self.job_request.project_definition)
-        except pydantic.ValidationError:
+        except (pydantic.ValidationError, YAMLError):
             return  # we don't have a valid config
 
         if action := pipeline.actions.get(self.action):

--- a/tests/unit/jobserver/models/test_core.py
+++ b/tests/unit/jobserver/models/test_core.py
@@ -138,6 +138,26 @@ def test_job_run_command_invalid_project_definition():
     assert JobFactory(job_request=job_request).run_command is None
 
 
+def test_job_run_command_invalid_project_definition_yaml():
+    """
+    Test an invalid project definition
+    """
+    pipeline = """
+    version: 3.0
+    expectations:
+      population_size: 1000
+    actions:
+      my_action:
+        run: cowsay research!
+      my_action:
+        run: cowsay research!
+    """
+
+    job_request = JobRequestFactory(project_definition=pipeline)
+
+    assert JobFactory(job_request=job_request).run_command is None
+
+
 def test_job_run_command_success():
     pipeline = """
     version: 3.0


### PR DESCRIPTION
This fixes the same issue as #2462 but for invalid YAML, rather than invalid _OpenSAFELY configs_.

Fixes [these](https://sentry.io/organizations/ebm-datalab/issues/3847330930/?project=5443358) [two](https://sentry.io/organizations/ebm-datalab/issues/3847331022/?project=5443358) Sentry errors.