### PR TITLE
re-instate checkout action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - uses: actions/checkout@v3
       - uses: "opensafely-core/setup-action@v1"
         with:
           python-version: "3.11"
@@ -41,6 +42,7 @@ jobs:
           --health-retries 5
 
     steps:
+      - uses: actions/checkout@v3
       - uses: "opensafely-core/setup-action@v1"
         with:
           python-version: "3.11"
@@ -93,6 +95,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - uses: actions/checkout@v3
       - uses: "opensafely-core/setup-action@v1"
         with:
           install-just: true
@@ -139,6 +142,7 @@ jobs:
     concurrency: deploy-production
 
     steps:
+      - uses: actions/checkout@v3
       - uses: "opensafely-core/setup-action@v1"
         with:
           install-just: true


### PR DESCRIPTION
we're removing this it from setup-action so calling workflows need to call it themselves.