### PR TITLE
List a user's 10 most recent jobs on their UserDetail page

### DIFF
--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -12,7 +12,7 @@ from django.views.generic import FormView, ListView, UpdateView
 from jobserver.authorization import roles
 from jobserver.authorization.decorators import require_permission
 from jobserver.authorization.utils import roles_for
-from jobserver.models import Backend, Org, Project, User
+from jobserver.models import Backend, Job, Org, Project, User
 from jobserver.utils import raise_if_not_int
 
 from ..forms import UserForm, UserOrgsForm
@@ -46,6 +46,9 @@ class UserDetail(UpdateView):
     def get_context_data(self, **kwargs):
         applications = self.object.applications.order_by("-created_at")
         copiloted_projects = self.object.copiloted_projects.order_by(Lower("name"))
+        jobs = Job.objects.filter(job_request__created_by=self.object).order_by(
+            "-created_at"
+        )[:10]
         orgs = [
             {
                 "name": m.org.name,
@@ -67,6 +70,7 @@ class UserDetail(UpdateView):
         return super().get_context_data(**kwargs) | {
             "applications": applications,
             "copiloted_projects": copiloted_projects,
+            "jobs": jobs,
             "orgs": orgs,
             "projects": projects,
         }

--- a/templates/staff/user_detail.html
+++ b/templates/staff/user_detail.html
@@ -225,6 +225,52 @@
         </div>
 
       </form>
+
+      <div id="jobs" class="mt-5">
+
+        <div class="d-flex justify-content-between">
+          <h2 class="h4">Jobs</h2>
+          <div>
+            <a class="btn btn-sm btn-primary" href="{% url 'job-list' %}?username={{ user.username }}">
+              View all ({{ jobs|length }})
+            </a>
+          </div>
+        </div>
+
+        <table class="table">
+          <thead>
+            <tr>
+              <th scope="col">Status</th>
+              <th scope="col">Job</th>
+              <th scope="col">Created</th>
+              <th scope="col">Runtime</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for job in jobs %}
+            <tr>
+              <td>
+                <div
+                  class="status status-icon {{ job.status }}"
+                  data-placement="bottom"
+                  data-toggle="tooltip"
+                  title="{{ job.status|capfirst }}"
+                >
+              </td>
+              <td><a href="{{ job.get_absolute_url }}">{{ job.identifier }}</a></td>
+              <td>
+                <time datetime="{{ job.created_at.isoformat }}">
+                  {{ job.created_at }}
+                </time>
+              </td>
+              <td>{{ job.runtime }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+
+      </div>
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
This adds the 10 most recent jobs to a user's page in the staff area.  This gives a viewer some idea of how active (and when) a user has been on the platform.  The view all button links to the event log page filtered by the user's username.

Fixes: #2484