### PR TITLE
Redirect interactive users to form

### DIFF
--- a/jobserver/authorization/permissions.py
+++ b/jobserver/authorization/permissions.py
@@ -1,4 +1,5 @@
 analysis_request_create = "analysis_request_create"
+analysis_request_view = "analysis_request_view"
 application_manage = "application_manage"
 backend_manage = "backend_manage"
 job_cancel = "job_cancel"

--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -1,5 +1,6 @@
 from .permissions import (
     analysis_request_create,
+    analysis_request_view,
     application_manage,
     backend_manage,
     job_cancel,
@@ -82,6 +83,7 @@ class InteractiveReporter:
     ]
     permissions = [
         analysis_request_create,
+        analysis_request_view,
     ]
 
 

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -566,6 +566,12 @@ class Project(models.Model):
             kwargs={"org_slug": self.org.slug, "project_slug": self.slug},
         )
 
+    def get_interactive_url(self):
+        return reverse(
+            "interactive:analysis-create",
+            kwargs={"org_slug": self.org.slug, "project_slug": self.slug},
+        )
+
     def get_staff_edit_url(self):
         return reverse("staff:project-edit", kwargs={"slug": self.slug})
 

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -2,7 +2,7 @@ import debug_toolbar
 import social_django.views as social_django_views
 from django.conf import settings
 from django.conf.urls.static import static
-from django.contrib.auth.views import LogoutView, PasswordResetConfirmView
+from django.contrib.auth.views import LogoutView
 from django.urls import include, path
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
@@ -52,7 +52,7 @@ from .views.releases import (
 )
 from .views.repos import RepoHandler, SignOffRepo
 from .views.status import DBAvailability, PerBackendStatus, Status
-from .views.users import ResetPassword, Settings, login_view
+from .views.users import ResetPassword, SetPassword, Settings, login_view
 from .views.workspaces import (
     WorkspaceArchiveToggle,
     WorkspaceBackendFiles,
@@ -191,16 +191,7 @@ releases_urls = [
 
 reset_password_urls = [
     path("", ResetPassword.as_view(), name="reset-password"),
-    path(
-        "<str:uidb64>/<str:token>/",
-        PasswordResetConfirmView.as_view(
-            post_reset_login=True,
-            post_reset_login_backend="django.contrib.auth.backends.ModelBackend",
-            success_url="/",
-            template_name="set_password.html",
-        ),
-        name="set-password",
-    ),
+    path("<str:uidb64>/<str:token>/", SetPassword.as_view(), name="set-password"),
 ]
 
 status_urls = [


### PR DESCRIPTION
This redirects an interactive user to the appropriate interactive page when they log in.

It assumes that someone using the SetPassword view with only InteractiveRole is an interactive user for now, so we don't annoy staff users or those who start with interactive and expand their usage of the site to the typical flow.