### PR TITLE
Disable "Run Jobs" button if workspace is archived

### DIFF
--- a/templates/workspace_detail.html
+++ b/templates/workspace_detail.html
@@ -76,10 +76,17 @@
         {% endif %}
 
         {% if user_can_run_jobs %}
-          {% #button href=run_jobs_url type="link" variant="success" %}
-            Run jobs
-            {% icon_play_outline class="h-4 w-4 ml-2 -mr-2" %}
-          {% /button %}
+          {% if workspace.is_archived %}
+            {% #button type="button" variant="info" disabled=True tooltip="Jobs cannot be run on an archived workspace" %}
+              Run jobs
+              {% icon_play_outline class="h-4 w-4 ml-2 -mr-2" %}
+            {% /button %}
+          {% else %}
+            {% #button href=run_jobs_url type="link" variant="success" %}
+              Run jobs
+              {% icon_play_outline class="h-4 w-4 ml-2 -mr-2" %}
+            {% /button %}
+          {% endif %}
         {% endif %}
 
         {% #button href=workspace.get_logs_url type="link" variant="primary" %}


### PR DESCRIPTION
- Closes #2461 (fixed)
- Closes #2463 (not required)

This button should have different functionality (link vs button), and it does not need to provide a URL to the disabled button. It should also show a tooltip when disabled.

<img width="473" alt="CleanShot 2023-01-17 at 16 47 04@2x" src="https://user-images.githubusercontent.com/24863179/212960349-3c203917-6133-40c0-ae86-f50d35da2da9.png">
