### PR TITLE
set missing created_by and updated_by fields

### DIFF
--- a/staff/views/orgs.py
+++ b/staff/views/orgs.py
@@ -34,6 +34,7 @@ def org_add_github_org(request, slug):
 
     name = form.cleaned_data["name"]
     org.github_orgs.append(name)
+    org.updated_by = request.user
     org.save()
 
     return redirect(org.get_staff_url())
@@ -47,6 +48,7 @@ class OrgCreate(CreateView):
     def form_valid(self, form):
         org = form.save(commit=False)
         org.created_by = self.request.user
+        org.updated_by = self.request.user
         org.save()
 
         org_detail = org.get_staff_url()
@@ -130,7 +132,9 @@ class OrgEdit(UpdateView):
         # mutation self.object under us
         old = self.get_object()
 
-        new = form.save()
+        new = form.save(commit=False)
+        new.updated_by = self.request.user
+        new.save()
 
         # check changed_data here instead of comparing self.object.slug to
         # new.slug because self.object is mutated when ModelForm._post_clean
@@ -179,6 +183,7 @@ class OrgProjectCreate(CreateView):
     def form_valid(self, form):
         project = form.save(commit=False)
         project.created_by = self.request.user
+        project.updated_by = self.request.user
         project.org = self.org
         project.save()
 
@@ -201,6 +206,7 @@ class OrgRemoveGitHubOrg(View):
         except ValueError:
             messages.error(request, f"{name} is not assigned to {org.name}")
         else:
+            org.updated_by = request.user
             org.save()
             messages.success(request, f"Removed {name} from {org.name}")
 

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -83,6 +83,7 @@ class ProjectCreate(CreateView):
     def form_valid(self, form):
         project = form.save(commit=False)
         project.created_by = self.request.user
+        project.updated_by = self.request.user
         project.save()
 
         project_detail = project.get_staff_url()

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -17,6 +17,7 @@ from jobserver.models import (
     Backend,
     Job,
     Org,
+    OrgMembership,
     Project,
     ProjectMembership,
     User,
@@ -72,7 +73,11 @@ class UserCreate(FormView):
             is_active=True,
         )
 
-        user.orgs.add(form.cleaned_data["org"])
+        OrgMembership.objects.create(
+            created_by=self.request.user,
+            org=form.cleaned_data["org"],
+            user=user,
+        )
 
         project = form.cleaned_data["project"]
         if application_url := form.cleaned_data.get("application_url"):
@@ -80,7 +85,10 @@ class UserCreate(FormView):
             project.save()
 
         ProjectMembership.objects.create(
-            project=project, user=user, roles=[InteractiveReporter]
+            created_by=self.request.user,
+            project=project,
+            user=user,
+            roles=[InteractiveReporter],
         )
 
         try:


### PR DESCRIPTION
Found while working #2531, these changes mean we should be consistently populating the created_by and updated_by on the relevant models.  I've opted to only fix the existing fields here, rather than add any missing fields to current models to keep the problem space small.  The cost of making sure we populate these types of fields is rising and I don't want to tackle that issue here.