### PR TITLE
Surface more repo sign off bits

### DIFF
--- a/templates/staff/project_detail.html
+++ b/templates/staff/project_detail.html
@@ -117,34 +117,35 @@
             </form>
           </div>
         </div>
-      {% empty %}
-        <p class="list-group-item">No members</p>
-      {% endfor %}
+        {% empty %}
+          <p class="list-group-item">No members</p>
+        {% endfor %}
+      </div>
+
+      <h2>Workspaces</h2>
+      <div class="list-group mb-3">
+        {% for workspace in workspaces %}
+        <a href="{{ workspace.get_staff_url }}" class="list-group-item list-group-item-action">
+          {{ workspace.name }}
+        </a>
+        {% empty %}
+          <p class="list-group-item">No workspaces</p>
+        {% endfor %}
+      </div>
+
+      <h2>Redirects</h2>
+      <div class="list-group mb-3">
+        {% for redirect in redirects %}
+        <a href="{{ redirect.get_staff_url }}" class="list-group-item list-group-item-action">
+          {{ redirect.old_url }}
+        </a>
+        {% empty %}
+          <p class="list-group-item">No redirects</p>
+        {% endfor %}
+      </div>
+
     </div>
 
-    <h2>Workspaces</h2>
-    <div class="list-group mb-3">
-      {% for workspace in workspaces %}
-      <a href="{{ workspace.get_staff_url }}" class="list-group-item list-group-item-action">
-        {{ workspace.name }}
-      </a>
-      {% empty %}
-        <p class="list-group-item">No workspaces</p>
-      {% endfor %}
-    </div>
-
-    <h2>Redirects</h2>
-    <div class="list-group mb-3">
-      {% for redirect in redirects %}
-      <a href="{{ redirect.get_staff_url }}" class="list-group-item list-group-item-action">
-        {{ redirect.old_url }}
-      </a>
-      {% empty %}
-        <p class="list-group-item">No redirects</p>
-      {% endfor %}
-    </div>
-
-    </div>
     <div class="col col-lg-3 col-xl-4">
       <div class="card mb-3">
         <h2 class="card-header h5">

--- a/templates/staff/project_detail.html
+++ b/templates/staff/project_detail.html
@@ -80,6 +80,14 @@
   <div class="row">
     <div class="col col-lg-9 col-xl-8">
 
+      <h2>Status</h2>
+      <div class="list-group mb-3">
+        <p>
+          <strong>Status:</strong> {{ project.get_status_display }}
+        </p>
+        <p><strong>Description:</strong> {{ project.status_description|default:"-" }}</p>
+      </div>
+
       <h2>Members</h2>
       <div class="list-group mb-3">
         {% for membership in memberships %}

--- a/templates/staff/workspace_detail.html
+++ b/templates/staff/workspace_detail.html
@@ -63,6 +63,11 @@
           </div>
 
           <div class="list-group-item">
+            <strong>Purpose</strong>
+            <p class="text-muted mb-0 mt-1">{{ workspace.purpose|default:"-" }}</p>
+          </div>
+
+          <div class="list-group-item">
             <strong>Notify when jobs finish:</strong>
             {% if workspace.should_notify %}Enabled{% else %}Disabled{% endif %}
             <p class="text-muted mb-0 mt-1">


### PR DESCRIPTION
When copilots go to internally sign off a repo they have to hunt around for these fields, typically jumping to the main site to see them.  Having them on the details page for each object saves a lot of clicking around.