### PR TITLE
Avoid O(N) queries on the homepage from workspace.repo

### DIFF
--- a/jobserver/views/index.py
+++ b/jobserver/views/index.py
@@ -12,7 +12,7 @@ class Index(TemplateView):
         ).order_by("-created_at")[:5]
         workspaces = (
             Workspace.objects.filter(is_archived=False)
-            .select_related("project", "project__org")
+            .select_related("project", "project__org", "repo")
             .order_by("name")
         )
 


### PR DESCRIPTION
Workspace.repo used to be a string value for the repo URL.  We moved to modelling repos as an object and missed the extra select_related value when doing so.