### PR TITLE
Get codelists for Interactive form

### DIFF
--- a/interactive/forms.py
+++ b/interactive/forms.py
@@ -1,0 +1,20 @@
+from django import forms
+
+
+def codelists_to_choices(codelists):
+    return [(c["slug"], c["name"]) for c in codelists]
+
+
+class AnalysisRequestForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        events = kwargs.pop("events")
+        medications = kwargs.pop("medications")
+
+        super().__init__(*args, **kwargs)
+
+        # combine both lists of codelists into a single set of choices.  Both
+        # codelist fields need to be able to accept a codelist from either list.
+        codelists = codelists_to_choices(events + medications)
+
+        self.fields["codelist_a"] = forms.ChoiceField(choices=codelists)
+        self.fields["codelist_b"] = forms.ChoiceField(choices=codelists)

--- a/interactive/forms.py
+++ b/interactive/forms.py
@@ -1,11 +1,27 @@
 from django import forms
 
 
+DEMOGRAPHICS = [
+    "age",
+    "ethnicity",
+    "imd",
+    "region",
+    "sex",
+]
+
+
 def codelists_to_choices(codelists):
     return [(c["slug"], c["name"]) for c in codelists]
 
 
 class AnalysisRequestForm(forms.Form):
+    frequency = forms.CharField()
+    time_value = forms.CharField()
+    time_scale = forms.CharField()
+    time_event = forms.CharField()
+    filter_population = forms.CharField()
+    demographics = forms.MultipleChoiceField(choices=[(d, "") for d in DEMOGRAPHICS])
+
     def __init__(self, *args, **kwargs):
         events = kwargs.pop("events")
         medications = kwargs.pop("medications")

--- a/interactive/opencodelists.py
+++ b/interactive/opencodelists.py
@@ -1,0 +1,78 @@
+import requests
+from furl import furl
+
+
+session = requests.Session()
+session.headers = {
+    "User-Agent": "OpenSAFELY Jobs",
+}
+
+
+class OpenCodelistsAPI:
+    """
+    A thin wrapper around requests, furl, and the OpenCodelists API.
+
+    Initialising this class with a token will set that token in the sessions
+    headers.
+
+    "public" functions should construct a URL and make requests against the
+    session object attached to the instance.
+
+    This object is not expected to be used in most tests so we can avoid mocking.
+    """
+
+    base_url = "https://www.opencodelists.org/api/v1"
+
+    def __init__(self, _session=session):
+        """
+        Initialise the wrapper with a session
+
+        We pass in the session here so that tests can pass in a fake object to
+        test internals.
+        """
+        self.session = _session
+
+    def _url(self, path_segments, query_args=None):
+        f = furl(self.base_url)
+
+        f.path.segments += path_segments
+
+        if query_args:
+            f.add(query_args)
+
+        return f.url
+
+    def _iter_codelists(self, codelists):
+        for codelist in codelists:
+            versions = [v for v in codelist["versions"] if v["status"] == "published"]
+
+            if not versions:
+                continue
+
+            latest = versions[-1]
+
+            yield {
+                "slug": latest["full_slug"],
+                "name": codelist["name"],
+                "organisation": codelist["organisation"],
+            }
+
+    def get_codelists(self, coding_system):
+        path_segments = [
+            "codelist",
+        ]
+        query_args = {
+            "coding_system_id": coding_system,
+        }
+        url = self._url(path_segments, query_args)
+
+        r = self.session.get(url)
+        r.raise_for_status()
+
+        data = self._iter_codelists(r.json()["codelists"])
+        return list(sorted(data, key=lambda c: c["name"].lower()))
+
+
+def _get_opencodelists_api():
+    """Simple invocation wrapper of OpenCodelistsAPI"""
+    return OpenCodelistsAPI(_session=session)  # pragma: no cover

--- a/justfile
+++ b/justfile
@@ -111,8 +111,8 @@ test-dev *args:
         {{ args }}
 
     # run with || so they both run regardless of failures
-    $BIN/coverage report --omit=jobserver/github.py,"tests/verification/*" \
-    || $BIN/coverage html --omit=jobserver/github.py,"tests/verification/*"
+    $BIN/coverage report --omit=interactive/opencodelists.py,jobserver/github.py,"tests/verification/*" \
+    || $BIN/coverage html --omit=interactive/opencodelists.py,jobserver/github.py,"tests/verification/*"
 
 
 test *args:

--- a/templates/interactive/analysis_request_create.html
+++ b/templates/interactive/analysis_request_create.html
@@ -19,15 +19,18 @@
 {% endblock breadcrumbs %}
 
 {% block content %}
+<div
+  data-events="{{ events }}"
+  data-medications="{{ medications }}"
+</div>
+
 <div>
-  <form method="POST">
-    {% csrf_token %}
+  <h3>Events</h3>
+  <pre>{{ events|pprint }}</pre>
+</div>
 
-    <p>I'm a form</p>
-
-    {% #button class="mt-2" type="submit" variant="primary" %}
-      Submit
-    {% /button %}
-  </form>
+<div>
+  <h3>Medications</h3>
+  <pre>{{ medications|pprint }}</pre>
 </div>
 {% endblock %}

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -109,3 +109,19 @@ class FakeGitHubAPI:
                 "topics": [],
             },
         ]
+
+
+class FakeOpenCodelistsAPI:
+    def get_codelists(self, coding_system):
+        return [
+            {
+                "slug": "bennett/event-codelist/event123",
+                "name": "Event Codelist",
+                "organisation": "Bennett Institute",
+            },
+            {
+                "slug": "bennett/medication-codelist/medication123",
+                "name": "Medication Codelist",
+                "organisation": "Bennett Institute",
+            },
+        ]

--- a/tests/unit/interactive/test_opencodelists.py
+++ b/tests/unit/interactive/test_opencodelists.py
@@ -1,0 +1,24 @@
+import pytest
+
+from interactive.opencodelists import OpenCodelistsAPI
+
+
+@pytest.mark.parametrize(
+    "parts,query_args,expected",
+    [
+        ([], None, ""),
+        ([], {"key": "value"}, "?key=value"),
+        (["path", "to", "page"], None, "/path/to/page"),
+        (
+            ["path", "to", "page"],
+            {"key": "value"},
+            "/path/to/page?key=value",
+        ),
+    ],
+)
+def test_opencodelistsapi_url(parts, query_args, expected):
+    api = OpenCodelistsAPI(_session=None)
+
+    output = api._url(parts, query_args)
+
+    assert output == f"https://www.opencodelists.org/api/v1{expected}"

--- a/tests/unit/interactive/test_views.py
+++ b/tests/unit/interactive/test_views.py
@@ -44,6 +44,12 @@ def test_analysisrequestcreate_post_success(rf):
     data = {
         "codelist_a": "bennett/medication-codelist/medication123",
         "codelist_b": "bennett/event-codelist/event123",
+        "frequency": "test",
+        "time_value": "test",
+        "time_scale": "test",
+        "time_event": "test",
+        "filter_population": "test",
+        "demographics": "age",
     }
     request = rf.post("/", data)
     request.user = user

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -4,6 +4,7 @@ from environs import Env
 from jobserver.github import GitHubAPI
 
 from ..fakes import FakeGitHubAPI
+from .utils import compare
 
 
 pytestmark = [
@@ -15,35 +16,6 @@ pytestmark = [
 def github_api():
     """create a new API instance so that we can use a separate token for these tests"""
     return GitHubAPI(token=Env().str("GITHUB_TOKEN_TESTING"))
-
-
-def compare(fake, real):
-    """
-    Compare outputs of FakeGitHubAPI instances to those from GitHubAPI
-
-    FakeGitHubAPI returns partial, non-real data from the methods it
-    implements.  For tests we haven't found the need to have those responses be
-    real data, but we still what their shape and values to be correct in terms
-    of GitHub's API response schema.  This function checks the correctness of
-    those values.
-    """
-
-    assert type(fake) == type(real)
-
-    if isinstance(fake, list):
-        for x, y in zip(fake, real):
-            compare(x, y)
-        return
-
-    if isinstance(fake, str):
-        return
-
-    for key, value in fake.items():
-        assert key in real
-        assert isinstance(value, type(real[key]))
-
-        if isinstance(value, dict):
-            compare(fake[key], real[key])
 
 
 def test_create_issue(enable_network, github_api):

--- a/tests/verification/test_opencodelists.py
+++ b/tests/verification/test_opencodelists.py
@@ -1,0 +1,39 @@
+import pytest
+
+from interactive.opencodelists import OpenCodelistsAPI
+
+from ..fakes import FakeOpenCodelistsAPI
+from .utils import compare
+
+
+pytestmark = [
+    pytest.mark.verification,
+]
+
+
+@pytest.fixture
+def opencodelists_api():
+    """create a new API instance for these tests"""
+    return OpenCodelistsAPI()
+
+
+def test_get_codelists(enable_network, opencodelists_api):
+    args = ["snomedct"]
+
+    real = opencodelists_api.get_codelists(*args)
+    fake = FakeOpenCodelistsAPI().get_codelists(*args)
+
+    compare(fake, real)
+
+    assert real is not None
+
+
+def test_get_codelists_with_unknown_coding_system(enable_network, opencodelists_api):
+    args = ["test"]
+
+    real = opencodelists_api.get_codelists(*args)
+    fake = FakeOpenCodelistsAPI().get_codelists(*args)
+
+    compare(fake, real)
+
+    assert real == []

--- a/tests/verification/utils.py
+++ b/tests/verification/utils.py
@@ -1,0 +1,27 @@
+def compare(fake, real):
+    """
+    Compare outputs of Fake* instances to those from API instances
+
+    Fake API instances return partial, non-real data from the methods they
+    implement.  For tests we haven't found the need to have those responses be
+    real data, but we still what their shape and values to be correct in terms
+    of the API response schemas.  This function checks the correctness of those
+    values.
+    """
+
+    assert type(fake) == type(real)
+
+    if isinstance(fake, list):
+        for x, y in zip(fake, real):
+            compare(x, y)
+        return
+
+    if isinstance(fake, str):
+        return
+
+    for key, value in fake.items():
+        assert key in real
+        assert isinstance(value, type(real[key]))
+
+        if isinstance(value, dict):
+            compare(fake[key], real[key])


### PR DESCRIPTION
This adds an API wrapper for the OpenCodelists API, copying the method we used for GitHub, testing with a Fake and then verifying the fake separately.

The form and the way it's used in the view are a rough version that will almost certainly need to change when we integrate the react app form (eg we're likely going to POST JSON, not form data at the view), but these changes have been focussed on getting the codelists and validating their slugs.  We can address the method of submission when integrating.

Fixes: #2542