### PR TITLE
Support optional menu items

### DIFF
--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -3,11 +3,11 @@ import functools
 import structlog
 from django.conf import settings
 from django.db.models import Max
-from django.urls import reverse
 
 from .authorization import CoreDeveloper, has_role
 from .backends import show_warning
 from .models import Backend
+from .nav import NavItem, iter_nav
 
 
 logger = structlog.get_logger(__name__)
@@ -50,83 +50,31 @@ def staff_nav(request):
     if not has_role(request.user, CoreDeveloper):
         return {"staff_nav": []}
 
-    _active = functools.partial(_is_active, request)
+    is_active = functools.partial(_is_active, request)
 
-    options = [
-        {
-            "name": "Analysis Requests",
-            "is_active": _active(reverse("staff:analysis-request-list")),
-            "url": reverse("staff:analysis-request-list"),
-        },
-        {
-            "name": "Applications",
-            "is_active": _active(reverse("staff:application-list")),
-            "url": reverse("staff:application-list"),
-        },
-        {
-            "name": "Backends",
-            "is_active": _active(reverse("staff:backend-list")),
-            "url": reverse("staff:backend-list"),
-        },
-        {
-            "name": "Dashboards",
-            "is_active": _active(reverse("staff:dashboard:index")),
-            "url": reverse("staff:dashboard:index"),
-        },
-        {
-            "name": "Orgs",
-            "is_active": _active(reverse("staff:org-list")),
-            "url": reverse("staff:org-list"),
-        },
-        {
-            "name": "Redirects",
-            "is_active": _active(reverse("staff:redirect-list")),
-            "url": reverse("staff:redirect-list"),
-        },
-        {
-            "name": "Projects",
-            "is_active": _active(reverse("staff:project-list")),
-            "url": reverse("staff:project-list"),
-        },
-        {
-            "name": "Reports",
-            "is_active": _active(reverse("staff:report-list")),
-            "url": reverse("staff:report-list"),
-        },
-        {
-            "name": "Repos",
-            "is_active": _active(reverse("staff:repo-list")),
-            "url": reverse("staff:repo-list"),
-        },
-        {
-            "name": "Users",
-            "is_active": _active(reverse("staff:user-list")),
-            "url": reverse("staff:user-list"),
-        },
-        {
-            "name": "Workspaces",
-            "is_active": _active(reverse("staff:workspace-list")),
-            "url": reverse("staff:workspace-list"),
-        },
+    items = [
+        NavItem(name="Analysis Requests", url_name="staff:analysis-request-list"),
+        NavItem(name="Applications", url_name="staff:application-list"),
+        NavItem(name="Backends", url_name="staff:backend-list"),
+        NavItem(name="Dashboards", url_name="staff:dashboard:index"),
+        NavItem(name="Orgs", url_name="staff:org-list"),
+        NavItem(name="Redirects", url_name="staff:redirect-list"),
+        NavItem(name="Projects", url_name="staff:project-list"),
+        NavItem(name="Reports", url_name="staff:report-list"),
+        NavItem(name="Repos", url_name="staff:repo-list"),
+        NavItem(name="Users", url_name="staff:user-list"),
+        NavItem(name="Workspaces", url_name="staff:workspace-list"),
     ]
 
-    return {"staff_nav": options}
+    return {"staff_nav": list(iter_nav(items, request, is_active))}
 
 
 def nav(request):
-    _active = functools.partial(_is_active, request)
+    is_active = functools.partial(_is_active, request)
 
-    return {
-        "nav": [
-            {
-                "name": "Event Log",
-                "is_active": _active(reverse("job-list")),
-                "url": reverse("job-list"),
-            },
-            {
-                "name": "Status",
-                "is_active": _active(reverse("status")),
-                "url": reverse("status"),
-            },
-        ],
-    }
+    items = [
+        NavItem(name="Event Log", url_name="job-list"),
+        NavItem(name="Status", url_name="status"),
+    ]
+
+    return {"nav": list(iter_nav(items, request, is_active))}

--- a/jobserver/nav.py
+++ b/jobserver/nav.py
@@ -1,0 +1,25 @@
+from collections.abc import Callable
+
+from attrs import define
+from django.http import HttpRequest
+from django.urls import reverse
+
+
+@define
+class NavItem:
+    name: str
+    url_name: str
+    predicate: Callable[[HttpRequest], bool] = lambda request: True
+
+
+def iter_nav(items, request, is_active):
+    for item in items:
+        if not item.predicate(request):
+            continue
+
+        url = reverse(item.url_name)
+        yield {
+            "name": item.name,
+            "is_active": is_active(url),
+            "url": url,
+        }

--- a/tests/unit/jobserver/test_nav.py
+++ b/tests/unit/jobserver/test_nav.py
@@ -1,0 +1,80 @@
+import pytest
+
+from jobserver.authorization import CoreDeveloper, has_role
+from jobserver.nav import NavItem, iter_nav
+
+from ...factories import UserFactory
+
+
+def test_iter_nav_all_items(rf):
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    items = [
+        NavItem(name="Orgs", url_name="org-list"),
+        NavItem(name="Event Log", url_name="job-list"),
+    ]
+
+    output = list(iter_nav(items, request, lambda url: url == "/orgs/"))
+
+    assert output == [
+        {
+            "name": "Orgs",
+            "is_active": True,
+            "url": "/orgs/",
+        },
+        {
+            "name": "Event Log",
+            "is_active": False,
+            "url": "/event-log/",
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "roles,expected",
+    [
+        (
+            [CoreDeveloper],
+            [
+                {
+                    "name": "Always Shown",
+                    "is_active": True,
+                    "url": "/orgs/",
+                },
+                {
+                    "name": "Only Shown for CoreDevs",
+                    "is_active": False,
+                    "url": "/staff/users/",
+                },
+            ],
+        ),
+        (
+            [],
+            [
+                {
+                    "name": "Always Shown",
+                    "is_active": True,
+                    "url": "/orgs/",
+                }
+            ],
+        ),
+    ],
+    ids=["both_nav_items", "one_nav_item"],
+)
+def test_iter_nav_optional_items(rf, roles, expected):
+    request = rf.get("/")
+    request.user = UserFactory(roles=roles)
+
+    items = [
+        NavItem(name="Always Shown", url_name="org-list"),
+        NavItem(
+            name="Only Shown for CoreDevs",
+            url_name="staff:user-list",
+            predicate=lambda request: has_role(request.user, CoreDeveloper),
+        ),
+    ]
+
+    output = list(iter_nav(items, request, lambda url: url == "/orgs/"))
+
+    assert output == expected


### PR DESCRIPTION
We have a number of use cases for optional menu items.  To test those out this adds a way to add items to the top level navs with an optional predicate which is checked when outputing the structure for the template.

The staff area nav has been included in this change for consistency, although we currently don't expect to use predicates for that.