### PR TITLE
only show the notifications button for users who are allowed to use it

### DIFF
--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -284,6 +284,9 @@ class WorkspaceDetail(View):
         can_run_jobs = has_permission(
             request.user, "job_run", project=workspace.project
         )
+        can_toggle_notifications = has_permission(
+            request.user, "workspace_toggle_notifications", project=workspace.project
+        )
 
         # should we display the releases section for this workspace?
         can_use_releases = can_view_files or can_view_releases or can_view_outputs
@@ -303,6 +306,7 @@ class WorkspaceDetail(View):
             "run_jobs_url": run_jobs_url,
             "user_can_archive_workspace": can_archive_workspace,
             "user_can_run_jobs": can_run_jobs,
+            "user_can_toggle_notifications": can_toggle_notifications,
             "user_can_use_releases": can_use_releases,
             "user_can_view_files": can_view_files,
             "user_can_view_outputs": can_view_outputs,

--- a/templates/workspace_detail.html
+++ b/templates/workspace_detail.html
@@ -122,6 +122,7 @@
           {% /button %}
           {% endif %}
 
+          {% if user_can_toggle_notifications %}
           <form method="POST" action="{{ workspace.get_notifications_toggle_url }}">
             {% csrf_token %}
             <input type="hidden" name="should_notify" value="{{ workspace.should_notify|yesno:",True" }}" />
@@ -136,6 +137,7 @@
               {% /button %}
             {% endif %}
           </form>
+          {% endif %}
         {% /card %}
       {% endif %}
 

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -463,6 +463,26 @@ def test_workspacedetail_authorized_private_repo_show_change_visibility_banner(r
     assert response.context_data["show_publish_repo_warning"]
 
 
+def test_workspacedetail_authorized_toggle_notifications(rf):
+    user = UserFactory(roles=[ProjectDeveloper])
+    workspace = WorkspaceFactory()
+
+    BackendMembershipFactory(user=user)
+
+    request = rf.get("/")
+    request.user = user
+
+    response = WorkspaceDetail.as_view(get_github_api=FakeGitHubAPI)(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+    assert response.context_data["user_can_toggle_notifications"]
+
+
 def test_workspacedetail_authorized_view_files(rf):
     backend = BackendFactory(level_4_url="http://test/")
     user = UserFactory(roles=[ProjectCollaborator])
@@ -647,6 +667,10 @@ def test_workspacedetail_unauthorized(rf):
     #   OR doesn't have the right permission to see outputs
     #   AND there are no published Snapshots to show the user.
     assert not response.context_data["user_can_view_outputs"]
+
+    # this is false because only a user with ProjectDeveloper should be able
+    # to do this
+    assert not response.context_data["user_can_toggle_notifications"]
 
 
 def test_workspacedetail_unknown_workspace(rf):


### PR DESCRIPTION
Toggling notifications on a workspace sets the default for notifications about the completion of a JobRequest.  Only a user with the workspace_toggle_notifications permission (via the ProjectDeveloper role) should be to see and use this button.

Fixes: #2522 