### PR TITLE
Fix disabled button tooltips in staff area

### DIFF
--- a/assets/src/scripts/staff.js
+++ b/assets/src/scripts/staff.js
@@ -1,0 +1,5 @@
+/* global $ */
+// Bootstrap tooltips
+$(() => {
+  $('[data-toggle="tooltip"]').tooltip();
+});

--- a/assets/src/styles/_utilities.scss
+++ b/assets/src/styles/_utilities.scss
@@ -41,3 +41,7 @@
   background-color: $oxford-600;
   border-radius: 0;
 }
+
+.no-pointer-events {
+  pointer-events: none;
+}

--- a/templates/sign_off_repo.html
+++ b/templates/sign_off_repo.html
@@ -330,11 +330,3 @@
 
 </div>
 {% endblock %}
-
-{% block extra_js %}
-<script type="text/javascript" nonce="{{ request.csp_nonce }}">
-  $(document).ready(function () {
-    $('[data-toggle="tooltip"]').tooltip()
-  });
-</script>
-{% endblock %}

--- a/templates/staff/base.html
+++ b/templates/staff/base.html
@@ -1,4 +1,9 @@
 {% extends "base.html" %}
+{% load django_vite %}
+
+{% block extra_meta %}
+{% vite_asset "assets/src/scripts/staff.js" %}
+{% endblock extra_meta %}
 
 {% block staff_nav %}
 <nav class="navbar navbar-expand-lg navbar-dark bg-danger py-lg-2">

--- a/templates/staff/repo_detail.html
+++ b/templates/staff/repo_detail.html
@@ -46,23 +46,33 @@
       <form method="POST" action="{{ repo.get_staff_sign_off_url }}">
         {% csrf_token %}
 
+        {% if disabled %}
+        <span
+          class="d-inline-block mr-1"
+          data-placement="bottom"
+          data-toggle="tooltip"
+          tabindex="0"
+          title="
+            {% if disabled.not_ready %}
+            A researcher has not yet signed this repo off
+            {% elif disabled.no_permission %}
+            The SignOffRepoWithOutputs role is required to sign off repos with outputs on GitHub
+            {% elif disabled.already_signed_off %}
+            This repo has already been internally signed off
+            {% endif %}
+          "
+        >
+        {% endif %}
         <button
-          class="btn btn-danger mr-1"
-          type="submit"
-          {% if disabled.not_ready %}
+          class="btn btn-danger no-pointer-events"
           disabled
-          data-toggle="tooltip" data-placement="bottom"
-          title="A researcher has not yet signed this repo off"
-          {% elif disabled.no_permission %}
-          disabled
-          data-toggle="tooltip" data-placement="bottom"
-          title="The SignOffRepoWithOutputs role is required to sign off repos with outputs on GitHub"
-          {% elif disabled.already_signed_off %}
-          disabled
-          data-toggle="tooltip" data-placement="bottom"
-          title="This repo has already been internally signed off"
-          {% endif %}
-          >Sign off to make public</button>
+          type="button"
+        >Sign off to make public</button>
+        {% if disabled %}
+        </span>
+        {% else %}
+        <button class="btn btn-danger mr-1" type="submit">Sign off to make public</button>
+        {% endif %}
       </form>
     </div>
   </div>

--- a/templates/staff/repo_detail.html
+++ b/templates/staff/repo_detail.html
@@ -222,11 +222,3 @@
 
 </div>
 {% endblock staff_content %}
-
-{% block extra_js %}
-<script type="text/javascript" nonce="{{ request.csp_nonce }}">
-  $(document).ready(function () {
-    $('[data-toggle="tooltip"]').tooltip()
-  });
-</script>
-{% endblock %}

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,7 @@ const config = {
         job_request_create: "./assets/src/scripts/job_request_create.js",
         main: "./assets/src/scripts/main.js",
         "outputs-viewer": "./assets/src/scripts/outputs-viewer/index.jsx",
+        staff: "./assets/src/scripts/staff.js",
         tw: "./assets/src/scripts/tw.js",
         workspace_create: "./assets/src/scripts/workspace_create.js",
       },


### PR DESCRIPTION
Disabled buttons do not allow pointer events, so the tooltip was not showing in Chrome.

Using the [fix from the Bootstrap Docs](https://getbootstrap.com/docs/4.6/components/tooltips/#disabled-elements), this will allow tabbing and display the tooltip.