### PR TITLE
Interactive spa base url

### DIFF
--- a/interactive/urls.py
+++ b/interactive/urls.py
@@ -7,5 +7,6 @@ app_name = "interactive"
 
 urlpatterns = [
     path("", AnalysisRequestCreate.as_view(), name="analysis-create"),
-    path("<str:slug>/", AnalysisRequestDetail.as_view(), name="analysis-detail"),
+    path("<slug:slug>/", AnalysisRequestDetail.as_view(), name="analysis-detail"),
+    path("<path>", AnalysisRequestCreate.as_view()),
 ]

--- a/interactive/views.py
+++ b/interactive/views.py
@@ -5,6 +5,7 @@ from django.views.generic import DetailView, FormView
 from jobserver.authorization import has_permission
 from jobserver.models import Backend, Project
 from jobserver.reports import process_html
+from jobserver.utils import build_spa_base_url
 
 from .dates import END_DATE, START_DATE
 from .forms import AnalysisRequestForm
@@ -72,7 +73,9 @@ class AnalysisRequestCreate(FormView):
         return redirect(analysis_request)
 
     def get_context_data(self, **kwargs):
+        base_path = build_spa_base_url(self.request.path, self.kwargs.get("path", ""))
         return super().get_context_data(**kwargs) | {
+            "base_path": base_path,
             "events": self.events,
             "medications": self.medications,
             "project": self.project,

--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -111,22 +111,6 @@ def build_outputs_zip(release_files, url_builder_func):
     return in_memory_zf
 
 
-def build_spa_base_url(full_path, file_path):
-    """
-    Break the full path of a page down into the URL path without any file path
-
-    Given a URL such as
-
-        /org/project/workspace/releases/string/path/to/file.csv
-
-    we want to tell the SPA about the page path
-
-        /org/project/workspace/releases/string/
-
-    """
-    return full_path.removesuffix(file_path)
-
-
 def check_not_already_uploaded(filename, filehash, backend):
     """Check if this filename/filehash combination has been uploaded before."""
     duplicate = ReleaseFile.objects.filter(

--- a/jobserver/utils.py
+++ b/jobserver/utils.py
@@ -3,6 +3,22 @@ from urllib.parse import urlparse
 from django.core.exceptions import BadRequest
 
 
+def build_spa_base_url(full_path, file_path):
+    """
+    Break the full path of a page down into the URL path without any file path
+
+    Given a URL such as
+
+        /org/project/workspace/releases/string/path/to/file.csv
+
+    we want to tell the SPA about the page path
+
+        /org/project/workspace/releases/string/
+
+    """
+    return full_path.removesuffix(file_path)
+
+
 def dotted_path(cls):
     """Get the dotted path for a given class"""
     return f"{cls.__module__}.{cls.__qualname__}"

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -12,12 +12,8 @@ from django.views.generic import View
 
 from ..authorization import has_permission
 from ..models import Project, Release, ReleaseFile, Snapshot, Workspace
-from ..releases import (
-    build_outputs_zip,
-    build_spa_base_url,
-    serve_file,
-    workspace_files,
-)
+from ..releases import build_outputs_zip, serve_file, workspace_files
+from ..utils import build_spa_base_url
 
 
 class ProjectReleaseList(View):

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -24,12 +24,8 @@ from ..forms import (
 )
 from ..github import _get_github_api
 from ..models import Backend, Job, JobRequest, Project, Repo, Workspace
-from ..releases import (
-    build_hatch_token_and_url,
-    build_outputs_zip,
-    build_spa_base_url,
-    workspace_files,
-)
+from ..releases import build_hatch_token_and_url, build_outputs_zip, workspace_files
+from ..utils import build_spa_base_url
 
 
 class WorkspaceArchiveToggle(View):

--- a/templates/interactive/analysis_request_create.html
+++ b/templates/interactive/analysis_request_create.html
@@ -24,6 +24,7 @@
 {{ medications|json_script:"codelist_medications" }}
 <div
   id="osi"
+  data-base-url="{{ base_url }}"
   data-events="codelist_events"
   data-medications="codelist_medications">
 </div>

--- a/tests/unit/jobserver/test_releases.py
+++ b/tests/unit/jobserver/test_releases.py
@@ -112,12 +112,6 @@ def test_build_outputs_zip_with_missing_files(build_release_with_files):
             assert "This file was redacted by" in zipped_contents, zipped_contents
 
 
-def test_build_spa_base_url():
-    base = releases.build_spa_base_url("/a/page/with/file.csv", "with/file.csv")
-
-    assert base == "/a/page/"
-
-
 def test_create_github_issue_external_success(build_release_with_files):
     release = build_release_with_files(["file1.txt", "graph.png"])
 

--- a/tests/unit/jobserver/test_utils.py
+++ b/tests/unit/jobserver/test_utils.py
@@ -1,8 +1,14 @@
 from jobserver.authorization import OutputChecker
 from jobserver.models import Job
-from jobserver.utils import dotted_path, is_safe_path, set_from_qs
+from jobserver.utils import build_spa_base_url, dotted_path, is_safe_path, set_from_qs
 
 from ...factories import JobFactory
+
+
+def test_build_spa_base_url():
+    base = build_spa_base_url("/a/page/with/file.csv", "with/file.csv")
+
+    assert base == "/a/page/"
 
 
 def test_dotted_path():


### PR DESCRIPTION
To allow the interactive SPA to keep its pages in the URL we need to tell it what URL prefix it can ignore since that prefix is already handled by Django.