### PR TITLE
Fix internal email bug for repos related to projects with numbers

### DIFF
--- a/jobserver/emails.py
+++ b/jobserver/emails.py
@@ -66,7 +66,7 @@ def send_repo_signed_off_notification_to_researchers(repo):
 
 
 def send_repo_signed_off_notification_to_staff(repo):
-    numbers = [w.project.number for w in repo.workspaces.all() if w.project.number]
+    numbers = [str(w.project.number) for w in repo.workspaces.all() if w.project.number]
     numbers = ",".join(numbers) if numbers else "X"
     subject = (
         f"[{numbers}] - Historic repo with outputs - sign off required {repo.name}"


### PR DESCRIPTION
This only affected repos with both outputs on GitHub and related project(s) with numbers assigned.  I've added a test for the email function which was missed when we added this email.

Fixes: #2578