### PR TITLE
Create interactive repo when creating a user

### DIFF
--- a/interactive/commands.py
+++ b/interactive/commands.py
@@ -1,0 +1,71 @@
+from jobserver.authorization import InteractiveReporter
+from jobserver.github import _get_github_api
+from jobserver.models import OrgMembership, ProjectMembership, Repo, User
+
+
+def create_repo(*, name, get_github_api=_get_github_api):
+    """
+    Create an interactive GitHub repo
+
+    The repo might already exist so we try to get it first, and then we ensure
+    it has the correct topics set.
+    """
+    api = get_github_api()
+
+    repo = api.get_repo("opensafely", name)
+
+    if repo is None:
+        repo = api.create_repo("opensafely", name)
+
+    # add interactive topic to the repo if it's not already there
+    topics = set(repo["topics"])
+    if "interactive" not in topics:
+        topics.add("interactive")
+        api.set_repo_topics("opensafely", name, list(topics))
+
+    api.add_repo_to_team("interactive", "opensafely", name)
+
+    return repo["html_url"]
+
+
+def create_user(*, creator, email, name, org, project):
+    """Create an interactive user"""
+    user = User.objects.create(
+        fullname=name,
+        email=email,
+        username=email,
+        created_by=creator,
+        is_active=True,
+    )
+
+    OrgMembership.objects.create(
+        created_by=creator,
+        org=org,
+        user=user,
+    )
+
+    ProjectMembership.objects.create(
+        created_by=creator,
+        project=project,
+        user=user,
+        roles=[InteractiveReporter],
+    )
+
+    return user
+
+
+def create_workspace(*, creator, project, repo_url):
+    """Create an interactive workspace"""
+    repo, _ = Repo.objects.get_or_create(url=repo_url)
+
+    workspace, _ = project.workspaces.get_or_create(
+        name=project.interactive_slug,
+        defaults={
+            "repo": repo,
+            "branch": "main",
+            "created_by": creator,
+            "purpose": "??",
+        },
+    )
+
+    return workspace

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -547,22 +547,6 @@ class Project(models.Model):
     def __str__(self):
         return f"{self.org.name} | {self.title}"
 
-    def create_interactive_workspace(self, creator):
-        name = f"{self.slug}-interactive"
-
-        # TODO: decide on which org interactive repos will live in
-        repo, _ = Repo.objects.get_or_create(
-            url=f"https://github.com/opensafely/{name}"
-        )
-
-        return self.workspaces.create(
-            repo=repo,
-            name=name,
-            branch="main",
-            created_by=creator,
-            purpose="??",
-        )
-
     def get_absolute_url(self):
         return reverse(
             "project-detail",
@@ -605,8 +589,12 @@ class Project(models.Model):
         return reverse("staff:project-feature-flags", kwargs={"slug": self.slug})
 
     @property
+    def interactive_slug(self):
+        return f"{self.slug}-interactive"
+
+    @property
     def interactive_workspace(self):
-        return self.workspaces.get(name=f"{self.slug}-interactive")
+        return self.workspaces.get(name=self.interactive_slug)
 
     def save(self, *args, **kwargs):
         if not self.slug:

--- a/templates/staff/user_create.html
+++ b/templates/staff/user_create.html
@@ -118,15 +118,6 @@
             {% endfor %}
           </div>
 
-          <div class="alert alert-warning" role="alert">
-            <p>
-              Please check whether a GitHub repository, called
-              <code>project.slug-interactive</code> exists. If it doesn't you
-              will need to create it.
-            </p>
-            <p>An Interactive workspace will be created automatically if one doesn't exist.</p>
-          </div>
-
           {% include "components/form_text.html" with field=form.name label="Name" name="name" %}
           {% include "components/form_text.html" with field=form.email label="Email address" name="email" %}
         </fieldset>

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -5,9 +5,18 @@ from django.utils.timezone import now
 
 
 class FakeGitHubAPI:
+    def add_repo_to_team(self, team, org, repo):
+        return
+
     def create_issue(self, org, repo, title, body, labels):
         return {
             "html_url": "http://example.com",
+        }
+
+    def create_repo(self, org, repo):
+        return {
+            "html_url": "http://example.com",
+            "topics": [],
         }
 
     def get_branch(self, org, repo, branch):
@@ -48,6 +57,7 @@ class FakeGitHubAPI:
     def get_repo(self, org, repo):
         return {
             "created_at": "2020-07-31T13:37:00Z",
+            "html_url": "http://example.com",
             "topics": ["github-releases"],
             "private": True,
         }
@@ -109,6 +119,11 @@ class FakeGitHubAPI:
                 "topics": [],
             },
         ]
+
+    def set_repo_topics(self, org, repo, topics):
+        return {
+            "names": [],
+        }
 
 
 class FakeOpenCodelistsAPI:


### PR DESCRIPTION
This updates the Create interactive user page to also create a repo on GitHub if it doesn't already exist.

I was struggling to find nice patterns to create methods on Project/User which match those in `interactive/commands.py`.  I felt like the wrong layer to have a Model know about an API, so in the end I tried pulling all the functionality into "commands", as per [CQRS terminology](https://martinfowler.com/bliki/CommandQuerySeparation.html).  I'm not sold on following CQRS strictly but I've been [curious to see how useful it would be in job-server for a while](https://github.com/opensafely-core/job-server/issues/827) and this feels like a reasonable place to give it a go, being fairly separate from the rest of the system, and tasks which require more than one Model or API call.

Fixes: #2617 