### PR TITLE
Set a default for the interactive template repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,6 @@ jobs:
         env:
           GITHUB_TOKEN_TESTING: ${{ secrets.OPENSAFELY_GITHUB_TESTING_ORG_PAT }}
           GITHUB_WRITEABLE_TOKEN:
-          INTERACTIVE_TEMPLATE_REPO:
         run: |
           # build docker and run test
           just docker-test

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -44,7 +44,6 @@ services:
     environment:
       - GITHUB_TOKEN=
       - GITHUB_WRITEABLE_TOKEN=
-      - INTERACTIVE_TEMPLATE_REPO=
       - SECRET_KEY=12345
       - SOCIAL_AUTH_GITHUB_KEY=test
       - SOCIAL_AUTH_GITHUB_SECRET=test

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -364,7 +364,10 @@ DISABLE_CREATING_JOBS = env.bool("DISABLE_CREATING_JOBS", default=False)
 GITHUB_WRITEABLE_TOKEN = env.str("GITHUB_WRITEABLE_TOKEN", default="")
 
 # Interactive Analyses Templates Repo
-INTERACTIVE_TEMPLATE_REPO = env.str("INTERACTIVE_TEMPLATE_REPO", default="")
+INTERACTIVE_TEMPLATE_REPO = env.str(
+    "INTERACTIVE_TEMPLATE_REPO",
+    default="https://github.com/opensafely-core/interactive-templates",
+)
 
 # Releases storage location.
 # Note: we deliberately don't use MEDIA_ROOT/MEDIA_URL here, to avoid any

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ addopts = "--disable-network --tb=native --no-migrations --ignore=./release-hatc
 DJANGO_SETTINGS_MODULE = "jobserver.settings"
 env = [
   "GITHUB_TOKEN=empty",
-  "INTERACTIVE_TEMPLATE_REPO=empty",
   "SECRET_KEY=12345",
   "SOCIAL_AUTH_GITHUB_KEY=test",
   "SOCIAL_AUTH_GITHUB_SECRET=test",


### PR DESCRIPTION
Now we have the template repo up and running we should be able to rely on it by default.