### PR TITLE
use a local repo when in debug mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ staticfiles
 uploads
 /release-hatch
 /assets/src/scripts/outputs-viewer/coverage
+/repos

--- a/interactive/commands.py
+++ b/interactive/commands.py
@@ -1,6 +1,10 @@
+from django.conf import settings
+
 from jobserver.authorization import InteractiveReporter
 from jobserver.github import _get_github_api
 from jobserver.models import OrgMembership, ProjectMembership, Repo, User
+
+from .submit import git
 
 
 def create_repo(*, name, get_github_api=_get_github_api):
@@ -10,6 +14,13 @@ def create_repo(*, name, get_github_api=_get_github_api):
     The repo might already exist so we try to get it first, and then we ensure
     it has the correct topics set.
     """
+    if settings.DEBUG:
+        path = settings.LOCAL_GIT_REPOS / name
+        path.mkdir(exist_ok=True, parents=True)
+
+        git("init", "--bare", ".", "--initial-branch", "main", cwd=path)
+        return path
+
     api = get_github_api()
 
     repo = api.get_repo("opensafely", name)

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -369,6 +369,10 @@ INTERACTIVE_TEMPLATE_REPO = env.str(
     default="https://github.com/opensafely-core/interactive-templates",
 )
 
+# path to where local git repos live, used when developing locally, for the
+# interactive functionality
+LOCAL_GIT_REPOS = BASE_DIR / "repos"
+
 # Releases storage location.
 # Note: we deliberately don't use MEDIA_ROOT/MEDIA_URL here, to avoid any
 # surprises with django's default uploads implementation.

--- a/tests/unit/interactive/test_commands.py
+++ b/tests/unit/interactive/test_commands.py
@@ -1,3 +1,6 @@
+import pytest
+from django.conf import settings
+
 from interactive.commands import create_repo, create_user, create_workspace
 from jobserver.authorization import InteractiveReporter
 from jobserver.utils import set_from_qs
@@ -12,10 +15,20 @@ from ...factories import (
 from ...fakes import FakeGitHubAPI
 
 
-def test_create_repo_with_existing_repo():
+@pytest.mark.parametrize(
+    "debug,expected",
+    [
+        (True, settings.BASE_DIR / "repos" / "testing"),
+        (False, "http://example.com"),
+    ],
+    ids=["debug-on", "debug-off"],
+)
+def test_create_repo_with_existing_repo(monkeypatch, debug, expected):
+    monkeypatch.setattr(settings, "DEBUG", debug)
+
     repo_url = create_repo(name="testing", get_github_api=FakeGitHubAPI)
 
-    assert repo_url == "http://example.com"
+    assert repo_url == expected
 
 
 def test_createrepo_with_existing_repo_and_exsting_interactive_topic():


### PR DESCRIPTION
This creates a local repo when creating an Interactive user when DEBUG is turned on, saving us from having to deal with the creation of repos in the `opensafely` org, or the creation of another org for local testing.