### PR TITLE
Fixes for pages expecting objects to have related jobs

### DIFF
--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -25,6 +25,9 @@ logger = structlog.get_logger(__name__)
 
 
 def ran_at(job):
+    if job is None:
+        return
+
     return job.started_at or job.created_at
 
 

--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -122,7 +122,10 @@ def test_projectdetail_with_multiple_releases(rf, freezer):
 
 def test_projectdetail_with_no_github(rf):
     project = ProjectFactory()
-    WorkspaceFactory(project=project)
+    WorkspaceFactory(
+        project=project, repo=RepoFactory(url="https://github.com/owner/repo")
+    )
+    WorkspaceFactory(project=project, repo=RepoFactory(url="/path/on/disk/to/repo"))
 
     request = rf.get("/")
     request.user = UserFactory()

--- a/tests/unit/staff/views/test_repos.py
+++ b/tests/unit/staff/views/test_repos.py
@@ -26,6 +26,7 @@ def test_ran_at():
 
     assert ran_at(JobFactory(created_at=created, started_at=None)) == created
     assert ran_at(JobFactory(created_at=created, started_at=started)) == started
+    assert ran_at(None) is None
 
 
 def test_repodetail_success(rf, core_developer):


### PR DESCRIPTION
It's so rare for objects to not have jobs that we've not hit errors with this before.  However when @lucyb was running through the OSI walking skeleton with a brand new Project the ProjectDetail and staff area's RepoDetail pages had errors, which are corrected by these changes.