### PR TITLE
Make AnalysisRequest.slug unique

### DIFF
--- a/interactive/models.py
+++ b/interactive/models.py
@@ -125,7 +125,7 @@ class AnalysisRequest(models.Model):
 
     def save(self, *args, **kwargs):
         if not self.slug:
-            self.slug = slugify(self.title)
+            self.slug = f"{slugify(self.title)}-{self.pk}"
 
         return super().save(*args, **kwargs)
 


### PR DESCRIPTION
We generate AnalysisRequest titles from the form the user submits, which means there are only so many titles we can ever generate.  Slugs also suffer from this, being generated from titles.  Suffixing the slug with the pk retains the read-ability of the slug but keeps it unique.