### PR TITLE
Reset codelistA and codelistB on form submission

### DIFF
--- a/assets/src/scripts/interactive/pages/find-codelists.jsx
+++ b/assets/src/scripts/interactive/pages/find-codelists.jsx
@@ -46,7 +46,12 @@ function FindCodelists() {
       initialValues={initialValues}
       onSubmit={(values, actions) => {
         actions.validateForm().then(() => {
-          setFormData({ ...formData, ...values });
+          setFormData({
+            ...formData,
+            ...values,
+            codelistA: null,
+            codelistB: null,
+          });
           if (secondCodelist) {
             return navigate("build-query");
           }


### PR DESCRIPTION
**BUG 🐛**

## Steps to replicate

1. Choose two codelists on page 1
2. Submit page two
3. Go back to page 1, choose two new codelists
4. Page two will still show the old codelists in the select boxes

## Fix

Page 1 should clear `codelistA` and `codelistB` from the global state when submitting the form.