### PR TITLE
fix: ensure credentials are not included in docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,4 @@ workspaces
 staticfiles
 # dockerfile image build its own dir
 assets/dist
+.git/


### PR DESCRIPTION
By default, the checkout action caches credentials in .git/config.

This allows subsequent workflow steps to use git commands w/o having to
manually specify GITHUB_TOKEN as auth.

However, when building job-server docker images, we include the .git
dir, including the credentials, cached in .git/config.

So we add .git/ to `.dockerignore` to avoid exposing these credentials,
and in general avoid adding uneccesary stuff to the docker image.