### PR TITLE
Explicitly call `.url` on furl object

### DIFF
--- a/interactive/opencodelists.py
+++ b/interactive/opencodelists.py
@@ -58,9 +58,10 @@ class OpenCodelistsAPI:
             }
 
     def get_codelist(self, slug):
-        url = furl("https://www.opencodelists.org") / "codelist" / slug / "download.csv"
-        url.args["fixed-headers"] = 1
-        r = requests.get(url)
+        f = furl("https://www.opencodelists.org") / "codelist" / slug / "download.csv"
+        f.args["fixed-headers"] = 1
+
+        r = requests.get(f.url)
         r.raise_for_status()
 
         return r.text


### PR DESCRIPTION
This was working fine in dev and tests because requests presumably casts URLs to strings.  However in production, where we have opentelemetry enabled, this raised an error because the passed furl object has no decode method.