### PR TITLE
Revert "Remove codelist type"

### DIFF
--- a/interactive/__init__.py
+++ b/interactive/__init__.py
@@ -8,6 +8,7 @@ class Codelist:
     label: str
     slug: str
     system: str
+    type: str  # noqa: A003
 
     # TODO: what are these again?
     path: str | None = None

--- a/interactive/views.py
+++ b/interactive/views.py
@@ -30,6 +30,7 @@ def build_codelist(data):
         label=data.get("label", ""),
         slug=data.get("value", ""),
         system=system,
+        type=codelist_type,
     )
 
 

--- a/tests/unit/interactive/test_submit.py
+++ b/tests/unit/interactive/test_submit.py
@@ -67,7 +67,7 @@ def test_clean_working_tree(tmp_path):
     [
         (None, "Codelist slug-a"),
         (
-            Codelist(label="", slug="slug-b", system=""),
+            Codelist(label="", slug="slug-b", system="", type=""),
             "Codelist slug-a and codelist slug-b",
         ),
     ],
@@ -83,7 +83,7 @@ def test_commit_and_push(build_repo, remote_repo, codelist_2, commit_message):
     pk = new_ulid_str()
 
     analysis = Analysis(
-        codelist_1=Codelist(label="", slug="slug-a", system=""),
+        codelist_1=Codelist(label="", slug="slug-a", system="", type=""),
         codelist_2=codelist_2,
         created_by=UserFactory().email,
         demographics="",
@@ -152,7 +152,7 @@ def test_create_commit(build_repo, remote_repo, template_repo, force):
     pk = new_ulid_str()
 
     analysis = Analysis(
-        codelist_1=Codelist(label="", slug="", system=""),
+        codelist_1=Codelist(label="", slug="", system="", type=""),
         codelist_2=None,
         created_by=UserFactory().email,
         demographics="",
@@ -207,7 +207,7 @@ def test_create_commit_bad_template_repo(build_repo, remote_repo, tmp_path):
     )
     pk = new_ulid_str()
     analysis = Analysis(
-        codelist_1=Codelist(label="", slug="", system=""),
+        codelist_1=Codelist(label="", slug="", system="", type=""),
         codelist_2=None,
         created_by=UserFactory().email,
         demographics="",
@@ -241,8 +241,8 @@ def test_create_commit_with_two_codelists(
     pk = new_ulid_str()
 
     analysis = Analysis(
-        codelist_1=Codelist(label="", slug="", system=""),
-        codelist_2=Codelist(label="", slug="slug-b", system=""),
+        codelist_1=Codelist(label="", slug="", system="", type=""),
+        codelist_2=Codelist(label="", slug="slug-b", system="", type=""),
         created_by=UserFactory().email,
         demographics="",
         filter_population="",
@@ -292,7 +292,7 @@ def test_submit_analysis(monkeypatch, remote_repo, template_repo):
     user = UserFactory()
 
     analysis = Analysis(
-        codelist_1=Codelist(label="", slug="slug-a", system=""),
+        codelist_1=Codelist(label="", slug="slug-a", system="", type=""),
         codelist_2=None,
         created_by=user.email,
         demographics="",


### PR DESCRIPTION
This reverts commit c9ad061586f1e7893d72050d8dfa4e64125ce4da.

We need to pass in the codelist type it turns out because the dm+d codelists are still defined with snomed codes so the analysis code needs to know if a codelist is a medication or event since it can't infer it from the coding system.