### PR TITLE
replace system with type when templating an analysis

### DIFF
--- a/interactive/__init__.py
+++ b/interactive/__init__.py
@@ -7,7 +7,6 @@ from interactive import dates
 class Codelist:
     label: str
     slug: str
-    system: str
     type: str  # noqa: A003
 
     # TODO: what are these again?

--- a/interactive/views.py
+++ b/interactive/views.py
@@ -23,14 +23,10 @@ def build_codelist(data):
     if data is None:
         return
 
-    codelist_type = data.get("type", "")
-    system = "dmd" if codelist_type == "medication" else "snomed"
-
     return Codelist(
         label=data.get("label", ""),
         slug=data.get("value", ""),
-        system=system,
-        type=codelist_type,
+        type=data.get("type", ""),
     )
 
 

--- a/tests/unit/interactive/test_submit.py
+++ b/tests/unit/interactive/test_submit.py
@@ -67,7 +67,7 @@ def test_clean_working_tree(tmp_path):
     [
         (None, "Codelist slug-a"),
         (
-            Codelist(label="", slug="slug-b", system="", type=""),
+            Codelist(label="", slug="slug-b", type=""),
             "Codelist slug-a and codelist slug-b",
         ),
     ],
@@ -83,7 +83,7 @@ def test_commit_and_push(build_repo, remote_repo, codelist_2, commit_message):
     pk = new_ulid_str()
 
     analysis = Analysis(
-        codelist_1=Codelist(label="", slug="slug-a", system="", type=""),
+        codelist_1=Codelist(label="", slug="slug-a", type=""),
         codelist_2=codelist_2,
         created_by=UserFactory().email,
         demographics="",
@@ -150,7 +150,7 @@ def test_create_commit(build_repo, remote_repo, template_repo, force):
     pk = new_ulid_str()
 
     analysis = Analysis(
-        codelist_1=Codelist(label="", slug="", system="", type=""),
+        codelist_1=Codelist(label="", slug="", type=""),
         codelist_2=None,
         created_by=UserFactory().email,
         demographics="",
@@ -203,7 +203,7 @@ def test_create_commit_bad_template_repo(build_repo, remote_repo, tmp_path):
     )
     pk = new_ulid_str()
     analysis = Analysis(
-        codelist_1=Codelist(label="", slug="", system="", type=""),
+        codelist_1=Codelist(label="", slug="", type=""),
         codelist_2=None,
         created_by=UserFactory().email,
         demographics="",
@@ -235,8 +235,8 @@ def test_create_commit_with_two_codelists(
     pk = new_ulid_str()
 
     analysis = Analysis(
-        codelist_1=Codelist(label="", slug="", system="", type=""),
-        codelist_2=Codelist(label="", slug="slug-b", system="", type=""),
+        codelist_1=Codelist(label="", slug="", type=""),
+        codelist_2=Codelist(label="", slug="slug-b", type=""),
         created_by=UserFactory().email,
         demographics="",
         filter_population="",
@@ -284,7 +284,7 @@ def test_submit_analysis(monkeypatch, remote_repo, template_repo):
     user = UserFactory()
 
     analysis = Analysis(
-        codelist_1=Codelist(label="", slug="slug-a", system="", type=""),
+        codelist_1=Codelist(label="", slug="slug-a", type=""),
         codelist_2=None,
         created_by=user.email,
         demographics="",


### PR DESCRIPTION
This switches us from passing in system to type (as defined in the form) since system isn't meaningful to the study (it's always snomed), fixing the input values for https://github.com/opensafely-core/interactive-templates/pull/20