### PR TITLE
Add buttons linking to the interactive form

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -1241,3 +1241,7 @@ class Workspace(models.Model):
             job = jobs.filter(action=action).order_by("-created_at").first()
             action_status_lut[action] = job.status
         return action_status_lut
+
+    @property
+    def is_interactive(self):
+        return self.name.endswith("-interactive")

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -69,9 +69,14 @@ class ProjectDetail(View):
             key=operator.itemgetter("name"),
         )
 
+        is_interactive_user = has_permission(
+            request.user, "analysis_request_create", project=project
+        )
+
         context = {
             "can_create_workspaces": can_create_workspaces,
             "first_job_ran_at": first_job_ran_at,
+            "is_interactive_user": is_interactive_user,
             "is_member": is_member,
             "memberships": memberships,
             "outputs": self.get_outputs(workspaces),

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -294,12 +294,20 @@ class WorkspaceDetail(View):
 
         honeycomb_can_view_links = has_role(self.request.user, CoreDeveloper)
 
+        is_interactive_user = has_permission(
+            request.user, "analysis_request_create", project=workspace.project
+        )
+        show_interactive_button = is_interactive_user and workspace.is_interactive
+
         context = {
             "first_job": first_job,
+            "honeycomb_can_view_links": honeycomb_can_view_links,
+            "honeycomb_link": f"https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production/datasets/job-server?query=%7B%22time_range%22%3A2419200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22status%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22current_runtime%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D%2C%7B%22column%22%3A%22workspace_name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{workspace.name}%22%7D%2C%7B%22column%22%3A%22completed%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3Atrue%7D%2C%7B%22column%22%3A%22status_change%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3Atrue%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D",
             "is_member": is_member,
             "repo_is_private": repo_is_private,
-            "show_publish_repo_warning": show_publish_repo_warning,
             "run_jobs_url": run_jobs_url,
+            "show_interactive_button": show_interactive_button,
+            "show_publish_repo_warning": show_publish_repo_warning,
             "user_can_archive_workspace": can_archive_workspace,
             "user_can_run_jobs": can_run_jobs,
             "user_can_toggle_notifications": can_toggle_notifications,
@@ -308,8 +316,6 @@ class WorkspaceDetail(View):
             "user_can_view_outputs": can_view_outputs,
             "user_can_view_releases": can_view_releases,
             "workspace": workspace,
-            "honeycomb_can_view_links": honeycomb_can_view_links,
-            "honeycomb_link": f"https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production/datasets/job-server?query=%7B%22time_range%22%3A2419200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22status%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22current_runtime%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22update_job%22%7D%2C%7B%22column%22%3A%22workspace_name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{workspace.name}%22%7D%2C%7B%22column%22%3A%22completed%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3Atrue%7D%2C%7B%22column%22%3A%22status_change%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3Atrue%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D",
         }
         return TemplateResponse(
             request,

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -89,7 +89,13 @@
     </div>
 
     {% if is_member %}
-      <div class="flex flex-row mb-6 justify-center lg:mb-0 lg:justify-end lg:items-start">
+      <div class="flex flex-row mb-6 justify-center lg:mb-0 lg:justify-end lg:items-start gap-2">
+        {% if is_interactive_user %}
+        {% #button href=project.get_interactive_url type="link" variant="primary" %}
+          Run interactive analysis
+          {% icon_play_outline class="h-4 w-4 ml-2 -mr-2" %}
+        {% /button %}
+        {% endif %}
         {% #button href=project.get_edit_url type="link" variant="secondary" %}
           Edit project
           {% icon_pencil_outline class="h-4 w-4 ml-2 -mr-2" %}

--- a/templates/workspace_detail.html
+++ b/templates/workspace_detail.html
@@ -99,10 +99,18 @@
           {% endif %}
         {% endif %}
 
+        {% if show_interactive_button %}
+        {% #button href=workspace.project.get_interactive_url type="link" variant="success" %}
+          Run interactive analysis
+          {% icon_play_outline class="h-4 w-4 ml-2 -mr-2" %}
+        {% /button %}
+        {% endif %}
+
         {% #button href=workspace.get_logs_url type="link" variant="primary" %}
           View logs
           {% icon_queue_list_outline class="h-4 w-4 ml-2 -mr-2" %}
         {% /button %}
+
       </div>
     </div>
 

--- a/tests/unit/jobserver/models/test_workspace.py
+++ b/tests/unit/jobserver/models/test_workspace.py
@@ -408,6 +408,11 @@ def test_workspace_get_action_status_lut_without_backend():
     assert output == expected
 
 
+def test_workspace_is_interactive():
+    assert WorkspaceFactory(name="test-interactive").is_interactive
+    assert not WorkspaceFactory().is_interactive
+
+
 def test_workspace_str():
     repo = RepoFactory(url="Corellia")
     workspace = WorkspaceFactory(name="Corellian Engineering Corporation", repo=repo)

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 from jobserver.authorization import (
     CoreDeveloper,
+    InteractiveReporter,
     OpensafelyInteractive,
     ProjectCollaborator,
     ProjectDeveloper,
@@ -609,6 +610,24 @@ def test_workspacedetail_authorized_honeycomb(rf):
         f"workspace_name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{workspace.name}"
         in response.rendered_content
     )
+
+
+def test_workspacedetail_for_interactive_button(rf, user):
+    workspace = WorkspaceFactory(name="testing-interactive")
+    user = UserFactory(roles=[InteractiveReporter])
+
+    request = rf.get("/")
+    request.user = user
+
+    response = WorkspaceDetail.as_view(get_github_api=FakeGitHubAPI)(
+        request,
+        org_slug=workspace.project.org.slug,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+    assert "Run interactive analysis" in response.rendered_content
 
 
 def test_workspacedetail_logged_out(rf):


### PR DESCRIPTION
We expect the happy path for Interactive users to be login -> redirect to the interactive form.  However it's possible they will end up on the appropriate Project/Workspace page, these buttons will give them a route to get to the form.

It will also benefit us while testing and debugging where we, as staff, won't be following the same path as the typical user, so having a clear route to get to the interactive form will be useful.

**Project page**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/04u69nOD/e2115a31-390a-48b9-a0fa-11d0a6f2728a.jpg?v=eb7780f98b0c431248328610795a9798)

**Workspace page**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/8LuqmenB/4175cacc-c865-4282-8da9-18a07c643af0.jpg?v=78a4a4798027ca52262052250cc68f6a)

Fix: #2704