### PR TITLE
ignore delete_repo not failing in coverage

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -251,7 +251,7 @@ class GitHubAPI:
         }
         r = self._delete(url, headers=headers)
 
-        if r.status_code == 404:
+        if r.status_code == 404:  # pragma: no cover
             # this method is for testing create_repo() so we don't mind if the
             # repo is already missing
             return


### PR DESCRIPTION
This path only exists so the method doesn't raise an exception when the repo doesn't exist.  This covers the verification tests trying to tear down a repo that has gone away or never existed for some reason.  We don't want it to fail in that situation because this is used in teardown code, not test cases themselves.