### PR TITLE
Re-add frequency and time_event with defaults

### DIFF
--- a/interactive/__init__.py
+++ b/interactive/__init__.py
@@ -33,5 +33,7 @@ class Analysis:
     time_value: str
     title: str
     id: str | None = None  # noqa: A003
+    frequency: str = "monthly"
+    time_event: str = "before"
     start_date: str = dates.START_DATE
     end_date: str = dates.END_DATE


### PR DESCRIPTION
The analysis template still needs these keys and values for rendering the code, however we're not exposing them to the users so using defaults here.