### PR TITLE
chore: add the minimal pyproject.yaml to make pip installable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,29 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jobserver"
+description = "jobserver"
+readme = "README.md"
+authors = [{name = "OpenSAFELY", email = "tech@opensafely.org"}]
+license = {file = "LICENSE"}
+classifiers = [
+  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+]
+requires-python = ">=3.11"
+dynamic = ["version"]
+
+[tool.setuptools]
+packages = [
+  "applications",
+  "interactive",
+  "jobserver",
+  "services",
+  "staff",
+]
+
+
 [tool.black]
 extend-exclude = '''
 (


### PR DESCRIPTION
Does not specify any dependencies, just enough metadata for pip to be
able to install it into a venv.

This is useful for downstream projects that want to use job-server as
a dependency for integration tests.
