### PR TITLE
Temporarily reduce the time period for testing

### DIFF
--- a/interactive/dates.py
+++ b/interactive/dates.py
@@ -15,5 +15,6 @@ def date_of_last_extract():
     return today - timedelta(days=offset, weeks=weeks)
 
 
-START_DATE = "2019-09-01"
+# Temporarily change this to look at the last six months while testing
+START_DATE = (date_of_last_extract() - timedelta(days=30 * 6)).strftime("%Y-%m-%d")
 END_DATE = date_of_last_extract().strftime("%Y-%m-%d")


### PR DESCRIPTION
Looking at only the last six months will reduce the runtime for the analysis code, shortening our feedback loop while we're making lots of changes. This needs to be changed back before go-live.