### PR TITLE
Allow users to download Interactive reports

### DIFF
--- a/assets/src/scripts/analysis-request-detail.js
+++ b/assets/src/scripts/analysis-request-detail.js
@@ -1,13 +1,1 @@
-import hljs from "highlight.js/lib/core";
-import json from "highlight.js/lib/languages/json";
-import "highlight.js/styles/github.css";
-
-hljs.registerLanguage("json", json);
-
-document.getElementById("analysisRequest").textContent = JSON.stringify(
-  JSON.parse(document.getElementById("analysisRequestData").textContent),
-  null,
-  2
-);
-
-hljs.highlightAll();
+// Silence

--- a/assets/src/scripts/analysis-request-detail.js
+++ b/assets/src/scripts/analysis-request-detail.js
@@ -1,0 +1,13 @@
+import hljs from "highlight.js/lib/core";
+import json from "highlight.js/lib/languages/json";
+import "highlight.js/styles/github.css";
+
+hljs.registerLanguage("json", json);
+
+document.getElementById("analysisRequest").textContent = JSON.stringify(
+  JSON.parse(document.getElementById("analysisRequestData").textContent),
+  null,
+  2
+);
+
+hljs.highlightAll();

--- a/assets/src/scripts/analysis-request-detail.js
+++ b/assets/src/scripts/analysis-request-detail.js
@@ -1,1 +1,29 @@
-// Silence
+import * as html2pdf from "html2pdf.js";
+
+const report = document.querySelector("#reportContainer");
+const downloadBtn = document.querySelector("#downloadBtn");
+const watermark = document.querySelector("#watermark");
+
+const options = {
+  margin: 2,
+  filename: `${downloadBtn.dataset.title} - Report.pdf`,
+  image: { type: "png" },
+  jsPDF: { unit: "mm", format: "a4", orientation: "portrait" },
+  html2canvas: {
+    ignore: () => report.querySelector("svg"),
+    scale: 2,
+  },
+};
+
+downloadBtn.addEventListener("click", () => {
+  watermark.classList.remove("hidden");
+  const singleInner = watermark.innerHTML;
+  watermark.innerHTML = watermark.innerHTML.repeat(300);
+
+  html2pdf().set(options).from(report).toContainer().toPdf().save();
+
+  setTimeout(() => {
+    watermark.classList.add("hidden");
+    watermark.innerHTML = singleInner;
+  }, 0);
+});

--- a/assets/src/scripts/analysis-request-detail.js
+++ b/assets/src/scripts/analysis-request-detail.js
@@ -1,5 +1,3 @@
-import * as html2pdf from "html2pdf.js";
-
 const report = document.querySelector("#reportContainer");
 const downloadBtn = document.querySelector("#downloadBtn");
 const watermark = document.querySelector("#watermark");
@@ -15,12 +13,14 @@ const options = {
   },
 };
 
-downloadBtn.addEventListener("click", () => {
+downloadBtn.addEventListener("click", async () => {
+  const html2pdf = await import("html2pdf.js");
+
   watermark.classList.remove("hidden");
   const singleInner = watermark.innerHTML;
   watermark.innerHTML = watermark.innerHTML.repeat(300);
 
-  html2pdf().set(options).from(report).toContainer().toPdf().save();
+  html2pdf.default().set(options).from(report).toContainer().toPdf().save();
 
   setTimeout(() => {
     watermark.classList.add("hidden");

--- a/assets/src/scripts/analysis-request-detail.js
+++ b/assets/src/scripts/analysis-request-detail.js
@@ -14,14 +14,18 @@ const options = {
 };
 
 downloadBtn.addEventListener("click", async () => {
+  // Load the JS on button click
   const html2pdf = await import("html2pdf.js");
 
-  watermark.classList.remove("hidden");
+  // Repeat the watermark 300 times on the container
   const singleInner = watermark.innerHTML;
+  watermark.classList.remove("hidden");
   watermark.innerHTML = watermark.innerHTML.repeat(300);
 
+  // Generate and download the PDF
   html2pdf.default().set(options).from(report).toContainer().toPdf().save();
 
+  // 0 timeout to remove watermark after the event loop has finished
   setTimeout(() => {
     watermark.classList.add("hidden");
     watermark.innerHTML = singleInner;

--- a/assets/src/scripts/staff.js
+++ b/assets/src/scripts/staff.js
@@ -10,10 +10,14 @@ $(() => {
 
 hljs.registerLanguage("json", json);
 
-document.getElementById("analysisRequest").textContent = JSON.stringify(
-  JSON.parse(document.getElementById("analysisRequestData").textContent),
-  null,
-  2
-);
+const analysisRequest = document.getElementById("analysisRequest");
+
+if (analysisRequest) {
+  analysisRequest.textContent = JSON.stringify(
+    JSON.parse(document.getElementById("analysisRequestData").textContent),
+    null,
+    2
+  );
+}
 
 hljs.highlightAll();

--- a/assets/src/scripts/staff.js
+++ b/assets/src/scripts/staff.js
@@ -1,5 +1,19 @@
 /* global $ */
 // Bootstrap tooltips
+import hljs from "highlight.js/lib/core";
+import json from "highlight.js/lib/languages/json";
+import "highlight.js/styles/github.css";
+
 $(() => {
   $('[data-toggle="tooltip"]').tooltip();
 });
+
+hljs.registerLanguage("json", json);
+
+document.getElementById("analysisRequest").textContent = JSON.stringify(
+  JSON.parse(document.getElementById("analysisRequestData").textContent),
+  null,
+  2
+);
+
+hljs.highlightAll();

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "bs-custom-file-input": "^1.3.4",
         "formik": "^2.2.9",
         "highlight.js": "^11.7.0",
+        "html2pdf.js": "^0.10.1",
         "htmx.org": "^1.8.5",
         "jquery": "^3.6.3",
         "just-debounce-it": "^3.2.0",
@@ -3187,6 +3188,12 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "18.0.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
@@ -3915,6 +3922,17 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.13",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
@@ -4022,6 +4040,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4142,6 +4168,17 @@
       "integrity": "sha512-NBsQzTnef3OW1MvdKBbMHAYHssCd613MSeJV7z2McXznWtVMnJCy7Ckyc+PwxV6Pk16cu6YBcYWh/ZE0XWNKCA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/buffer": {
@@ -4267,6 +4304,25 @@
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
+      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chai": {
       "version": "4.3.7",
@@ -4590,7 +4646,7 @@
       "version": "3.29.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.0.tgz",
       "integrity": "sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -4634,6 +4690,14 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -5112,6 +5176,12 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz",
+      "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA==",
+      "optional": true
+    },
     "node_modules/domutils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -5262,6 +5332,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/esbuild": {
       "version": "0.16.17",
@@ -5986,6 +6061,11 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -6536,6 +6616,28 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/html2pdf.js": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.10.1.tgz",
+      "integrity": "sha512-3onwwhOWsZfNjIZwV6YIJ6FVhXk+X9YxHSqzeS6hup+1dGi2DHI+zZYUJ+iFnvtaYcjlhyrILL1fvRCUOa8Fcg==",
+      "dependencies": {
+        "es6-promise": "^4.2.5",
+        "html2canvas": "^1.0.0",
+        "jspdf": "^2.3.1"
+      }
     },
     "node_modules/htmx.org": {
       "version": "1.8.5",
@@ -7448,6 +7550,23 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -8435,6 +8554,12 @@
         "node": "*"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -9264,6 +9389,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -9638,6 +9772,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -9978,6 +10121,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
+      "integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.2.tgz",
@@ -10190,6 +10342,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/svgo": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
@@ -10321,6 +10482,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -10690,6 +10859,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
@@ -13385,6 +13562,12 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
+    "@types/raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==",
+      "optional": true
+    },
     "@types/react": {
       "version": "18.0.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
@@ -13933,6 +14116,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
     "autoprefixer": {
       "version": "10.4.13",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
@@ -14004,6 +14192,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -14072,6 +14265,11 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/bs-custom-file-input/-/bs-custom-file-input-1.3.4.tgz",
       "integrity": "sha512-NBsQzTnef3OW1MvdKBbMHAYHssCd613MSeJV7z2McXznWtVMnJCy7Ckyc+PwxV6Pk16cu6YBcYWh/ZE0XWNKCA=="
+    },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
     "buffer": {
       "version": "5.7.1",
@@ -14154,6 +14352,22 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001458.tgz",
       "integrity": "sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==",
       "dev": true
+    },
+    "canvg": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
+      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "optional": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      }
     },
     "chai": {
       "version": "4.3.7",
@@ -14386,7 +14600,7 @@
       "version": "3.29.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.0.tgz",
       "integrity": "sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg==",
-      "dev": true
+      "devOptional": true
     },
     "core-js-compat": {
       "version": "3.29.0",
@@ -14414,6 +14628,14 @@
       "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
       "dev": true,
       "requires": {}
+    },
+    "css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "requires": {
+        "utrie": "^1.0.2"
+      }
     },
     "css-select": {
       "version": "4.3.0",
@@ -14773,6 +14995,12 @@
         "domelementtype": "^2.2.0"
       }
     },
+    "dompurify": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz",
+      "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA==",
+      "optional": true
+    },
     "domutils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -14896,6 +15124,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "esbuild": {
       "version": "0.16.17",
@@ -15436,6 +15669,11 @@
         "reusify": "^1.0.4"
       }
     },
+    "fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -15832,6 +16070,25 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "requires": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      }
+    },
+    "html2pdf.js": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.10.1.tgz",
+      "integrity": "sha512-3onwwhOWsZfNjIZwV6YIJ6FVhXk+X9YxHSqzeS6hup+1dGi2DHI+zZYUJ+iFnvtaYcjlhyrILL1fvRCUOa8Fcg==",
+      "requires": {
+        "es6-promise": "^4.2.5",
+        "html2canvas": "^1.0.0",
+        "jspdf": "^2.3.1"
+      }
     },
     "htmx.org": {
       "version": "1.8.5",
@@ -16493,6 +16750,21 @@
           "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         }
+      }
+    },
+    "jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "fflate": "^0.4.8",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "jsx-ast-utils": {
@@ -17224,6 +17496,12 @@
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "optional": true
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -17756,6 +18034,15 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "optional": true,
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -18029,6 +18316,12 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
+    "rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -18270,6 +18563,12 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
     },
+    "stackblur-canvas": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
+      "integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==",
+      "optional": true
+    },
     "std-env": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.2.tgz",
@@ -18433,6 +18732,12 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
+    "svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true
+    },
     "svgo": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
@@ -18540,6 +18845,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
+      }
+    },
+    "text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "requires": {
+        "utrie": "^1.0.2"
       }
     },
     "text-table": {
@@ -18820,6 +19133,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "requires": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "bs-custom-file-input": "^1.3.4",
     "formik": "^2.2.9",
     "highlight.js": "^11.7.0",
+    "html2pdf.js": "^0.10.1",
     "htmx.org": "^1.8.5",
     "jquery": "^3.6.3",
     "just-debounce-it": "^3.2.0",

--- a/templates/_components/button.html
+++ b/templates/_components/button.html
@@ -7,7 +7,7 @@
     {% endif %}
 {% else %}
   <button
-    {% attrs disabled type=type|default:"button" id name %}
+    {% attrs data_title disabled type=type|default:"button" id name %}
     {% if x_bind %}x-bind="{{ x_bind }}"{% endif %}
 {% endif %}
 

--- a/templates/_components/footer.html
+++ b/templates/_components/footer.html
@@ -68,7 +68,7 @@
           Science {% now 'Y' %}. This work may be copied freely for
           non-commercial research and study. If you wish to do any of the other
           acts restricted by the copyright you should apply in writing to
-          {% spaceless %}{% link text="bennett@phc.ox.ac.uk" href="mailto:bennett@phc.ox.ac.uk" %}{% endspaceless %}.
+          {% link text="bennett@phc.ox.ac.uk" href="mailto:bennett@phc.ox.ac.uk" append_after="." %}
         </p>
       </div>
     </div>

--- a/templates/_components/link.html
+++ b/templates/_components/link.html
@@ -8,4 +8,4 @@
   {% if new_tab %}
     target="_blank" rel="noopener noreferrer"
   {% endif %}
->{{ text }}</a>
+>{{ text }}</a>{{ append_after }}

--- a/templates/_icons/custom/spinner.svg
+++ b/templates/_icons/custom/spinner.svg
@@ -1,0 +1,4 @@
+<svg class="{{ class }}" fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+  <path class="stroke-current opacity-25" d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" />
+  <path d="M12 2C6.47715 2 2 6.47715 2 12C2 14.7255 3.09032 17.1962 4.85857 19" />
+</svg>

--- a/templates/components.yaml
+++ b/templates/components.yaml
@@ -46,3 +46,4 @@ components:
   icon_user_outline: "_icons/user-outline.svg"
   icon_user_group_outline: "_icons/user-group-outline.svg"
   icon_x_outline: "_icons/x-outline.svg"
+  icon_custom_spinner: "_icons/custom/spinner.svg"

--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -58,11 +58,19 @@
 
     <div class="flex flex-col mt-2 sm:flex-row gap-2 lg:items-start">
       {% if not object.publish_request %}
-        {% #button type="link" href=analysis_request.get_publish_url variant="success" %}
-          Request report is published
-        {% /button %}
+        {% if not report %}
+          {% #button type="button" variant="success" disabled=True tooltip="Report has not been processed" %}
+            Publish report
+          {% /button %}
+        {% else %}
+          {% #button type="link" href=analysis_request.get_publish_url variant="success" %}
+            Publish report
+          {% /button %}
+        {% endif %}
       {% else %}
-        <p>has publish request, {% link href=object.publish_request.get_absolute_url text="View" %}</p>
+        {% #button type="link" href=object.publish_request.get_absolute_url variant="primary" %}
+          View published report
+        {% /button %}
       {% endif %}
 
       {% #button type="link" href=analysis_request.job_request.get_absolute_url variant="secondary" %}
@@ -71,15 +79,42 @@
     </div>
   </div>
 
-  {# {% if report %} #}
-    <div class="grid gap-6 place-content-stretch lg:col-span-2">
+  <div class="grid gap-6 place-content-stretch lg:col-span-2">
+    {% if report %}
       {% #card title="Report" container=True class="font-lg text-slate-700" %}
         {{ report }}
       {% /card %}
-    </div>
-  {# {% endif %} #}
+    {% else %}
+      {% #card class="lg:col-span-2" %}
+        <div class="text-center p-8">
+          {% icon_custom_spinner class="h-12 w-12 mb-4 mx-auto flex-1 animate-spin stroke-current stroke-2 text-slate-600" %}
+          <h2 class="mt-2 mb-4 text-xl font-semibold text-slate-900">
+            Your request is being processed
+          </h2>
+          <div class="grid gap-y-2 max-w-prose mx-auto">
+            <p>
+              The results will be checked carefully by our team for privacy and
+              security reasons.
+            </p>
+            <p>
+              We aim to process requests within two working days, although it may
+              take up to five working days. We are working to improve this for
+              the future.
+            </p>
+            <p class="text-slate-600 pt-4 mt-2 border-t border-slate-200">
+              If you'd like any more information about requesting an analysis
+              <span class="md:block">
+                or have any questions,
+                {% link href="mailto:team@opensafely.org" text="contact us" append_after="." %}
+              </span>
+            </p>
+          </div>
+        </div>
+      {% /card %}
+    {% endif %}
+  </div>
 
-  <div class="space-y-6 md:space-y-6 lg:col-span-1 lg:row-start-2">
+  <div class="space-y-6 md:space-y-6 lg:col-span-1">
     {% #card title="Analysis Request" %}
       <dl class="border-t border-slate-200 sm:divide-y sm:divide-slate-200">
         {% #description_item stacked=True title="Created at" %}

--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -58,12 +58,12 @@
 
     <div class="flex flex-col mt-2 sm:flex-row gap-2 lg:items-start">
       {% if not object.publish_request %}
-        {% if not report %}
-          {% #button type="button" variant="success" disabled=True tooltip="Report has not been processed" %}
+        {% if report %}
+          {% #button type="link" href=analysis_request.get_publish_url variant="success" %}
             Publish report
           {% /button %}
         {% else %}
-          {% #button type="link" href=analysis_request.get_publish_url variant="success" %}
+          {% #button type="button" variant="success" disabled=True tooltip="Report has not been processed" %}
             Publish report
           {% /button %}
         {% endif %}
@@ -73,9 +73,15 @@
         {% /button %}
       {% endif %}
 
-      {% #button type="button" id="downloadBtn" variant="primary" data_title=analysis_request.title %}
-        Download report
-      {% /button %}
+      {% if report %}
+        {% #button type="button" id="downloadBtn" variant="primary" data_title=analysis_request.title %}
+          Download report
+        {% /button %}
+      {% else %}
+        {% #button type="button" variant="primary" disabled=True tooltip="Report has not been processed" %}
+          Download report
+        {% /button %}
+      {% endif %}
     </div>
   </div>
 

--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -110,7 +110,8 @@
           </div>
         </div>
         <div id="watermark" class="hidden absolute inset-0 text-center w-full h-full text-5xl font-bold text-gray-900/10">
-          <span class="py-32 block">Not for publication</span>
+          <span class="py-16 block">Confidential</span>
+          <span class="py-16 block">Not for publication</span>
         </div>
       {% /card %}
     {% endif %}

--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -128,7 +128,7 @@
       <dl class="border-t border-slate-200 sm:divide-y sm:divide-slate-200">
         {% #description_item stacked=True title="Created at" %}
           {{ analysis_request.created_at }}
-          <time datetime='{{ analysis_request.created_at|date:"Y-m-d H:i:sO" }}'></time>
+          <time datetime="{{ analysis_request.created_at|date:"Y-m-d H:i:sO" }}"></time>
         {% /description_item %}
 
         {% #description_item stacked=True title="Created by" %}

--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -2,12 +2,17 @@
 
 {% load django_vite %}
 {% load humanize %}
+{% load static %}
 
 {% block metatitle %}{{ analysis_request.project.name }} Analysis | OpenSAFELY Jobs{% endblock metatitle %}
 
 {% block extra_meta %}
 <meta name="description" content="{{ analysis_request.project.name }} is an OpenSAFELY project from {{ analysis_request.project.org.name }}. Every time a researcher runs their analytic code against patient data, it is audited in public here.">
 {% endblock %}
+
+{% block extra_styles %}
+<link rel="stylesheet" href="{% static 'highlighting.css' %}">
+{% endblock extra_styles %}
 
 {% block breadcrumbs %}
   {% url "home" as home_url %}
@@ -46,7 +51,7 @@
     <dl class="border-t border-slate-200 sm:divide-y sm:divide-slate-200">
       {% #description_item title="Created at" %}
         {{ analysis_request.created_at }}
-        <time datetime="{{ analysis_request.created_at|date:"Y-m-d H:i:sO" }}"></time>
+        <time datetime='{{ analysis_request.created_at|date:"Y-m-d H:i:sO" }}'></time>
       {% /description_item %}
 
       {% #description_item title="Created by" %}
@@ -58,7 +63,8 @@
       {% /description_item %}
 
       {% #description_item title="Template data" %}
-        <pre>{{ analysis_request.template_data|pprint }}</pre>
+        {{ analysis_request.template_data|json_script:"analysisRequestData" }}
+        <div class="overflow-scroll max-h-96"><pre><code class="language-json !p-0" id="analysisRequest">{{ analysis_request.template_data|pprint }}</code></pre></div>
       {% /description_item %}
 
     </dl>
@@ -98,5 +104,6 @@
     });
   </script>
 
+  {% vite_asset "assets/src/scripts/analysis-request-detail.js" %}
   {% vite_legacy_polyfills %}
 {% endblock %}

--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -26,58 +26,75 @@
 {% endblock breadcrumbs %}
 
 {% block content %}
-<div class="mb-5">
-  <h1 class="text-3xl tracking-tight break-words sm:text-4xl font-bold text-slate-900">
-    Analysis for {{ analysis_request.project.name }}
-  </h1>
+<div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+  <div class="flex flex-col text-center items-center gap-y-2 lg:text-left lg:items-start lg:col-span-full">
+    <div class="flex flex-col items-center gap-y-2 w-full lg:flex-row lg:justify-between lg:items-start">
+      <div class="order-2 w-full lg:mr-auto lg:order-1">
+        <h1 class="mb-2 text-3xl tracking-tight break-words font-bold text-slate-900 sm:text-4xl">
+          {{ analysis_request.title }}
+        </h1>
+        <dl class="flex flex-col gap-2 text-sm text-slate-600 items-center sm:flex-row sm:gap-x-6 sm:justify-center lg:justify-start">
+          <dt class="sr-only">Organisation:</dt>
+          <dd class="flex flex-row items-start overflow-hidden">
+            {% icon_building_library_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
+            <span class="truncate">{{ analysis_request.project.org.name }}</span>
+          </dd>
+          <dt class="sr-only">Project:</dt>
+          <dd class="flex flex-row items-start overflow-hidden">
+            {% icon_rectangle_stack_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
+            <span class="truncate">{{ analysis_request.project.name }}</span>
+          </dd>
+        </dl>
+      </div>
+      {% if user_can_view_staff_area %}
+        <div class="order-1 lg:order-2 flex-shrink-0">
+          {% #button href=analysis_request.get_staff_url type="link" variant="danger" class="flex-shrink-0" %}
+            View in Staff Area
+            {% icon_lifebuoy_outline class="h-4 w-4 ml-2 -mr-2" %}
+          {% /button %}
+        </div>
+      {% endif %}
+    </div>
 
-  {% #button type="link" href=analysis_request.job_request.get_absolute_url variant="" %}
-    View job request
-  {% /button %}
+    <div class="flex flex-col mt-2 sm:flex-row gap-2 lg:items-start">
+      {% if not object.publish_request %}
+        {% #button type="link" href=analysis_request.get_publish_url variant="success" %}
+          Request report is published
+        {% /button %}
+      {% else %}
+        <p>has publish request, {% link href=object.publish_request.get_absolute_url text="View" %}</p>
+      {% endif %}
 
-  {% if not object.publish_request %}
-  {% #button type="link" href=analysis_request.get_publish_url variant="success" %}
-    Request report is published
-  {% /button %}
-  {% else %}
-  <p>has publish request, {% link href=object.publish_request.get_absolute_url text="View" %}</p>
-  {% endif %}
-
-</div>
-
-<div>
-
-  {% #card title="Analysis Request" %}
-    <dl class="border-t border-slate-200 sm:divide-y sm:divide-slate-200">
-      {% #description_item title="Created at" %}
-        {{ analysis_request.created_at }}
-        <time datetime='{{ analysis_request.created_at|date:"Y-m-d H:i:sO" }}'></time>
-      {% /description_item %}
-
-      {% #description_item title="Created by" %}
-        {% link href=analysis_request.created_by.get_staff_url text=analysis_request.created_by.fullname %}
-      {% /description_item %}
-
-      {% #description_item title="Title" %}
-        {{ analysis_request.title }}
-      {% /description_item %}
-
-      {% #description_item title="Template data" %}
-        {{ analysis_request.template_data|json_script:"analysisRequestData" }}
-        <div class="overflow-scroll max-h-96"><pre><code class="language-json !p-0" id="analysisRequest">{{ analysis_request.template_data|pprint }}</code></pre></div>
-      {% /description_item %}
-
-    </dl>
-  {% /card %}
-
-  {% if report %}
-  <div>
-    {{ report }}
+      {% #button type="link" href=analysis_request.job_request.get_absolute_url variant="secondary" %}
+        View job request
+      {% /button %}
+    </div>
   </div>
-  {% endif %}
 
+  {# {% if report %} #}
+    <div class="grid gap-6 place-content-stretch lg:col-span-2">
+      {% #card title="Report" container=True class="font-lg text-slate-700" %}
+        {{ report }}
+      {% /card %}
+    </div>
+  {# {% endif %} #}
+
+  <div class="space-y-6 md:space-y-6 lg:col-span-1 lg:row-start-2">
+    {% #card title="Analysis Request" %}
+      <dl class="border-t border-slate-200 sm:divide-y sm:divide-slate-200">
+        {% #description_item stacked=True title="Created at" %}
+          {{ analysis_request.created_at }}
+          <time datetime='{{ analysis_request.created_at|date:"Y-m-d H:i:sO" }}'></time>
+        {% /description_item %}
+
+        {% #description_item stacked=True title="Created by" %}
+          {% link href=analysis_request.created_by.get_staff_url text=analysis_request.created_by.fullname %}
+        {% /description_item %}
+      </dl>
+    {% /card %}
+  </div>
 </div>
-{% endblock %}
+{% endblock content %}
 
 {% block extra_js %}
   <script type="text/x-mathjax-config">
@@ -105,5 +122,4 @@
   </script>
 
   {% vite_asset "assets/src/scripts/analysis-request-detail.js" %}
-  {% vite_legacy_polyfills %}
 {% endblock %}

--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -73,20 +73,20 @@
         {% /button %}
       {% endif %}
 
-      {% #button type="link" href=analysis_request.job_request.get_absolute_url variant="secondary" %}
-        View job request
+      {% #button type="button" id="downloadBtn" variant="primary" data_title=analysis_request.title %}
+        Download report
       {% /button %}
     </div>
   </div>
 
-  <div class="grid gap-6 place-content-stretch lg:col-span-2">
+  <div class="relative grid gap-6 place-content-stretch lg:col-span-2" id="reportContainer">
     {% if report %}
       {% #card title="Report" container=True class="font-lg text-slate-700" %}
-        {{ report }}
+        <div class="z-10 relative">{{ report }}</div>
       {% /card %}
     {% else %}
-      {% #card class="lg:col-span-2" %}
-        <div class="text-center p-8">
+      {% #card class="lg:col-span-2 overflow-hidden relative" %}
+        <div class="text-center p-8 z-10 relative">
           {% icon_custom_spinner class="h-12 w-12 mb-4 mx-auto flex-1 animate-spin stroke-current stroke-2 text-slate-600" %}
           <h2 class="mt-2 mb-4 text-xl font-semibold text-slate-900">
             Your request is being processed
@@ -97,9 +97,8 @@
               security reasons.
             </p>
             <p>
-              We aim to process requests within two working days, although it may
-              take up to five working days. We are working to improve this for
-              the future.
+              We aim to process requests within five working days. We are
+              working to improve this for future requests.
             </p>
             <p class="text-slate-600 pt-4 mt-2 border-t border-slate-200">
               If you'd like any more information about requesting an analysis
@@ -109,6 +108,9 @@
               </span>
             </p>
           </div>
+        </div>
+        <div id="watermark" class="hidden absolute inset-0 text-center w-full h-full text-5xl font-bold text-gray-900/10">
+          <span class="py-32 block">Not for publication</span>
         </div>
       {% /card %}
     {% endif %}

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -22,9 +22,7 @@
     {% #alert variant="warning" title="This is an internal OpenSAFELY project" class="mb-6" %}
       This project exists for internal purposes only.
       More information can be found in the
-      {% spaceless %}
-        {% link text="OpenSAFELY access policy" href="https://docs.opensafely.org/developer-access-policy/" %}
-      {% endspaceless %}.
+      {% link text="OpenSAFELY access policy" href="https://docs.opensafely.org/developer-access-policy/" append_after="." %}
     {% /alert %}
   {% endif %}
 
@@ -71,9 +69,8 @@
         <div class="max-w-prose font-lg text-slate-600">
           <p>
             {{ project.name }} is an OpenSAFELY project from
-            {% spaceless %}
-              {% link href=project.org.get_absolute_url text=project.org.name %}
-            {% endspaceless %}. Every time a researcher runs their analytic
+            {% link href=project.org.get_absolute_url text=project.org.name append_after="." %}
+            Every time a researcher runs their analytic
             code against patient data, it is audited in public here.
           </p>
           <p class="mt-4">

--- a/templates/staff/analysis_request_detail.html
+++ b/templates/staff/analysis_request_detail.html
@@ -52,7 +52,7 @@
     <div class="col col-lg-9 col-xl-8">
      <section class="card mb-3">
         <div class="card-header">
-          <h2 class="card-title">Details</h2>
+          <h2 class="card-title mb-0">Details</h2>
         </div>
 
         <div class="list-group list-group-flush">
@@ -76,6 +76,18 @@
               An email is sent to the request creator only when the report has been approved for release.
             </p>
           </div>
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="card-header">
+          <h2 class="card-title mb-0">
+            Request data
+          </h2>
+        </div>
+        <div class="card-body">
+          {{ analysis_request.template_data|json_script:"analysisRequestData" }}
+          <div class="overflow-scroll"><pre class="mb-0"><code class="language-json p-0" id="analysisRequest">{{ analysis_request.template_data|pprint }}</code></pre></div>
         </div>
       </section>
     </div>

--- a/templates/workspace_detail.html
+++ b/templates/workspace_detail.html
@@ -30,9 +30,7 @@
       </p>
       <p class="text-sm">
         If you think this has been done in error,
-        {% spaceless %}
-          {% link text="contact an admin" href="mailto:team@opensafely.org" %}
-        {% endspaceless %}.
+        {% link text="contact an admin" href="mailto:team@opensafely.org" append_after="." %}
       </p>
     {% /alert %}
   {% endif %}
@@ -41,9 +39,7 @@
     {% #alert variant="warning" title="This workspace belongs to an internal OpenSAFELY project" class="mb-6" %}
       The project exists for internal purposes only.
       More information can be found in the
-      {% spaceless %}
-        {% link text="OpenSAFELY access policy" href="https://docs.opensafely.org/developer-access-policy/" %}
-      {% endspaceless %}.
+      {% link text="OpenSAFELY access policy" href="https://docs.opensafely.org/developer-access-policy/" append_after="." %}
     {% /alert %}
   {% endif %}
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,8 @@ const config = {
     rollupOptions: {
       input: {
         "application-form": "./assets/src/scripts/application-form.js",
+        "analysis-request-detail":
+          "./assets/src/scripts/analysis-request-detail.js",
         "outputs-viewer": "./assets/src/scripts/outputs-viewer/index.jsx",
         components: "./assets/src/scripts/components.js",
         index: "./assets/src/scripts/index.js",


### PR DESCRIPTION
Starter files for downloading reports. This PR adds the dependencies and scaffolding code to enable downloads – but as we don't have formatted and outputted reports yet, it will only download the "empty" state.

- Move debug information to the Staff Area (and syntax highlight the JSON)
- Add [html2pdf](url) dependency
- Load dependency on "Download" button click
- Add a watermark to the download
- Disable buttons until the report is generated
- Add an empty/loading state whilst the report is generating
- **Fix:** A fix for links that require a character straight after a link (`append_after`)

Linked to https://github.com/opensafely-core/job-server/issues/2670