### PR TITLE
Run checks on merge group to enable checks for PRs in the merge queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ env:
   SSH_AUTH_SOCK: /tmp/agent.sock
 
 on:
+  merge_group:
   push:
 
 jobs:


### PR DESCRIPTION
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

I'm hoping this fixes our problem dependabot PRs not running checks in the merge queue but we won't know until it's merged and those PRs have been rebased by dependabot.

Ref: #2751 