### PR TITLE
Update terms.md

### DIFF
--- a/snippets/start_page.md
+++ b/snippets/start_page.md
@@ -22,3 +22,9 @@ NOTE: For NHSE/I/X applicants review by a local / institutional Research Ethics 
 ## How we use your data
 
 We use data submitted by this form as described in [our privacy policy](https://www.opensafely.org/privacy/).
+
+## Before you start your application
+
+Here is a copy of [our online application form](https://drive.google.com/drive/folders/1-0AvOOKHm9yaQAl_HljgwC8qugHNQQIW), including a checklist at the end.
+This is only to be used as a guide to help you understand the information needed to assess our application.
+Do not use the PDF file to submit an application.

--- a/snippets/terms.md
+++ b/snippets/terms.md
@@ -46,6 +46,3 @@ We have written [detailed documentation](https://docs.opensafely.org/) about the
 We have a [Q&A forum](https://github.com/opensafely/documentation/discussions).
 
 We also offer researchers a [co-pilot](https://www.bennett.ox.ac.uk/blog/2021/08/opensafely-co-pilot-programme-assisting-users-on-their-opensafely-journey/): a member of the OpenSAFELY team who joins you on your OpenSAFELY journey, to help you achieve a completed analysis within an agreed timeframe (usually 4 weeks).
-
-## Before you start your application
-Please download [our PDF application](https://drive.google.com/file/d/1f6PzT-wqR2FExrQ2FSwZSV8XNPE_p_HN/view), as we've added a checklist at the end to help you before you finally submit your application online.


### PR DESCRIPTION
Removing information and link to PDF application, as we've decided it is best placed to move link to before the start button on Jobserver. 

Please could application form be moved to the following page https://github.com/opensafely-core/job-server/edit/main/snippets/start_page.md along with an update of the following text, to be inserted at the bottom of the page form just before the start button

Title - Before you start your application

Text update- Here is a copy of our online application form, including a checklist at the end. This is only to be used as a guide to help you understand the information needed to assess our application. Do not use the PDF file to submit an application.

*The link that needs to be inserted in the text above can be found here https://drive.google.com/drive/folders/1-0AvOOKHm9yaQAl_HljgwC8qugHNQQIW