### PR TITLE
Revert "Run checks on merge group to enable checks for PRs in the mer…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,6 @@ env:
   SSH_AUTH_SOCK: /tmp/agent.sock
 
 on:
-  merge_group:
   push:
 
 jobs:


### PR DESCRIPTION
…ge queue"

This reverts commit 507bdbbcc459981e34f78c4f813635eb50e74338.

It looks like the inclusion of this trigger has been creating extra runs in CI.

Take the `magic-login-link` (#2750), this is the final run from the PR:

https://github.com/opensafely-core/job-server/actions/runs/4355931746

While these two runs were triggered while it was in the merge queue:

https://github.com/opensafely-core/job-server/actions/runs/4356110568
https://github.com/opensafely-core/job-server/actions/runs/4356017243

I added this trigger to try and unblock dependabot PRs from failing to add checks when in the queue, but instead it's added more runs, further holding up the queue.