### PR TITLE
Rework creating interactive projects and users

### DIFF
--- a/interactive/commands.py
+++ b/interactive/commands.py
@@ -39,7 +39,7 @@ def create_repo(*, name, get_github_api=_get_github_api):
     return repo["html_url"]
 
 
-def create_user(*, creator, email, name, org, project):
+def create_user(*, creator, email, name, project):
     """Create an interactive user"""
     user = User.objects.create(
         fullname=name,
@@ -51,7 +51,7 @@ def create_user(*, creator, email, name, org, project):
 
     OrgMembership.objects.create(
         created_by=creator,
-        org=org,
+        org=project.org,
         user=user,
     )
 

--- a/staff/forms.py
+++ b/staff/forms.py
@@ -188,27 +188,14 @@ class ResearcherRegistrationEditForm(forms.ModelForm):
 
 
 class UserCreateForm(forms.Form):
-    application_url = forms.URLField(required=False)
-    org = forms.ModelChoiceField(queryset=Org.objects.order_by(Lower("name")))
     project = forms.ModelChoiceField(
-        queryset=Project.objects.order_by(Lower("org__name"), Lower("name"))
+        queryset=Project.objects.filter(workspaces__name__endswith="interactive")
+        .select_related("org")
+        .distinct()
+        .order_by(Lower("org__name"), Lower("name"))
     )
     name = forms.CharField()
     email = forms.EmailField()
-
-    def clean(self):
-        cleaned_data = super().clean()
-        application_url = cleaned_data.get("application_url")
-        project = cleaned_data.get("project")
-
-        if project:
-            if project.applications.exists() and application_url:
-                msg = "Cannot set an application URL for a project which already has an application linked to it"
-                self.add_error("application_url", msg)
-
-            if project.application_url and application_url:
-                msg = "Cannot set an application URL for a project which already has an application URL"
-                self.add_error("application_url", msg)
 
 
 class UserForm(RolesForm):

--- a/staff/forms.py
+++ b/staff/forms.py
@@ -86,6 +86,7 @@ class ProjectAddMemberForm(PickUsersMixin, RolesForm):
 class ProjectCreateForm(forms.ModelForm):
     class Meta:
         fields = [
+            "application_url",
             "name",
             "org",
         ]

--- a/templates/staff/project_create.form.html
+++ b/templates/staff/project_create.form.html
@@ -25,6 +25,8 @@
       {% endfor %}
     </div>
 
+    {% include "components/form_text.html" with field=form.application_url label="Application URL" name="application_url" %}
+
     {% include "components/form_text.html" with field=form.name label="Set the project name" name="name" %}
   </fieldset>
 

--- a/templates/staff/project_create.html
+++ b/templates/staff/project_create.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="{% static 'vendor/select2-bootstrap4.min.css' %}">
 {% endblock %}
 
-{% block metatitle %}{{ org.name }}: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+{% block metatitle %}Create an interactive project: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
 
 {% block breadcrumbs %}
 <nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
@@ -20,7 +20,7 @@
         <a href="{% url 'staff:project-list' %}">Projects</a>
       </li>
       <li class="breadcrumb-item active" aria-current="page">
-        Create a project
+        Create an interactive project
       </li>
     </ol>
   </div>
@@ -30,7 +30,7 @@
 {% block jumbotron %}
 <div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
   <div class="container">
-    <h1 class="display-4">Create a project</h1>
+    <h1 class="display-4">Create an interactive project</h1>
   </div>
 </div>
 {% endblock jumbotron %}
@@ -39,7 +39,7 @@
 <div class="container">
   <div class="row">
     <div class="col-lg-9 col-xl-8">
-      <h2 class="sr-only">Create a Project</h2>
+      <h2 class="sr-only">Create an Interactive Project</h2>
 
       {% include "staff/project_create.form.html" %}
 

--- a/templates/staff/project_list.html
+++ b/templates/staff/project_list.html
@@ -27,7 +27,7 @@
 
     <div class="d-flex">
       <a class="btn btn-primary" href="{% url 'staff:project-create' %}">
-        Create a Project
+        Create an Interactive Project
       </a>
     </div>
   </div>

--- a/templates/staff/user_create.html
+++ b/templates/staff/user_create.html
@@ -62,35 +62,6 @@
         <fieldset class="mb-3">
           <legend class="h3 mb-3">Set the user's details</legend>
 
-          {% include "components/form_text.html" with field=form.application_url label="Application URL" name="application_url" %}
-
-          <div class="form-group">
-            <label class="font-weight-bold" for="id_org">Select an org</label>
-            <select id="id_org" name="org" aria-describedby="orgHelpBlock" required>
-              {% for value, label in form.fields.org.choices %}
-                <option
-                  value="{{ value }}"
-                  {% if form.org.value == value %}selected{% endif %}
-                  >{{ label }}</option>
-              {% endfor %}
-            </select>
-            <p id="orgHelpBlock" class="form-text text-muted">
-              If the org doesn't exist, you can
-              <button
-                hx-get="{% url 'staff:org-create' %}{{ query_args }}"
-                hx-target="#dialog"
-                hx-trigger="click"
-                class="btn btn-link m-0 p-0 border-0 font-weight-bold align-baseline"
-                >
-                add a new org
-              </button>
-            </p>
-
-            {% for error in form.orgs.errors %}
-              <p class="text-danger">{{ error }}</p>
-            {% endfor %}
-          </div>
-
           <div class="form-group">
             <label class="font-weight-bold" for="id_project">Select an project</label>
             <select id="id_project" name="project" aria-describedby="projectHelpBlock" required>
@@ -104,7 +75,7 @@
             <p id="projectHelpBlock" class="form-text text-muted">
               If the project doesn't exist, you can
               <button
-                hx-get="{% url 'staff:project-create' %}{{ query_args }}"
+                hx-get="{% url 'staff:project-create' %}"
                 hx-target="#dialog"
                 hx-trigger="click"
                 class="btn btn-link m-0 p-0 border-0 font-weight-bold align-baseline"

--- a/tests/unit/interactive/test_commands.py
+++ b/tests/unit/interactive/test_commands.py
@@ -5,13 +5,7 @@ from interactive.commands import create_repo, create_user, create_workspace
 from jobserver.authorization import InteractiveReporter
 from jobserver.utils import set_from_qs
 
-from ...factories import (
-    OrgFactory,
-    ProjectFactory,
-    RepoFactory,
-    UserFactory,
-    WorkspaceFactory,
-)
+from ...factories import ProjectFactory, RepoFactory, UserFactory, WorkspaceFactory
 from ...fakes import FakeGitHubAPI
 
 
@@ -56,21 +50,19 @@ def test_createrepo_with_missing_repo():
 
 def test_create_user():
     creator = UserFactory()
-    org = OrgFactory()
     project = ProjectFactory()
 
     user = create_user(
         creator=creator,
         email="test@example.com",
         name="Testing McTesterson",
-        org=org,
         project=project,
     )
 
     assert user.created_by == creator
     assert user.name == "Testing McTesterson"
     assert user.email == "test@example.com"
-    assert set_from_qs(user.orgs.all()) == {org.pk}
+    assert set_from_qs(user.orgs.all()) == {project.org.pk}
     assert set_from_qs(user.projects.all()) == {project.pk}
 
     assert user.project_memberships.first().roles == [InteractiveReporter]

--- a/tests/unit/staff/test_forms.py
+++ b/tests/unit/staff/test_forms.py
@@ -148,78 +148,8 @@ def test_projectlinkapplicationform_with_unknown_application():
     assert form.errors == {"application": ["Unknown Application"]}
 
 
-def test_usercreateform_application_url_for_project_with_application():
-    project = ProjectFactory()
-    ApplicationFactory(project=project)
-
-    data = {
-        "application_url": "example.com",
-        "org": OrgFactory().pk,
-        "project": project.pk,
-        "name": "test",
-        "email": "test@example.com",
-    }
-    form = UserCreateForm(data=data)
-
-    assert not form.is_valid()
-    assert form.errors == {
-        "application_url": [
-            "Cannot set an application URL for a project which already has an application linked to it"
-        ]
-    }
-
-
-def test_usercreateform_application_url_for_project_with_application_url():
-    project = ProjectFactory(application_url="another-domain.tld")
-
-    data = {
-        "application_url": "example.com",
-        "org": OrgFactory().pk,
-        "project": project.pk,
-        "name": "test",
-        "email": "test@example.com",
-    }
-    form = UserCreateForm(data=data)
-
-    assert not form.is_valid()
-    assert form.errors == {
-        "application_url": [
-            "Cannot set an application URL for a project which already has an application URL"
-        ]
-    }
-
-
-def test_usercreateform_with_application_url_success():
-    data = {
-        "application_url": "example.com",
-        "org": OrgFactory().pk,
-        "project": ProjectFactory().pk,
-        "name": "test",
-        "email": "test@example.com",
-    }
-    form = UserCreateForm(data=data)
-
-    assert form.is_valid(), form.errors
-
-
-def test_usercreateform_without_application_url_success():
-    project = ProjectFactory()
-    ApplicationFactory(project=project)
-
-    data = {
-        "org": OrgFactory().pk,
-        "project": project.pk,
-        "name": "test",
-        "email": "test@example.com",
-    }
-    form = UserCreateForm(data=data)
-
-    assert form.is_valid(), form.errors
-
-
 def test_usercreateform_without_project():
     data = {
-        "org": OrgFactory().pk,
         "name": "test",
         "email": "test@example.com",
     }


### PR DESCRIPTION
This shifts the boundary of where we create interactive workspaces (and their connected repo-on-GitHub and Repo instance) from the create user form to the project one.

For OSIv2 we're sticking with one interactive workspace per project and we're planning to use a different application process for those projects so we can't use our typical approval flow to create them.  Since we need to create projects in the staff area anyway it makes sense to create the workspace and related repo bits at the same time.  This also means we can add multiple users to an interactive project from the same create user form.

Ref: #2760