### PR TITLE
Check all roles for magic link login access

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -873,6 +873,27 @@ class User(AbstractBaseUser):
     def __str__(self):
         return self.name
 
+    @property
+    def all_roles(self):
+        """
+        All roles, including those given via memberships, for the User
+
+        Typically we look up whether the user has permission or a role in the
+        context of another object (eg a project).  However there are times when
+        we want to check all the roles available to a user.  This property
+        allows us to use typical python membership checks when doing that, eg:
+
+            if InteractiveReporter not in user.all_roles:
+        """
+        membership_roles = list(
+            itertools.chain.from_iterable(
+                [m.roles for m in self.project_memberships.all()]
+                + [m.roles for m in self.org_memberships.all()]
+            )
+        )
+
+        return set(self.roles + membership_roles)
+
     def clean(self):
         super().clean()
         self.email = self.__class__.objects.normalize_email(self.email)

--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -14,7 +14,7 @@ from django.views.generic import FormView, UpdateView, View
 from furl import furl
 from opentelemetry import trace
 
-from jobserver.authorization import InteractiveReporter, has_role
+from jobserver.authorization import InteractiveReporter
 
 from ..emails import send_github_login_email, send_login_email
 from ..forms import EmailLoginForm
@@ -48,7 +48,7 @@ class Login(FormView):
         user = User.objects.filter(email=form.cleaned_data["email"]).first()
 
         if user:
-            if not has_role(user, InteractiveReporter):
+            if InteractiveReporter not in user.all_roles:
                 messages.error(
                     self.request,
                     "Only users who have signed up to OpenSAFELY Interactive can log in via email",
@@ -140,7 +140,7 @@ class LoginWithURL(View):
             messages.error(request, msg)
             return redirect("login")
 
-        if not has_role(user, InteractiveReporter):
+        if InteractiveReporter not in user.all_roles:
             messages.error(
                 request,
                 "Only users who have signed up to OpenSAFELY Interactive can log in via email",

--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -70,7 +70,10 @@ class Login(FormView):
                     user, login_url, timeout_minutes=settings.LOGIN_URL_TIMEOUT_MINUTES
                 )
 
-        msg = "If you have a user account we'll send you an email with the login details shortly. If you don't receive an email please check your spam folder."
+        msg = (
+            "If you have signed up to OpenSAFELY Interactive we'll send you an email with the login details shortly. "
+            "If you don't receive an email please check your spam folder."
+        )
         messages.success(self.request, msg)
 
         return self.render_to_response(self.get_context_data())

--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -48,13 +48,6 @@ class Login(FormView):
         user = User.objects.filter(email=form.cleaned_data["email"]).first()
 
         if user:
-            if InteractiveReporter not in user.all_roles:
-                messages.error(
-                    self.request,
-                    "Only users who have signed up to OpenSAFELY Interactive can log in via email",
-                )
-                return redirect("login")
-
             if user.social_auth.exists():
                 # we don't want to expose users email address to a bad actor
                 # via the login page form so we're emailing them with a link
@@ -62,7 +55,7 @@ class Login(FormView):
                 # We can't email them with a link to the social auth entrypoint
                 # because it only accepts POSTs.
                 send_github_login_email(user)
-            else:
+            elif InteractiveReporter in user.all_roles:
                 # generate a secret token we can sign for the URL
                 token = secrets.token_urlsafe(64)
                 signed_token = TimestampSigner(salt="login").sign(token)

--- a/tests/unit/jobserver/models/test_user.py
+++ b/tests/unit/jobserver/models/test_user.py
@@ -25,6 +25,22 @@ from ....factories import (
 )
 
 
+def test_user_all_roles():
+    project = ProjectFactory()
+    user = UserFactory(roles=[DataInvestigator])
+
+    OrgMembershipFactory(org=project.org, user=user, roles=[DataInvestigator])
+    ProjectMembershipFactory(project=project, user=user, roles=[ProjectCollaborator])
+
+    expected = {DataInvestigator, ProjectCollaborator}
+
+    assert user.all_roles == expected
+
+
+def test_user_all_roles_empty():
+    assert UserFactory().all_roles == set()
+
+
 def test_user_constraints_pat_token_and_pat_expires_at_both_set():
     UserFactory(pat_token="test", pat_expires_at=timezone.now())
 

--- a/tests/unit/jobserver/views/test_users.py
+++ b/tests/unit/jobserver/views/test_users.py
@@ -139,13 +139,12 @@ def test_login_post_unauthorised(rf, mailoutbox):
 
     response = Login.as_view()(request)
 
-    assert response.status_code == 302
-    assert response.url == reverse("login")
+    assert response.status_code == 200
 
     # check we have a message for the user
     messages = list(messages)
     assert len(messages) == 1
-    msg = "Only users who have signed up to OpenSAFELY Interactive can log in via email"
+    msg = "If you have a user account we'll send you an email with the login details shortly. If you don't receive an email please check your spam folder."
     assert str(messages[0]) == msg
 
 

--- a/tests/unit/jobserver/views/test_users.py
+++ b/tests/unit/jobserver/views/test_users.py
@@ -88,7 +88,7 @@ def test_login_post_success_with_email_user(rf, mailoutbox):
     # check we have a message for the user
     messages = list(messages)
     assert len(messages) == 1
-    msg = "If you have a user account we'll send you an email with the login details shortly. If you don't receive an email please check your spam folder."
+    msg = "If you have signed up to OpenSAFELY Interactive we'll send you an email with the login details shortly. If you don't receive an email please check your spam folder."
     assert str(messages[0]) == msg
 
     # differentiate from the GitHub user use case
@@ -116,7 +116,7 @@ def test_login_post_success_with_github_user(rf, mailoutbox):
     # check we have a message for the user
     messages = list(messages)
     assert len(messages) == 1
-    msg = "If you have a user account we'll send you an email with the login details shortly. If you don't receive an email please check your spam folder."
+    msg = "If you have signed up to OpenSAFELY Interactive we'll send you an email with the login details shortly. If you don't receive an email please check your spam folder."
     assert str(messages[0]) == msg
 
     # differentiate from the email user use case
@@ -144,7 +144,7 @@ def test_login_post_unauthorised(rf, mailoutbox):
     # check we have a message for the user
     messages = list(messages)
     assert len(messages) == 1
-    msg = "If you have a user account we'll send you an email with the login details shortly. If you don't receive an email please check your spam folder."
+    msg = "If you have signed up to OpenSAFELY Interactive we'll send you an email with the login details shortly. If you don't receive an email please check your spam folder."
     assert str(messages[0]) == msg
 
 
@@ -165,7 +165,7 @@ def test_login_post_unknown_user(rf):
     # check we have a message for the user
     messages = list(messages)
     assert len(messages) == 1
-    msg = "If you have a user account we'll send you an email with the login details shortly. If you don't receive an email please check your spam folder."
+    msg = "If you have signed up to OpenSAFELY Interactive we'll send you an email with the login details shortly. If you don't receive an email please check your spam folder."
     assert str(messages[0]) == msg
 
 


### PR DESCRIPTION
`has_role` looks at the "global" roles of a user, optionally searching any extra context we give it.  Rather than look up all the possible org and project memberships of the user in the view this adds a property to the User model which grabs them as a set so we can have simple membership checks.