### PR TITLE
Redirect all magic link users to their interactive page

### DIFF
--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -149,8 +149,11 @@ class LoginWithURL(View):
 
         login(request, user, "django.contrib.auth.backends.ModelBackend")
 
-        next_url = request.GET.get("next") or "/"
-        return redirect(next_url)
+        # TODO: decide what to do when a user has more than one project.
+        # we don't expect this to happen for a while but we need to make
+        # a call.
+        project = user.projects.first()
+        return redirect(project.interactive_workspace)
 
 
 @method_decorator(login_required, name="dispatch")

--- a/tests/unit/jobserver/views/test_users.py
+++ b/tests/unit/jobserver/views/test_users.py
@@ -11,7 +11,13 @@ from freezegun import freeze_time
 from jobserver.authorization import InteractiveReporter
 from jobserver.views.users import Login, LoginWithURL, Settings
 
-from ....factories import UserFactory, UserSocialAuthFactory
+from ....factories import (
+    ProjectFactory,
+    ProjectMembershipFactory,
+    UserFactory,
+    UserSocialAuthFactory,
+    WorkspaceFactory,
+)
 
 
 def test_login_already_logged_in_with_next_url(rf):
@@ -195,7 +201,10 @@ def test_loginwithurl_bad_token(rf):
 
 
 def test_loginwithurl_success(rf):
-    user = UserFactory(roles=[InteractiveReporter])
+    project = ProjectFactory()
+    user = UserFactory()
+    ProjectMembershipFactory(project=project, user=user, roles=[InteractiveReporter])
+    WorkspaceFactory(project=project, name=project.interactive_slug)
 
     signed_token = TimestampSigner(salt="login").sign("test")
 
@@ -206,7 +215,7 @@ def test_loginwithurl_success(rf):
     response = LoginWithURL.as_view()(request, token=signed_token)
 
     assert response.status_code == 302
-    assert response.url == "/"
+    assert response.url == project.interactive_workspace.get_absolute_url()
 
 
 def test_loginwithurl_unauthorized(rf):
@@ -340,7 +349,6 @@ def test_settings_post(rf):
     assert response.url == "/"
 
     user2.refresh_from_db()
-
     assert user2.notifications_email == "changed@example.com"
     assert user2.fullname == "Mr Testerson"
 


### PR DESCRIPTION
This assumes that interactive users will have been correctly set up when they login but since they _should_ have been created using the staff area this should be good enough for now.