### PR TITLE
Redirect interactive users to the interactive form after login

### DIFF
--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -149,7 +149,7 @@ class LoginWithURL(View):
         # we don't expect this to happen for a while but we need to make
         # a call.
         project = user.projects.first()
-        return redirect(project.interactive_workspace)
+        return redirect(project.get_interactive_url())
 
 
 @method_decorator(login_required, name="dispatch")

--- a/tests/unit/jobserver/views/test_users.py
+++ b/tests/unit/jobserver/views/test_users.py
@@ -214,7 +214,7 @@ def test_loginwithurl_success(rf):
     response = LoginWithURL.as_view()(request, token=signed_token)
 
     assert response.status_code == 302
-    assert response.url == project.interactive_workspace.get_absolute_url()
+    assert response.url == project.get_interactive_url()
 
 
 def test_loginwithurl_unauthorized(rf):


### PR DESCRIPTION
This was incorrectly redirecting to the workspace previously.