### PR TITLE
Use a URLField for application URL

### DIFF
--- a/staff/forms.py
+++ b/staff/forms.py
@@ -84,6 +84,8 @@ class ProjectAddMemberForm(PickUsersMixin, RolesForm):
 
 
 class ProjectCreateForm(forms.ModelForm):
+    application_url = forms.URLField()
+
     class Meta:
         fields = [
             "application_url",

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -125,6 +125,7 @@ class ProjectCreate(CreateView):
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {
+            "application_url_attributes": {"type": "url"},
             "query_args": get_query_args(self.request.GET),
         }
 

--- a/templates/staff/project_create.form.html
+++ b/templates/staff/project_create.form.html
@@ -25,7 +25,7 @@
       {% endfor %}
     </div>
 
-    {% include "components/form_text.html" with field=form.application_url label="Application URL" name="application_url" %}
+    {% include "components/form_text.html" with field=form.application_url label="Application URL" name="application_url" extra_attributes=application_url_attributes %}
 
     {% include "components/form_text.html" with field=form.name label="Set the project name" name="name" %}
   </fieldset>


### PR DESCRIPTION
This ensures we get a protocol, meaning when we display the URL it's not interpreted as a relative URL.

Fix: #2803 