### PR TITLE
Remove unrelated fields from user page for email-only users

### DIFF
--- a/templates/staff/user_detail_with_email.html
+++ b/templates/staff/user_detail_with_email.html
@@ -1,0 +1,112 @@
+{% extends "staff/base.html" %}
+
+{% load humanize %}
+
+{% block metatitle %}{{ user.username }}: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:index' %}">Staff area</a>
+      </li>
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:user-list' %}">Users</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        {{ user.username }}
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
+  <div class="container">
+    <h1 class="display-4">{{ user.name }}</h1>
+
+    <ul class="list-unstyled lead">
+      <li>
+        <strong>Email:</strong>
+        {% if user.notifications_email %}
+        {{ user.notifications_email }}
+        {% else %}
+        {{ user.email }}
+        {% endif %}
+      </li>
+
+      <li>
+        <strong>Created at:</strong> {{ user.date_joined }}
+      </li>
+    </ul>
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block staff_content %}
+<div class="container">
+  <div class="row">
+    <div class="col col-lg-9 col-xl-8">
+
+      <form method="POST">
+        {% csrf_token %}
+
+        {% if form.non_field_errors %}
+        <ul>
+          {% for error in form.non_field_errors %}
+          <li class="text-danger">{{ error }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+        <div class="mb-5">
+          {% include "components/form_text.html" with field=form.fullname label="Full name" name="fullname" %}
+          {% include "components/form_text.html" with field=form.email label="Email" name="email" %}
+        </div>
+
+        <div class="form-group mb-5">
+          <div class="d-flex justify-content-between align-items-center">
+            <h2 id="orgs" class="h4">Organisations</h2>
+            <a class="btn btn-sm btn-primary" href="{% url 'staff:user-set-orgs' username=user.username %}">
+              Add to organisation
+            </a>
+          </div>
+
+          <div class="list-group mb-3">
+            {% for org in orgs %}
+            <a class="list-group-item list-group-item-action d-flex" href="{{ org.staff_url }}">
+              <span class="mr-auto">{{ org.name }}</span>
+              {% for role in org.roles %}
+              <span class="badge badge-secondary ml-1">{{ role }}</span>
+              {% endfor %}
+            </a>
+            {% endfor %}
+          </div>
+        </div>
+
+        <div class="form-group mb-5">
+          <h2 id="projects" class="h4">Projects</h2>
+
+          <div class="list-group mb-3">
+            {% for project in projects %}
+            <a class="list-group-item list-group-item-action d-flex align-items-center" href="{{ project.staff_url }}">
+              <span class="mr-auto">{{ project.name }}</span>
+              {% for role in project.roles %}
+              <span class="badge badge-secondary ml-1">{{ role }}</span>
+              {% endfor %}
+            </a>
+            {% endfor %}
+          </div>
+        </div>
+
+        <div class="form-group">
+          <button class="btn btn-primary" type="submit">Save</button>
+        </div>
+
+      </form>
+
+  </div>
+</div>
+{% endblock staff_content %}

--- a/templates/staff/user_detail_with_oauth.html
+++ b/templates/staff/user_detail_with_oauth.html
@@ -25,16 +25,15 @@
 {% block jumbotron %}
 <div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
   <div class="container">
-    <h1 class="display-4">{{ user.username }}</h1>
+    <h1 class="display-4">{{ user.name }}</h1>
 
     <ul class="list-unstyled lead">
-      {% if user.get_full_name %}
       <li>
-        {{ user.get_full_name }}
+        <strong>Username:</strong> {{ user.username }}
       </li>
-      {% endif %}
 
       <li>
+        <strong>Email:</strong>
         {% if user.notifications_email %}
         {{ user.notifications_email }}
         {% else %}


### PR DESCRIPTION
Our email-only users don't get access to various related objects or fields, so the staff area's UserDetail page was a little confusing for those users.

This splits the page into two views, one for users who sign in with OAuth and one for users who sign in with email.  Rather than splitting up the URLs and causing confusion with which type to use these views both work with a single URL deferring to each other in their dispatch() methods when the user type calls for it.

Fix: #2808