### PR TITLE
Always show the outputs links on WorkspaceDetail pages

### DIFF
--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -320,7 +320,7 @@ class WorkspaceReleaseList(View):
                 "title": build_title(r),
                 "view_url": r.get_absolute_url(),
             }
-            for r in workspace.releases.select_related("created_by")
+            for r in workspace.releases.select_related("backend", "created_by")
             .prefetch_related(
                 Prefetch("files", queryset=ReleaseFile.objects.order_by("name"))
             )

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -302,12 +302,11 @@ class WorkspaceDetail(View):
         )
 
     def get_output_permissions(self, user, workspace):
+        # a user can see backend files if they have access to at least one
+        # backend and the permissions required to see outputs
         is_privileged_user = has_permission(
             user, "release_file_view", project=workspace.project
         )
-
-        # a user can see backend files if they have access to at least one
-        # backend and the permissions required to see outputs
         has_backends = (
             user.is_authenticated and user.backends.exclude(level_4_url="").exists()
         )
@@ -316,26 +315,12 @@ class WorkspaceDetail(View):
         # are there any releases to show for the workspace?
         can_view_releases = workspace.releases.exists()
 
-        # unprivileged users can only see published snapshots, but privileged
-        # users can see snapshots if there are any releases since they can also
-        # prepare and publish them from the same views.
-        has_published_snapshots = workspace.snapshots.exclude(
-            published_at=None
-        ).exists()
-        has_any_snapshots = workspace.snapshots.exists()
-        can_view_outputs = has_published_snapshots or (
-            is_privileged_user and (can_view_releases or has_any_snapshots)
-        )
-
         return {
             "level_4": {
                 "disabled": not can_view_files,
             },
             "released": {
                 "disabled": not can_view_releases,
-            },
-            "published": {
-                "disabled": not can_view_outputs,
             },
         }
 

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -259,6 +259,11 @@ class WorkspaceDetail(View):
             request.user, "workspace_toggle_notifications", project=workspace.project
         )
 
+        # should we show the admin section in the UI?
+        show_admin = (
+            can_archive_workspace or repo_is_private or can_toggle_notifications
+        )
+
         honeycomb_can_view_links = has_role(self.request.user, CoreDeveloper)
 
         is_interactive_user = has_permission(
@@ -282,6 +287,7 @@ class WorkspaceDetail(View):
             "outputs": outputs,
             "repo_is_private": repo_is_private,
             "reports": reports,
+            "show_admin": show_admin,
             "show_interactive_button": show_interactive_button,
             "show_publish_repo_warning": show_publish_repo_warning,
             "user_can_archive_workspace": can_archive_workspace,

--- a/templates/workspace_detail.html
+++ b/templates/workspace_detail.html
@@ -155,7 +155,7 @@
         {% /card %}
       {% endif %}
 
-      {% #card title="Job information" %}
+      {% #card title="Workspace information" %}
         <dl class="border-t border-slate-200 sm:divide-y sm:divide-slate-200">
           {% #description_item title="Repo" %}
             {% link text=workspace.repo.name href=workspace.repo.url %}

--- a/templates/workspace_detail.html
+++ b/templates/workspace_detail.html
@@ -111,7 +111,7 @@
     </div>
 
     <div class="space-y-6 md:space-y-6 lg:col-span-1 lg:row-start-2">
-      {% if is_member %}
+      {% if show_admin %}
         {% #card title="Workspace admin" class="text-center" container=True %}
           {% if user_can_archive_workspace %}
           <form method="POST" action="{{ workspace.get_archive_toggle_url }}" class="mb-2">

--- a/templates/workspace_detail.html
+++ b/templates/workspace_detail.html
@@ -256,7 +256,7 @@
             Released Outputs
           {% /list_group_item%}
 
-          {% #list_group_item href=workspace.get_outputs_url disabled=outputs.published.disabled %}
+          {% #list_group_item href=workspace.get_outputs_url %}
             Published Outputs
           {% /list_group_item%}
         {% /list_group %}

--- a/templates/workspace_detail.html
+++ b/templates/workspace_detail.html
@@ -245,30 +245,22 @@
         {% /card %}
       {% endif %}
 
-      {% if user_can_use_releases %}
-        {% #card title="Releases" %}
-          {% #list_group small=True %}
-            {% if user_can_view_files %}
-              {% #list_group_item href=workspace.get_files_url %}
-                <span class="mr-2">Level 4 Outputs</span>
-                {% pill text="VPN Required" variant="primary" %}
-              {% /list_group_item%}
-            {% endif %}
+      {% #card title="Releases" %}
+        {% #list_group small=True %}
+          {% #list_group_item href=workspace.get_files_url disabled=outputs.level_4.disabled %}
+            <span class="mr-2">Level 4 Outputs</span>
+            {% pill text="VPN Required" variant="primary" %}
+          {% /list_group_item%}
 
-            {% if user_can_view_releases %}
-              {% #list_group_item href=workspace.get_releases_url %}
-                Released Outputs
-              {% /list_group_item%}
-            {% endif %}
+          {% #list_group_item href=workspace.get_releases_url disabled=outputs.released.disabled %}
+            Released Outputs
+          {% /list_group_item%}
 
-            {% if user_can_view_outputs %}
-              {% #list_group_item href=workspace.get_outputs_url %}
-                Published Outputs
-              {% /list_group_item%}
-            {% endif %}
-          {% /list_group %}
-        {% /card %}
-      {% endif %}
+          {% #list_group_item href=workspace.get_outputs_url disabled=outputs.published.disabled %}
+            Published Outputs
+          {% /list_group_item%}
+        {% /list_group %}
+      {% /card %}
 
       {% #card title="Reports" %}
         {% #list_group small=True %}

--- a/templates/workspace_output_list.html
+++ b/templates/workspace_output_list.html
@@ -54,7 +54,7 @@
             </dd>
           </dl>
           <p class="max-w-prose font-lg text-slate-600">
-            Listed below are the outputs for the <strong>{{ workspace.name }}</strong> workspace.
+            Listed below are the published outputs for the <strong>{{ workspace.name }}</strong> workspace.
           </p>
         </div>
       </div>

--- a/templates/workspace_release_list.html
+++ b/templates/workspace_release_list.html
@@ -100,7 +100,13 @@
             x-title="release-{{ release.id }}"
         >
           <div class="flex flex-col md:flex-row md:flex-wrap gap-2 items-center justify-between">
-            <span class="mr-auto">{% link href=release.view_url text=release.title %}</span>
+            <span class="mr-auto">
+              {% if release.can_view_files %}
+              {% link href=release.view_url text=release.title disabled=True %}
+              {% else %}
+              {{ release.title }}
+              {% endif %}
+            </span>
             {% if release.can_view_files %}
             <div class="flex-shrink-0 ml-auto">
               {% #button class="min-w-[16ch]" variant="primary" type="link" href=release.download_url %}

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -508,7 +508,6 @@ def test_workspacedetail_authorized_view_outputs(rf):
 
     assert not response.context_data["outputs"]["level_4"]["disabled"]
     assert not response.context_data["outputs"]["released"]["disabled"]
-    assert not response.context_data["outputs"]["published"]["disabled"]
 
 
 def test_workspacedetail_authorized_run_jobs(rf):
@@ -597,12 +596,6 @@ def test_workspacedetail_logged_out(rf):
     assert not response.context_data["user_can_run_jobs"]
     assert response.context_data["outputs"]["released"]["disabled"]
 
-    # this is false because:
-    # the user is either logged out
-    #   OR doesn't have the right permission to see outputs
-    #   AND there are no published Snapshots to show the user.
-    assert response.context_data["outputs"]["published"]["disabled"]
-
 
 def test_workspacedetail_unauthorized(rf):
     workspace = WorkspaceFactory()
@@ -625,12 +618,6 @@ def test_workspacedetail_unauthorized(rf):
 
     assert not response.context_data["user_can_run_jobs"]
     assert response.context_data["outputs"]["released"]["disabled"]
-
-    # this is false because:
-    # the user is either logged out
-    #   OR doesn't have the right permission to see outputs
-    #   AND there are no published Snapshots to show the user.
-    assert response.context_data["outputs"]["published"]["disabled"]
 
     # this is false because only a user with ProjectDeveloper should be able
     # to do this

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -483,10 +483,14 @@ def test_workspacedetail_authorized_toggle_notifications(rf):
     assert response.context_data["user_can_toggle_notifications"]
 
 
-def test_workspacedetail_authorized_view_files(rf):
+def test_workspacedetail_authorized_view_outputs(rf):
     backend = BackendFactory(level_4_url="http://test/")
     user = UserFactory(roles=[ProjectCollaborator])
     workspace = WorkspaceFactory()
+    ReleaseFactory(workspace=workspace)
+    SnapshotFactory(
+        workspace=workspace, published_by=UserFactory(), published_at=timezone.now()
+    )
 
     BackendMembershipFactory(backend=backend, user=user)
 
@@ -501,25 +505,10 @@ def test_workspacedetail_authorized_view_files(rf):
     )
 
     assert response.status_code == 200
-    assert response.context_data["user_can_view_files"]
 
-
-def test_workspacedetail_authorized_view_releases(rf):
-    workspace = WorkspaceFactory()
-    ReleaseFactory(workspace=workspace)
-
-    request = rf.get("/")
-    request.user = UserFactory()
-
-    response = WorkspaceDetail.as_view(get_github_api=FakeGitHubAPI)(
-        request,
-        org_slug=workspace.project.org.slug,
-        project_slug=workspace.project.slug,
-        workspace_slug=workspace.name,
-    )
-
-    assert response.status_code == 200
-    assert response.context_data["user_can_view_releases"]
+    assert not response.context_data["outputs"]["level_4"]["disabled"]
+    assert not response.context_data["outputs"]["released"]["disabled"]
+    assert not response.context_data["outputs"]["published"]["disabled"]
 
 
 def test_workspacedetail_authorized_run_jobs(rf):
@@ -542,26 +531,6 @@ def test_workspacedetail_authorized_run_jobs(rf):
 
     assert response.status_code == 200
     assert response.context_data["user_can_run_jobs"]
-
-
-def test_workspacedetail_authorized_view_snaphots(rf):
-    workspace = WorkspaceFactory()
-    SnapshotFactory(
-        workspace=workspace, published_by=UserFactory(), published_at=timezone.now()
-    )
-
-    request = rf.get("/")
-    request.user = UserFactory()
-
-    response = WorkspaceDetail.as_view(get_github_api=FakeGitHubAPI)(
-        request,
-        org_slug=workspace.project.org.slug,
-        project_slug=workspace.project.slug,
-        workspace_slug=workspace.name,
-    )
-
-    assert response.status_code == 200
-    assert response.context_data["user_can_view_outputs"]
 
 
 def test_workspacedetail_authorized_honeycomb(rf):
@@ -623,16 +592,16 @@ def test_workspacedetail_logged_out(rf):
 
     # this is false because while the user can view outputs, but they have no
     # Backends with a level 4 URL set up.
-    assert not response.context_data["user_can_view_files"]
+    assert response.context_data["outputs"]["level_4"]["disabled"]
 
     assert not response.context_data["user_can_run_jobs"]
-    assert not response.context_data["user_can_view_releases"]
+    assert response.context_data["outputs"]["released"]["disabled"]
 
     # this is false because:
     # the user is either logged out
     #   OR doesn't have the right permission to see outputs
     #   AND there are no published Snapshots to show the user.
-    assert not response.context_data["user_can_view_outputs"]
+    assert response.context_data["outputs"]["published"]["disabled"]
 
 
 def test_workspacedetail_unauthorized(rf):
@@ -652,16 +621,16 @@ def test_workspacedetail_unauthorized(rf):
 
     # this is false because while the user can view outputs, but they have no
     # Backends with a level 4 URL set up.
-    assert not response.context_data["user_can_view_files"]
+    assert response.context_data["outputs"]["level_4"]["disabled"]
 
     assert not response.context_data["user_can_run_jobs"]
-    assert not response.context_data["user_can_view_releases"]
+    assert response.context_data["outputs"]["released"]["disabled"]
 
     # this is false because:
     # the user is either logged out
     #   OR doesn't have the right permission to see outputs
     #   AND there are no published Snapshots to show the user.
-    assert not response.context_data["user_can_view_outputs"]
+    assert response.context_data["outputs"]["published"]["disabled"]
 
     # this is false because only a user with ProjectDeveloper should be able
     # to do this


### PR DESCRIPTION
Matching how we handle buttons that a user doesn't have access to this disables the outputs links when a user doesn't have access to them.

As part of this I've reworked how we expose the aggregated permissions checks to the template so they're easier to work with there.

Fix: #2799 