### PR TITLE
Call our checks from the local venv in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,31 +2,38 @@ default_language_version:
   python: python3.11
 
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.2
-    hooks:
-    - id: pyupgrade
-
-  - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.7.0
-    hooks:
-      - id: django-upgrade
-        args: [--target-version, "3.2"]
-
-  - repo: https://github.com/psf/black
-    rev: 22.6.0
+  - repo: local
     hooks:
     - id: black
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
+      name: black
+      entry: just black
+      language: system
+      types: [python]
+      require_serial: true
+    - id: django-upgrade
+      name: django-upgrade
+      entry: just django-upgrade
+      language: system
+      types: [python]
+      require_serial: true
     - id: flake8
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
-    hooks:
+      name: flake8
+      entry: just flake8
+      language: system
+      types: [python]
+      require_serial: true
     - id: isort
+      name: isort
+      entry: just isort
+      language: system
+      types: [python]
+      require_serial: true
+    - id: pyupgrade
+      name: pyupgrade
+      entry: just pyupgrade
+      language: system
+      types: [python]
+      require_serial: true
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0

--- a/justfile
+++ b/justfile
@@ -122,13 +122,23 @@ test *args:
     $BIN/coverage report || $BIN/coverage html
 
 
+black *args=".": devenv
+    $BIN/black --check {{ args }}
+
+isort *args=".": devenv
+    $BIN/isort --check-only --diff {{ args }}
+
+flake8 *args="": devenv
+    $BIN/flake8 {{ args }}
+
+pyupgrade *args="$(find applications jobserver services tests -name '*.py' -type f)": devenv
+    $BIN/pyupgrade --py310-plus {{ args }}
+
+django-upgrade *args="$(find applications jobserver services tests -name '*.py' -type f)": devenv
+    $BIN/django-upgrade --target-version=3.2 {{ args }}
+
 # run the various dev checks but does not change any files
-check: devenv
-    $BIN/black --check .
-    $BIN/isort --check-only --diff .
-    $BIN/flake8
-    $BIN/pyupgrade --py310-plus $(find applications jobserver services tests -name "*.py" -type f)
-    $BIN/django-upgrade --target-version=3.2 $(find applications jobserver services tests -name "*.py" -type f)
+check: black isort flake8 pyupgrade django-upgrade
 
 
 check-migrations: devenv


### PR DESCRIPTION
pre-commit passes the paths of staged files to hooks so this splits up the checks into separate targets in the justfile (still grouped under the `check` target), with default args where necessary.