### PR TITLE
Fix queries on roles fields

### DIFF
--- a/jobserver/authorization/fields.py
+++ b/jobserver/authorization/fields.py
@@ -1,3 +1,5 @@
+import collections
+
 from django.db import models
 
 from .parsing import _ensure_role_paths, parse_roles
@@ -31,6 +33,15 @@ class RolesField(models.JSONField):
         """Convert Role classes to dotted paths for storage in the db"""
         if not roles:
             return super().get_prep_value(roles)
+
+        # we want to deal with iterables here but it's valid to construct a
+        # query like:
+        #
+        #   filter(roles__contains=MyRoleClass)
+        #
+        # In this case we want to wrap the value of roles in a list.
+        if not isinstance(roles, collections.abc.Iterable):
+            roles = [roles]
 
         # convert each Role to a dotted path string
         paths = {dotted_path(r) for r in roles}

--- a/tests/unit/jobserver/authorization/test_fields.py
+++ b/tests/unit/jobserver/authorization/test_fields.py
@@ -2,6 +2,7 @@ from django.db import connection
 
 from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.fields import RolesField
+from jobserver.models import User
 
 from ....factories import UserFactory
 
@@ -92,3 +93,12 @@ def test_roles_field_to_python_with_empty_list():
 def test_roles_field_to_python_with_falsey_value():
     assert RolesField().to_python(None) is None
     assert RolesField().to_python([]) == []
+
+
+def test_query_by_roles():
+    user = UserFactory(roles=[CoreDeveloper])
+
+    qs = User.objects.filter(roles__contains=CoreDeveloper)
+
+    assert qs.count() == 1
+    assert qs.first() == user


### PR DESCRIPTION
We typically only access roles fields via the helper functions provided in the authorizations package so querying them directly hasn't come up much before.  However, when one is trying to filter for models with a particular role using __contains and passing in the given role we still want that to work.  The RolesField implementation expects an iterable when preparing values so we cast that when we only get one now.