### PR TITLE
Fix OSI report-is-done email

### DIFF
--- a/interactive/commands.py
+++ b/interactive/commands.py
@@ -46,6 +46,7 @@ def create_user(*, creator, email, name, project):
     user = User.objects.create(
         fullname=name,
         email=email,
+        notifications_email=email,
         username=email,
         created_by=creator,
         is_active=True,

--- a/interactive/emails.py
+++ b/interactive/emails.py
@@ -13,7 +13,7 @@ def send_report_uploaded_notification(analysis_request):
     }
 
     send(
-        to=analysis_request.created_by.email,
+        to=analysis_request.created_by.notifications_email,
         sender="notifications@jobs.opensafely.org",
         subject="Your OpenSAFELY Interactive report is ready to view",
         template_name="emails/notify_report_uploaded.txt",

--- a/jobserver/emails.py
+++ b/jobserver/emails.py
@@ -65,9 +65,7 @@ def send_login_email(user, login_url, timeout_minutes):
 
 def send_repo_signed_off_notification_to_researchers(repo):
     creators = User.objects.filter(workspaces__repo=repo)
-    emails = [
-        u.notifications_email if u.notifications_email else u.email for u in creators
-    ]
+    emails = [u.notifications_email for u in creators]
 
     send(
         to="notifications@jobs.opensafely.org",

--- a/templates/staff/user_detail_with_email.html
+++ b/templates/staff/user_detail_with_email.html
@@ -30,11 +30,7 @@
     <ul class="list-unstyled lead">
       <li>
         <strong>Email:</strong>
-        {% if user.notifications_email %}
         {{ user.notifications_email }}
-        {% else %}
-        {{ user.email }}
-        {% endif %}
       </li>
 
       <li>

--- a/templates/staff/user_detail_with_oauth.html
+++ b/templates/staff/user_detail_with_oauth.html
@@ -34,11 +34,7 @@
 
       <li>
         <strong>Email:</strong>
-        {% if user.notifications_email %}
         {{ user.notifications_email }}
-        {% else %}
-        {{ user.email }}
-        {% endif %}
       </li>
 
       <li>

--- a/tests/unit/interactive/test_commands.py
+++ b/tests/unit/interactive/test_commands.py
@@ -62,6 +62,7 @@ def test_create_user():
     assert user.created_by == creator
     assert user.name == "Testing McTesterson"
     assert user.email == "test@example.com"
+    assert user.notifications_email == "test@example.com"
     assert set_from_qs(user.orgs.all()) == {project.org.pk}
     assert set_from_qs(user.projects.all()) == {project.pk}
 

--- a/tests/unit/interactive/test_emails.py
+++ b/tests/unit/interactive/test_emails.py
@@ -11,4 +11,4 @@ def test_send_report_uploaded_notification(mailoutbox):
     m = mailoutbox[0]
 
     assert analysis_request.get_absolute_url() in m.body
-    assert list(m.to) == [analysis_request.created_by.email]
+    assert list(m.to) == [analysis_request.created_by.notifications_email]


### PR DESCRIPTION
This covers the two facets to this:
* send the email to the address in `notifications_email` so users have control over where they get their notifications.
* create interactive users with `notifications_email` set, to mirror how GitHub-based users are created.