### PR TITLE
restore django-upgrade directory config

### DIFF
--- a/justfile
+++ b/justfile
@@ -125,7 +125,7 @@ test *args:
 black *args=".": devenv
     $BIN/black --check {{ args }}
 
-django-upgrade *args="$(find applications jobserver services tests -name '*.py' -type f)": devenv
+django-upgrade *args="$(find applications interactive jobserver redirects services staff tests -name '*.py' -type f)": devenv
     $BIN/django-upgrade --target-version=4.1 {{ args }}
 
 ruff *args=".": devenv


### PR DESCRIPTION
A bad rebase and then a bad push left this in a modified state in #2839 after it was fixed in #2836.  This restores the correct config.