### PR TITLE
Link Project.number uniqueness failures to their form field

### DIFF
--- a/staff/forms.py
+++ b/staff/forms.py
@@ -83,28 +83,14 @@ class ProjectAddMemberForm(PickUsersMixin, RolesForm):
     pass
 
 
-class ProjectCreateForm(forms.ModelForm):
+class ProjectCreateForm(forms.Form):
     application_url = forms.URLField()
+    copilot = UserModelChoiceField(
+        queryset=User.objects.order_by(Lower("fullname"), "username")
+    )
+    name = forms.CharField()
     number = forms.IntegerField()
-
-    class Meta:
-        fields = [
-            "application_url",
-            "copilot",
-            "name",
-            "number",
-            "org",
-        ]
-        model = Project
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        users = User.objects.order_by(Lower("fullname"), "username")
-        self.fields["copilot"] = UserModelChoiceField(queryset=users)
-
-        orgs = Org.objects.order_by("name")
-        self.fields["org"] = forms.ModelChoiceField(queryset=orgs)
+    org = forms.ModelChoiceField(queryset=Org.objects.order_by("name"))
 
 
 class ProjectEditForm(forms.ModelForm):

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -1,5 +1,6 @@
 from django.contrib import messages
-from django.db import transaction
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.db.models.functions import Lower
 from django.shortcuts import get_object_or_404, redirect
@@ -96,10 +97,11 @@ class ProjectCreate(CreateView):
         # wrap the transaction in a try so it can rollback when that fires
         try:
             with transaction.atomic():
-                project = form.save(commit=False)
-                project.created_by = self.request.user
-                project.updated_by = self.request.user
-                project.save()
+                project = Project.objects.create(
+                    **form.cleaned_data,
+                    created_by=self.request.user,
+                    updated_by=self.request.user,
+                )
 
                 # make sure the relevant interactive repo exists on GitHub
                 repo_url = create_repo(
@@ -118,6 +120,18 @@ class ProjectCreate(CreateView):
                 None,
                 "An error occurred when trying to create the required Repo on GitHub",
             )
+            return self.form_invalid(form)
+        except IntegrityError as e:
+            if "unique_number_ignore_null" not in str(e.__cause__):
+                raise  # pragma: no cover
+
+            # We have a constraint ensuring Project.number is unique (ignoring
+            # nulls).  This catches failures of that constraint and attaches it
+            # to the number field of the form so it gets displayed next to it
+            # in the UI.
+            # Previously we used a ModelForm for this page but it suffered from
+            # a similar issue, putting this error into non_field_errors.
+            form.add_error("number", ValidationError("Project number must be unique"))
             return self.form_invalid(form)
 
         project_detail = project.get_staff_url()
@@ -147,6 +161,14 @@ class ProjectCreate(CreateView):
             },
             "post_url": f.url,
         }
+
+    def get_form_kwargs(self, **kwargs):
+        kwargs = super().get_form_kwargs(**kwargs)
+
+        # ProjectCreateForm isn't a ModelForm so don't pass instance to it
+        del kwargs["instance"]
+
+        return kwargs
 
     def get_template_names(self):
         suffix = ".htmx" if self.request.htmx else ""


### PR DESCRIPTION
When a constraint fails a ModelForm puts the error into the non_field_errors, which we display at the top of our form.  The IntegrityError is also raised somewhere in the ModelForm's clean stack (originally coming from the link model's clean stack).

Since this failure is specifically for the number field that feels quite confusing in the UI.

This change moves ProjectCreateForm to a plain Form so we can handle the validation of the model where we create it (sticking to the principle of locality of behaviour), and thus attach the error to the correct field on our form instance allowing our error handling to display it next to the number field.