### PR TITLE
Cache User.all_roles

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -15,6 +15,7 @@ from django.db import models
 from django.db.models import Min, Q
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.text import slugify
 from environs import Env
 from furl import furl
@@ -872,7 +873,7 @@ class User(AbstractBaseUser):
     def __str__(self):
         return self.name
 
-    @property
+    @cached_property
     def all_roles(self):
         """
         All roles, including those given via memberships, for the User


### PR DESCRIPTION
This property makes two queries each time it is accessed.  This caches the result, to the lifetime of the User instance, avoiding the extra queries.