### PR TITLE
List workspace reports

### DIFF
--- a/templates/workspace_detail.html
+++ b/templates/workspace_detail.html
@@ -270,6 +270,21 @@
         {% /card %}
       {% endif %}
 
+      {% #card title="Reports" %}
+        {% #list_group small=True %}
+          {% for report in reports %}
+          {% #list_group_item href=report.get_absolute_url %}
+            {{ report.title }}
+            {% if not report.is_published %}
+              {% pill class="ml-2" text="Not published" variant="primary" %}
+            {% endif %}
+          {% /list_group_item %}
+          {% empty %}
+          {% list_group_empty description="No reports added to this workspace" %}
+          {% endfor %}
+        {% /list_group %}
+      {% /card %}
+
       {% #card title="Monitoring" subtitle="Honeycomb login required" %}
         {% #list_group small=True %}
           {% #list_group_item href=honeycomb_link %}


### PR DESCRIPTION
This lists the reports built on files released to a given workspace.

**Without reports**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/E0uX9x7K/a7e7b44f-50ad-4f32-8011-c52ddb7ac223.jpg?v=36591c8ba06ee48bfe3a4dbae3523aa7)

**With reports**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/yAuJ6djQ/7675ee84-e900-45a1-a99d-871cb2d387d6.jpg?v=7db01d9d5dfc03e583a9e4b29ae64271)

Fix: #2837 