### PR TITLE
Add "view in staff area" button

### DIFF
--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -84,7 +84,14 @@
         {% endif %}
       </div>
     </div>
-
+    {% if user_can_view_staff_area %}
+    <div class="flex lg:justify-end lg:items-start">
+      {% #button href=project.get_staff_url type="link" variant="danger" class="flex-shrink-0" %}
+        View in Staff Area
+        {% icon_lifebuoy_outline class="h-4 w-4 ml-2 -mr-2" %}
+      {% /button %}
+    </div>
+   {% endif %}
     {% if is_member %}
       <div class="flex flex-row mb-6 justify-center lg:mb-0 lg:justify-end lg:items-start gap-2">
         {% if is_interactive_user %}


### PR DESCRIPTION
We're expecting that staff members will want to edit projects quite frequently, so we're adding a convenient button to take them from viewing a project to the related staff area page.

Fixes #2890


![Screenshot from 2023-03-28 16-53-06](https://user-images.githubusercontent.com/3889554/228296958-9e14ae35-5c30-4210-bf01-d2ea73c8ff41.png)
