### PR TITLE
Fix RepoDetail pages with many workspaces

### DIFF
--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -93,7 +93,7 @@ class RepoDetail(View):
             "url": db_repo.url,
         }
 
-    def build_workspaces(self, workspaces, all_users):
+    def build_workspaces(self, workspaces):
         for workspace in workspaces:
             """
             Build a dictionary representation of the Workspace data for the template
@@ -108,7 +108,7 @@ class RepoDetail(View):
             # get the users who created jobs in this workspace or created it,
             # just in case the creator has not run any jobs.
             users = list(
-                all_users.filter(job_requests__workspace=workspace)
+                User.objects.filter(job_requests__workspace=workspace)
                 .distinct()
                 .order_by(Lower("username"), Lower("fullname"))
             )
@@ -138,7 +138,6 @@ class RepoDetail(View):
             .distinct()
             .order_by("name")
         )
-        users = User.objects.filter(job_requests__workspace__in=workspaces).distinct()
 
         num_signed_off = sum(1 for w in workspaces if w.signed_off_at)
 
@@ -149,7 +148,7 @@ class RepoDetail(View):
             "num_signed_off": num_signed_off,
             "projects": projects,
             "repo": self.build_repo(api_repo, repo),
-            "workspaces": list(self.build_workspaces(workspaces, users)),
+            "workspaces": list(self.build_workspaces(workspaces)),
         }
 
         return TemplateResponse(

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -47,6 +47,16 @@ def ran_at(job):
 class RepoDetail(View):
     get_github_api = staticmethod(_get_github_api)
 
+    def build_contacts(self, workspaces):
+        def build_contact(user):
+            return (
+                f"{user.fullname} <{user.notifications_email}>"
+                if user.fullname
+                else user.notifications_email
+            )
+
+        return "; ".join({build_contact(w.created_by) for w in workspaces})
+
     def build_disabled(self, repo, user):
         can_sign_off = has_permission(user, "repo_sign_off_with_outputs")
         return Disabled(
@@ -112,17 +122,8 @@ class RepoDetail(View):
 
         workspaces = [build_workspace(w, users) for w in workspaces]
 
-        def build_contact(user):
-            return (
-                f"{user.fullname} <{user.notifications_email}>"
-                if user.fullname
-                else user.notifications_email
-            )
-
-        contacts = "; ".join({build_contact(w["created_by"]) for w in workspaces})
-
         context = {
-            "contacts": contacts,
+            "contacts": self.build_contacts(workspaces),
             "first_job_ran_at": first_job_ran_at,
             "disabled": self.build_disabled(repo, request.user),
             "last_job_ran_at": last_job_ran_at,

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -65,6 +65,19 @@ class RepoDetail(View):
             not_ready=repo.researcher_signed_off_at is None,
         )
 
+    def build_repo(self, api_repo, db_repo):
+        return {
+            "created_at": api_repo["created_at"],
+            "has_github_outputs": db_repo.has_github_outputs,
+            "internal_signed_off_at": db_repo.internal_signed_off_at,
+            "is_private": api_repo["private"],
+            "get_staff_sign_off_url": db_repo.get_staff_sign_off_url(),
+            "name": db_repo.name,
+            "owner": db_repo.owner,
+            "researcher_signed_off_at": db_repo.researcher_signed_off_at,
+            "url": db_repo.url,
+        }
+
     def get(self, request, *args, **kwargs):
         repo = get_object_or_404(Repo, url=unquote(self.kwargs["repo_url"]))
 
@@ -129,17 +142,7 @@ class RepoDetail(View):
             "last_job_ran_at": last_job_ran_at,
             "num_signed_off": num_signed_off,
             "projects": projects,
-            "repo": {
-                "created_at": api_repo["created_at"],
-                "has_github_outputs": repo.has_github_outputs,
-                "internal_signed_off_at": repo.internal_signed_off_at,
-                "is_private": api_repo["private"],
-                "get_staff_sign_off_url": repo.get_staff_sign_off_url(),
-                "name": repo.name,
-                "owner": repo.owner,
-                "researcher_signed_off_at": repo.researcher_signed_off_at,
-                "url": repo.url,
-            },
+            "repo": self.build_repo(api_repo, repo),
             "twelve_month_limit": twelve_month_limit,
             "workspaces": workspaces,
         }

--- a/templates/staff/repo_detail.html
+++ b/templates/staff/repo_detail.html
@@ -145,20 +145,20 @@
         <div class="card-body mb-0">
           <p>
             <strong>Repo created:</strong>
-            <span title="{{ repo.created_at.isoformat }}">{{ repo.created_at }}</span>
+            <span title="{{ dates.repo_created_at.isoformat }}">{{ dates.repo_created_at }}</span>
           </p>
           <p>
             <strong>Project first job run:</strong>
-            <span title="{{ first_job_ran_at.isoformat }}">{{ first_job_ran_at }}</span>
+            <span title="{{ dates.first_job_ran_at.isoformat }}">{{ dates.first_job_ran_at }}</span>
           </p>
           <p>
             <strong>Project last job run:</strong>
-            <span title="{{ last_job_ran_at.isoformat }}">{{ last_job_ran_at }}</span>
+            <span title="{{ dates.last_job_ran_at.isoformat }}">{{ dates.last_job_ran_at }}</span>
           </p>
           <p>
             <strong>12 month limit:</strong>
-            <span title="{{ twelve_month_limit.isoformat }}">
-              {{ twelve_month_limit|naturalday }}
+            <span title="{{ dates.twelve_month_limit.isoformat }}">
+              {{ dates.twelve_month_limit|naturalday }}
             </span>
           </p>
         </div>


### PR DESCRIPTION
This improves the render time of the staff area's RepoDetail page.  Locally it goes from ~16800ms (43 queries in ~15900ms) to ~875ms (43 queries in ~127ms).  As the final commit details it's double filtering of the users which created a more complex query plan which added the extra time.

We're still doing some O(N) queries when we look up the users for a workspace but I've yet to find a way around those.  Given our data model (arrows are the many side of the relationships):

                    ┌─────────┐
                    │         │
                    │ Project │
                    │         │
                    └────┬────┘
                         │
                         │
                         │
                         │
                         │
     ┌──────┐      ┌─────▼─────┐
     │      │      │           │
     │ Repo ├──────► Workspace │
     │      │      │           │
     └──────┘      └─────┬─────┘
                         │
                         │
                         │
                         │
                         │
                   ┌─────▼──────┐     ┌──────┐
                   │            │     │      │
                   │ JobRequest ◄─────┤ User │
                   │            │     │      │
                   └────────────┘     └──────┘

We're trying to get a set of users who have created a job request for a given workspace, in the QuerySet of all workspaces for the given repo.  We can prefetch this relationship with `prefetch_related("job_requests__created_by")`, but when we come to iterate the workspaces we're still the wrong side of the JobRequest M-1 User relationship.

I've tried to get fancy with something like `Prefetch("job_requests__created_by", to_attr="job_creators")` but the lack of `job_creators` on the workspaces makes me think that isn't working.

Are we happy with a middle ground of speed up and coming back to this later?

Ref: #2894 