### PR TITLE
Include codelists from users in the interactive codelist search

### DIFF
--- a/assets/src/scripts/interactive/components/ComboboxItem.jsx
+++ b/assets/src/scripts/interactive/components/ComboboxItem.jsx
@@ -73,7 +73,10 @@ function ComboboxItem({ codelistGroup, codelistID, query }) {
                   }`}
                 >
                   <div className="flex flex-row gap-1">
-                    <dt>From:</dt> <dd>{codelist.organisation}</dd>
+                    <dt>From:</dt>{" "}
+                    <dd>
+                      {codelist.organisation ? codelist.organisation : "N/A"}
+                    </dd>
                   </div>
                   <div className="flex flex-row gap-1 ml-2 border-l border-l-gray-300 pl-2">
                     <dt>Last updated:</dt>{" "}

--- a/interactive/opencodelists.py
+++ b/interactive/opencodelists.py
@@ -68,6 +68,7 @@ class OpenCodelistsAPI:
         ]
         query_args = {
             "coding_system_id": coding_system,
+            "include-users": True,
         }
         url = self._url(path_segments, query_args)
 


### PR DESCRIPTION
Opencodelists doesn't return a user field from their API so we're setting it to N/A for now, pending something better TBD.

Fix: #2909 