### PR TITLE
Add application URL to staff area's ProjectEdit

### DIFF
--- a/staff/forms.py
+++ b/staff/forms.py
@@ -83,7 +83,26 @@ class ProjectAddMemberForm(PickUsersMixin, RolesForm):
     pass
 
 
-class ProjectCreateForm(forms.Form):
+class ProjectCleanNumberMixin:
+    def clean_number(self):
+        number = self.cleaned_data["number"]
+
+        # We have a constraint ensuring Project.number is unique (ignoring
+        # nulls).  Unfortunately that fires when we save a model, giving us an
+        # IntegrityError.  We have to handle this in the view if we're using a
+        # plain Form, while a ModelForm will put the failure message in the form
+        # instance's non_field_errors unless we manually handle the failure and
+        # attach it to the number field on the form.
+        #
+        # Neither of these are ideal so we're also validating it here so that it
+        # gets attached to the number field on forms using this mixin.
+        if Project.objects.exclude(number=None).filter(number=number).exists():
+            raise forms.ValidationError("Project number must be unique")
+
+        return number
+
+
+class ProjectCreateForm(ProjectCleanNumberMixin, forms.Form):
     application_url = forms.URLField()
     copilot = UserModelChoiceField(
         queryset=User.objects.order_by(Lower("fullname"), "username")
@@ -93,7 +112,7 @@ class ProjectCreateForm(forms.Form):
     org = forms.ModelChoiceField(queryset=Org.objects.order_by("name"))
 
 
-class ProjectEditForm(forms.ModelForm):
+class ProjectEditForm(ProjectCleanNumberMixin, forms.ModelForm):
     class Meta:
         fields = [
             "application_url",

--- a/staff/forms.py
+++ b/staff/forms.py
@@ -108,13 +108,14 @@ class ProjectEditForm(forms.ModelForm):
         ]
         model = Project
 
-    def __init__(self, users, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.fields["number"].required = False
 
-        users = users.order_by(Lower("username"))
-        self.fields["copilot"] = UserModelChoiceField(queryset=users, required=False)
+        self.fields["copilot"] = UserModelChoiceField(
+            queryset=User.objects.order_by(Lower("username")), required=False
+        )
         self.fields["copilot_support_ends_at"].required = False
 
 

--- a/staff/forms.py
+++ b/staff/forms.py
@@ -96,21 +96,23 @@ class ProjectCreateForm(forms.Form):
 class ProjectEditForm(forms.ModelForm):
     class Meta:
         fields = [
-            "name",
-            "slug",
-            "number",
+            "application_url",
             "copilot",
-            "copilot_support_ends_at",
             "copilot_notes",
+            "copilot_support_ends_at",
+            "name",
+            "number",
+            "org",
+            "slug",
             "status",
             "status_description",
-            "org",
         ]
         model = Project
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.fields["application_url"].required = False
         self.fields["number"].required = False
 
         self.fields["copilot"] = UserModelChoiceField(

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -226,7 +226,8 @@ class ProjectEdit(UpdateView):
         # components yet so doing this here is a bit of a hack because we can't
         # construct dicts in a template
         return super().get_context_data(**kwargs) | {
-            "extra_field_attributes": {"type": "number"},
+            "application_url_attributes": {"type": "url"},
+            "number_attributes": {"type": "number"},
         }
 
 

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -229,11 +229,6 @@ class ProjectEdit(UpdateView):
             "extra_field_attributes": {"type": "number"},
         }
 
-    def get_form_kwargs(self):
-        return super().get_form_kwargs() | {
-            "users": User.objects.all(),
-        }
-
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
 class ProjectFeatureFlags(TemplateView):

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -1,6 +1,5 @@
 from django.contrib import messages
-from django.core.exceptions import ValidationError
-from django.db import IntegrityError, transaction
+from django.db import transaction
 from django.db.models import Q
 from django.db.models.functions import Lower
 from django.shortcuts import get_object_or_404, redirect
@@ -120,18 +119,6 @@ class ProjectCreate(CreateView):
                 None,
                 "An error occurred when trying to create the required Repo on GitHub",
             )
-            return self.form_invalid(form)
-        except IntegrityError as e:
-            if "unique_number_ignore_null" not in str(e.__cause__):
-                raise  # pragma: no cover
-
-            # We have a constraint ensuring Project.number is unique (ignoring
-            # nulls).  This catches failures of that constraint and attaches it
-            # to the number field of the form so it gets displayed next to it
-            # in the UI.
-            # Previously we used a ModelForm for this page but it suffered from
-            # a similar issue, putting this error into non_field_errors.
-            form.add_error("number", ValidationError("Project number must be unique"))
             return self.form_invalid(form)
 
         project_detail = project.get_staff_url()

--- a/templates/staff/project_edit.html
+++ b/templates/staff/project_edit.html
@@ -45,6 +45,14 @@
       <form class="mb-3" method="POST">
         {% csrf_token %}
 
+        {% if form.non_field_errors %}
+        <ul>
+          {% for error in form.non_field_errors %}
+          <li class="text-danger">{{ error }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
         <fieldset>
           {% include "components/form_text.html" with field=form.name label="Project name" name="name" %}
           {% include "components/form_text.html" with field=form.slug label="URL slug" name="slug" %}

--- a/templates/staff/project_edit.html
+++ b/templates/staff/project_edit.html
@@ -56,7 +56,7 @@
         <fieldset>
           {% include "components/form_text.html" with field=form.name label="Project name" name="name" %}
           {% include "components/form_text.html" with field=form.slug label="URL slug" name="slug" %}
-          {% include "components/form_text.html" with field=form.number label="Project number" name="number" extra_attributes=extra_field_attributes %}
+          {% include "components/form_text.html" with field=form.number label="Project number" name="number" extra_attributes=number_attributes %}
 
           <div class="form-group">
             <label class="font-weight-bold" for="id_org">Org</label>
@@ -76,6 +76,23 @@
             <p class="text-danger">{{ error }}</p>
             {% endfor %}
           </div>
+        </fieldset>
+
+        <hr />
+
+        <fieldset>
+          <legend>Application</legend>
+
+          {% if project.applications.exists %}
+          <p>This project is linked to an application, which cannot be edited here.</p>
+          {% else %}
+          <div class="alert alert-warning" role="alert">
+            If you are looking to link to an application created on this site
+            use the "Find and Link" button on the
+            <a href="{{ project.get_staff_url }}">detail page</a>.
+          </div>
+          {% include "components/form_text.html" with field=form.application_url label="Application URL" name="application_url" extra_attributes=application_url_attributes %}
+          {% endif %}
         </fieldset>
 
         <hr />

--- a/templates/staff/project_edit.html
+++ b/templates/staff/project_edit.html
@@ -45,91 +45,105 @@
       <form class="mb-3" method="POST">
         {% csrf_token %}
 
-        {% include "components/form_text.html" with field=form.name label="Project name" name="name" %}
-        {% include "components/form_text.html" with field=form.slug label="URL slug" name="slug" %}
-        {% include "components/form_text.html" with field=form.number label="Project number" name="number" extra_attributes=extra_field_attributes %}
+        <fieldset>
+          {% include "components/form_text.html" with field=form.name label="Project name" name="name" %}
+          {% include "components/form_text.html" with field=form.slug label="URL slug" name="slug" %}
+          {% include "components/form_text.html" with field=form.number label="Project number" name="number" extra_attributes=extra_field_attributes %}
 
-        <div class="form-group">
-          <label class="font-weight-bold" for="id_org">Org</label>
+          <div class="form-group">
+            <label class="font-weight-bold" for="id_org">Org</label>
 
-          <select id="id_org" name="org" class="form-control">
-            {% for value, label in form.fields.org.choices %}
-            <option
-              value="{{ value }}"
-              {% if form.org.value|stringformat:"s" == value|stringformat:"s" %}selected{% endif %}
-            >
-              {{ label }}
-            </option>
+            <select id="id_org" name="org" class="form-control">
+              {% for value, label in form.fields.org.choices %}
+              <option
+                value="{{ value }}"
+                {% if form.org.value|stringformat:"s" == value|stringformat:"s" %}selected{% endif %}
+              >
+                {{ label }}
+              </option>
+              {% endfor %}
+            </select>
+
+            {% for error in form.org.errors %}
+            <p class="text-danger">{{ error }}</p>
             {% endfor %}
-          </select>
+          </div>
+        </fieldset>
 
-          {% for error in form.org.errors %}
-          <p class="text-danger">{{ error }}</p>
-          {% endfor %}
-        </div>
+        <hr />
 
-        <div class="form-group">
-          <label class="font-weight-bold" for="id_copilot">Co-pilot</label>
+        <fieldset>
+          <legend>Internal co-pilot details</legend>
 
-          <select id="id_copilot" name="copilot" class="form-control">
-            {% for value, label in form.fields.copilot.choices %}
-            <option
-              value="{{ value }}"
-              {% if form.copilot.value == value %}selected{% endif %}
-            >
-              {{ label }}
-            </option>
+          <div class="form-group">
+            <label class="font-weight-bold" for="id_copilot">Co-pilot</label>
+
+            <select id="id_copilot" name="copilot" class="form-control">
+              {% for value, label in form.fields.copilot.choices %}
+              <option
+                value="{{ value }}"
+                {% if form.copilot.value == value %}selected{% endif %}
+              >
+                {{ label }}
+              </option>
+              {% endfor %}
+            </select>
+
+            {% for error in form.copilot.errors %}
+            <p class="text-danger">{{ error }}</p>
             {% endfor %}
-          </select>
+          </div>
 
-          {% for error in form.copilot.errors %}
-          <p class="text-danger">{{ error }}</p>
-          {% endfor %}
-        </div>
+          <div class="form-group">
+            <label class="font-weight-bold" for="id_copilot_support_ends_at">
+              Co-pilot support ends at
+            </label>
 
-        <div class="form-group">
-          <label class="font-weight-bold" for="id_copilot_support_ends_at">
-            Co-pilot support ends at
-          </label>
+            <input
+              type="date"
+              class="form-control"
+              id="id_copilot_support_ends_at"
+              name="copilot_support_ends_at"
+              aria-describedby="{{ name }}HelpBlock"
+              {% if form.copilot_support_ends_at.value %}
+              value="{{ form.copilot_support_ends_at.value|date:"Y-m-d" }}"
+              {% endif %}
+            />
 
-          <input
-            type="date"
-            class="form-control"
-            id="id_copilot_support_ends_at"
-            name="copilot_support_ends_at"
-            aria-describedby="{{ name }}HelpBlock"
-            {% if form.copilot_support_ends_at.value %}
-            value="{{ form.copilot_support_ends_at.value|date:"Y-m-d" }}"
-            {% endif %}
-          />
-
-          {% for error in form.copilot_support_ends_at.errors %}
-          <p class="text-danger">{{ error }}</p>
-          {% endfor %}
-        </div>
-
-        {% include "components/form_textarea.html" with field=form.copilot_notes label="Co-pilot notes" name="copilot_notes" %}
-
-        <div class="form-group">
-          <label class="font-weight-bold" for="id_status">Status</label>
-
-          <select id="id_status" name="status" class="form-control">
-            {% for value, label in form.fields.status.choices %}
-            <option
-              value="{{ value }}"
-              {% if form.status.value|stringformat:"s" == value|stringformat:"s" %}selected{% endif %}
-            >
-              {{ label }}
-            </option>
+            {% for error in form.copilot_support_ends_at.errors %}
+            <p class="text-danger">{{ error }}</p>
             {% endfor %}
-          </select>
+          </div>
 
-          {% for error in form.status.errors %}
-          <p class="text-danger">{{ error }}</p>
-          {% endfor %}
-        </div>
+          {% include "components/form_textarea.html" with field=form.copilot_notes label="Co-pilot notes" name="copilot_notes" %}
+        </fieldset>
 
-        {% include "components/form_textarea.html" with field=form.status_description label="Status description" name="status_description" %}
+        <hr />
+
+        <fieldset>
+          <legend>Internal status</legend>
+
+          <div class="form-group">
+            <label class="font-weight-bold" for="id_status">Status</label>
+
+            <select id="id_status" name="status" class="form-control">
+              {% for value, label in form.fields.status.choices %}
+              <option
+                value="{{ value }}"
+                {% if form.status.value|stringformat:"s" == value|stringformat:"s" %}selected{% endif %}
+              >
+                {{ label }}
+              </option>
+              {% endfor %}
+            </select>
+
+            {% for error in form.status.errors %}
+            <p class="text-danger">{{ error }}</p>
+            {% endfor %}
+          </div>
+
+          {% include "components/form_textarea.html" with field=form.status_description label="Status description" name="status_description" %}
+        </fieldset>
 
         <button class="btn btn-primary" type="submit">
           Save

--- a/tests/unit/staff/test_forms.py
+++ b/tests/unit/staff/test_forms.py
@@ -1,4 +1,4 @@
-from jobserver.models import Backend, Project, User
+from jobserver.models import Backend, Project
 from jobserver.utils import set_from_qs
 from staff.forms import (
     ApplicationApproveForm,
@@ -88,7 +88,6 @@ def test_projecteditform_number_is_not_required():
     project.
     """
     org = OrgFactory()
-    users = User.objects.all()
 
     data = {
         "name": "Test",
@@ -97,10 +96,10 @@ def test_projecteditform_number_is_not_required():
         "status": Project.Statuses.RETIRED,
     }
 
-    form = ProjectEditForm(data=data, users=users)
+    form = ProjectEditForm(data=data)
     assert form.is_valid(), form.errors
 
-    form = ProjectEditForm(data=data | {"number": 123}, users=users)
+    form = ProjectEditForm(data=data | {"number": 123})
     assert form.is_valid(), form.errors
 
 

--- a/tests/unit/staff/test_forms.py
+++ b/tests/unit/staff/test_forms.py
@@ -2,6 +2,7 @@ from jobserver.models import Backend, Project
 from jobserver.utils import set_from_qs
 from staff.forms import (
     ApplicationApproveForm,
+    ProjectCreateForm,
     ProjectEditForm,
     ProjectFeatureFlagsForm,
     ProjectLinkApplicationForm,
@@ -9,7 +10,13 @@ from staff.forms import (
     UserForm,
 )
 
-from ...factories import ApplicationFactory, BackendFactory, OrgFactory, ProjectFactory
+from ...factories import (
+    ApplicationFactory,
+    BackendFactory,
+    OrgFactory,
+    ProjectFactory,
+    UserFactory,
+)
 
 
 def test_applicationapproveform_success():
@@ -101,6 +108,43 @@ def test_projecteditform_number_is_not_required():
 
     form = ProjectEditForm(data=data | {"number": 123})
     assert form.is_valid(), form.errors
+
+
+def test_projectcreateform_with_duplicate_number():
+    copilot = UserFactory()
+    org = OrgFactory()
+    project = ProjectFactory(number=42)
+
+    data = {
+        "org": str(org.pk),
+        "copilot": str(copilot.pk),
+        "application_url": "http://example.com",
+        "name": "Test",
+        "number": project.number,
+    }
+    form = ProjectCreateForm(data=data)
+
+    assert not form.is_valid()
+
+    assert form.errors == {"number": ["Project number must be unique"]}
+
+
+def test_projecteditform_with_duplicate_number():
+    project = ProjectFactory()
+    other_project = ProjectFactory(number=42)
+
+    data = {
+        "name": project.name,
+        "slug": project.slug,
+        "number": other_project.number,
+        "org": str(project.org.pk),
+        "status": project.status,
+    }
+    form = ProjectEditForm(data=data, instance=project)
+
+    assert not form.is_valid()
+
+    assert form.errors == {"number": ["Project number must be unique"]}
 
 
 def test_projectfeatureflagsform_with_unknown_value():


### PR DESCRIPTION
This adds the application URL field to a Project's edit page in the staff area if it's not already linked to an application, including a note on what to do if a user is looking to link the project to an application:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/bLulqy4O/70ca3a8c-3f7b-452b-979d-678a937aa21c.jpg?v=1aaae738209b79b1d8740b3b57cfc8b6)

There's several housekeeping changes here to make the form a little more useable with so many fields, handle duplicate numbers, etc.

Fix: #2888 