### PR TITLE
Clarified wording

### DIFF
--- a/assets/src/scripts/interactive/pages/glossary.jsx
+++ b/assets/src/scripts/interactive/pages/glossary.jsx
@@ -7,11 +7,10 @@ function Glossary() {
 
   return (
     <>
-      <h2 className="text-4xl font-bold mb-6">Request an analysis</h2>
       <div className="prose prose-blue">
         <p className="text-lg">
-          Requesting an Analysis requires you to select two SNOMED CT or dm+d
-          Codelists to compare over time.
+          Requesting an analysis requires you to select two SNOMED CT or dm+d
+          codelists to see how they are used in combination over time.
         </p>
         <p className="text-lg">
           To make sure this is the right tool for you, check that you understand
@@ -100,7 +99,8 @@ function Glossary() {
         <p>
           dm+d codelists can query data related to prescriptions that have been
           issued for medicines or devices, for example: a prescription for
-          Paracetamol 500mg tablets or for Levobunolol 0.5% eye drops.
+          Paracetamol 500mg tablets or for a Salbutamol 100micrograms/dose
+          inhaler.
         </p>
       </div>
 


### PR DESCRIPTION
These are minor changes based on Brian's feedback in Friday's user testing session.

I appreciate we'll probably want to make some larger changes around where the wording sits within the form, but this seemed like an easy start.

Before
![Screenshot from 2023-04-03 13-49-03](https://user-images.githubusercontent.com/3889554/229515136-8cfd71ad-446e-4861-8ebb-22e5b9551b96.png)

![Screenshot from 2023-04-03 13-49-08](https://user-images.githubusercontent.com/3889554/229514840-923e937f-ea37-489b-b603-19fea6531189.png)


After
![Screenshot from 2023-04-03 13-48-26](https://user-images.githubusercontent.com/3889554/229514868-5e38149a-084b-4e7e-8fbb-3c352c20507a.png)
![Screenshot from 2023-04-03 13-48-35](https://user-images.githubusercontent.com/3889554/229514888-dfe84a68-a5fe-44c9-a4d3-5a9304080938.png)

