### PR TITLE
Only link to a user for staff

### DIFF
--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -134,7 +134,11 @@
         {% /description_item %}
 
         {% #description_item stacked=True title="Created by" %}
+          {% if user_can_view_staff_area %}
           {% link href=analysis_request.created_by.get_staff_url text=analysis_request.created_by.fullname %}
+          {% else %}
+          {{ analysis_request.created_by.fullname }}
+          {% endif %}
         {% /description_item %}
 
         {% #description_item stacked=True title="Purpose" %}


### PR DESCRIPTION
We show the creator of analyses on their detail page, but linking to that user in the staff area gives a 404 for non-staff.  This switches the link to just the user's name when the viewer is not a member of staff.