### PR TITLE
Add HTML emails

### DIFF
--- a/applications/emails.py
+++ b/applications/emails.py
@@ -16,5 +16,6 @@ def send_submitted_application_email(email, application):
         sender="notifications@jobs.opensafely.org",
         subject="Thank you for applying to use OpenSAFELY",
         template_name="applications/emails/submission_confirmation.txt",
+        html_template_name="applications/emails/submission_confirmation.html",
         context=context,
     )

--- a/interactive/emails.py
+++ b/interactive/emails.py
@@ -17,5 +17,6 @@ def send_report_uploaded_notification(analysis_request):
         sender="notifications@jobs.opensafely.org",
         subject="Your OpenSAFELY Interactive report is ready to view",
         template_name="emails/notify_report_uploaded.txt",
+        html_template_name="emails/notify_report_uploaded.html",
         context=context,
     )

--- a/jobserver/emails.py
+++ b/jobserver/emails.py
@@ -26,6 +26,7 @@ def send_finished_notification(email, job):
         sender="notifications@jobs.opensafely.org",
         subject=f"{job.status}: [os {workspace_name}] {job.action}",
         template_name="emails/notify_finished.txt",
+        html_template_name="emails/notify_finished.html",
         context=context,
     )
 
@@ -41,6 +42,7 @@ def send_github_login_email(user):
         sender="notifications@jobs.opensafely.org",
         reply_to=["OpenSAFELY Team <team@opensafely.org>"],
         template_name="emails/login_via_github.txt",
+        html_template_name="emails/login_via_github.html",
         context=context,
     )
 
@@ -59,6 +61,7 @@ def send_login_email(user, login_url, timeout_minutes):
         sender="notifications@jobs.opensafely.org",
         reply_to=["OpenSAFELY Team <team@opensafely.org>"],
         template_name="emails/login.txt",
+        html_template_name="emails/login.html",
         context=context,
     )
 
@@ -73,6 +76,7 @@ def send_repo_signed_off_notification_to_researchers(repo):
         sender="notifications@jobs.opensafely.org",
         subject=f"Repo {repo.name} was signed off by {repo.researcher_signed_off_by.name}",
         template_name="emails/notify_researcher_repo_signed_off.txt",
+        html_template_name="emails/notify_researcher_repo_signed_off.html",
         context={"repo": repo},
     )
 
@@ -91,6 +95,7 @@ def send_repo_signed_off_notification_to_staff(repo):
         sender="notifications@jobs.opensafely.org",
         subject=subject,
         template_name="emails/notify_staff_repo_signed_off.txt",
+        html_template_name="emails/notify_staff_repo_signed_off.html",
         context={"repo": repo, "staff_url": staff_url},
     )
 
@@ -110,6 +115,7 @@ def send_welcome_email(user):
         sender="notifications@jobs.opensafely.org",
         reply_to=["OpenSAFELY Team <team@opensafely.org>"],
         template_name="emails/welcome.txt",
+        html_template_name="emails/welcome.html",
         context=context,
     )
 
@@ -121,6 +127,7 @@ def send_token_login_generated_email(user):
         sender="notifications@jobs.opensafely.org",
         reply_to=["OpenSAFELY Team <team@opensafely.org>"],
         template_name="emails/login_token_generated.txt",
+        html_template_name="emails/login_token_generated.html",
     )
 
 
@@ -131,4 +138,5 @@ def send_token_login_used_email(user):
         sender="notifications@jobs.opensafely.org",
         reply_to=["OpenSAFELY Team <team@opensafely.org>"],
         template_name="emails/login_token_used.txt",
+        html_template_name="emails/login_token_used.html",
     )

--- a/jobserver/emails.py
+++ b/jobserver/emails.py
@@ -37,7 +37,7 @@ def send_github_login_email(user):
     }
 
     send(
-        to=user.email,
+        to=user.notifications_email,
         subject="Log into OpenSAFELY",
         sender="notifications@jobs.opensafely.org",
         reply_to=["OpenSAFELY Team <team@opensafely.org>"],
@@ -56,7 +56,7 @@ def send_login_email(user, login_url, timeout_minutes):
     }
 
     send(
-        to=user.email,
+        to=user.notifications_email,
         subject="Log into OpenSAFELY",
         sender="notifications@jobs.opensafely.org",
         reply_to=["OpenSAFELY Team <team@opensafely.org>"],
@@ -110,7 +110,7 @@ def send_welcome_email(user):
     }
 
     send(
-        to=user.email,
+        to=user.notifications_email,
         subject="Welcome to OpenSAFELY",
         sender="notifications@jobs.opensafely.org",
         reply_to=["OpenSAFELY Team <team@opensafely.org>"],

--- a/templates/applications/emails/submission_confirmation.html
+++ b/templates/applications/emails/submission_confirmation.html
@@ -1,0 +1,9 @@
+{% extends "emails/base.html" %}
+
+{% block content %}
+<p>Thank you for applying to use the OpenSAFELY platform.</p>
+
+<p>You can view your <a href="{{ url }}">submitted application here</a>.</p>
+
+<p>We are a very committed, but still small and busy team, so feel free to email us at team@opensafely.org if you haven't had any response after three weeks from the date of application submission.</p>
+{% endblock content %}

--- a/templates/applications/emails/submission_confirmation.txt
+++ b/templates/applications/emails/submission_confirmation.txt
@@ -1,3 +1,6 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
 Thank you for applying to use the OpenSAFELY platform.
 
 You can view your submitted application here:
@@ -5,3 +8,4 @@ You can view your submitted application here:
 {{ url }}
 
 We are a very committed, but still small and busy team, so feel free to email us at team@opensafely.org if you haven't had any response after three weeks from the date of application submission.
+{% endblock content %}

--- a/templates/emails/base.html
+++ b/templates/emails/base.html
@@ -1,0 +1,4 @@
+{% block content %}{% endblock %}
+
+<p>From,</p>
+<p><a href="mailto:team@opensafely.org">The OpenSAFELY Team</a></p>

--- a/templates/emails/base.txt
+++ b/templates/emails/base.txt
@@ -1,0 +1,5 @@
+{% block content %}{% endblock %}
+
+From,
+The OpenSAFELY Team
+team@opensafely.org

--- a/templates/emails/login.html
+++ b/templates/emails/login.html
@@ -1,0 +1,9 @@
+{% extends "emails/base.html" %}
+
+{% block content %}
+<p>We have received a request to log into OpenSAFELY for your account. If you think this was made in error please ignore this email.</p>
+
+<p>Otherwise, please <a href="{{ url }}">click to log in.</p>
+
+<p>This link is valid for {{ timeout_minutes }} minutes.</p>
+{% endblock content %}

--- a/templates/emails/login.txt
+++ b/templates/emails/login.txt
@@ -1,5 +1,9 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
 We have received a request to log into OpenSAFELY for your account. If you think this was made in error please ignore this email.
 
 Otherwise, please click the link below to log in, it is valid for {{ timeout_minutes }} minutes:
 
 {{ url }}
+{% endblock content %}

--- a/templates/emails/login_token_generated.html
+++ b/templates/emails/login_token_generated.html
@@ -1,0 +1,7 @@
+{% extends "emails/base.html" %}
+
+{% block content %}
+<p>A new login token has been generated for your OpenSAFELY account.</p>
+
+<p>If this was not you, please <a href="https://docs.opensafely.org/how-to-get-help/#slack">contact tech-support</a> immediately.</p>
+{% endblock content %}

--- a/templates/emails/login_token_generated.txt
+++ b/templates/emails/login_token_generated.txt
@@ -1,6 +1,9 @@
+{% extends "emails/base.txt" %}
 
+{% block content %}
 A new login token has been generated for your OpenSAFELY account.
 
 If this was not you, please contact tech-support immediately.
 
 https://docs.opensafely.org/how-to-get-help/#slack
+{% endblock content %}

--- a/templates/emails/login_token_used.html
+++ b/templates/emails/login_token_used.html
@@ -1,0 +1,7 @@
+{% extends "emails/base.html" %}
+
+{% block content %}
+<p>A login token was used to login into your OpenSAFELY account.</p>
+
+<p>If this was not you, please <a href="https://docs.opensafely.org/how-to-get-help/#slack">contact tech-support</a> immediately.</p>
+{% endblock content %}

--- a/templates/emails/login_token_used.txt
+++ b/templates/emails/login_token_used.txt
@@ -1,6 +1,9 @@
+{% extends "emails/base.txt" %}
 
+{% block content %}
 A login token was used to login into your OpenSAFELY account.
 
 If this was not you, please contact tech-support immediately.
 
 https://docs.opensafely.org/how-to-get-help/#slack
+{% endblock content %}

--- a/templates/emails/login_via_github.html
+++ b/templates/emails/login_via_github.html
@@ -1,0 +1,9 @@
+{% extends "emails/base.html" %}
+
+{% block content %}
+<p>We have received a request to log into OpenSAFELY for your account. If you think this was made in error please ignore this email.</p>
+
+<p>You registered with OpenSAFELY by using your GitHub account and can click the GitHub button on our login page next time you need to.</p>
+
+<p>Visit our <a href="{{ url }}">login page</a> now to log in with your GitHub account.</p>
+{% endblock content %}

--- a/templates/emails/login_via_github.txt
+++ b/templates/emails/login_via_github.txt
@@ -1,3 +1,6 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
 We have received a request to log into OpenSAFELY for your account. If you think this was made in error please ignore this email.
 
 You registered with OpenSAFELY by using your GitHub account and can click the GitHub button on our login page next time you need to.
@@ -5,3 +8,4 @@ You registered with OpenSAFELY by using your GitHub account and can click the Gi
 Please use the link below to take you to the login page directly.
 
 {{ url }}
+{% endblock content %}

--- a/templates/emails/notify_finished.html
+++ b/templates/emails/notify_finished.html
@@ -1,0 +1,9 @@
+{% extends "emails/base.html" %}
+
+{% block content %}
+<p>{{ action }} in workspace {{ workspace }} {{ status }} {% if elapsed_time %} after {{ elapsed_time }} seconds {% endif %}with the following message:</p>
+
+<p>{{ status_message }}</p>
+
+<p><a href="{{ url }}">You can view the job here</a></p>
+{% endblock content %}

--- a/templates/emails/notify_finished.txt
+++ b/templates/emails/notify_finished.txt
@@ -1,3 +1,6 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
 {{ action }} in workspace {{ workspace }} {{ status }} {% if elapsed_time %} after {{ elapsed_time }} seconds {% endif %}with the following message:
 
 {{ status_message }}
@@ -5,3 +8,4 @@
 You can view the Job here:
 
 {{ url }}
+{% endblock content %}

--- a/templates/emails/notify_report_uploaded.html
+++ b/templates/emails/notify_report_uploaded.html
@@ -1,0 +1,11 @@
+{% extends "emails/base.html" %}
+
+{% block content %}
+<p>Hi {{ name }},</p>
+
+<p>Your analysis titled "{{ title }}" using OpenSAFELY Interactive has now finished running.</p>
+
+<p><a href="{{ url }}">View the results</a></p>
+
+<p>This report is not publicly accessible and is only viewable when logged into your OpenSAFELY Interactive account. Please only share these results with your immediate team. If you would like to share the report more widely, please send an email to us at <a href="mailto:team@opensafely.org">team@opensafely.org</a></p>
+{% endblock content %}

--- a/templates/emails/notify_report_uploaded.txt
+++ b/templates/emails/notify_report_uploaded.txt
@@ -1,3 +1,6 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
 Hi {{ name }},
 
 Your analysis titled "{{ title }}" using OpenSAFELY Interactive has now finished running. You can view the results at:
@@ -5,3 +8,4 @@ Your analysis titled "{{ title }}" using OpenSAFELY Interactive has now finished
 {{ url }}
 
 This report is not publicly accessible and is only viewable when logged into your OpenSAFELY Interactive account. Please only share these results with your immediate team. If you would like to share the report more widely, please send an email to us at team@opensafely.org
+{% endblock content %}

--- a/templates/emails/notify_researcher_repo_signed_off.html
+++ b/templates/emails/notify_researcher_repo_signed_off.html
@@ -1,0 +1,12 @@
+{% extends "emails/base.html" %}
+
+{% block content %}
+<p>Hello workspace creator,</p>
+
+<p>
+The repository, {{ repo.name }}, has been signed off by {{ repo.researcher_signed_off_by.name }}.
+It will now be reviewed by the OpenSAFELY team and if everything is in order we will mark the repo as public.
+</p>
+
+<p>If you think this has been done in error, please email <a href="mailto:publications@opensafely.org">publications@opensafely.org</a></p>
+{% endblock content %}

--- a/templates/emails/notify_researcher_repo_signed_off.txt
+++ b/templates/emails/notify_researcher_repo_signed_off.txt
@@ -1,3 +1,6 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
 Hello workspace creator,
 
 The repository, {{ repo.name }}, has been signed off by {{ repo.researcher_signed_off_by.name }}.
@@ -6,3 +9,4 @@ It will now be reviewed by the OpenSAFELY team and if everything is in order we 
 If you think this has been done in error, please email publications@opensafely.org
 
 The OpenSAFELY team
+{% endblock content %}

--- a/templates/emails/notify_staff_repo_signed_off.html
+++ b/templates/emails/notify_staff_repo_signed_off.html
@@ -1,0 +1,5 @@
+<p>The repository, {{ repo.name }}, has been signed off by {{ repo.researcher_signed_off_by.name }}.</p>
+
+<p>This historic Github repo contains outputs released from a backend, and needs additional sign off.</p>
+
+<p>You can view the repo, with all relevant details, <a href="{{ staff_url }}">in the staff area</a>.</p>

--- a/templates/emails/project_invite.txt
+++ b/templates/emails/project_invite.txt
@@ -1,5 +1,0 @@
-You have been invited to join the {{ project_name }} project on OpenSAFELY by {{ inviter_name }}.
-
-To accept the invite click the link below:
-
-{{ url }}

--- a/templates/emails/reset_password.txt
+++ b/templates/emails/reset_password.txt
@@ -1,3 +1,6 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
 A request to reset your password has been made.
 
 If you did not make this request then you can safely ignore this email.
@@ -5,3 +8,4 @@ If you did not make this request then you can safely ignore this email.
 Otherwise, please click the link below to reset your password:
 
 {{ url }}
+{% endblock content %}

--- a/templates/emails/welcome.html
+++ b/templates/emails/welcome.html
@@ -1,0 +1,13 @@
+{% extends "emails/base.html" %}
+
+{% block content %}
+<p>Hi {{ name }},</p>
+
+<p>Thank you for your interest in OpenSAFELY.</p>
+
+<p><a href="{{ url }}">Click to finish setting up your account</a></p>
+
+<p>Once you've setup your account, you'll be logged into to the website, {{ domain }}, and taken to the "Request an analysis" page where you can design and request your analysis.</p>
+
+<p>Once your analysis has been run, we will send you an email with instructions on how to view the results.</p>
+{% endblock content %}

--- a/templates/emails/welcome.txt
+++ b/templates/emails/welcome.txt
@@ -1,3 +1,6 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
 Hi {{ name }},
 
 Thank you for your interest in OpenSAFELY.
@@ -9,3 +12,4 @@ Please click on the link to finish setting up your account:
 Once you've setup your account, you'll be logged into to the website, {{ domain }}, and taken to the "Request an analysis" page where you can design and request your analysis.
 
 Once your analysis has been run, we will send you an email with instructions on how to view the results.
+{% endblock content %}


### PR DESCRIPTION
This both adds HTML versions of all emails and a base template for the text emails to help them match the HTML emails.

A few things to check during review:
* Do the base templates' footers make sense/could they contain more information
* Have I typo'd anything in the HTML emails?  I coverted the text emails into HTML but have modified various link sections to use hyperlinks to better suit the medium.

I've tested this locally with my datalab email, do we think that's enough?

Fix: #2786 