### PR TITLE
Remove User.objects.filter_by_role

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -7,8 +7,7 @@ from urllib.parse import quote
 import pydantic
 import structlog
 from django.contrib.auth.hashers import check_password, make_password
-from django.contrib.auth.models import AbstractBaseUser
-from django.contrib.auth.models import UserManager as BaseUserManager
+from django.contrib.auth.models import AbstractBaseUser, UserManager
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import validate_slug
@@ -28,7 +27,6 @@ from xkcdpass import xkcd_password
 
 from ..authorization import InteractiveReporter
 from ..authorization.fields import RolesField
-from ..authorization.utils import strings_to_roles
 from ..hash_utils import hash_user_pat
 from ..runtime import Runtime
 
@@ -757,31 +755,6 @@ class Repo(models.Model):
             raise Exception("Repo URL not in expected format, appears to have no path")
 
         return f
-
-
-class UserQuerySet(models.QuerySet):
-    def filter_by_role(self, role):
-        """
-        Filter the Users by a given Role (class or string)
-
-        Roles are converted to a dotted path and quoted to make sure we filter
-        for a dotted path with surrounding quotes.
-        """
-        if isinstance(role, str):
-            role = strings_to_roles([role])[0]
-
-        return self.filter(roles__contains=[role])
-
-
-class UserManager(BaseUserManager.from_queryset(UserQuerySet), BaseUserManager):
-    """
-    Custom Manager built from the custom QuerySet above
-
-    This exists so we have a concrete Manager which can be serialised in
-    Migrations.
-    """
-
-    pass
 
 
 WORDLIST = xkcd_password.generate_wordlist("eff-long")

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -14,7 +14,7 @@ from social_django.models import UserSocialAuth
 from interactive.commands import create_user
 from jobserver.authorization import roles
 from jobserver.authorization.decorators import require_permission
-from jobserver.authorization.utils import roles_for
+from jobserver.authorization.utils import roles_for, strings_to_roles
 from jobserver.emails import send_welcome_email
 from jobserver.models import Backend, Job, Org, Project, User
 from jobserver.utils import raise_if_not_int
@@ -242,7 +242,8 @@ class UserList(ListView):
             qs = qs.filter(orgs__slug=org)
 
         if role := self.request.GET.get("role"):
-            qs = qs.filter_by_role(role)
+            roles = strings_to_roles([role])
+            qs = qs.filter(roles__contains=roles)
 
         return qs
 

--- a/tests/unit/jobserver/models/test_user.py
+++ b/tests/unit/jobserver/models/test_user.py
@@ -10,8 +10,6 @@ from jobserver.authorization.roles import (
     DataInvestigator,
     InteractiveReporter,
     OrgCoordinator,
-    OutputChecker,
-    OutputPublisher,
     ProjectCollaborator,
     ProjectDeveloper,
 )
@@ -267,23 +265,6 @@ def test_user_valid_pat_with_invalid_token():
     user.rotate_token()
 
     assert not user.has_valid_pat("invalid")
-
-
-def test_userqueryset_success():
-    user1 = UserFactory(roles=[CoreDeveloper, OutputChecker])
-    user2 = UserFactory(roles=[OutputChecker])
-    user3 = UserFactory(roles=[OutputPublisher])
-
-    users = User.objects.filter_by_role(OutputChecker)
-
-    assert user1 in users
-    assert user2 in users
-    assert user3 not in users
-
-
-def test_userqueryset_unknown_role():
-    with pytest.raises(Exception, match="Unknown Roles:.*"):
-        User.objects.filter_by_role("unknown")
 
 
 def test_user_validate_token_login_allowed():


### PR DESCRIPTION
This method existed to wrap converting a role to its dotted path notation and to do a `contains` lookup.  There doesn't seem much utility to this when it requires a custom Manager and QuerySet.

Fix: #2957 