### PR TITLE
Tidy wording of the Interactive welcome email

### DIFF
--- a/templates/emails/login.html
+++ b/templates/emails/login.html
@@ -3,7 +3,7 @@
 {% block content %}
 <p>We have received a request to log into OpenSAFELY for your account. If you think this was made in error please ignore this email.</p>
 
-<p>Otherwise, please <a href="{{ url }}">click to log in.</p>
+<p>Otherwise, please <a href="{{ url }}">click to log in.</a></p>
 
 <p>This link is valid for {{ timeout_minutes }} minutes.</p>
 {% endblock content %}

--- a/templates/emails/welcome.html
+++ b/templates/emails/welcome.html
@@ -3,11 +3,11 @@
 {% block content %}
 <p>Hi {{ name }},</p>
 
-<p>Thank you for your interest in OpenSAFELY.</p>
+<p>Thank you for your interest in OpenSAFELY Interactive.</p>
 
-<p><a href="{{ url }}">Click to finish setting up your account</a></p>
+<p><a href="{{ url }}">Click here to get started.</a></p>
 
-<p>Once you've setup your account, you'll be logged into to the website, {{ domain }}, and taken to the "Request an analysis" page where you can design and request your analysis.</p>
+<p>Clicking on the link will take you to the login page of, <a href="{{ domain }}">{{ domain }}</a>. You'll log in by requesting a one-time link, sent to your email address. Once you're logged in, you'll be taken to the "Request an analysis" page where you can design and request your Interactive analysis.</p>
 
 <p>Once your analysis has been run, we will send you an email with instructions on how to view the results.</p>
 {% endblock content %}

--- a/templates/emails/welcome.txt
+++ b/templates/emails/welcome.txt
@@ -3,13 +3,13 @@
 {% block content %}
 Hi {{ name }},
 
-Thank you for your interest in OpenSAFELY.
+Thank you for your interest in OpenSAFELY Interactive.
 
-Please click on the link to finish setting up your account:
+Please click on the link to get started:
 
 {{ url }}
 
-Once you've setup your account, you'll be logged into to the website, {{ domain }}, and taken to the "Request an analysis" page where you can design and request your analysis.
+Clicking on the link will take you to the login page of {{ domain }}. You'll log in by requesting a one-time link, sent to your email address. Once you're logged in, you'll be taken to the "Request an analysis" page where you can design and request your Interactive analysis.
 
 Once your analysis has been run, we will send you an email with instructions on how to view the results.
 {% endblock content %}


### PR DESCRIPTION
This is the email that users receive when their account is added to Job Server. No more set up is required once it's created, so they should just be able to log in and start an analysis.

I also noticed the one-time link to login didn't have a closing tag in the login.html template, so have added that.