### PR TITLE
Stop passing purpose into AnalysisRequest

### DIFF
--- a/interactive/submit.py
+++ b/interactive/submit.py
@@ -25,6 +25,7 @@ def submit_analysis(
     backend,
     creator,
     project,
+    purpose,
     report_title,
     title,
     force=False,
@@ -44,7 +45,7 @@ def submit_analysis(
         created_by=creator,
         updated_by=creator,
         title=title,
-        purpose=analysis.purpose,
+        purpose=purpose,
         report_title=report_title,
         template_data=asdict(analysis),
     )

--- a/interactive/views.py
+++ b/interactive/views.py
@@ -59,7 +59,6 @@ class AnalysisRequestCreate(View):
             created_by=self.request.user.email,
             demographics=data["demographics"],
             filter_population=data["filter_population"],
-            purpose=data["purpose"],
             repo=project.interactive_workspace.repo.url,
             time_ever=data["time_ever"],
             time_scale=data["time_scale"],
@@ -140,6 +139,7 @@ class AnalysisRequestCreate(View):
             backend=Backend.objects.get(slug="tpp"),
             creator=request.user,
             project=self.project,
+            purpose=form.cleaned_data["purpose"],
             report_title=form.cleaned_data["report_title"],
             title=title,
         )

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -17,7 +17,7 @@ furl
 https://github.com/opensafely-core/pipeline/archive/refs/tags/v0.0.3.zip#egg=opensafely-pipeline
 gunicorn
 incuna-mail
-interactive_templates@https://github.com/opensafely-core/interactive-templates/archive/713d0007a279538a06f7f92357b71edf9686c8dc.zip
+interactive_templates@https://github.com/opensafely-core/interactive-templates/archive/8915f612a97189a1c313d2ac5fde0213d41fa0cf.zip
 itsdangerous
 lxml
 markdown

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -349,8 +349,8 @@ incuna-mail==4.1.1 \
     --hash=sha256:4071949a7cc70f88c1acea5f06ac8ba439029f655ff5d8c98277bbc8cc8d4bd5 \
     --hash=sha256:d8ef4979264fba729fa1478819d71f66af17a795e82d9607d8e7ccd7edaafe10
     # via -r requirements.prod.in
-interactive_templates @ https://github.com/opensafely-core/interactive-templates/archive/713d0007a279538a06f7f92357b71edf9686c8dc.zip \
-    --hash=sha256:665023826603df960cd3057d55dd5d6a289bcb022495f464fa1ef3c43c11bb27
+interactive_templates @ https://github.com/opensafely-core/interactive-templates/archive/8915f612a97189a1c313d2ac5fde0213d41fa0cf.zip \
+    --hash=sha256:d7a3cc984bf8ace025a9436117e82268c18d5c3f16a72f46924c8d3deb283119
     # via -r requirements.prod.in
 itsdangerous==2.1.2 \
     --hash=sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44 \

--- a/tests/unit/interactive/test_submit.py
+++ b/tests/unit/interactive/test_submit.py
@@ -89,7 +89,6 @@ def test_commit_and_push(build_repo, remote_repo, codelist_2, commit_message):
         filter_population="",
         repo=repo,
         id=pk,
-        purpose="",
         time_ever=False,
         time_scale="",
         time_value=1,
@@ -160,7 +159,6 @@ def test_create_commit(remote_repo, add_codelist, force):
         filter_population="",
         repo=str(remote_repo),
         id=pk,
-        purpose="",
         time_ever=False,
         time_scale="",
         time_value=1,
@@ -205,7 +203,6 @@ def test_submit_analysis(remote_repo, add_codelist):
         created_by=user.email,
         demographics=[],
         filter_population="",
-        purpose="test",
         repo=str(remote_repo),
         time_ever=False,
         time_scale="",
@@ -217,6 +214,7 @@ def test_submit_analysis(remote_repo, add_codelist):
         backend=backend,
         creator=user,
         project=project,
+        purpose="test",
         report_title="report title",
         title="analysis title",
     )
@@ -226,6 +224,7 @@ def test_submit_analysis(remote_repo, add_codelist):
     assert analysis_request.project == project
     assert analysis_request.template_data["codelist_1"]["slug"] == "org/slug-a"
     assert analysis_request.template_data["codelist_2"]["slug"] == "org/slug-b"
+    assert analysis_request.purpose == "test"
     assert analysis_request.report_title == "report title"
     assert analysis_request.title == "analysis title"
 


### PR DESCRIPTION
It's not used in the research template so there's no need to pass it into that system.

Ref: opensafely-core/interactive-templates#100