### PR TITLE
Add ability to edit Report title and description.

### DIFF
--- a/interactive/commands.py
+++ b/interactive/commands.py
@@ -47,12 +47,11 @@ def create_report(*, analysis_request, rfile, user):
     report = Report.objects.create(
         project=rfile.workspace.project,
         release_file=rfile,
-        title=analysis_request.title,
-        description="TODO fill from AR",
+        title=analysis_request.report_title,
+        description="",
         created_by=user,
         updated_by=user,
     )
-
     analysis_request.report = report
     analysis_request.save(update_fields=["report"])
 

--- a/interactive/models.py
+++ b/interactive/models.py
@@ -36,7 +36,8 @@ class AnalysisRequest(models.Model):
     purpose = models.TextField()
 
     # we capture this in the form before the analysis is run so we know what to
-    # set report.title to when automatically generating that.
+    # set report.title to when automatically generating that. Once the Report
+    # object exists, this is no longer used
     report_title = models.TextField()
 
     # store the analysis-specific templating context here.  The schema of this

--- a/interactive/urls.py
+++ b/interactive/urls.py
@@ -5,7 +5,7 @@ from jobserver.views.reports import (
     ReportPublishRequestUpdate,
 )
 
-from .views import AnalysisRequestCreate, AnalysisRequestDetail
+from .views import AnalysisReportUpdate, AnalysisRequestCreate, AnalysisRequestDetail
 
 
 app_name = "interactive"
@@ -14,6 +14,7 @@ urlpatterns = [
     path("", AnalysisRequestCreate.as_view(), name="analysis-create"),
     path("<slug:slug>/", AnalysisRequestDetail.as_view(), name="analysis-detail"),
     path("<str:slug>/", AnalysisRequestDetail.as_view(), name="analysis-detail"),
+    path("<str:slug>/update", AnalysisReportUpdate.as_view(), name="report-update"),
     path(
         "<str:slug>/publish/",
         ReportPublishRequestCreate.as_view(),

--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -21,7 +21,7 @@
     {% breadcrumb title="Home" url=home_url %}
     {% breadcrumb title=analysis_request.project.org.name url=analysis_request.project.org.get_absolute_url location="Organisation" %}
     {% breadcrumb title=analysis_request.project.name url=analysis_request.project.get_absolute_url location="Project" %}
-    {% breadcrumb title="View an analysis" active=True %}
+    {% breadcrumb title=analysis_request.title location="Analysis Request" active=True %}
   {% /breadcrumbs %}
 {% endblock breadcrumbs %}
 
@@ -73,6 +73,20 @@
         {% /button %}
       {% endif %}
 
+      {% if not report %}
+        {% #button type="link" variant="primary" disabled=True tooltip="Report has not been processed" %}
+          Update title and summary
+        {% /button %}
+      {% elif object.publish_request %}
+        {% #button type="link" variant="primary" disabled=True tooltip="Cannot edit while publishing review is ongoing" %}
+          Update title and summary
+        {% /button %}
+      {% else %}
+        {% #button type="link" variant="primary" href=update_url %}
+          Update title and summary
+        {% /button %}
+      {% endif %}
+
       {% if report %}
         {% #button type="button" id="downloadBtn" variant="primary" data_title=analysis_request.title %}
           Download report
@@ -110,6 +124,14 @@
 
       {% #card title="Report" container=True class="relative font-lg text-slate-700 xl:col-span-6" header_class="sr-only" %}
         <div class="z-10 relative py-2 prose prose-lg prose-blue mx-auto [&_h1]:hidden !max-w-3xl" id="report">
+          <header id="editable_header">
+          <h2 class="mb-2 text-3xl tracking-tight break-words font-bold text-slate-900 sm:text-4xl">
+            {{ analysis_request.report.title }}
+          </h2>
+          <h3>Description</h3>
+          <p>{{ analysis_request.report.description|linebreaksbr }}</p>
+          </header>
+
           {{ report }}
         </div>
         <div id="watermark" class="hidden absolute inset-0 text-center w-full h-full text-5xl font-bold text-gray-900/10">

--- a/templates/interactive/report_update.html
+++ b/templates/interactive/report_update.html
@@ -1,0 +1,108 @@
+{% extends "base-tw.html" %}
+
+{% load django_vite %}
+{% load humanize %}
+{% load static %}
+
+{% block metatitle %}{{ analysis_request.project.name }} Analysis | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block extra_meta %}
+<meta name="description" content="{{ analysis_request.project.name }} is an OpenSAFELY project from {{ analysis_request.project.org.name }}. Every time a researcher runs their analytic code against patient data, it is audited in public here.">
+{% endblock %}
+
+{% block extra_styles %}
+<link rel="stylesheet" href="{% static 'highlighting.css' %}">
+{% endblock extra_styles %}
+
+{% block breadcrumbs %}
+  {% url "home" as home_url %}
+
+  {% #breadcrumbs %}
+    {% breadcrumb title="Home" url=home_url %}
+    {% breadcrumb title=analysis_request.project.org.name url=analysis_request.project.org.get_absolute_url location="Organisation" %}
+    {% breadcrumb title=analysis_request.project.name url=analysis_request.project.get_absolute_url location="Project" %}
+    {% breadcrumb title=analysis_request.title url=analysis_request.get_absolute_url location="Analysis Request" %}
+    {% breadcrumb title="Edit analysis title and summary" active=True %}
+  {% /breadcrumbs %}
+{% endblock breadcrumbs %}
+
+{% block content %}
+<div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+  <div class="flex flex-col text-center items-center gap-y-2 lg:text-left lg:items-start lg:col-span-full">
+    <div class="flex flex-col items-center gap-y-2 w-full lg:flex-row lg:justify-between lg:items-start">
+      <div class="order-2 w-full lg:mr-auto lg:order-1">
+        <h1 class="mb-2 text-3xl tracking-tight break-words font-bold text-slate-900 sm:text-4xl">
+          Edit analysis title and summary
+        </h1>
+        <dl class="flex flex-col gap-2 text-sm text-slate-600 items-center sm:flex-row sm:gap-x-6 sm:justify-center lg:justify-start">
+          <dt class="sr-only">Organisation:</dt>
+          <dd class="flex flex-row items-start overflow-hidden">
+            {% icon_building_library_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
+            <span class="truncate">{{ analysis_request.project.org.name }}</span>
+          </dd>
+          <dt class="sr-only">Project:</dt>
+          <dd class="flex flex-row items-start overflow-hidden">
+            {% icon_rectangle_stack_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
+            <span class="truncate">{{ analysis_request.project.name }}</span>
+          </dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid gap-6 lg:col-span-3 xl:grid-cols-6" id="reportContainer">
+    {% #card title="Request information" class="xl:col-span-4 xl:col-start-2" header_class="sr-only" %}
+    <dl class="border-t border-slate-200 sm:divide-y sm:divide-slate-200">
+        {% #description_item title="Title" %}
+        {{ analysis_request.title }}
+        {% /description_item %}
+
+        {% #description_item title="Created at" %}
+        {{ analysis_request.created_at }}
+        <time datetime="{{ analysis_request.created_at|date:"Y-m-d H:i:sO" }}"></time>
+        {% /description_item %}
+
+        {% #description_item title="Created by" %}
+        {% if user_can_view_staff_area %}
+        {% link href=analysis_request.created_by.get_staff_url text=analysis_request.created_by.fullname %}
+        {% else %}
+        {{ analysis_request.created_by.fullname }}
+        {% endif %}
+        {% /description_item %}
+
+        {% #description_item title="Purpose" %}
+        {{ analysis_request.purpose }}
+        {% /description_item %}
+    </dl>
+    {% /card %}
+  </div>
+
+  <div class="grid gap-6 lg:col-span-3 xl:grid-cols-6" id="request_form">
+    {% #card title="Update Request Details" container=True class="relative font-lg text-slate-700 xl:col-span-6" header_class="sr-only" %}
+    <form method="POST" class="flex flex-col gap-y-6 items-start">
+        {% csrf_token %}
+        <div className="-mt-2 mb-0.5 text-sm text-gray-700 flex flex-col gap-y-1">
+            <p>This title will be used when the report is made public</p>
+        </div>
+        {% form_input class="w-full max-w-prose" field=form.title %}
+        <div className="-mt-2 mb-0.5 text-sm text-gray-700 flex flex-col gap-y-1">
+          <p>
+            This is a high-level description of the report. It will be part
+            of the final public report, and should summarise the findings and
+            any conclusions drawn or further work needed.
+          </p>
+        </div>
+        {% form_textarea class="w-full max-w-prose" field=form.description resize=True rows=10 %}
+        {% #button type="submit" variant="primary" %}
+        Update Report
+        {% /button %}
+    </form>
+    {% /card %}
+  </div>
+</div>
+
+{% endblock content %}
+
+{% block extra_js %}
+  {% vite_asset "assets/src/scripts/analysis-request-detail.js" %}
+{% endblock %}

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -301,7 +301,9 @@ def test_releaseapi_post_success_for_analysis_request(
 
     job_request = JobRequestFactory(created_by=creating_user)
     analysis_request = AnalysisRequestFactory(
-        created_by=creating_user, job_request=job_request
+        created_by=creating_user,
+        job_request=job_request,
+        report_title="report title",
     )
 
     assert not analysis_request.report
@@ -345,6 +347,8 @@ def test_releaseapi_post_success_for_analysis_request(
 
     analysis_request.refresh_from_db()
     assert analysis_request.report
+    assert analysis_request.report.title == analysis_request.report_title
+    assert analysis_request.report.description == ""
 
 
 def test_releaseapi_post_success_for_html_not_linked_to_an_analysis_request(


### PR DESCRIPTION
* Stores the values in the already existing `Report.title` and
  `Report.description` fields
* Fix: set `Report.title` to be `AnalysisRequest.report_title` that was
  captured via the create form.
* Displays the user supplied title and description at the top of the
  report, and provides new button to edit
