### PR TITLE
Week of latest extract

### DIFF
--- a/interactive/dates.py
+++ b/interactive/dates.py
@@ -40,5 +40,12 @@ def end_date(date) -> date:
     return date.replace(year=new_year, month=new_month, day=day_count)
 
 
+def week_of_latest_extract():
+    last_full_week = date_of_last_extract() - timedelta(weeks=1)
+    monday = last_full_week - timedelta(days=last_full_week.weekday())
+    return monday
+
+
 START_DATE = "2019-09-01"
 END_DATE = end_date(date_of_last_extract()).strftime("%Y-%m-%d")
+WEEK_OF_LATEST_EXTRACT = week_of_latest_extract().strftime("%Y-%m-%d")

--- a/interactive/views.py
+++ b/interactive/views.py
@@ -11,7 +11,7 @@ from jobserver.models import Backend, Project
 from jobserver.reports import process_html
 from jobserver.utils import build_spa_base_url
 
-from .dates import END_DATE, START_DATE
+from .dates import END_DATE, START_DATE, WEEK_OF_LATEST_EXTRACT
 from .forms import AnalysisRequestForm
 from .models import AnalysisRequest
 from .opencodelists import _get_opencodelists_api
@@ -65,6 +65,7 @@ class AnalysisRequestCreate(View):
             time_value=data["time_value"],
             start_date=START_DATE,
             end_date=END_DATE,
+            week_of_latest_extract=WEEK_OF_LATEST_EXTRACT,
         )
 
     def dispatch(self, request, *args, **kwargs):

--- a/tests/unit/interactive/test_dates.py
+++ b/tests/unit/interactive/test_dates.py
@@ -2,7 +2,7 @@ from datetime import date
 
 import pytest
 
-from interactive.dates import date_of_last_extract, end_date
+from interactive.dates import date_of_last_extract, end_date, week_of_latest_extract
 
 
 def test_date_of_last_extract_mon_to_previous_wed(freezer):
@@ -47,3 +47,24 @@ def test_date_of_last_extract_wed_to_previous_wed(freezer):
 )
 def test_end_date(last_extract, expected):
     assert end_date(last_extract) == expected
+
+
+@pytest.mark.parametrize(
+    "today,expected",
+    [
+        (date(2023, 4, 24), date(2023, 4, 3)),
+        (date(2023, 4, 3), date(2023, 3, 13)),
+        (date(2020, 3, 3), date(2020, 2, 17)),
+        (date(2023, 1, 2), date(2022, 12, 12)),
+    ],
+    ids=[
+        "same month",
+        "april -> march",
+        "march -> leap february",
+        "previous year",
+    ],
+)
+def test_week_of_latest_extract(today, expected, freezer):
+    freezer.move_to(today)
+
+    assert week_of_latest_extract() == expected


### PR DESCRIPTION
This calculates the Monday of the week with the most recent complete extract of
data from TPP. This is passed into the Analysis and used to calculate the
number of people with matching events in that week. This number is then shown
on the report (with low number redaction).

Fixes https://github.com/opensafely-core/interactive-templates/issues/17