### PR TITLE
Make next action explicit in issue text

### DIFF
--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -205,6 +205,8 @@ class RepoSignOff(View):
         This repo has been checked and approved by {request.user.name}.
 
         An owner of the `opensafely` org is required to make this change, they can do so on the [repo settings page]({repo.url}/settings).
+
+        Once the repo is public please close this issue.
         """
 
         with transaction.atomic():


### PR DESCRIPTION
This was [explained][1] in the team manual, but it would have helped resolve the uncertainty on my part if it was explicit in the issue text itself.

Incidentally, the ability to do an org-wide Github search for the text I wanted to change without having any idea what system generated it felt like a super-power.

[1]: https://bennettinstitute-team-manual.pages.dev/tech-group/tech-support/#making-research-repos-public