### PR TITLE
Fix state handling of values in TextArea component

### DIFF
--- a/assets/src/scripts/interactive/components/CharCount.jsx
+++ b/assets/src/scripts/interactive/components/CharCount.jsx
@@ -1,7 +1,11 @@
-import { number } from "prop-types";
+import { useFormikContext } from "formik";
+import { number, string } from "prop-types";
 import React from "react";
 
-function CharCount({ current, min, max }) {
+function CharCount({ field, min, max }) {
+  const { values } = useFormikContext();
+  const current = values?.[field].length;
+
   if (current === max) {
     return <p className="text-sm">No characters remaining</p>;
   }
@@ -27,7 +31,7 @@ CharCount.defaultProps = {
 };
 
 CharCount.propTypes = {
-  current: number.isRequired,
+  field: string.isRequired,
   min: number,
   max: number,
 };

--- a/assets/src/scripts/interactive/components/Textarea.jsx
+++ b/assets/src/scripts/interactive/components/Textarea.jsx
@@ -24,8 +24,7 @@ function Textarea({
 
   useEffect(() => {
     setFieldValue(id, values[id] || value);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className={`flex flex-col gap-y-3 text-lg leading-tight ${className}`}>
@@ -49,11 +48,7 @@ function Textarea({
         rows={rows}
       />
       {characterCount && (minlength || maxlength) ? (
-        <CharCount
-          current={values?.[id].length}
-          max={maxlength}
-          min={minlength}
-        />
+        <CharCount field={id} max={maxlength} min={minlength} />
       ) : null}
       {children}
     </div>

--- a/assets/src/scripts/interactive/components/Textarea.jsx
+++ b/assets/src/scripts/interactive/components/Textarea.jsx
@@ -1,6 +1,6 @@
 import { Field, useFormikContext } from "formik";
 import { bool, node, number, string } from "prop-types";
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import CharCount from "./CharCount";
 import HintText from "./HintText";
 
@@ -21,11 +21,11 @@ function Textarea({
   value,
 }) {
   const { setFieldValue, values } = useFormikContext();
-  const [textVal, setTextVal] = useState(values[id] || value);
 
   useEffect(() => {
-    setFieldValue(id, textVal);
-  }, [textVal, id, setFieldValue, value]);
+    setFieldValue(id, values[id] || value);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className={`flex flex-col gap-y-3 text-lg leading-tight ${className}`}>
@@ -44,15 +44,16 @@ function Textarea({
         maxLength={maxlength}
         minLength={minlength}
         name={name}
-        onChange={(e) => setTextVal(e.target.value)}
         placeholder={placeholder}
         required={required}
         rows={rows}
-      >
-        {textVal}
-      </Field>
+      />
       {characterCount && (minlength || maxlength) ? (
-        <CharCount current={textVal.length} max={maxlength} min={minlength} />
+        <CharCount
+          current={values?.[id].length}
+          max={maxlength}
+          min={minlength}
+        />
       ) : null}
       {children}
     </div>


### PR DESCRIPTION
There is currently issues where the state is being updated twice. This causes a users cursor to jump to the end of the text area when they try to edit somewhere in the text area not at the end.

This removes the double-update, and simplifies the character count logic.