### PR TITLE
Add channel to the log context of failed slack messages

### DIFF
--- a/services/slack.py
+++ b/services/slack.py
@@ -28,7 +28,9 @@ def post(text, channel):
         client.chat_postMessage(channel=channel, text=text)
     except SlackApiError:
         # failing to slack is never fatal, so log and do not error
-        logger.exception("Failed to notify slack")
+        logger.exception(
+            f"Failed to notify slack in channel: {channel}", channel=channel
+        )
 
 
 def link(url, text=None):

--- a/tests/unit/services/test_slack.py
+++ b/tests/unit/services/test_slack.py
@@ -25,8 +25,9 @@ def test_post_error(mocker, log_output):
     # check we logged the slack failure
     assert len(log_output.entries) == 1, log_output.entries
     assert log_output.entries[0] == {
+        "channel": "channel",
         "exc_info": True,
-        "event": "Failed to notify slack",
+        "event": "Failed to notify slack in channel: channel",
         "log_level": "error",
     }
 


### PR DESCRIPTION
When we fail to send a slack message Sentry picks up on the exception log we emit, but it doesn't currently have any useful context around what triggered the message or any config.  We expect knowing which channel it was trying to post to will solve that.