### PR TITLE
Stop touching prod requiremnts on every invocation

### DIFF
--- a/justfile
+++ b/justfile
@@ -65,7 +65,6 @@ prodenv: requirements-prod
     # than providing explicit versions. This means we need to uninstall and reinstall the package to pick up any changes.
     # Note: this is not a problem in CI because it is building from a fresh environment each time.
     $PIP uninstall -y interactive_templates
-    touch requirements.prod.in
 
     # --no-deps is recommended when using hashes, and also worksaround a bug with constraints and hashes.
     # https://pip.pypa.io/en/stable/topics/secure-installs/#do-not-use-setuptools-directly


### PR DESCRIPTION
This removed caching from our stack.  This was triggering our _compile target inside requirements-prod on every invocation.  However without it we will still do the right thing with interactive_templates (and other deps) because any changes to requirements.prod.in will trigger a recompile, updating requirements.prod.txt, meaning we run the uninstall line above this change and then run install on the pinned deps.