### PR TITLE
Notify copilots of publish request

### DIFF
--- a/interactive/issues.py
+++ b/interactive/issues.py
@@ -1,7 +1,7 @@
-import textwrap
-
 from django.conf import settings
 from furl import furl
+
+from jobserver.utils import strip_whitespace
 
 
 def create_output_checking_request(job_request, github_api):
@@ -40,7 +40,7 @@ def create_output_checking_request(job_request, github_api):
     The HTML report contains all relevant data, so the individual CSVs and images do NOT need to be released.
     """
 
-    body = textwrap.dedent(body.strip("\n"))
+    body = strip_whitespace(body)
 
     return github_api.create_issue(
         org="ebmdatalab",

--- a/interactive/issues.py
+++ b/interactive/issues.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from furl import furl
 
 
-def notify_output_checkers(job_request, github_api):
+def create_output_checking_request(job_request, github_api):
     workspace_url = furl(settings.BASE_URL) / job_request.workspace.get_absolute_url()
 
     # handle newlines in purpose so we can use dedent on it later

--- a/interactive/slacks.py
+++ b/interactive/slacks.py
@@ -4,8 +4,7 @@ Functions for specific slack messages jobserver sends.
 These functions should always take a `channel` argument, so that we can test
 them on a different channel.
 """
-import textwrap
-
+from jobserver.utils import strip_whitespace
 from services import slack
 
 
@@ -28,7 +27,7 @@ def notify_analysis_request_submitted(analysis_request, channel="interactive-req
     {analysis_url}
     """
 
-    message = textwrap.dedent(message.strip())
+    message = strip_whitespace(message)
 
     slack.post(message, channel)
 
@@ -60,6 +59,6 @@ def notify_report_uploaded(analysis_request, channel="interactive-requests"):
     {analysis_url}
     """
 
-    message = textwrap.dedent(message.strip())
+    message = strip_whitespace(message)
 
     slack.post(message, channel)

--- a/jobserver/api/jobs.py
+++ b/jobserver/api/jobs.py
@@ -13,7 +13,7 @@ from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from interactive.notifications import notify_output_checkers
+from interactive import issues
 from interactive.slacks import notify_tech_support_of_failed_analysis
 from jobserver.api.authentication import get_backend_from_token
 from jobserver.emails import send_finished_notification
@@ -218,7 +218,7 @@ def handle_job_notifications(request, job_request, job):
 def handle_job_request_notifications(job_request, status, github_api):
     if hasattr(job_request, "analysis_request"):
         if status == "succeeded":
-            notify_output_checkers(job_request, github_api)
+            issues.create_output_checking_request(job_request, github_api)
 
         if status == "failed":
             notify_tech_support_of_failed_analysis(job_request)

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -285,7 +285,7 @@ class ReleaseWorkspaceAPI(APIView):
         # Current osrelease workflow should not create a Github issues, so allow that to be supressed
         # Note: this is broken and spamming issues, so comment out for now
         # if request.headers.get("Suppress-Github-Issue") is None:  # pragma: no cover
-        #   releases.create_github_issue(release, self.get_github_api())
+        #   issues.create_output_checking_request(release, self.get_github_api())
 
         body = {
             "release_id": str(release.id),

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -2,6 +2,7 @@ import json
 from datetime import UTC, datetime
 
 import requests
+from django.conf import settings
 from environs import Env
 from furl import furl
 
@@ -186,6 +187,15 @@ class GitHubAPI:
         return
 
     def create_issue(self, org, repo, title, body, labels):
+        if settings.DEBUG:  # pragma: no cover
+            print("")
+            print(f"Repo: https://github.com/{org}/{repo}/")
+            print(f"Title: {title}")
+            print("Message:")
+            print(body)
+            print("")
+            return {"html_url": "http://example.com"}
+
         path_segments = [
             "repos",
             org,

--- a/jobserver/issues.py
+++ b/jobserver/issues.py
@@ -1,0 +1,85 @@
+import textwrap
+
+from django.conf import settings
+from furl import furl
+
+
+def _size_formatter(value):
+    """
+    Format the value, in bytes, with a size suffix
+
+    Kilobytes (Kb) and Megabytes (Mb) will be automatically selected if the
+    values is large enough.
+    """
+    if value < 1024:
+        return f"{value}b"
+
+    if value < 1024**2:
+        value = round(value / 1024, 2)
+        return f"{value}Kb"
+
+    value = round(value / 1024**2, 2)
+    return f"{value}Mb"
+
+
+def create_output_checking_request(release, github_api):
+    is_internal = release.created_by.orgs.filter(slug="datalab").exists()
+
+    files = release.files.all()
+    number = len(files)
+    size = _size_formatter(sum(f.size for f in files))
+    review_form = "" if is_internal else "[Review request form]()"
+
+    base_url = furl(settings.BASE_URL)
+    release_url = base_url / release.get_absolute_url()
+    requester_url = base_url / release.created_by.get_staff_url()
+    workspace_url = base_url / release.workspace.get_absolute_url()
+
+    body = f"""
+    Requested by: [{release.created_by.name}]({requester_url})
+    Release: [{release.id}]({release_url})
+    GitHub repo: [{release.workspace.repo.name}]({release.workspace.repo.url})
+    Workspace: [{release.workspace.name}]({workspace_url})
+
+    {number} files have been selected for review, with a total size of {size}.
+
+    {review_form}
+
+    **When you start a review please react to this message with :eyes:. When you have completed your review add a :thumbsup:. Once two reviews have been completed and a response has been sent to the requester, please close the issue.**
+    """
+
+    body = textwrap.dedent(body.strip("\n"))
+
+    data = github_api.create_issue(
+        org="ebmdatalab",
+        repo="opensafely-output-review",
+        title=release.workspace.name,
+        body=body,
+        labels=["internal" if is_internal else "external"],
+    )
+
+    return data["html_url"]
+
+
+def create_switch_repo_to_public_request(repo, user, github_api):
+    body = f"""
+    The [{repo.name}]({repo.url}) repo is ready to be made public.
+
+    This repo has been checked and approved by {user.name}.
+
+    An owner of the `opensafely` org is required to make this change, they can do so on the [repo settings page]({repo.url}/settings).
+
+    Once the repo is public please close this issue.
+    """
+
+    body = textwrap.dedent(body.strip("\n"))
+
+    data = github_api.create_issue(
+        org="ebmdatalab",
+        repo="tech-support",
+        title=f"Switch {repo.name} repo to public",
+        body=body,
+        labels=[],
+    )
+
+    return data["html_url"]

--- a/jobserver/issues.py
+++ b/jobserver/issues.py
@@ -1,7 +1,7 @@
-import textwrap
-
 from django.conf import settings
 from furl import furl
+
+from .utils import strip_whitespace
 
 
 def _size_formatter(value):
@@ -48,7 +48,7 @@ def create_output_checking_request(release, github_api):
     **When you start a review please react to this message with :eyes:. When you have completed your review add a :thumbsup:. Once two reviews have been completed and a response has been sent to the requester, please close the issue.**
     """
 
-    body = textwrap.dedent(body.strip("\n"))
+    body = strip_whitespace(body)
 
     data = github_api.create_issue(
         org="ebmdatalab",
@@ -72,7 +72,7 @@ def create_switch_repo_to_public_request(repo, user, github_api):
     Once the repo is public please close this issue.
     """
 
-    body = textwrap.dedent(body.strip("\n"))
+    body = strip_whitespace(body)
 
     data = github_api.create_issue(
         org="ebmdatalab",

--- a/jobserver/issues.py
+++ b/jobserver/issues.py
@@ -22,6 +22,70 @@ def _size_formatter(value):
     return f"{value}Mb"
 
 
+def create_copilot_publish_report_request(publish_request, github_api):
+    copilot_name = publish_request.report.project.copilot
+    if not copilot_name:
+        copilot_name = ""
+
+    base_url = furl(settings.BASE_URL)
+    project_url = base_url / publish_request.report.project.get_staff_url()
+    report_url = base_url / publish_request.report.get_absolute_url()
+
+    body = f"""
+    ### Report details
+    Copilot: {copilot_name}
+    Project: {project_url}
+    Report: {report_url}
+
+    ### Checklist
+
+    1. Co-pilot carries out assurance checks[^1]
+        - [ ] Assurance check (co-pilot)
+          - [ ] Do the results of the project match the original aims of the application?
+          - [ ] Are the results COPI compliant?
+          - [ ] Are the analysis and discussion focused on a COVID-19 related theme?
+          - [ ] Have non COVID-19 related inferences been made, and how extensive are they?
+          - [ ] Are all assumptions about the study population/data appropriate and reasonable?
+          - [ ] Have the authors interpreted the results appropriately? (There is a risk that these users will not be sufficiently experienced to judge if the quality of the GP data will be good enough to answer their questions. We have agreed to mitigate this risk by checking their reports carefully before publication.)
+          - [ ] Are all necessary limitations included?
+          - [ ] Are all recommendations appropriate and reasonable?
+          - [ ] Is there any contentious or politically sensitive content?
+          - [ ] Are NHSE or any other organisations likely to want the right to reply?
+    2. If required[^2], co-pilot shares the manuscript with Ops Team[^3] and Amir.
+        - [ ] Ops Team review (Ops Team member)
+        - [ ] IG review (@amirmehrkar)
+        - [ ] Co-pilot corresponds with pilot regarding changes. To make a change, the co-pilot must reject the current request and ask the user to make edits and then re-submit the request.
+
+    ** Steps 2-4 are repeated as required to meet assurance checks **
+
+    3. Co-pilot downloads a copy of the report and submits to Amir, who will prompt IG review with NHSE
+        - [ ] Report submitted to Amir for NHSE review
+    4. Amir informs co-pilot of decision (accept/reject)
+    5. Co-pilot publishes the report or rejects the request by following this process [link to new process(es) once written]
+        - [ ] Published
+        - [ ] Rejected
+    6. Upon publication, co-pilot should consider if project status10 should be updated, and if any external outputs should be linked to in the status description
+        - [ ] Project status updated
+
+
+    [^1]: Further details regarding what is included in an assurance check is available [here](https://bennettinstitute-team-manual.pages.dev/products/publication-process-copiloted/#assurance-check).
+    [^2]: If the assurance check raises any issues.
+    [^3]: Further information about the Ops Team is available [here](https://bennettinstitute-team-manual.pages.dev/the-teams/ops-team/).
+    """
+
+    body = strip_whitespace(body)
+
+    data = github_api.create_issue(
+        org="ebmdatalab",
+        repo="publications-copiloted",
+        title="Publication checklist for projects copiloted by the Bennett Institute",
+        body=body,
+        labels=["publication-copiloted"],
+    )
+
+    return data["html_url"]
+
+
 def create_output_checking_request(release, github_api):
     is_internal = release.created_by.orgs.filter(slug="datalab").exists()
 

--- a/jobserver/slacks.py
+++ b/jobserver/slacks.py
@@ -1,12 +1,17 @@
-"""Functions for  specific slack messages jobserver sends.
+"""
+Functions for  specific slack messages jobserver sends.
 
-
-These functions should always take a `channel` argument, so that we can test them on a different channel.
+These functions should always take a `channel` argument, so that we can test
+them on a different channel.
 """
 
+from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturalday
+from furl import furl
 
 from services import slack
+
+from .utils import strip_whitespace
 
 
 def notify_github_release(
@@ -122,3 +127,21 @@ def notify_copilots_of_repo_sign_off(repo, channel="co-pilot-support"):
     message.append(f"Copilot: {copilot_link}")
 
     slack.post(text="\n".join(message), channel=channel)
+
+
+def notify_copilots_of_publish_request(
+    publish_request, issue_url, channel="co-pilot-support"
+):
+    report_url = furl(settings.BASE_URL) / publish_request.report.get_absolute_url()
+
+    message = f"""
+    *Request to publish a report*
+    By: {publish_request.created_by.email}
+    GitHub Issue: {issue_url}
+
+    {report_url}
+    """
+
+    message = strip_whitespace(message)
+
+    slack.post(text=message, channel=channel)

--- a/jobserver/utils.py
+++ b/jobserver/utils.py
@@ -1,3 +1,4 @@
+import textwrap
 from urllib.parse import urlparse
 
 from django.core.exceptions import BadRequest
@@ -39,6 +40,23 @@ def raise_if_not_int(value):
         int(value)
     except ValueError:
         raise BadRequest
+
+
+def strip_whitespace(text):
+    """
+    Strip various whitespace from text
+
+    When we create messages, for example for GitHub Issues or Slack, we use
+    triple quoted strings so we have a template like structure.  Because of the
+    way triple-quoted strings work we end up with a leading newline, and `\n
+    ` at the end of the string.  This function strips all of that away while
+    allowing us to have readable body templates.
+    """
+    text = text.strip("\n")
+
+    text = textwrap.dedent(text)
+
+    return text.strip("\n")
 
 
 def set_from_qs(qs, field="pk"):

--- a/services/slack.py
+++ b/services/slack.py
@@ -18,8 +18,8 @@ client = WebClient(token=slack_token)
 def post(text, channel):
     if settings.DEBUG:  # pragma: no cover
         print("")
-        print(f"channel: {channel}")
-        print("")
+        print(f"Channel: {channel}")
+        print("Message:")
         print(text)
         print("")
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 import structlog
+from attrs import define
 from django.conf import settings
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.backends.db import SessionStore
@@ -254,3 +255,27 @@ def token_login_user():
     UserSocialAuthFactory(user=user)
     BackendMembershipFactory(user=user, backend=backend)
     return user
+
+
+@pytest.fixture
+def github_api():
+    class CapturingGitHubAPI:
+        issues = []
+
+        def create_issue(self, **kwargs):
+            @define
+            class Issue:
+                org: str
+                repo: str
+                title: str
+                body: str
+                labels: list[str]
+
+            # capture all the values so they can interrogated later
+            self.issues.append(Issue(**kwargs))
+
+            return {
+                "html_url": "http://example.com",
+            }
+
+    return CapturingGitHubAPI()

--- a/tests/unit/interactive/test_issues.py
+++ b/tests/unit/interactive/test_issues.py
@@ -1,26 +1,17 @@
+from first import first
+
 from interactive.issues import create_output_checking_request
 
 from ...factories import AnalysisRequestFactory, JobRequestFactory
 
 
-def test_create_output_checking_request():
+def test_create_output_checking_request(github_api):
     job_request = JobRequestFactory()
     AnalysisRequestFactory(job_request=job_request, purpose="important\n\nresearch")
 
-    class CapturingAPI:
-        def create_issue(self, org, repo, title, body, labels):
-            # capture all the values so they can interrogated later
-            self.org = org
-            self.repo = repo
-            self.title = title
-            self.body = body
-            self.labels = labels
+    create_output_checking_request(job_request, github_api)
 
-    issue = CapturingAPI()
-
-    create_output_checking_request(job_request, issue)
-
-    lines = issue.body.split("\n")
+    lines = first(github_api.issues).body.split("\n")
 
     assert lines[0] == "### GitHub repo"
     assert lines[1] == job_request.workspace.repo.url

--- a/tests/unit/interactive/test_issues.py
+++ b/tests/unit/interactive/test_issues.py
@@ -1,9 +1,9 @@
-from interactive.notifications import notify_output_checkers
+from interactive.issues import create_output_checking_request
 
 from ...factories import AnalysisRequestFactory, JobRequestFactory
 
 
-def test_notify_output_checkers():
+def test_create_output_checking_request():
     job_request = JobRequestFactory()
     AnalysisRequestFactory(job_request=job_request, purpose="important\n\nresearch")
 
@@ -18,7 +18,7 @@ def test_notify_output_checkers():
 
     issue = CapturingAPI()
 
-    notify_output_checkers(job_request, issue)
+    create_output_checking_request(job_request, issue)
 
     lines = issue.body.split("\n")
 

--- a/tests/unit/jobserver/api/test_jobs.py
+++ b/tests/unit/jobserver/api/test_jobs.py
@@ -385,8 +385,8 @@ def test_jobapiupdate_notifications_on_without_move_to_completed(api_rf, mocker)
     mocked_send_finished = mocker.patch(
         "jobserver.api.jobs.send_finished_notification", autospec=True
     )
-    mocked_notify_output_checkers = mocker.patch(
-        "jobserver.api.jobs.notify_output_checkers", autospec=True
+    mocked_create_output_checking_request = mocker.patch(
+        "jobserver.api.jobs.issues.create_output_checking_request", autospec=True
     )
 
     data = [
@@ -413,7 +413,7 @@ def test_jobapiupdate_notifications_on_without_move_to_completed(api_rf, mocker)
     response = JobAPIUpdate.as_view(get_github_api=FakeGitHubAPI)(request)
 
     mocked_send_finished.assert_not_called()
-    mocked_notify_output_checkers.assert_not_called()
+    mocked_create_output_checking_request.assert_not_called()
     assert response.status_code == 200
 
 

--- a/tests/unit/jobserver/test_issues.py
+++ b/tests/unit/jobserver/test_issues.py
@@ -1,0 +1,79 @@
+from django.conf import settings
+
+from jobserver.issues import _size_formatter, create_output_checking_request
+
+from ...factories import OrgFactory, OrgMembershipFactory, UserFactory
+
+
+def test_size_formatter_bytes():
+    assert _size_formatter(0) == "0b"
+    assert _size_formatter(742) == "742b"
+
+
+def test_size_formatter_kilobytes():
+    assert _size_formatter(1024) == "1.0Kb"
+    assert _size_formatter(1400) == "1.37Kb"
+
+
+def test_size_formatter_megabytes():
+    assert _size_formatter(1048576) == "1.0Mb"
+    assert _size_formatter(1600000) == "1.53Mb"
+
+
+def test_create_github_issue_external_success(build_release_with_files):
+    release = build_release_with_files(["file1.txt", "graph.png"])
+
+    class CapturingAPI:
+        def create_issue(self, org, repo, title, body, labels):
+            # capture all the values so they can interrogated later
+            self.org = org
+            self.repo = repo
+            self.title = title
+            self.body = body
+            self.labels = labels
+
+    issue = CapturingAPI()
+
+    create_output_checking_request(release, github_api=issue)
+
+    assert issue.title == release.workspace.name
+
+    # check we have URLs to everything
+    assert settings.BASE_URL in issue.body
+    assert release.created_by.get_staff_url() in issue.body
+    assert release.get_absolute_url() in issue.body
+    assert release.workspace.get_absolute_url() in issue.body
+
+    # check dedent worked as expected
+    assert not issue.body.startswith(" "), issue.body
+
+
+def test_create_github_issue_internal_success(build_release_with_files):
+    org = OrgFactory(slug="datalab")
+    user = UserFactory()
+    OrgMembershipFactory(org=org, user=user)
+    release = build_release_with_files(["file1.txt", "graph.png"], created_by=user)
+
+    class CapturingAPI:
+        def create_issue(self, org, repo, title, body, labels):
+            # capture all the values so they can interrogated later
+            self.org = org
+            self.repo = repo
+            self.title = title
+            self.body = body
+            self.labels = labels
+
+    issue = CapturingAPI()
+
+    create_output_checking_request(release, github_api=issue)
+
+    assert issue.title == release.workspace.name
+
+    # check we have URLs to everything
+    assert settings.BASE_URL in issue.body
+    assert release.created_by.get_staff_url() in issue.body
+    assert release.get_absolute_url() in issue.body
+    assert release.workspace.get_absolute_url() in issue.body
+
+    # check dedent worked as expected
+    assert not issue.body.startswith(" ")

--- a/tests/unit/jobserver/test_releases.py
+++ b/tests/unit/jobserver/test_releases.py
@@ -4,7 +4,6 @@ import zipfile
 from datetime import timedelta
 
 import pytest
-from django.conf import settings
 from django.db import DatabaseError
 from django.utils import timezone
 from rest_framework.exceptions import NotFound
@@ -14,8 +13,6 @@ from jobserver.models import ReleaseFile
 from jobserver.models.outputs import absolute_file_path
 from tests.factories import (
     BackendFactory,
-    OrgFactory,
-    OrgMembershipFactory,
     ReleaseFileFactory,
     UserFactory,
     WorkspaceFactory,
@@ -110,65 +107,6 @@ def test_build_outputs_zip_with_missing_files(build_release_with_files):
             rfile = files.get(name=name)
             assert rfile.get_absolute_url() in zipped_contents, zipped_contents
             assert "This file was redacted by" in zipped_contents, zipped_contents
-
-
-def test_create_github_issue_external_success(build_release_with_files):
-    release = build_release_with_files(["file1.txt", "graph.png"])
-
-    class CapturingAPI:
-        def create_issue(self, org, repo, title, body, labels):
-            # capture all the values so they can interrogated later
-            self.org = org
-            self.repo = repo
-            self.title = title
-            self.body = body
-            self.labels = labels
-
-    issue = CapturingAPI()
-
-    releases.create_github_issue(release, github_api=issue)
-
-    assert issue.title == release.workspace.name
-
-    # check we have URLs to everything
-    assert settings.BASE_URL in issue.body
-    assert release.created_by.get_staff_url() in issue.body
-    assert release.get_absolute_url() in issue.body
-    assert release.workspace.get_absolute_url() in issue.body
-
-    # check dedent worked as expected
-    assert not issue.body.startswith(" ")
-
-
-def test_create_github_issue_internal_success(build_release_with_files):
-    org = OrgFactory(slug="datalab")
-    user = UserFactory()
-    OrgMembershipFactory(org=org, user=user)
-    release = build_release_with_files(["file1.txt", "graph.png"], created_by=user)
-
-    class CapturingAPI:
-        def create_issue(self, org, repo, title, body, labels):
-            # capture all the values so they can interrogated later
-            self.org = org
-            self.repo = repo
-            self.title = title
-            self.body = body
-            self.labels = labels
-
-    issue = CapturingAPI()
-
-    releases.create_github_issue(release, github_api=issue)
-
-    assert issue.title == release.workspace.name
-
-    # check we have URLs to everything
-    assert settings.BASE_URL in issue.body
-    assert release.created_by.get_staff_url() in issue.body
-    assert release.get_absolute_url() in issue.body
-    assert release.workspace.get_absolute_url() in issue.body
-
-    # check dedent worked as expected
-    assert not issue.body.startswith(" ")
 
 
 def test_create_release_new_style_reupload():
@@ -353,21 +291,6 @@ def test_serve_file(rf):
 
     with pytest.raises(NotFound):
         releases.serve_file(request, rfile)
-
-
-def test_size_formatter_bytes():
-    assert releases.size_formatter(0) == "0b"
-    assert releases.size_formatter(742) == "742b"
-
-
-def test_size_formatter_kilobytes():
-    assert releases.size_formatter(1024) == "1.0Kb"
-    assert releases.size_formatter(1400) == "1.37Kb"
-
-
-def test_size_formatter_megabytes():
-    assert releases.size_formatter(1048576) == "1.0Mb"
-    assert releases.size_formatter(1600000) == "1.53Mb"
 
 
 def test_workspace_files_no_releases():

--- a/tests/unit/jobserver/test_utils.py
+++ b/tests/unit/jobserver/test_utils.py
@@ -1,6 +1,12 @@
 from jobserver.authorization import OutputChecker
 from jobserver.models import Job
-from jobserver.utils import build_spa_base_url, dotted_path, is_safe_path, set_from_qs
+from jobserver.utils import (
+    build_spa_base_url,
+    dotted_path,
+    is_safe_path,
+    set_from_qs,
+    strip_whitespace,
+)
 
 from ...factories import JobFactory
 
@@ -22,6 +28,16 @@ def test_is_safe_path_with_safe_path():
 
 def test_is_safe_path_with_unsafe_path():
     assert not is_safe_path("https://steal-your-bank-details.com/")
+
+
+def test_strip_whitespace():
+    text = """
+    testing text
+    """
+
+    output = strip_whitespace(text)
+
+    assert output == "testing text"
 
 
 def test_set_from_qs():


### PR DESCRIPTION
This creates a GitHub issue and related Slack message when a user requests a report is published.

There are several code improvements that sprung up as part of this:
* Organise the functions which create GitHub issues into `issues.py` modules, matching how we handle emails and slacks.
* Add a `github_api` fixture for capturing calls to an API instance for use in tests, similar to how the `slack_messages` fixture works (h/t to @bloodearnest for this one!)
* Fix and refactor the whitespace removal code we use for GitHub issues and slacks into a utility function.
* Print issue contents when working locally (DEBUG=True)

Fix: #3011 