### PR TITLE
Detect OSI Reports created via management command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 htmlcov
 jobserver.dump
 node_modules/
+workspaces
 releases
 staticfiles
 uploads

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -314,10 +314,19 @@ This has allowed us some benefits:
 
 
 ## Interactive Testing
-To help us build out interactive functionality in this project the `add_osi_report` management command has been added.
+Job Server uses the interactive-templates repo code, imported as a Python package, to run OS Interactive analyses and to generate reports.
 
-This takes a username of an existing user and sets up various objects to generate an Analysis with a related Report.
+To facilitate local testing, the `osi_run` Django management command has been created to produce a report from an Analysis Request. It's used like this:
 
+`python manage.py osi_run <analysis-request-slug>`
+
+The resulting report is output into the `workspaces` directory and can be released, so that it's visible within Job Server, using the `osi_release` management command:
+
+`python manage.py osi_release <analysis-request-slug> <user-name>`
+
+These two actions can be combined using the `osi_run_and_release` management command.
+
+`python manage.py osi_run_and_release <analysis-request-slug> <user-name>`
 
 ## Dumping co-pilot reporting data
 Co-pilots [have a report](https://github.com/ebmdatalab/copiloting/tree/copiloting-report) they run every few months, building on data from this service.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -320,13 +320,17 @@ To facilitate local testing, the `osi_run` Django management command has been cr
 
 `python manage.py osi_run <analysis-request-slug>`
 
-The resulting report is output into the `workspaces` directory and can be released, so that it's visible within Job Server, using the `osi_release` management command:
+The resulting HTML report is output into the `workspaces` directory and can be released, so that it's visible within Job Server, using the `osi_release` management command:
 
-`python manage.py osi_release <analysis-request-slug> <user-name>`
+`python manage.py osi_release <analysis-request-slug> <user-name> --report workspaces/<analysis-request-pk>/report.html`
 
-These two actions can be combined using the `osi_run_and_release` management command.
+These two actions can be combined using the `osi_run_and_release` management command:
 
 `python manage.py osi_run_and_release <analysis-request-slug> <user-name>`
+
+Alternatively, the `osi_release` command can be used without running an analysis first, for fast development, using a fake report:
+
+`python manage.py osi_release <analysis-request-slug> <user-name>`
 
 ## Dumping co-pilot reporting data
 Co-pilots [have a report](https://github.com/ebmdatalab/copiloting/tree/copiloting-report) they run every few months, building on data from this service.

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -75,12 +75,14 @@ def is_interactive_report(rfile):
     """
 
     path = Path(rfile.name)
-    if len(path.parts) != 3:
+    if (
+        len(path.parts) == 3
+        and path.parts[0] == "output"
+        and path.parts[2] == "report.html"
+    ):
+        identifier = path.parts[1]
+    else:
         return
-    if not (path.parts[0] == "output" or path.parts[2] == "report.html"):
-        return
-
-    identifier = path.parts[1]
 
     return AnalysisRequest.objects.filter(pk=identifier).first()
 

--- a/jobserver/management/commands/osi_release.py
+++ b/jobserver/management/commands/osi_release.py
@@ -1,6 +1,7 @@
 import hashlib
 import sys
 from datetime import UTC, datetime
+from pathlib import Path
 
 import requests
 from django.conf import settings
@@ -65,6 +66,13 @@ class Command(BaseCommand):
             help="Analysis request slug to link the released file to",
         )
         parser.add_argument("username", help="User to release the file under")
+        parser.add_argument(
+            "--report",
+            "-r",
+            type=Path,
+            default=f"{settings.BASE_DIR}/outputs/interactive_report.html",
+            help="Specify the report file to release. This is usually the output of osi_run.py. Defaults to a local fake report",
+        )
 
     def handle(self, *args, **options):
         username = options["username"]
@@ -83,10 +91,8 @@ class Command(BaseCommand):
 
         tpp = Backend.objects.get(slug="tpp")
 
+        local_file = options["report"]
         release_filename = f"output/{analysis_request.pk}/report.html"
-        local_file = (
-            settings.BASE_DIR / "workspaces" / analysis_request.pk / "report.html"
-        )
 
         release_id = create_release(
             backend=tpp,

--- a/jobserver/management/commands/osi_run.py
+++ b/jobserver/management/commands/osi_run.py
@@ -34,11 +34,6 @@ class Command(BaseCommand):
 
         repo = analysis_request.project.interactive_workspace.repo
 
-        if repo.url.startswith("https://github.com"):
-            msg = f"This tool only works with local repos, the given repo lives at: {repo.url}"
-            self.stderr.write(self.style.ERROR(msg))
-            sys.exit(1)
-
         with tempfile.TemporaryDirectory(suffix=f"repo-{analysis_request.pk}") as path:
             git("clone", repo.url, path)
 

--- a/jobserver/management/commands/osi_run.py
+++ b/jobserver/management/commands/osi_run.py
@@ -1,11 +1,21 @@
+import shutil
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 
 from django.core.management.base import BaseCommand
 
 from interactive.models import AnalysisRequest
 from interactive.submit import git
+
+
+def copy_report(*, from_path, analysis_request):
+    report_path = Path(from_path) / "output" / analysis_request.pk / "report.html"
+    new_path = Path("workspaces") / analysis_request.pk / "report.html"
+    new_path.parent.mkdir(parents=True, exist_ok=True)
+
+    shutil.copy(report_path, new_path)
 
 
 class Command(BaseCommand):
@@ -44,3 +54,5 @@ class Command(BaseCommand):
             self.stdout.write(f"Executing: {' '.join(cmd)}")
 
             subprocess.run(cmd, check=True)
+
+            copy_report(from_path=path, analysis_request=analysis_request)

--- a/jobserver/management/commands/osi_run.py
+++ b/jobserver/management/commands/osi_run.py
@@ -5,9 +5,9 @@ import tempfile
 from pathlib import Path
 
 from django.core.management.base import BaseCommand
+from interactive_templates import git
 
 from interactive.models import AnalysisRequest
-from interactive.submit import git
 
 
 def copy_report(*, from_path, analysis_request):

--- a/jobserver/management/commands/osi_run_and_release.py
+++ b/jobserver/management/commands/osi_run_and_release.py
@@ -11,7 +11,12 @@ class Command(BaseCommand):
         parser.add_argument("username", help="User to release the file under")
 
     def handle(self, *args, **options):
+        analysis_request_pk = options["analysis_request_slug"].split("-")[-1]
+        report = f"workspaces/{analysis_request_pk}/report.html"
         call_command("osi_run", options["analysis_request_slug"])
         call_command(
-            "osi_release", options["analysis_request_slug"], options["username"]
+            "osi_release",
+            options["analysis_request_slug"],
+            options["username"],
+            report=report,
         )

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -68,6 +68,14 @@ def test_is_interactive_report_no_match():
     )
 
 
+def test_is_interactive_report_matches():
+    AnalysisRequestFactory.create(id="foo")
+    assert (
+        is_interactive_report(ReleaseFileFactory(name="output/foo/report.html"))
+        is not None
+    )
+
+
 def test_releaseapi_get_unknown_release(api_rf):
     request = api_rf.get("/")
 


### PR DESCRIPTION
This is still a work in progress, but happy to get feedback at this point.

A few questions still outstanding
* I couldn't see a way to get reports from osi_run into osi_release without copying them into a local directory. I don't know if there's a better way? If not, then the directory probably needs renaming to something more sensible.
* Is the sample report, `outputs/interactive_report.html`, still needed if we're keeping reports from osi_run around? I think I need to understand more about people's current development process..