### PR TITLE
Use a set to avoid different ordering of users

### DIFF
--- a/tests/unit/jobserver/test_emails.py
+++ b/tests/unit/jobserver/test_emails.py
@@ -97,7 +97,7 @@ def test_send_repo_signed_off_notification_to_researchers(mailoutbox):
     m = mailoutbox[0]
 
     assert list(m.to) == ["notifications@jobs.opensafely.org"]
-    assert list(m.bcc) == [user1.email, user2.email, user3.email]
+    assert set(m.bcc) == {user1.email, user2.email, user3.email}
 
 
 def test_send_repo_signed_off_notification_to_staff(mailoutbox):


### PR DESCRIPTION
We're not ordering the users in the query inside `send_repo_signed_off_notificationto_researchers` so this uses a set to ignore the order we have them in our test db.