### PR TITLE
Fix various snapshot views

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -217,7 +217,7 @@ def validate_snapshot_access(request, snapshot):
 
     This validation uses Django's regular User auth.
     """
-    if snapshot.published_at:
+    if snapshot.is_published:
         return
 
     if request.user.is_anonymous:
@@ -438,10 +438,6 @@ class SnapshotAPI(APIView):
             pk=self.kwargs["snapshot_id"],
         )
 
-        # grab whether the Snapshot has been published so we can annotate a
-        # static value to each ReleaseFile in the query below.
-        is_published = snapshot.published_at is not None
-
         validate_snapshot_access(request, snapshot)
         files = {
             f.name: f
@@ -452,7 +448,7 @@ class SnapshotAPI(APIView):
                 "workspace",
                 "workspace__project",
                 "workspace__project__org",
-            ).annotate(is_published=Value(is_published))
+            ).annotate(is_published=Value(snapshot.is_published))
         }
 
         return Response(generate_index(files))

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -87,7 +87,9 @@ class PublishedSnapshotFile(View):
         """Return the content of a specific ReleaseFile which has been published"""
         rfile = get_object_or_404(ReleaseFile, id=self.kwargs["file_id"])
 
-        is_published = rfile.snapshots.exclude(published_at=None).exists()
+        is_published = rfile.snapshots.filter(
+            publish_requests__decision=SnapshotPublishRequest.Decisions.APPROVED
+        ).exists()
         if not is_published:
             raise Http404
 

--- a/templates/workspace_output_list.html
+++ b/templates/workspace_output_list.html
@@ -84,7 +84,7 @@
                   {% if user_can_view_all_files %}
                     <dt class="sr-only">Status:</dt>
                     <dd class="ml-auto flex-shrink-0">
-                      {% if snapshot.published_at %}
+                      {% if snapshot.is_published %}
                         {% pill variant="success" text="Published" %}
                       {% else %}
                         {% pill variant="warning" text="Draft" %}

--- a/tests/integration/test_release_api_access.py
+++ b/tests/integration/test_release_api_access.py
@@ -1,16 +1,26 @@
 from django.urls import reverse
 from django.utils import timezone
 
-from ..factories import SnapshotFactory, UserFactory, WorkspaceFactory
+from ..factories import (
+    SnapshotFactory,
+    SnapshotPublishRequest,
+    SnapshotPublishRequestFactory,
+    UserFactory,
+    WorkspaceFactory,
+)
 
 
 def test_published_output_access(client, release):
     user = UserFactory()
     workspace = WorkspaceFactory()
-    snapshot = SnapshotFactory(
-        workspace=workspace, published_by=user, published_at=timezone.now()
-    )
+    snapshot = SnapshotFactory(workspace=workspace)
     snapshot.files.set(release.files.all())
+    SnapshotPublishRequestFactory(
+        snapshot=snapshot,
+        decision=SnapshotPublishRequest.Decisions.APPROVED,
+        decision_at=timezone.now(),
+        decision_by=UserFactory(),
+    )
 
     response = client.get(snapshot.get_api_url())
     assert response.status_code == 200

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1003,7 +1003,13 @@ def test_reviewapi_success(api_rf):
 
 
 def test_snapshotapi_published_with_anonymous_user(api_rf, freezer):
-    snapshot = SnapshotFactory(published_by=UserFactory(), published_at=timezone.now())
+    snapshot = SnapshotFactory()
+    SnapshotPublishRequestFactory(
+        snapshot=snapshot,
+        decision=SnapshotPublishRequest.Decisions.APPROVED,
+        decision_at=timezone.now(),
+        decision_by=UserFactory(),
+    )
 
     request = api_rf.get("/")
 
@@ -1035,7 +1041,13 @@ def test_snapshotapi_published_with_permission(api_rf):
 
 
 def test_snapshotapi_published_without_permission(api_rf):
-    snapshot = SnapshotFactory(published_by=UserFactory(), published_at=timezone.now())
+    snapshot = SnapshotFactory()
+    SnapshotPublishRequestFactory(
+        snapshot=snapshot,
+        decision=SnapshotPublishRequest.Decisions.APPROVED,
+        decision_at=timezone.now(),
+        decision_by=UserFactory(),
+    )
 
     request = api_rf.get("/")
     request.user = UserFactory()  # logged in, but no permission

--- a/tests/unit/jobserver/views/test_releases.py
+++ b/tests/unit/jobserver/views/test_releases.py
@@ -109,8 +109,14 @@ def test_projectreleaselist_with_delete_permission(rf, build_release_with_files)
 
 def test_publishedsnapshotfile_success(rf, release):
     rfile = release.files.first()
-    snapshot = SnapshotFactory(published_by=UserFactory(), published_at=timezone.now())
+    snapshot = SnapshotFactory()
     snapshot.files.add(rfile)
+    SnapshotPublishRequestFactory(
+        snapshot=snapshot,
+        decision=SnapshotPublishRequest.Decisions.APPROVED,
+        decision_at=timezone.now(),
+        decision_by=UserFactory(),
+    )
 
     rfile = release.files.first()
 


### PR DESCRIPTION
When moving the existing snapshots/outputs-viewer bits of the codebase over to publish requests a few places were missed.  This moves the remaining uses of Snapshot's published fields to publish requests and the is_published property.

Fix: #3136 