### PR TITLE
Handle extra statuses when listing projects on an org page

### DIFF
--- a/templates/org_detail.html
+++ b/templates/org_detail.html
@@ -55,9 +55,13 @@
                       {% pill sr_only="Status:" variant="warning" text=project.get_status_display %}
                     {% elif project.status == "ongoing" %}
                       {% pill sr_only="Status:" variant="primary" text=project.get_status_display %}
+                    {% elif project.status == "ongoing-and-linked" %}
+                      {% pill sr_only="Status:" variant="primary" text=project.get_status_display %}
                     {% elif project.status == "postponed" %}
                       {% pill sr_only="Status:" variant="danger" text=project.get_status_display %}
-                    {% elif project.status == "completed" %}
+                    {% elif project.status == "completed-and-linked" %}
+                      {% pill sr_only="Status:" variant="success" text=project.get_status_display %}
+                    {% elif project.status == "completed-and-awaiting" %}
                       {% pill sr_only="Status:" variant="success" text=project.get_status_display %}
                     {% endif %}
                   </div>


### PR DESCRIPTION
We added some extra statuses at the end of the signing off repos initiative to very loosely handle some new states we identified as part of moving project state into job-server.

Fix: #3139 