### PR TITLE
require a user is logged in when viewing an AnalysisRequest

### DIFF
--- a/interactive/views.py
+++ b/interactive/views.py
@@ -1,9 +1,11 @@
 import json
 
+from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
+from django.utils.decorators import method_decorator
 from django.views.generic import DetailView, UpdateView, View
 from interactive_templates.schema import Codelist, v2
 
@@ -176,6 +178,7 @@ class AnalysisRequestCreate(View):
         )
 
 
+@method_decorator(login_required, name="dispatch")
 class AnalysisRequestDetail(DetailView):
     context_object_name = "analysis_request"
     model = AnalysisRequest

--- a/tests/unit/interactive/test_views.py
+++ b/tests/unit/interactive/test_views.py
@@ -1,6 +1,8 @@
 import json
 
 import pytest
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 
@@ -152,6 +154,23 @@ def test_analysisrequestdetail_success(rf):
     )
 
     assert response.status_code == 200
+
+
+def test_analysisrequestdetail_unauthorized(rf):
+    analysis_request = AnalysisRequestFactory()
+
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    response = AnalysisRequestDetail.as_view()(
+        request,
+        org_slug=analysis_request.project.org.slug,
+        project_slug=analysis_request.project.slug,
+        slug=analysis_request.slug,
+    )
+
+    assert response.status_code == 302
+    assert response.url == f"{settings.LOGIN_URL}?next=/"
 
 
 def test_analysisrequestdetail_with_global_interactivereporter(rf):


### PR DESCRIPTION
While this isn't necessary thanks to our permissions check it means that Django will redirect the user away to the login page and bring them back to the correct page when they're done.

Fix: #3028