### PR TITLE
Pass report path as a Path object

### DIFF
--- a/jobserver/management/commands/osi_run_and_release.py
+++ b/jobserver/management/commands/osi_run_and_release.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
@@ -12,7 +14,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         analysis_request_pk = options["analysis_request_slug"].split("-")[-1]
-        report = f"workspaces/{analysis_request_pk}/report.html"
+        report = Path(f"workspaces/{analysis_request_pk}/report.html")
         call_command("osi_run", options["analysis_request_slug"])
         call_command(
             "osi_release",


### PR DESCRIPTION
We're expecting the report path to be a Path instance so when invoking directly we need to pass it in as one.

Fix: #3084 