### PR TITLE
Limit report publish requests

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -481,12 +481,9 @@ class SnapshotCreateAPI(APIView):
         if missing := file_ids - set_from_qs(files):
             raise ParseError(f"Unknown file IDs: {', '.join(missing)}")
 
-        try:
-            publish_request = SnapshotPublishRequest.create_from_files(
-                files=files, user=request.user, workspace=workspace
-            )
-        except Snapshot.DuplicateSnapshotError as e:
-            raise ParseError(str(e))
+        publish_request = SnapshotPublishRequest.create_from_files(
+            files=files, user=request.user, workspace=workspace
+        )
 
         return Response(
             {"url": publish_request.snapshot.get_absolute_url()}, status=201

--- a/jobserver/models/reports.py
+++ b/jobserver/models/reports.py
@@ -220,8 +220,16 @@ class ReportPublishRequest(models.Model):
                 workspace=report.release_file.workspace,
             )
 
+            # There should only ever be one pending publish request for a
+            # Report, enforce that here.
+            latest_publish_request = report.publish_requests.order_by(
+                "-created_at"
+            ).first()
+            if latest_publish_request and latest_publish_request.decision is None:
+                return latest_publish_request
+
             # create a request to publish the report
-            return ReportPublishRequest.objects.create(
+            return cls.objects.create(
                 report=report,
                 snapshot_publish_request=snapshot_publish_request,
                 created_by=user,

--- a/jobserver/models/reports.py
+++ b/jobserver/models/reports.py
@@ -262,6 +262,18 @@ class ReportPublishRequest(models.Model):
             kwargs={"pk": self.report.pk, "publish_request_pk": self.pk},
         )
 
+    @property
+    def is_approved(self):
+        return self.decision == self.Decisions.APPROVED
+
+    @property
+    def is_pending(self):
+        return self.decision is None
+
+    @property
+    def is_rejected(self):
+        return self.decision == self.Decisions.REJECTED
+
     def reject(self, *, user):
         self.decision_at = timezone.now()
         self.decision_by = user

--- a/jobserver/views/reports.py
+++ b/jobserver/views/reports.py
@@ -27,10 +27,6 @@ class ReportPublishRequestCreate(CreateView):
             slug=self.kwargs["slug"],
         )
 
-        if self.analysis_request.publish_request:
-            messages.error(request, "A request to publish this report already exists")
-            return redirect(self.analysis_request)
-
         if not has_permission(
             self.request.user,
             "analysis_request_view",

--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -57,16 +57,22 @@
     </div>
 
     <div class="flex flex-col mt-2 sm:flex-row gap-2 lg:items-start">
-      {% if not object.publish_request %}
-        {% if report %}
-          {% #button type="link" href=analysis_request.get_publish_url variant="success" %}
-            Publish report
-          {% /button %}
-        {% else %}
-          {% #button type="button" variant="success" disabled=True tooltip="Report has not been processed" %}
-            Publish report
-          {% /button %}
-        {% endif %}
+      {% if not object.report %}
+        {% #button type="button" variant="success" disabled=True tooltip="Report has not been processed" %}
+          Publish report
+        {% /button %}
+      {% elif object.publish_request.is_approved %}
+        {% #button type="button" variant="success" disabled=True tooltip="Report has been approved" %}
+          Publish report
+        {% /button %}
+      {% elif object.publish_request.is_pending %}
+        {% #button type="button" variant="success" disabled=True tooltip="A publishing review is ongoing" %}
+          Publish report
+        {% /button %}
+      {% elif object.publish_request is None or object.publish_request.is_rejected %}
+        {% #button type="link" href=analysis_request.get_publish_url variant="success" %}
+          Publish report
+        {% /button %}
       {% endif %}
 
       {% if not report %}

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1149,10 +1149,8 @@ def test_snapshotcreate_with_existing_snapshot(api_rf, build_release_with_files)
 
     response = SnapshotCreateAPI.as_view()(request, workspace_id=workspace.name)
 
-    assert response.status_code == 400, response.data
-
-    msg = "A release with the current files already exists"
-    assert msg in response.data["detail"], response.data
+    assert response.status_code == 201, response.data
+    assert response.data["url"] == snapshot.get_absolute_url()
 
 
 def test_snapshotcreate_with_permission(api_rf, build_release_with_files):

--- a/tests/unit/jobserver/models/test_outputs.py
+++ b/tests/unit/jobserver/models/test_outputs.py
@@ -253,6 +253,22 @@ def test_releasefilepublishrequest_create_from_files_with_existing_snapshot():
         )
 
 
+def test_releasefilepublishrequest_create_from_files_with_existing_publish_request():
+    workspace = WorkspaceFactory()
+    files = ReleaseFileFactory.create_batch(3, workspace=workspace)
+    snapshot = SnapshotFactory(workspace=workspace)
+    snapshot.files.set(files)
+    user = UserFactory()
+
+    publish_request = SnapshotPublishRequestFactory(snapshot=snapshot, created_by=user)
+
+    output = SnapshotPublishRequest.create_from_files(
+        files=files, user=user, workspace=workspace
+    )
+
+    assert output == publish_request
+
+
 def test_releasefilepublishrequest_create_from_files_with_duplicate_files():
     rfile = ReleaseFileFactory()
     workspace = WorkspaceFactory()

--- a/tests/unit/jobserver/models/test_outputs.py
+++ b/tests/unit/jobserver/models/test_outputs.py
@@ -237,6 +237,22 @@ def test_releasefilepublishrequest_create_from_files_success():
     assert set_from_qs(request.snapshot.files.all()) == {rfile.pk}
 
 
+def test_releasefilepublishrequest_create_from_files_with_existing_snapshot():
+    workspace = WorkspaceFactory()
+    files = ReleaseFileFactory.create_batch(3, workspace=workspace)
+
+    snapshot1 = SnapshotFactory(workspace=workspace)
+    snapshot1.files.set(files)
+
+    snapshot2 = SnapshotFactory(workspace=workspace)
+    snapshot2.files.set(files)
+
+    with pytest.raises(Snapshot.MultipleObjectsReturned):
+        SnapshotPublishRequest.create_from_files(
+            files=files, user=UserFactory(), workspace=workspace
+        )
+
+
 def test_releasefilepublishrequest_create_from_files_with_duplicate_files():
     rfile = ReleaseFileFactory()
     workspace = WorkspaceFactory()
@@ -246,10 +262,11 @@ def test_releasefilepublishrequest_create_from_files_with_duplicate_files():
 
     user = UserFactory()
 
-    with pytest.raises(Snapshot.DuplicateSnapshotError):
-        SnapshotPublishRequest.create_from_files(
-            files=[rfile], user=user, workspace=workspace
-        )
+    publish_request = SnapshotPublishRequest.create_from_files(
+        files=[rfile], user=user, workspace=workspace
+    )
+
+    assert publish_request.snapshot == snapshot
 
 
 @pytest.mark.parametrize("field", ["created_at", "created_by"])

--- a/tests/unit/jobserver/models/test_reports.py
+++ b/tests/unit/jobserver/models/test_reports.py
@@ -171,6 +171,18 @@ def test_reportpublishrequest_create_from_report_success():
     assert request.snapshot_publish_request
 
 
+def test_reportpublishrequest_create_from_report_with_existing_publish_request():
+    report = ReportFactory()
+    AnalysisRequestFactory(report=report)
+    user = UserFactory()
+
+    publish_request = ReportPublishRequestFactory(report=report, created_by=user)
+
+    output = ReportPublishRequest.create_from_report(report=report, user=user)
+
+    assert output == publish_request
+
+
 def test_reportpublishrequest_get_approve_url():
     publish_request = ReportPublishRequestFactory()
 

--- a/tests/unit/jobserver/models/test_reports.py
+++ b/tests/unit/jobserver/models/test_reports.py
@@ -211,6 +211,30 @@ def test_reportpublishrequest_get_reject_url():
     )
 
 
+def test_reportpublishrequest_is_approved():
+    publish_request = ReportPublishRequestFactory(
+        decision=ReportPublishRequest.Decisions.APPROVED,
+        decision_at=timezone.now(),
+        decision_by=UserFactory(),
+    )
+
+    assert publish_request.is_approved
+
+
+def test_reportpublishrequest_is_pending():
+    assert ReportPublishRequestFactory().is_pending
+
+
+def test_reportpublishrequest_is_rejected():
+    publish_request = ReportPublishRequestFactory(
+        decision=ReportPublishRequest.Decisions.REJECTED,
+        decision_at=timezone.now(),
+        decision_by=UserFactory(),
+    )
+
+    assert publish_request.is_rejected
+
+
 def test_reportpublishrequest_reject(freezer):
     request = ReportPublishRequestFactory()
     user = UserFactory()


### PR DESCRIPTION
This updates the UI to allow for having multiple publish requests (missed in #3108) and then limits the UI based on the state of the latest publish request, exposing why to the user with our typical use of hover state.

Things to look out for:
Instead of raising an error when we get a duplicate Snapshot this is now returning that Snapshot.  I couldn't think of a good reason where we'd want to commuicate that back to the user instead of just picking the Snapshot they've asked for.  

The code to do that lookup has changed slightly in an attempt to do a bit more of the lookup in the db, see [this range](https://github.com/opensafely-core/job-server/commit/8529a2c0fa9d432537d35732a66bc9ee90480a1b#diff-5729bca3c56ffaa3482b819ac344adad1e4bb425671e924321b62c5ed2d5c6d8L501-L507).

---

You will likely notice some duplication between ReportPublishRequest and SnapshotPublishRequest.  I have a branch that removes ReportPublishRequest because I realised at BennettCon that we could do away with it (and _obviously_ the best time to madly hack on these types of things is a crowded train).  I wanted to get this and several recent changes in so we can start working on the handover doc for OSI, and to give myself a bit of time to ponder on the change.  Having done that I'm now certain it's the right direction to take.  Knowing that I've not gone to a huge amount of effort to flatten some blocks of code (ie [this](https://github.com/opensafely-core/job-server/commit/8529a2c0fa9d432537d35732a66bc9ee90480a1b#diff-5729bca3c56ffaa3482b819ac344adad1e4bb425671e924321b62c5ed2d5c6d8L501-L507) and [this](https://github.com/opensafely-core/job-server/commit/8529a2c0fa9d432537d35732a66bc9ee90480a1b#diff-5729bca3c56ffaa3482b819ac344adad1e4bb425671e924321b62c5ed2d5c6d8L501-L507)) because I'm planning to tackle them in the PR removing ReportPublishRequest.

Fix: #3154