### PR TITLE
Allow anyone to look at a published report

### DIFF
--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -57,36 +57,38 @@
     </div>
 
     <div class="flex flex-col mt-2 sm:flex-row gap-2 lg:items-start">
-      {% if not object.report %}
-        {% #button type="button" variant="success" disabled=True tooltip="Report has not been processed" %}
-          Publish report
-        {% /button %}
-      {% elif object.publish_request.is_approved %}
-        {% #button type="button" variant="success" disabled=True tooltip="Report has been approved" %}
-          Publish report
-        {% /button %}
-      {% elif object.publish_request.is_pending %}
-        {% #button type="button" variant="success" disabled=True tooltip="A publishing review is ongoing" %}
-          Publish report
-        {% /button %}
-      {% elif object.publish_request is None or object.publish_request.is_rejected %}
-        {% #button type="link" href=analysis_request.get_publish_url variant="success" %}
-          Publish report
-        {% /button %}
-      {% endif %}
+      {% if request.user.is_authenticated %}
+        {% if not object.report %}
+          {% #button type="button" variant="success" disabled=True tooltip="Report has not been processed" %}
+            Publish report
+          {% /button %}
+        {% elif object.publish_request.is_approved %}
+          {% #button type="button" variant="success" disabled=True tooltip="Report has been approved" %}
+            Publish report
+          {% /button %}
+        {% elif object.publish_request.is_pending %}
+          {% #button type="button" variant="success" disabled=True tooltip="A publishing review is ongoing" %}
+            Publish report
+          {% /button %}
+        {% elif object.publish_request is None or object.publish_request.is_rejected %}
+          {% #button type="link" href=analysis_request.get_publish_url variant="success" %}
+            Publish report
+          {% /button %}
+        {% endif %}
 
-      {% if not report %}
-        {% #button type="link" variant="primary" disabled=True tooltip="Report has not been processed" %}
-          Update title and summary
-        {% /button %}
-      {% elif object.report.is_locked %}
-        {% #button type="link" variant="primary" disabled=True tooltip="Cannot edit while publishing review is ongoing" %}
-          Update title and summary
-        {% /button %}
-      {% else %}
-        {% #button type="link" variant="primary" href=analysis_request.get_edit_url %}
-          Update title and summary
-        {% /button %}
+        {% if not report %}
+          {% #button type="link" variant="primary" disabled=True tooltip="Report has not been processed" %}
+            Update title and summary
+          {% /button %}
+        {% elif object.report.is_locked %}
+          {% #button type="link" variant="primary" disabled=True tooltip="Cannot edit while publishing review is ongoing" %}
+            Update title and summary
+          {% /button %}
+        {% else %}
+          {% #button type="link" variant="primary" href=analysis_request.get_edit_url %}
+            Update title and summary
+          {% /button %}
+        {% endif %}
       {% endif %}
 
       {% if report %}

--- a/tests/unit/interactive/test_views.py
+++ b/tests/unit/interactive/test_views.py
@@ -225,6 +225,89 @@ def test_analysisrequestdetail_with_no_interactivereporter_role(rf):
         )
 
 
+def test_analysisrequestdetail_login_redirect_with_different_domain(rf, settings):
+    """
+    Test login code with a different LOGIN_URL
+
+    Django's login_required decorator handles the LOGIN_URL being on a
+    different domain.  We don't currently support that but we don't want to
+    have to remember this one specific view needs updating if we ever did make
+    that change so we've copied the contents of the login_required decorator as
+    is to maintain continuity with views using the decorator as expected.
+    """
+    settings.LOGIN_URL = "http://server/login/"
+
+    project = ProjectFactory()
+    user = UserFactory()
+    ProjectMembershipFactory(project=project, user=user, roles=[InteractiveReporter])
+
+    analysis_request = AnalysisRequestFactory(project=project, created_by=user)
+
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    response = AnalysisRequestDetail.as_view()(
+        request,
+        org_slug=analysis_request.project.org.slug,
+        project_slug=analysis_request.project.slug,
+        slug=analysis_request.slug,
+    )
+
+    assert response.status_code == 302
+    assert response.url == "http://server/login/?next=http%3A//testserver/"
+
+
+def test_analysisrequestdetail_login_redirect_with_normal_settings(rf):
+    project = ProjectFactory()
+    user = UserFactory()
+    ProjectMembershipFactory(project=project, user=user, roles=[InteractiveReporter])
+
+    analysis_request = AnalysisRequestFactory(project=project, created_by=user)
+
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    response = AnalysisRequestDetail.as_view()(
+        request,
+        org_slug=analysis_request.project.org.slug,
+        project_slug=analysis_request.project.slug,
+        slug=analysis_request.slug,
+    )
+
+    assert response.status_code == 302
+    assert response.url == f"{settings.LOGIN_URL}?next=/"
+
+
+def test_analysisrequestdetail_with_published_report(rf):
+    project = ProjectFactory()
+    user = UserFactory()
+    ProjectMembershipFactory(project=project, user=user, roles=[InteractiveReporter])
+
+    report = ReportFactory(title="Testing report")
+    ReportPublishRequestFactory(
+        report=report,
+        decision=ReportPublishRequest.Decisions.APPROVED,
+        decision_at=timezone.now(),
+        decision_by=UserFactory(),
+    )
+
+    analysis_request = AnalysisRequestFactory(
+        project=project, created_by=user, report=report
+    )
+
+    request = rf.get("/")
+    request.user = user
+
+    response = AnalysisRequestDetail.as_view()(
+        request,
+        org_slug=analysis_request.project.org.slug,
+        project_slug=analysis_request.project.slug,
+        slug=analysis_request.slug,
+    )
+
+    assert response.status_code == 200
+
+
 def test_from_codelist():
     data = {
         "first": {


### PR DESCRIPTION
I've switch from overriding `get_object` to `get` because we now need to return respones or redirects based on the user being logged in/out.

The redirect logic has been pulled straight from [Django's `login_required` implementation](https://github.com/django/django/blob/4.1.9/django/contrib/auth/decorators.py#L24-L34) (which is technically a wrapper of `user_passes_test`).  Do the comments on the code and test adequately explain why I've done that?

Fix: #3152