### PR TITLE
Remove the yellow highlighting from text in the PDF download modal

### DIFF
--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -273,7 +273,7 @@
         team (e.g. key members of the relevant scientific advisory groups; relevant
         external expert collaborators) you must ensure the content being shared has
         been reviewed and approved by the senior sponsor and your line manager and
-        <mark>provide your co-pilot with a copy of the content.</mark>
+        provide your co-pilot with a copy of the content.
       </li>
       <li>
         All recipients must be reminded that the content is shared in confidence and


### PR DESCRIPTION
Fix: #3020