### PR TITLE
Fix list of publish requests on AnalysisRequestDetail view

### DIFF
--- a/staff/views/analysis_requests.py
+++ b/staff/views/analysis_requests.py
@@ -22,7 +22,7 @@ class AnalysisRequestDetail(DetailView):
 
     def get_context_data(self, **kwargs):
         publish_requests = (
-            self.object.report.publish_requests if self.object.report else []
+            self.object.report.publish_requests.all() if self.object.report else []
         )
 
         return super().get_context_data(**kwargs) | {


### PR DESCRIPTION
This is a leftover from the refactor to consolidate publish request models.  It was missed because test_analysisrequestdetail_success didn't exercise the if statement in get_context_data.