### PR TITLE
Remove AnalysisRequest.purpose from report page

### DIFF
--- a/templates/interactive/analysis_request_detail.html
+++ b/templates/interactive/analysis_request_detail.html
@@ -120,10 +120,6 @@
             {{ analysis_request.created_by.fullname }}
             {% endif %}
           {% /description_item %}
-
-          {% #description_item title="Purpose" %}
-            {{ analysis_request.purpose }}
-          {% /description_item %}
         </dl>
       {% /card %}
 


### PR DESCRIPTION
Users can only set this when filling in the new AnalysisRequest form so if they don't understand what they're filling in they're then stuck with their response.  Rather than leave them stuck in this position we're removing the field from this page to avoid confusion.

Fix: #3133