### PR TITLE
Expose repo status(es) on the copiloting dashboard

### DIFF
--- a/assets/src/js/copiloting-tablesorter.js
+++ b/assets/src/js/copiloting-tablesorter.js
@@ -20,6 +20,7 @@ $(() => {
         "form-control",
         "form-control",
         "form-control",
+        "form-control",
       ],
     },
   });

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -482,6 +482,31 @@ class GitHubAPI:
                 "topics": topics,
             }
 
+    def get_repos_with_status_and_url(self, orgs):
+        query = """
+        query reposWithStatusAndURL($cursor: String, $org_name: String!) {
+          organization(login: $org_name) {
+            repositories(first: 100, after: $cursor) {
+              nodes {
+                url
+                isPrivate
+              }
+              pageInfo {
+                  endCursor
+                  hasNextPage
+              }
+            }
+          }
+        }
+        """
+        for org in orgs:
+            results = list(self._iter_query_results(query, org_name=org))
+            for repo in results:
+                yield {
+                    "is_private": repo["isPrivate"],
+                    "url": repo["url"],
+                }
+
     def set_repo_topics(self, org, repo, topics):
         path_segments = [
             "repos",

--- a/staff/views/dashboards/copiloting.py
+++ b/staff/views/dashboards/copiloting.py
@@ -1,19 +1,87 @@
 import itertools
 
+import requests
+import structlog
 from csp.decorators import csp_exempt
-from django.db.models import Count, Min
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.db.models import Count, Min, Value
 from django.db.models.functions import Least
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
 from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_role
-from jobserver.models import Project, ReleaseFile
+from jobserver.github import _get_github_api
+from jobserver.models import Project, ReleaseFile, Repo
+
+
+logger = structlog.get_logger(__name__)
+
+
+class MissingGitHubReposError(Exception):
+    pass
+
+
+def build_repos_by_project(projects, get_github_api=_get_github_api):
+    """
+    Build a dict with a list of repos indexed by project PK
+
+    We need to get public/private status from GitHub and we want to do that in
+    as few GraphQL and DB queries as possible.  This function gets all the
+    relevant repos from the db, and from GitHub, and combines them up into a
+    single structure.
+
+    It returns a dict of project PK -> list of relevant repos, pulled from the
+    list of combined ones.
+
+    By building this structure up front we avoid various DB and HTTP queries.
+    """
+    # get all the Repo instances from the db
+    db_repos = Repo.objects.filter(workspaces__project__in=projects).distinct()
+
+    # Get a set of GitHub orgs so the API can pull repo details from each one
+    repo_orgs = {r.owner for r in db_repos}
+
+    try:
+        github_repos = list(get_github_api().get_repos_with_status_and_url(repo_orgs))
+    except requests.HTTPError:
+        # if the GitHub API is down log some details but don't block the page
+        logger.exception(
+            "Failed to get repo status and URL from GitHub API", repo_orgs=repo_orgs
+        )
+        return {}
+
+    # index GitHub repo dicts by URL so they're easier to lookup
+    github_repos_by_url = {r["url"]: r for r in github_repos}
+
+    # sense check that we're not missing any repos from GitHub.  We shouldn't
+    # ever hit this path but it will be a lot easier to debug if we ever do
+    # manage to get into this state.
+    urls = {r.url for r in db_repos}
+    if missing := urls - set(github_repos_by_url.keys()):
+        output = "\n * ".join(missing)
+        raise MissingGitHubReposError(f"Missing repo URLs: {output}")
+
+    # merge the two representations of repo data into a single dict per repo
+    repos = [
+        {
+            "get_staff_url": r.get_staff_url(),
+            "is_private": github_repos_by_url[r.url]["is_private"],
+            "name": r.name,
+            "pk": r.pk,
+        }
+        for r in db_repos
+    ]
+
+    # Filter the repos for each project using the repos_ids we annotated onto
+    # the QuerySet so we get {project_pk: repos} for each project on the page.
+    return {p.pk: [r for r in repos if r["pk"] in p.repo_ids] for p in projects}
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
 @method_decorator(csp_exempt, name="dispatch")
 class Copiloting(TemplateView):
+    get_github_api = staticmethod(_get_github_api)
     template_name = "staff/dashboards/copiloting.html"
 
     def get_context_data(self, **kwargs):
@@ -32,9 +100,12 @@ class Copiloting(TemplateView):
                         "workspaces__job_requests__jobs__created_at",
                     )
                 ),
+                repo_ids=ArrayAgg(
+                    "workspaces__repo_id", default=Value([]), distinct=True
+                ),
             )
+            .prefetch_related("workspaces__repo")
             .order_by("name")
-            .iterator()
         )
 
         release_files_by_project = itertools.groupby(
@@ -48,7 +119,12 @@ class Copiloting(TemplateView):
             p: len(list(files)) for p, files in release_files_by_project
         }
 
-        def iter_projects(projects, file_counts_by_project):
+        repos_by_project = build_repos_by_project(
+            projects=projects,
+            get_github_api=self.get_github_api,
+        )
+
+        def iter_projects(projects, file_counts_by_project, repos_by_project):
             """
             Build a project representation
 
@@ -63,6 +139,7 @@ class Copiloting(TemplateView):
             """
             for project in projects:
                 files_released_count = file_counts_by_project.get(project.pk, 0)
+                repos = repos_by_project.get(project.pk, [])
 
                 yield {
                     "copilot": project.copilot,
@@ -73,13 +150,18 @@ class Copiloting(TemplateView):
                     "name": project.name,
                     "number": project.number,
                     "org": project.org,
+                    "repos": repos,
                     "status": project.get_status_display(),
                     "workspace_count": project.workspace_count,
                 }
 
         projects = list(
             sorted(
-                iter_projects(projects, file_counts_by_project),
+                iter_projects(
+                    projects,
+                    file_counts_by_project,
+                    repos_by_project,
+                ),
                 key=lambda p: p["name"].lower(),
             )
         )

--- a/templates/staff/dashboards/copiloting.html
+++ b/templates/staff/dashboards/copiloting.html
@@ -47,7 +47,8 @@
               <th>Project</th>
               <th>Organisation</th>
               <th>Copilot</th>
-              <th>Status</th>
+              <th>Project status</th>
+              <th>Repo status</th>
               <th class="text-right">Number of workspaces</th>
               <th class="text-right">Number of job requests run</th>
               <th class="text-right">Date of first run job</th>
@@ -72,6 +73,43 @@
                 {% endif %}
               </td>
               <td>{{ project.status }}</td>
+              <td>
+                {% if project.repos|length > 1 %}
+                  <details>
+                    <summary>
+                      <span class="summary--show">Show</span>
+                      <span class="summary--hide">Hide</span>
+                      {{ project.repos|length }} repos
+                    </summary>
+                    <ul class="mt-1 mb-0 pl-2 ml-2">
+                      {% for repo in project.repos %}
+                      <li>
+                        <div class="d-flex">
+                          <a href="{{ repo.get_staff_url }}">
+                            {{ repo.name }}
+                          </a>
+                          <div class="ml-2">
+                            {% if repo.is_private %}
+                            <span class="badge badge-warning">Private</span>
+                            {% else %}
+                            <span class="badge badge-success">Public</span>
+                            {% endif %}
+                          </div>
+                        </div>
+                      </li>
+                      {% endfor %}
+                    </ul>
+                  </details>
+                {% else %}
+                  {% for repo in project.repos %}
+                    {% if repo.is_private %}
+                    <span class="badge badge-warning">Private</span>
+                    {% else %}
+                    <span class="badge badge-success">Public</span>
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
+              </td>
               <td class="text-right">{{ project.workspace_count }}</td>
               <td class="text-right">{{ project.job_request_count }}</td>
               <td class="text-right text-nowrap text-monospace">{{ project.date_first_run|date:"d M Y" }}</td>

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -113,6 +113,30 @@ class FakeGitHubAPI:
             },
         ]
 
+    def get_repos_with_status_and_url(self, orgs):
+        return [
+            {
+                "is_private": True,
+                "url": "https://github.com/opensafely/research-repo-1",
+            },
+            {
+                "is_private": True,
+                "url": "https://github.com/opensafely/research-repo-2",
+            },
+            {
+                "is_private": False,
+                "url": "https://github.com/opensafely/research-repo-3",
+            },
+            {
+                "is_private": True,
+                "url": "https://github.com/opensafely/research-repo-4",
+            },
+            {
+                "is_private": True,
+                "url": "https://github.com/opensafely/research-repo-5",
+            },
+        ]
+
     def set_repo_topics(self, org, repo, topics):
         return {
             "names": [],

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -254,6 +254,15 @@ def test_get_repos_with_dates(enable_network, github_api):
     compare(fake, real)
 
 
+def test_get_repos_with_status_and_url(enable_network, github_api):
+    args = ["opensafely-testing"]
+
+    real = list(github_api.get_repos_with_status_and_url(args))
+    fake = FakeGitHubAPI().get_repos_with_status_and_url(args)
+
+    compare(fake, real)
+
+
 def test_graphql_error_handling(enable_network, github_api):
     """
     Are we raising errors around unexpected GraphQL responses?


### PR DESCRIPTION
This is more complex than it might seem is necessary because we have to get the status for each repo from GitHub so it does all the processing up front to avoid extra HTTP and DB calls.

Fix: #3138