### PR TITLE
Normalise HTMX template tests

### DIFF
--- a/tests/unit/staff/views/test_orgs.py
+++ b/tests/unit/staff/views/test_orgs.py
@@ -89,6 +89,7 @@ def test_orgcreate_get_success(rf, core_developer):
     response = OrgCreate.as_view()(request)
 
     assert response.status_code == 200
+    assert response.template_name == ["staff/org_create.html"]
 
 
 def test_orgcreate_get_htmx_success(rf, core_developer):

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -92,6 +92,18 @@ def test_projectcreate_get_success(rf, core_developer):
     response = ProjectCreate.as_view(get_github_api=FakeGitHubAPI)(request)
 
     assert response.status_code == 200
+    assert response.template_name == ["staff/project_create.html"]
+
+
+def test_projectcreate_get_htmx_success(rf, core_developer):
+    request = rf.get("/")
+    request.htmx = True
+    request.user = core_developer
+
+    response = ProjectCreate.as_view()(request)
+
+    assert response.status_code == 200
+    assert response.template_name == ["staff/project_create.htmx.html"]
 
 
 def test_projectcreate_post_htmx_success_with_next(rf, core_developer):


### PR DESCRIPTION
Add the missing test for the ProjectCreate view and check the template names in the non-HTMX tests.