### PR TITLE
Test all icon tags in our templates are valid tags

### DIFF
--- a/tests/unit/jobserver/test_icons.py
+++ b/tests/unit/jobserver/test_icons.py
@@ -1,0 +1,30 @@
+import itertools
+import re
+from pathlib import Path
+
+
+def test_all_icons(subtests):
+    """Ensure icon tag names defined in templates are valid tags"""
+    templates = [p for p in Path("templates").glob("**/*.html")]
+
+    # remove templates with no icon tag so we can simplify the regex matching
+    # code below
+    icon_templates = [p for p in templates if "{% icon_" in p.read_text()]
+
+    # look for the start of an icon templatetag and capture the full name
+    icon_pat = re.compile(r"{% (icon_[^\s]+)")
+
+    # get a set of icon names in the Django templates
+    icons = set(
+        itertools.chain.from_iterable(
+            icon_pat.search(t.read_text()).groups() for t in icon_templates
+        )
+    )
+
+    # read the component config contents into memory so we don't have to open
+    # it for each icon
+    config = Path("templates/components.yaml").read_text()
+    for icon in icons:
+        # use subtests to avoid failing the test at the first broken icon
+        with subtests.test(icon=icon):
+            assert icon in config


### PR DESCRIPTION
We don't test every template fully renders because of the time penalty rendering templates imposes on the test suite.  The downside of this approach is sometimes there are template-only things which need testing. Typically one of those failures results in a test case where the rendered template is checked.  However, for icons this would place an overhead on frontend/UI development which we don't think is useful.

This test finds every icon tag definition across all our templates, and checks those names are defined in the components configuration file. This is intended to catch spelling mistakes or icon renames.

Tom hit this problem when renaming an icon in #3223 but we didn't want to hold that PR up while I created this test.

---

Something to consider when reviewing: I've not parsed the yaml config so potentially we could have a non-icon component with the `icon_` prefix.  I chose not to handle this case because that is still a valid component name which won't stop template rendering which is what this test is aimed at catching.