### PR TITLE
Fallback to user if a codelist has not organisation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,13 +59,13 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install node_modules
-        run: npm ci --ignore-scripts
+        run: just assets-install --ignore-scripts
 
       - name: Lint assets
         run: npm run lint
 
       - name: Run JS tests
-        run: npm run test:coverage
+        run: just assets-test
 
       - name: Build assets
         run: just assets-build

--- a/assets/src/scripts/interactive/components/ComboboxItem.jsx
+++ b/assets/src/scripts/interactive/components/ComboboxItem.jsx
@@ -75,7 +75,9 @@ function ComboboxItem({ codelistGroup, codelistID, query }) {
                   <div className="flex flex-row gap-1">
                     <dt>From:</dt>{" "}
                     <dd>
-                      {codelist.organisation ? codelist.organisation : "N/A"}
+                      {codelist.organisation
+                        ? codelist.organisation
+                        : codelist.user}
                     </dd>
                   </div>
                   <div className="flex flex-row gap-1 ml-2 border-l border-l-gray-300 pl-2">

--- a/assets/src/scripts/interactive/props/index.js
+++ b/assets/src/scripts/interactive/props/index.js
@@ -4,6 +4,7 @@ export const singleCodelistProps = {
   label: string,
   organisation: string,
   type: string,
+  user: string,
   value: string,
 };
 

--- a/assets/src/scripts/interactive/utils/index.js
+++ b/assets/src/scripts/interactive/utils/index.js
@@ -20,6 +20,7 @@ export function getCodelistPageData(scriptID) {
     label: codelist.name,
     organisation: codelist.organisation,
     type: scriptID.slice(9, scriptID.length - 1),
+    user: codelist.user,
     value: codelist.slug,
     updatedDate: codelist.updated_date,
   }));

--- a/interactive/opencodelists.py
+++ b/interactive/opencodelists.py
@@ -60,6 +60,7 @@ class OpenCodelistsAPI:
                 "name": codelist["name"],
                 "organisation": codelist["organisation"],
                 "updated_date": latest["updated_date"],
+                "user": codelist["user"],
             }
 
     def get_codelists(self, coding_system):

--- a/justfile
+++ b/justfile
@@ -181,7 +181,7 @@ assets-clean:
 
 
 # Install the Node.js dependencies
-assets-install:
+assets-install *args="":
     #!/usr/bin/env bash
     set -eu
 
@@ -189,7 +189,7 @@ assets-install:
     # but we negate with || to avoid error exit code
     test package-lock.json -nt node_modules/.written || exit 0
 
-    npm ci
+    npm ci {{ args }}
     touch node_modules/.written
 
 

--- a/justfile
+++ b/justfile
@@ -232,6 +232,10 @@ assets-run: assets-install
     npm run dev
 
 
+assets-test: assets-install
+    npm run test:coverage
+
+
 # run a local release hatch instance, including adding and configuring a backend to use with it.
 release-hatch:
     ./scripts/local-release-hatch.sh


### PR DESCRIPTION
Fix: #2978

I've also added the `assets-test` recipe to make testing assets more obvious.  ~I didn't upgrade the GHA workflow because the install there has some extra options.~  Just's `*args` to the rescue, I've updated the GHA workflow to install and test the assets via the justfile too.