### PR TITLE
Test the publishing flow

### DIFF
--- a/jobserver/views/reports.py
+++ b/jobserver/views/reports.py
@@ -32,6 +32,19 @@ class PublishRequestCreate(View):
         ):
             raise PermissionDenied
 
+        if self.analysis_request.report.is_locked:
+            publish_request = self.analysis_request.report.publish_requests.order_by(
+                "-created_at"
+            ).first()
+            return TemplateResponse(
+                request,
+                "interactive/publish_request_create_locked.html",
+                context={
+                    "analysis_request": self.analysis_request,
+                    "publish_request": publish_request,
+                },
+            )
+
         return super().dispatch(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):

--- a/templates/interactive/publish_request_create_locked.html
+++ b/templates/interactive/publish_request_create_locked.html
@@ -1,0 +1,78 @@
+{% extends "base-tw.html" %}
+
+{% load humanize %}
+{% load static %}
+
+{% block metatitle %}{{ analysis_request.report.title }} is Locked | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block extra_meta %}
+<meta name="description" content="{{ analysis_request.project.name }} is an OpenSAFELY project from {{ analysis_request.project.org.name }}. Every time a researcher runs their analytic code against patient data, it is audited in public here.">
+{% endblock %}
+
+{% block extra_styles %}
+<link rel="stylesheet" href="{% static 'highlighting.css' %}">
+{% endblock extra_styles %}
+
+{% block breadcrumbs %}
+  {% url "home" as home_url %}
+
+  {% #breadcrumbs %}
+    {% breadcrumb title="Home" url=home_url %}
+    {% breadcrumb title=analysis_request.project.org.name url=analysis_request.project.org.get_absolute_url location="Organisation" %}
+    {% breadcrumb title=analysis_request.project.name url=analysis_request.project.get_absolute_url location="Project" %}
+    {% breadcrumb title=analysis_request.title url=analysis_request.get_absolute_url location="Analysis Request" %}
+    {% breadcrumb title="This report is locked" active=True %}
+  {% /breadcrumbs %}
+{% endblock breadcrumbs %}
+
+{% block content %}
+<div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+  <div class="flex flex-col text-center items-center gap-y-2 lg:text-left lg:items-start lg:col-span-full">
+    <div class="flex flex-col items-center gap-y-2 w-full lg:flex-row lg:justify-between lg:items-start">
+      <div class="order-2 w-full lg:mr-auto lg:order-1">
+        <h1 class="mb-2 text-3xl tracking-tight break-words font-bold text-slate-900 sm:text-4xl">
+          This report is locked
+        </h1>
+        <dl class="flex flex-col gap-2 text-sm text-slate-600 items-center sm:flex-row sm:gap-x-6 sm:justify-center lg:justify-start">
+          <dt class="sr-only">Organisation:</dt>
+          <dd class="flex flex-row items-start overflow-hidden">
+            {% icon_building_library_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
+            <span class="truncate">{{ analysis_request.project.org.name }}</span>
+          </dd>
+          <dt class="sr-only">Project:</dt>
+          <dd class="flex flex-row items-start overflow-hidden">
+            {% icon_rectangle_stack_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
+            <span class="truncate">{{ analysis_request.project.name }}</span>
+          </dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+
+  {% #card class="overflow-hidden relative xl:col-span-4 xl:col-start-1" %}
+    <div class="text-center p-8 z-10 relative">
+      {% icon_lock_closed_solid class="h-12 w-12 mb-4 mx-auto text-slate-600" %}
+      <h2 class="mt-2 mb-3 text-2xl font-bold text-slate-900">
+        This report is currently locked
+      </h2>
+      <div class="grid gap-y-2 max-w-prose mx-auto">
+        {% if publish_request.is_pending %}
+        <p>
+          A request to publish this report is currently awaiting a decision.
+          Further requests to publish the report cannot be created at this
+          time.
+        </p>
+        {% elif publish_request.is_approved %}
+        <p>
+          This report has been published and cannot have further requests to publish it.
+        </p>
+        {% endif %}
+        <p class="text-slate-600 pt-4 mt-2 border-t border-slate-200">
+          If you have any questions,
+          {% link href="mailto:team@opensafely.org" text="contact us" append_after="." %}
+        </p>
+      </div>
+    </div>
+  {% /card %}
+</div>
+{% endblock content %}

--- a/tests/unit/jobserver/views/test_reports.py
+++ b/tests/unit/jobserver/views/test_reports.py
@@ -2,6 +2,7 @@ import pytest
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
+from django.utils import timezone
 
 from jobserver.authorization import InteractiveReporter
 from jobserver.models import PublishRequest
@@ -10,14 +11,19 @@ from jobserver.views.reports import PublishRequestCreate
 from ....factories import (
     AnalysisRequestFactory,
     ProjectFactory,
+    ProjectMembershipFactory,
+    PublishRequestFactory,
+    ReleaseFileFactory,
     ReportFactory,
+    SnapshotFactory,
     UserFactory,
 )
 from ....fakes import FakeGitHubAPI
 
 
 def test_publishrequestcreate_get_success(rf):
-    analysis_request = AnalysisRequestFactory()
+    report = ReportFactory()
+    analysis_request = AnalysisRequestFactory(report=report)
 
     request = rf.get("/")
     request.user = UserFactory(roles=[InteractiveReporter])
@@ -30,6 +36,102 @@ def test_publishrequestcreate_get_success(rf):
     )
 
     assert response.status_code == 200
+
+
+def test_publishrequestcreate_locked_with_approved_decision(rf):
+    project = ProjectFactory()
+    user = UserFactory()
+    ProjectMembershipFactory(project=project, user=user, roles=[InteractiveReporter])
+
+    rfile = ReleaseFileFactory()
+    snapshot = SnapshotFactory()
+    snapshot.files.set([rfile])
+    report = ReportFactory(release_file=rfile)
+    analysis_request = AnalysisRequestFactory(project=project, report=report)
+
+    request = rf.post("/")
+    request.user = UserFactory(roles=[InteractiveReporter])
+
+    PublishRequestFactory(
+        report=report,
+        snapshot=snapshot,
+        decision=PublishRequest.Decisions.APPROVED,
+        decision_at=timezone.now(),
+        decision_by=UserFactory(),
+    )
+
+    request = rf.get("/")
+    request.user = user
+
+    response = PublishRequestCreate.as_view()(
+        request,
+        org_slug=analysis_request.project.org.slug,
+        project_slug=analysis_request.project.slug,
+        slug=analysis_request.slug,
+    )
+
+    assert response.status_code == 200
+    assert response.template_name == "interactive/publish_request_create_locked.html"
+
+
+def test_publishrequestcreate_locked_with_pending_decision(rf):
+    project = ProjectFactory()
+    user = UserFactory()
+    ProjectMembershipFactory(project=project, user=user, roles=[InteractiveReporter])
+
+    rfile = ReleaseFileFactory()
+    snapshot = SnapshotFactory()
+    snapshot.files.set([rfile])
+    report = ReportFactory(release_file=rfile)
+    analysis_request = AnalysisRequestFactory(project=project, report=report)
+
+    PublishRequestFactory(report=report, snapshot=snapshot)
+
+    request = rf.get("/")
+    request.user = user
+
+    response = PublishRequestCreate.as_view()(
+        request,
+        org_slug=analysis_request.project.org.slug,
+        project_slug=analysis_request.project.slug,
+        slug=analysis_request.slug,
+    )
+
+    assert response.status_code == 200
+    assert response.template_name == "interactive/publish_request_create_locked.html"
+
+
+def test_reportedit_unlocked_with_rejected_decision(rf):
+    project = ProjectFactory()
+    user = UserFactory()
+    ProjectMembershipFactory(project=project, user=user, roles=[InteractiveReporter])
+
+    rfile = ReleaseFileFactory()
+    snapshot = SnapshotFactory()
+    snapshot.files.set([rfile])
+    report = ReportFactory(release_file=rfile)
+    analysis_request = AnalysisRequestFactory(project=project, report=report)
+
+    PublishRequestFactory(
+        report=report,
+        snapshot=snapshot,
+        decision=PublishRequest.Decisions.REJECTED,
+        decision_at=timezone.now(),
+        decision_by=UserFactory(),
+    )
+
+    request = rf.get("/")
+    request.user = user
+
+    response = PublishRequestCreate.as_view()(
+        request,
+        org_slug=analysis_request.project.org.slug,
+        project_slug=analysis_request.project.slug,
+        slug=analysis_request.slug,
+    )
+
+    assert response.status_code == 200
+    assert response.template_name == "interactive/publish_request_create.html"
 
 
 def test_publishrequestcreate_post_success(rf, slack_messages):
@@ -99,38 +201,3 @@ def test_publishrequestcreate_unknown_analysis_request(rf):
             project_slug=project.slug,
             slug="",
         )
-
-
-def test_publishrequestcreate_with_existing_publish_request(
-    rf, slack_messages, publish_request_with_report
-):
-    analysis_request = AnalysisRequestFactory(
-        project=publish_request_with_report.workspace.project,
-        report=publish_request_with_report.report,
-    )
-    assert analysis_request.publish_request == publish_request_with_report
-
-    request = rf.post("/")
-    request.user = UserFactory(roles=[InteractiveReporter])
-
-    # set up messages framework
-    request.session = "session"
-    messages = FallbackStorage(request)
-    request._messages = messages
-
-    response = PublishRequestCreate.as_view(get_github_api=FakeGitHubAPI)(
-        request,
-        org_slug=analysis_request.project.org.slug,
-        project_slug=analysis_request.project.slug,
-        slug=analysis_request.slug,
-    )
-
-    assert response.status_code == 302, PublishRequest.objects.count()
-    assert response.url == analysis_request.get_absolute_url()
-
-    # check we have a message for the user
-    messages = list(messages)
-    assert len(messages) == 1
-    assert (
-        str(messages[0]) == "Your request to publish this report was successfully sent"
-    )


### PR DESCRIPTION
Now that publishing is just about considered done and we've documented it, this adds an integration test to codify the flow.

While adding this test I discovered the PublishRequestCreate page doesn't handle a report being locked.  I've mirrored the ReportEdit page's flow, showing a locked template in that situation:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/8LuYjW6D/2c286b9f-530d-4386-8233-7f0a4db3749c.jpg?v=6a04196dafd3499f37b80038b8ed612a)