### PR TITLE
Update issue template content

### DIFF
--- a/jobserver/issues.py
+++ b/jobserver/issues.py
@@ -41,34 +41,37 @@ def create_copilot_publish_report_request(report, github_api):
     ### Checklist
 
     1. Co-pilot carries out assurance checks[^1]
-        - [ ] Assurance check (co-pilot)
-          - [ ] Do the results of the project match the original aims of the application?
-          - [ ] Are the results COPI compliant?
-          - [ ] Are the analysis and discussion focused on a COVID-19 related theme?
-          - [ ] Have non COVID-19 related inferences been made, and how extensive are they?
-          - [ ] Are all assumptions about the study population/data appropriate and reasonable?
-          - [ ] Have the authors interpreted the results appropriately? (There is a risk that these users will not be sufficiently experienced to judge if the quality of the GP data will be good enough to answer their questions. We have agreed to mitigate this risk by checking their reports carefully before publication.)
-          - [ ] Are all necessary limitations included?
-          - [ ] Are all recommendations appropriate and reasonable?
-          - [ ] Is there any contentious or politically sensitive content?
-          - [ ] Are NHSE or any other organisations likely to want the right to reply?
-    2. If required[^2], co-pilot shares the manuscript with Ops Team[^3] and Amir.
+        - [ ] Do the results of the project match the original aims of the [application](LINK)?
+        - [ ] Are the results COPI compliant[^2]?
+        - [ ] Is the summary focused on a COVID-19 related theme?
+        - [ ] Have non COVID-19 related inferences been made, and how extensive are they?
+        - [ ] Are all assumptions about the study population/data appropriate and reasonable?
+        - [ ] Have the authors interpreted the results appropriately? (There is a risk that these users will not be sufficiently experienced to judge if the quality of the GP data will be good enough to answer their questions. We have agreed to mitigate this risk by checking their reports carefully before publication.)
+        - [ ] Are all necessary limitations included?
+        - [ ] Are all recommendations appropriate and reasonable?
+        - [ ] Is there any contentious or politically sensitive content?
+        - [ ] Are NHSE or any other organisations likely to want the right to reply?
+    2. If the assurance check raises any issues, co-pilot shares the report with Ops Team[^3].
         - [ ] Ops Team review (Ops Team member)
-        - [ ] IG review (@amirmehrkar)
         - [ ] Co-pilot corresponds with pilot regarding changes. To make a change, the co-pilot must reject the current request and ask the user to make edits and then re-submit the request.
-
-    ** Steps 2-4 are repeated as required to meet assurance checks **
-
     3. Co-pilot downloads a copy of the report and submits to Amir, who will prompt IG review with NHSE
         - [ ] Report submitted to Amir for NHSE review
     4. Amir informs co-pilot of decision (accept/reject)
     5. Co-pilot approves or rejects the request [on the report page]({report_staff_url})
-    6. Upon publication, co-pilot should consider if project status should be updated, and if any external outputs should be linked to in the status description
+    6. Upon publication, co-pilot should consider if project status should be updated, and if any external outputs should be linked to in the status description. This can be done from the staff area for the project.
         - [ ] Project status updated
 
 
     [^1]: Further details regarding what is included in an assurance check is available [here](https://bennettinstitute-team-manual.pages.dev/products/publication-process-copiloted/#assurance-check).
-    [^2]: If the assurance check raises any issues.
+    [^2]: A COVID-19 purpose includes but is not limited to the following:
+        * understanding COVID-19 and risks to public health, trends in COVID-19 and such risks, and controlling and preventing the spread of COVID-19 and such risks
+        * processing to support the NHS Test and Trace programme
+        * identifying and understanding information about patients or potential patients with or at risk of COVID-19, information about incidents of patient exposure to COVID-19 and the management of patients with or at risk of COVID-19 including: locating, contacting, screening, flagging and monitoring such patients and collecting information about and providing services in relation to testing, diagnosis, self-isolation, fitness to work, treatment, medical and social interventions and recovery from COVID-19
+        * understanding information about patient access to health services and adult social care services and the need for wider care of patients and vulnerable groups as a direct or indirect result of COVID-19 and the availability and capacity of those services or that care
+        * monitoring and managing the response to COVID-19 by health and social care bodies and the government including:
+            * providing information to the public about COVID-19 and its effectiveness and information about capacity, medicines, equipment, supplies, services and the workforce within the health services and adult social care services
+            * delivering services to patients, clinicians, the health services and adult social care services workforce and the public about and in connection with COVID-19, including the provision of information, fit notes and the provision of healthcare and adult social care services
+        * research and planning in relation to COVID-19
     [^3]: Further information about the Ops Team is available [here](https://bennettinstitute-team-manual.pages.dev/the-teams/ops-team/).
     """
 

--- a/jobserver/issues.py
+++ b/jobserver/issues.py
@@ -28,7 +28,9 @@ def create_copilot_publish_report_request(report, github_api):
         copilot_name = ""
 
     base_url = furl(settings.BASE_URL)
+    application_url = report.project.application_url
     project_url = base_url / report.project.get_staff_url()
+    project_edit_url = base_url / report.project.get_staff_edit_url()
     report_url = base_url / report.get_absolute_url()
     report_staff_url = base_url / report.get_staff_url()
 
@@ -41,7 +43,7 @@ def create_copilot_publish_report_request(report, github_api):
     ### Checklist
 
     1. Co-pilot carries out assurance checks[^1]
-        - [ ] Do the results of the project match the original aims of the [application](LINK)?
+        - [ ] Do the results of the project match the original aims of the [application]({application_url})?
         - [ ] Are the results COPI compliant[^2]?
         - [ ] Is the summary focused on a COVID-19 related theme?
         - [ ] Have non COVID-19 related inferences been made, and how extensive are they?
@@ -52,14 +54,14 @@ def create_copilot_publish_report_request(report, github_api):
         - [ ] Is there any contentious or politically sensitive content?
         - [ ] Are NHSE or any other organisations likely to want the right to reply?
     2. If the assurance check raises any issues, co-pilot shares the report with Ops Team[^3].
-        - [ ] Ops Team review (Ops Team member)
+        - [ ] Ops Team review (by an [Ops Team member](https://bennettinstitute-team-manual.pages.dev/the-teams/ops-team/#current-team-members))
         - [ ] Co-pilot corresponds with pilot regarding changes. To make a change, the co-pilot must reject the current request and ask the user to make edits and then re-submit the request.
     3. Co-pilot downloads a copy of the report and submits to Amir, who will prompt IG review with NHSE
         - [ ] Report submitted to Amir for NHSE review
     4. Amir informs co-pilot of decision (accept/reject)
     5. Co-pilot approves or rejects the request [on the report page]({report_staff_url})
     6. Upon publication, co-pilot should consider if project status should be updated, and if any external outputs should be linked to in the status description. This can be done from the staff area for the project.
-        - [ ] Project status updated
+        - [ ] [Project status updated]({project_edit_url})
 
 
     [^1]: Further details regarding what is included in an assurance check is available [here](https://bennettinstitute-team-manual.pages.dev/products/publication-process-copiloted/#assurance-check).

--- a/jobserver/views/reports.py
+++ b/jobserver/views/reports.py
@@ -71,7 +71,8 @@ class PublishRequestCreate(View):
         )
 
         messages.success(
-            self.request, "Your request to publish this report was successfully sent"
+            self.request,
+            "Your request to publish this report was successfully sent to the OpenSAFELY team",
         )
 
         return redirect(self.analysis_request)

--- a/templates/staff/project_edit.html
+++ b/templates/staff/project_edit.html
@@ -146,7 +146,7 @@
         <hr />
 
         <fieldset>
-          <legend>Internal status</legend>
+          <legend>Status</legend>
 
           <div class="form-group">
             <label class="font-weight-bold" for="id_status">Status</label>

--- a/tests/unit/jobserver/views/test_reports.py
+++ b/tests/unit/jobserver/views/test_reports.py
@@ -162,9 +162,8 @@ def test_publishrequestcreate_post_success(rf, slack_messages):
     # check we have a message for the user
     messages = list(messages)
     assert len(messages) == 1
-    assert (
-        str(messages[0]) == "Your request to publish this report was successfully sent"
-    )
+    msg = "Your request to publish this report was successfully sent to the OpenSAFELY team"
+    assert str(messages[0]) == msg
 
     assert len(slack_messages) == 1
     text, channel = slack_messages[0]


### PR DESCRIPTION
Makes some small updates to the OSI issue template content following a mock publish request.

- Removes redundant steps
- Adds explainer around COPI compliance
- Adds a bit more signposting to where/how to complete some steps. There is one empty link that needs populating here and we could potentially provide more.