### PR TITLE
Add a reports card and page under projects

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -574,17 +574,23 @@ class Project(models.Model):
             kwargs={"org_slug": self.org.slug, "project_slug": self.slug},
         )
 
-    def get_staff_edit_url(self):
-        return reverse("staff:project-edit", kwargs={"slug": self.slug})
-
     def get_releases_url(self):
         return reverse(
             "project-release-list",
             kwargs={"org_slug": self.org.slug, "project_slug": self.slug},
         )
 
+    def get_reports_url(self):
+        return reverse(
+            "project-report-list",
+            kwargs={"org_slug": self.org.slug, "project_slug": self.slug},
+        )
+
     def get_staff_url(self):
         return reverse("staff:project-detail", kwargs={"slug": self.slug})
+
+    def get_staff_edit_url(self):
+        return reverse("staff:project-edit", kwargs={"slug": self.slug})
 
     def get_staff_feature_flags_url(self):
         return reverse("staff:project-feature-flags", kwargs={"slug": self.slug})

--- a/jobserver/models/reports.py
+++ b/jobserver/models/reports.py
@@ -112,3 +112,17 @@ class Report(models.Model):
             return False
 
         return latest.decision == PublishRequest.Decisions.APPROVED
+
+    @property
+    def published_at(self):
+        # We support multiple publish requests over time but we only look at
+        # the latest one to get published date.
+        latest = self.publish_requests.order_by("-created_at").first()
+
+        if not latest:
+            return False
+
+        if latest.decision != PublishRequest.Decisions.APPROVED:
+            return False
+
+        return latest.created_at

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -39,7 +39,7 @@ from .views.job_requests import (
 )
 from .views.jobs import JobCancel, JobDetail, JobDetailRedirect
 from .views.orgs import OrgDetail, OrgList
-from .views.projects import ProjectDetail, ProjectEdit
+from .views.projects import ProjectDetail, ProjectEdit, ProjectReportList
 from .views.releases import (
     ProjectReleaseList,
     PublishedSnapshotFile,
@@ -255,6 +255,7 @@ project_urls = [
     path("interactive/", include("interactive.urls")),
     path("new-workspace/", WorkspaceCreate.as_view(), name="workspace-create"),
     path("releases/", ProjectReleaseList.as_view(), name="project-release-list"),
+    path("reports/", ProjectReportList.as_view(), name="project-report-list"),
     path("<str:workspace_slug>/", include(workspace_urls)),
 ]
 

--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -236,6 +236,24 @@
         {% /card %}
       {% endif %}
 
+      {% #card title="Reports" subtitle="Recently published reports" %}
+        {% #list_group %}
+          {% for report in reports %}
+            {% #list_group_item href=report.get_absolute_url %}
+              {{ report.title }}
+            {% /list_group_item %}
+          {% empty %}
+            {% list_group_empty icon=True title="No reports" description="This project does not currently have any published reports" %}
+          {% endfor %}
+        {% /list_group %}
+
+        {% if counts.reports > reports|length %}
+          {% #card_footer no_container=True %}
+            {% link href=project.get_reports_url text="View all reports →" %}
+          {% /card_footer %}
+        {% endif %}
+      {% /card %}
+
       {% if memberships %}
         {% #card title="Researchers" %}
           <div class="border-t border-t-slate-200">

--- a/templates/project_report_list.html
+++ b/templates/project_report_list.html
@@ -1,0 +1,44 @@
+{% extends "base-tw.html" %}
+
+{% block metatitle %}Reports for {{ project.name }} | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+  {% #breadcrumbs %}
+    {% url 'home' as home_url %}
+    {% breadcrumb title="Home" url=home_url %}
+    {% breadcrumb location="Organisation" title=project.org.name url=project.org.get_absolute_url %}
+    {% breadcrumb location="Project" title=project.name url=project.get_absolute_url %}
+    {% breadcrumb title="Reports" active=True %}
+  {% /breadcrumbs %}
+{% endblock breadcrumbs %}
+
+{% block content %}
+  {% #card title="Reports" %}
+    {% if object_list %}
+      {% #list_group %}
+        {% for report in object_list %}
+          {% #list_group_item href=report.get_absolute_url %}
+            {{ report.title }}
+            {% if user_can_view_unpublished_reports %}
+              {% if report.is_published %}
+              {% pill class="ml-2" text="Published" variant="success" %}
+              {% else %}
+              {% pill class="ml-2" text="Draft" variant="info" %}
+              {% endif %}
+            {% endif %}
+          {% /list_group_item %}
+        {% endfor %}
+      {% /list_group %}
+    {% else %}
+      <div class="border-t border-t-slate200 text-center p-8">
+        {% icon_folder_outline class="mx-auto h-8 w-8 text-slate-400" %}
+        <h2 class="mt-2 text-lg font-semibold text-slate-900">
+          No reports
+        </h2>
+        <p class="mt-2 text-sm text-slate-600">
+          There are currently no {% if not user_can_view_unpublished_reports %}published {% endif %}reports for this project
+        </p>
+      </div>
+    {% endif %}
+  {% /card %}
+{% endblock content %}

--- a/tests/unit/jobserver/models/test_project.py
+++ b/tests/unit/jobserver/models/test_project.py
@@ -38,14 +38,6 @@ def test_project_get_edit_url():
     )
 
 
-def test_project_get_staff_edit_url():
-    project = ProjectFactory()
-
-    url = project.get_staff_edit_url()
-
-    assert url == reverse("staff:project-edit", kwargs={"slug": project.slug})
-
-
 def test_project_get_releases_url():
     project = ProjectFactory()
 
@@ -60,12 +52,34 @@ def test_project_get_releases_url():
     )
 
 
+def test_project_get_reports_url():
+    project = ProjectFactory()
+
+    url = project.get_reports_url()
+
+    assert url == reverse(
+        "project-report-list",
+        kwargs={
+            "org_slug": project.org.slug,
+            "project_slug": project.slug,
+        },
+    )
+
+
 def test_project_get_staff_url():
     project = ProjectFactory()
 
     url = project.get_staff_url()
 
     assert url == reverse("staff:project-detail", kwargs={"slug": project.slug})
+
+
+def test_project_get_staff_edit_url():
+    project = ProjectFactory()
+
+    url = project.get_staff_edit_url()
+
+    assert url == reverse("staff:project-edit", kwargs={"slug": project.slug})
 
 
 def test_project_get_staff_feature_flags_url():

--- a/tests/unit/jobserver/models/test_reports.py
+++ b/tests/unit/jobserver/models/test_reports.py
@@ -112,6 +112,19 @@ def test_report_is_published():
     assert report.is_published
 
 
+def test_report_published_at():
+    report = ReportFactory()
+    assert not report.published_at
+
+    snapshot = SnapshotFactory()
+    snapshot.files.set([report.release_file])
+    publish_request = PublishRequestFactory(report=report, snapshot=snapshot)
+    assert not report.published_at
+
+    publish_request.approve(user=UserFactory())
+    assert report.published_at
+
+
 def test_report_str():
     report = ReportFactory(title="test")
 


### PR DESCRIPTION
We have reports on the relevant workspace pages, so this bubbles them up to the relevant project pages.

I've copied the "latest 5 with link to all of them when total>5" paradigm from the new homepage design.  To test locally it's probably easier to replace the `all_reports` variable with `project.reports.all()` to see the link and second page in action.

**Card**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/yAu9YbnL/e9daf0b9-a476-47ee-9bc4-6831dc1ea3ed.jpg?v=3bccec7a7605463775e88e85da3e0e5d)

**Page**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/NQupgrBK/bb79586a-2134-483a-abb1-01f9c3bf3738.jpg?v=2cbfe9e04ffde2748dd79074e368ee28)