### PR TITLE
Upload the HTML coverage report when coverage fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,17 @@ jobs:
           just check-migrations
           just test --migrations
 
+      - name: Upload HTML coverage report if tests failed
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-coverage-report
+          path: htmlcov
+          # don't fail the job because no files were found, we expect this when
+          #  * the tests passed with 100% coverage
+          #  * a test failed and coverage didn't run
+          if-no-files-found: ignore
+        if: ${{ failure() }}  # only upload when the previous step, run tests, fails
+
   lint-dockerfile:
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
Sometimes we get coverage failures in CI, and it can be useful to have a quick pointer as to why without running the test suite locally.  This uploads the HTML output from coverage.py to GitHub if any has been generated.  It only runs if the previous step has failed, which <100% coverage will do.  It's ignoring a missing htmlcov directory because we know that will happen when coverage is 100% or doesn't run because a test failed.

This would have been useful a handful of times previously so I'm adding it now in case it ever comes up again.