### PR TITLE
Print response details when a request fails

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -106,6 +106,11 @@ class GitHubAPI:
         payload = {"query": query, "variables": variables}
 
         r = self._post("https://api.github.com/graphql", json=payload)
+
+        if not r.ok:  # pragma: no cover
+            print(r.headers)
+            print(r.content)
+
         r.raise_for_status()
         results = r.json()
 


### PR DESCRIPTION
I can't replicate the GraphQL failures we've been seeing in CI so I'm adding this for when they next happen in the hope that the response from GitHub tells us something (anything!) about the situation.

Ref: #3179 