### PR TITLE
Try to avoid dangling repos from verification tests

### DIFF
--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -85,30 +85,34 @@ def test_create_issue(enable_network, github_api):
 
 
 def test_create_repo(enable_network, github_api, testing_repo):
-    # create a unique ID for this test using our existing ULID function.
-    # we can have multiple CI runs executing concurrently which means this
-    # test can be running in different CI jobs at the same time.  Given the
-    # test talks to an external API we can't use the same repo name for every
-    # execution.  Instead we use our new_ulid_str since it's already available
-    # and should have more than enough uniqueness for our needs to create
-    # a unique repo name.
-    unique_id = new_ulid_str()
-    args = [
-        "opensafely-testing",
-        f"testing-create_repo-{unique_id}",
-    ]
+    try:
+        # create a unique ID for this test using our existing ULID function.
+        # we can have multiple CI runs executing concurrently which means this
+        # test can be running in different CI jobs at the same time.  Given the
+        # test talks to an external API we can't use the same repo name for every
+        # execution.  Instead we use our new_ulid_str since it's already available
+        # and should have more than enough uniqueness for our needs to create
+        # a unique repo name.
+        unique_id = new_ulid_str()
+        args = [
+            "opensafely-testing",
+            f"testing-create_repo-{unique_id}",
+        ]
 
-    real = github_api.create_repo(*args)
-    fake = FakeGitHubAPI().create_repo(*args)
+        real = github_api.create_repo(*args)
+        fake = FakeGitHubAPI().create_repo(*args)
 
-    # does the fake work as expected?
-    compare(fake, real)
+        # does the fake work as expected?
+        compare(fake, real)
 
-    assert real is not None
+        assert real is not None
 
-    # do we get the appropriate error when the repo already exists?
-    with pytest.raises(RepoAlreadyExists):
-        github_api.create_repo(*args)
+        # do we get the appropriate error when the repo already exists?
+        with pytest.raises(RepoAlreadyExists):
+            github_api.create_repo(*args)
+    finally:
+        # clean up after the test
+        github_api.delete_repo(*args)
 
 
 def test_get_branch(enable_network, github_api):

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -36,24 +36,6 @@ def github_api():
     return GitHubAPI(token=Env().str("GITHUB_TOKEN_TESTING"))
 
 
-@pytest.fixture
-def testing_repo(github_api):
-    args = [
-        "opensafely-testing",
-        "testing-create_repo",
-    ]
-
-    # make sure it doesn't already exist
-    github_api.delete_repo(*args)
-
-    try:
-        yield
-    finally:
-        # tidy up the repo we just created, this will complain loudly if
-        # something goes wrong
-        github_api.delete_repo(*args)
-
-
 def test_add_repo_to_team(enable_network, github_api):
     args = [
         "testing",
@@ -84,7 +66,7 @@ def test_create_issue(enable_network, github_api):
     assert real is not None
 
 
-def test_create_repo(enable_network, github_api, testing_repo):
+def test_create_repo(enable_network, github_api):
     try:
         # create a unique ID for this test using our existing ULID function.
         # we can have multiple CI runs executing concurrently which means this


### PR DESCRIPTION
We've been building up testing repos in opensafely-testing over time.  It's unclear exactly where these have come from, but this PR adds some changes to hopefully avoid creating them:

The `testing_repo` fixture now suffixes its repos with a unique ID to match the `test_create_repo` test but also changes the repo prefix to `testing-repo` so should we still have this problem we can at least track it to a code path.

`test_create_repo` now deletes its repo when done and doesn't create an extra repo via the `testing_repo` fixture.