### PR TITLE
Update service-evaluation-audit-rubric.md

### DIFF
--- a/snippets/service-evaluation-audit-rubric.md
+++ b/snippets/service-evaluation-audit-rubric.md
@@ -2,8 +2,8 @@ We will need the following information:
 
 1. evidence that your study is a service evaluation or audit (e.g. from your [NHS R&D office](https://rdforum.nhs.uk/rd-contacts-directory/); from your institutional ethics committee agreeing it is a service evaluation/audit; by using the [HRA “is it research” decision tool](http://www.hra-decisiontools.org.uk/research/); or if you are still unsure, please contact the HRA for advice);
 
-2. evidence of a favourable opinion from your institutional ethics review process/committee (not required by NHSE/I/X applicants);
+2. evidence of a favourable opinion from your institutional ethics review process/committee (not required by NHSE applicants);
 
-3. evidence of support from a senior sponsor, usually an NHSE/X individual, such as a national clinical lead, band 9, director, or the sponsor might be a member of SAGE, JCVI, etc.
+3. evidence of support from a senior sponsor, usually an NHSE individual, such as a national clinical lead, band 9, director, or the sponsor might be a member of SAGE, JCVI, etc.
 
 Note: for the existing approved Bennett Institute/LSHTM Service Restoration Observatory and Aftershocks workstream, sponsorship is not required, but may be requested on a case-by-case basis by the OpenSAFELY team.


### PR DESCRIPTION
NHSE X/I no longer exists separately from NHSE and are now a part of NHSE, making a reference to NHSE/X/I now redundant.