### PR TITLE
Skip any falsey value in Sentry parser

### DIFF
--- a/services/sentry.py
+++ b/services/sentry.py
@@ -60,7 +60,7 @@ def parse(data):
     for token in tokens:
         value = env.str(token, default=None)
 
-        if value is None:
+        if not value:
             continue
 
         if value in data:


### PR DESCRIPTION
Declaring an empty env var means the value of `value` is an empty string when we hit this check, and we also want to skip on that.