### PR TITLE
fix: add default crawl-delay setting

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -2,6 +2,7 @@ User-agent: Amazonbot               # Amazon's user agent
 Disallow: /
 
 User-agent: *
+Crawl-delay: 1
 Disallow: /api/
 Disallow: /applications/
 Disallow: /complete/


### PR DESCRIPTION
* This will politely ask crawlers to only request 1 page per second
* This should help workaround performance issues on some pages