### PR TITLE
Script publishing a list of files

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -482,7 +482,7 @@ class SnapshotCreateAPI(APIView):
             raise ParseError(f"Unknown file IDs: {', '.join(missing)}")
 
         publish_request = PublishRequest.create_from_files(
-            files=files, user=request.user, workspace=workspace
+            files=files, user=request.user
         )
 
         return Response(

--- a/jobserver/management/commands/publish_files.py
+++ b/jobserver/management/commands/publish_files.py
@@ -1,0 +1,35 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from furl import furl
+
+from jobserver import models
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("username", type=str)
+        parser.add_argument(
+            "ids", nargs="+", type=str, help="ReleaseFile IDs to add to Snapshot"
+        )
+
+    def handle(self, *args, **options):
+        ids = set(options["ids"])
+        username = options["username"]
+
+        try:
+            user = models.User.objects.get(username=username)
+        except models.User.DoesNotExist:
+            raise CommandError(f"Unknown username: {username}")
+
+        rfiles = models.ReleaseFile.objects.filter(pk__in=ids)
+
+        found = set(rfiles.values_list("pk", flat=True))
+        if unknown := ids - found:
+            raise CommandError(f"Unknown ReleaseFiles: {', '.join(unknown)}")
+
+        publish_request = models.PublishRequest.create_from_files(
+            files=rfiles, user=user
+        )
+
+        url = furl(settings.BASE_URL) / publish_request.snapshot.get_absolute_url()
+        print(url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ omit = [
   "jobserver/management/commands/get_transitional_projects.py",
   "jobserver/management/commands/inflate_release_files.py",
   "jobserver/management/commands/list_missing_repos.py",
+  "jobserver/management/commands/publish_files.py",
   "jobserver/management/commands/release.py",
   "jobserver/settings.py",
   "jobserver/wsgi.py",

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1135,7 +1135,8 @@ def test_snapshotcreate_unknown_files(api_rf):
 
 def test_snapshotcreate_with_existing_snapshot(api_rf, build_release_with_files):
     workspace = WorkspaceFactory()
-    release = build_release_with_files(["file1.txt"])
+    release = build_release_with_files(["file1.txt"], workspace=workspace)
+    release.files.update(workspace=workspace)
     snapshot = SnapshotFactory(workspace=workspace)
     snapshot.files.set(release.files.all())
 


### PR DESCRIPTION
This adds a check to ensure that Snapshots are made with files from the same workspace.  We're creating all Snapshots via the PublishRequest.create_from_files method so we can rely on the check there.

Fix: #3276 