### PR TITLE
Add JobRequests to the staff area

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -305,6 +305,14 @@ class JobRequest(models.Model):
         f.path.segments += ["tree", self.sha]
         return f.url
 
+    def get_staff_url(self):
+        return reverse(
+            "staff:job-request-detail",
+            kwargs={
+                "pk": self.pk,
+            },
+        )
+
     @property
     def is_completed(self):
         return self.status in ["failed", "succeeded"]

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -188,7 +188,7 @@ class Job(models.Model):
 
 
 class JobRequestManager(models.Manager):
-    def get_queryset(self):
+    def with_started_at(self):
         return (
             super()
             .get_queryset()

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -249,6 +249,9 @@ class JobRequest(models.Model):
             ),
         ]
 
+    def __str__(self):
+        return str(self.pk)
+
     def get_absolute_url(self):
         return reverse(
             "job-request-detail",

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -25,6 +25,7 @@ from .views.dashboards.index import DashboardIndex
 from .views.dashboards.projects import ProjectsDashboard
 from .views.dashboards.repos import PrivateReposDashboard, ReposWithMultipleProjects
 from .views.index import Index
+from .views.job_requests import JobRequestList
 from .views.orgs import (
     OrgCreate,
     OrgDetail,
@@ -115,6 +116,10 @@ dashboard_urls = [
         ReposWithMultipleProjects.as_view(),
         name="repos-with-multiple-projects",
     ),
+]
+
+job_request_urls = [
+    path("", JobRequestList.as_view(), name="job-request-list"),
 ]
 
 org_urls = [
@@ -216,6 +221,7 @@ urlpatterns = [
     path("applications/", include(application_urls)),
     path("backends/", include(backend_urls)),
     path("dashboards/", include((dashboard_urls, "dashboards"), namespace="dashboard")),
+    path("job-requests/", include(job_request_urls)),
     path("orgs/", include(org_urls)),
     path("projects/", include(project_urls)),
     path("redirects/", include(redirect_urls)),

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -25,7 +25,7 @@ from .views.dashboards.index import DashboardIndex
 from .views.dashboards.projects import ProjectsDashboard
 from .views.dashboards.repos import PrivateReposDashboard, ReposWithMultipleProjects
 from .views.index import Index
-from .views.job_requests import JobRequestList
+from .views.job_requests import JobRequestDetail, JobRequestList
 from .views.orgs import (
     OrgCreate,
     OrgDetail,
@@ -120,6 +120,7 @@ dashboard_urls = [
 
 job_request_urls = [
     path("", JobRequestList.as_view(), name="job-request-list"),
+    path("<int:pk>/", JobRequestDetail.as_view(), name="job-request-detail"),
 ]
 
 org_urls = [

--- a/staff/views/job_requests.py
+++ b/staff/views/job_requests.py
@@ -36,6 +36,7 @@ class JobRequestList(ListView):
                 "created_by__fullname",
                 "created_by__username",
                 "identifier",
+                "jobs__identifier",
                 "pk",
                 "workspace__name",
                 "workspace__project__name",

--- a/staff/views/job_requests.py
+++ b/staff/views/job_requests.py
@@ -2,11 +2,18 @@ import functools
 
 from django.db.models import Q
 from django.utils.decorators import method_decorator
-from django.views.generic import ListView
+from django.views.generic import DetailView, ListView
 
 from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_role
 from jobserver.models import JobRequest
+
+
+@method_decorator(require_role(CoreDeveloper), name="dispatch")
+class JobRequestDetail(DetailView):
+    context_object_name = "job_request"
+    model = JobRequest
+    template_name = "staff/job_request_detail.html"
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")

--- a/staff/views/job_requests.py
+++ b/staff/views/job_requests.py
@@ -1,0 +1,47 @@
+import functools
+
+from django.db.models import Q
+from django.utils.decorators import method_decorator
+from django.views.generic import ListView
+
+from jobserver.authorization import CoreDeveloper
+from jobserver.authorization.decorators import require_role
+from jobserver.models import JobRequest
+
+
+@method_decorator(require_role(CoreDeveloper), name="dispatch")
+class JobRequestList(ListView):
+    model = JobRequest
+    ordering = "-created_at"
+    paginate_by = 25
+    template_name = "staff/job_request_list.html"
+
+    def get_queryset(self):
+        qs = (
+            super()
+            .get_queryset()
+            .select_related("created_by")
+            .defer("project_definition")
+        )
+
+        if q := self.request.GET.get("q"):
+            fields = [
+                "created_by__fullname",
+                "created_by__username",
+                "identifier",
+                "pk",
+                "workspace__name",
+                "workspace__project__name",
+                "workspace__project__org__name",
+            ]
+
+            # build up Q objects OR'd together.  We need to build them with
+            # functools.reduce so we can optionally add the PK filter to the
+            # list
+            qwargs = functools.reduce(
+                Q.__or__, (Q(**{f"{f}__icontains": q}) for f in fields)
+            )
+
+            qs = qs.filter(qwargs)
+
+        return qs.distinct()

--- a/staff/views/job_requests.py
+++ b/staff/views/job_requests.py
@@ -51,4 +51,7 @@ class JobRequestList(ListView):
 
             qs = qs.filter(qwargs)
 
+        if workspace := self.request.GET.get("workspace"):
+            qs = qs.filter(workspace__name=workspace)
+
         return qs.distinct()

--- a/staff/views/workspaces.py
+++ b/staff/views/workspaces.py
@@ -18,8 +18,14 @@ class WorkspaceDetail(DetailView):
     template_name = "staff/workspace_detail.html"
 
     def get_context_data(self, **kwargs):
+        job_requests = self.object.job_requests.select_related("created_by").order_by(
+            "-created_at"
+        )[:10]
+        redirects = self.object.redirects.order_by("old_url")
+
         return super().get_context_data(**kwargs) | {
-            "redirects": self.object.redirects.order_by("old_url"),
+            "job_requests": job_requests,
+            "redirects": redirects,
         }
 
 

--- a/templates/job_request_detail.html
+++ b/templates/job_request_detail.html
@@ -28,57 +28,64 @@
 {% endblock breadcrumbs %}
 
 {% block content %}
-  <div class="grid grid-cols-1 gap-6 lg:grid-cols-6">
-    <div class="
-      flex flex-col items-center gap-y-4
-      lg:flex-row lg:flex-wrap lg:items-start lg:col-span-4 lg:mb-4
-    ">
-      <div class="flex flex-col text-center items-center gap-y-2 lg:text-left lg:items-start">
-        <h1 class="text-3xl tracking-tight break-words font-bold text-slate-900 sm:text-4xl">
-          Job request: {{ job_request.pk }}
-        </h1>
-        <dl class="flex flex-col gap-2 text-sm text-slate-600 items-center sm:flex-row sm:gap-x-6 sm:justify-center lg:justify-start">
-          <dt class="sr-only">Workspace:</dt>
-          <dd class="flex flex-row items-start overflow-hidden">
-            {% icon_folder_open_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
-            <span class="truncate">{{ job_request.workspace.name }}</span>
-          </dd>
-          <dt class="sr-only">ID:</dt>
-          <dd class="flex flex-row items-start overflow-hidden relative">
-            {% icon_code_bracket_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
-            <span class="truncate">{{ job_request.identifier }}</span>
-          </dd>
-        </dl>
-
-        <div class="flex flex-col mt-2 sm:flex-row gap-2 lg:items-start">
-          {% #button href=job_request.get_repo_url type="link" variant="primary" %}
-            {% icon_github_outline class="h-4 w-4 mr-2" %}
-            View repo
-          {% /button %}
-
-          {% #button href=project_yaml_url type="link" variant="secondary" %}
-            View project.yaml
-          {% /button %}
-
-          {% if user_can_cancel_jobs %}
-            <form class="d-inline-block" method="POST" action="{{ job_request.get_cancel_url }}">
-              {% csrf_token %}
-              {% if job_request.is_completed %}
-                {% #button type="submit" disabled=True tooltip="This job request can no longer be cancelled" %}
-                  Cancel this job
-                {% /button %}
-              {% else %}
-                {% #button type="submit" variant="danger" %}
-                  Cancel this job
-                {% /button %}
-              {% endif %}
-            </form>
-          {% endif %}
+  <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+    <div class="flex flex-col text-center items-center gap-y-2 lg:text-left lg:items-start lg:col-span-full">
+      <div class="flex flex-col items-center gap-y-2 w-full lg:flex-row lg:justify-between lg:items-start">
+        <div class="order-2 w-full lg:mr-auto lg:order-1">
+          <h1 class="text-3xl tracking-tight break-words font-bold text-slate-900 sm:text-4xl">
+            Job request: {{ job_request.pk }}
+          </h1>
+          <dl class="flex flex-col gap-2 text-sm text-slate-600 items-center sm:flex-row sm:gap-x-6 sm:justify-center lg:justify-start">
+            <dt class="sr-only">Workspace:</dt>
+            <dd class="flex flex-row items-start overflow-hidden">
+              {% icon_folder_open_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
+              <span class="truncate">{{ job_request.workspace.name }}</span>
+            </dd>
+            <dt class="sr-only">ID:</dt>
+            <dd class="flex flex-row items-start overflow-hidden relative">
+              {% icon_code_bracket_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
+              <span class="truncate">{{ job_request.identifier }}</span>
+            </dd>
+          </dl>
         </div>
+        {% if user_can_view_staff_area %}
+          <div class="order-1 lg:order-2 flex-shrink-0">
+            {% #button href=job_request.get_staff_url type="link" variant="danger" class="flex-shrink-0" %}
+              View in Staff Area
+              {% icon_lifebuoy_outline class="h-4 w-4 ml-2 -mr-2" %}
+            {% /button %}
+          </div>
+        {% endif %}
+      </div>
+
+      <div class="flex flex-col mt-2 sm:flex-row gap-2 lg:items-start">
+        {% #button href=job_request.get_repo_url type="link" variant="primary" %}
+          {% icon_github_outline class="h-4 w-4 mr-2" %}
+          View repo
+        {% /button %}
+
+        {% #button href=project_yaml_url type="link" variant="secondary" %}
+          View project.yaml
+        {% /button %}
+
+        {% if user_can_cancel_jobs %}
+          <form class="d-inline-block" method="POST" action="{{ job_request.get_cancel_url }}">
+            {% csrf_token %}
+            {% if job_request.is_completed %}
+              {% #button type="submit" disabled=True tooltip="This job request can no longer be cancelled" %}
+                Cancel this job
+              {% /button %}
+            {% else %}
+              {% #button type="submit" variant="danger" %}
+                Cancel this job
+              {% /button %}
+            {% endif %}
+          </form>
+        {% endif %}
       </div>
     </div>
 
-    <div class="lg:col-span-4 flex flex-col gap-y-6">
+    <div class="space-y-6 md:space-y-6 lg:col-span-2 lg:row-start-2">
       {% #card container=True %}
         <div class="flex flex-col gap-y-4 text-slate-700">
           <p>
@@ -182,7 +189,7 @@
       {% endif %}
     </div>
 
-    <div class="lg:col-span-2 flex flex-col gap-y-6">
+    <div class="gap-6 place-content-start lg:col-span-1 flex flex-col">
       {% #card title="Timeline" container=True %}
         <ul class="flow-root">
           {% #timeline_item background="blue" title="Created:" time=job_request.created_at %}

--- a/templates/staff/index.html
+++ b/templates/staff/index.html
@@ -46,6 +46,7 @@
         <a href="{% url 'staff:application-list' %}" class="list-group-item list-group-item-action">Applications</a>
         <a href="{% url 'staff:backend-list' %}" class="list-group-item list-group-item-action">Backends</a>
         <a href="{% url 'staff:dashboard:index' %}" class="list-group-item list-group-item-action">Dashboards</a>
+        <a href="{% url 'staff:job-request-list' %}" class="list-group-item list-group-item-action">Job Requests</a>
         <a href="{% url 'staff:org-list' %}" class="list-group-item list-group-item-action">Organisations</a>
         <a href="{% url 'staff:project-list' %}" class="list-group-item list-group-item-action">Projects</a>
         <a href="{% url 'staff:redirect-list' %}" class="list-group-item list-group-item-action">Redirects</a>

--- a/templates/staff/job_request_detail.html
+++ b/templates/staff/job_request_detail.html
@@ -1,0 +1,113 @@
+{% extends "staff/base.html" %}
+
+{% block metatitle %}Job Request {{ job_request.pk }}: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:index' %}">Staff area</a>
+      </li>
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:job-request-list' %}">Job Requests</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        {{ job_request.pk }}
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
+  <div class="container">
+    <h1 class="display-4">{{ job_request.pk }}</h1>
+
+    <ul class="list-unstyled lead">
+      <li>
+        <strong>Identifier:</strong> <code>{{ job_request.identifier }}</code>
+      </li>
+      <li>
+        <strong>Created by:</strong>
+        <a href="{{ job_request.created_by.get_staff_url }}">{{ job_request.created_by.name }}</a>
+      </li>
+
+      <li>
+        <strong>Created at:</strong> {{ job_request.created_at }}
+      </li>
+    </ul>
+
+    <div class="d-flex">
+      <a class="btn btn-primary" href="{{ job_request.get_absolute_url }}">View on Site</a>
+    </div>
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div class="col col-lg-9 col-xl-8">
+
+      <h2>Cancelled actions</h2>
+      <div class="list-group mb-3">
+        {% for action in job_request.cancelled_actions %}
+        <div class="list-group-item">
+          <code>{{ action }}</code>
+        </div>
+        {% empty %}
+          <p class="list-group-item">No actions have been requested for cancellation</p>
+        {% endfor %}
+      </div>
+
+      <h2>Requested actions</h2>
+      <div class="list-group mb-3">
+        {% for action in job_request.requested_actions %}
+        <div class="list-group-item">
+          <code>{{ action }}</code>
+        </div>
+        {% endfor %}
+      </div>
+
+    </div>
+    <div class="col col-lg-3 col-xl-4">
+      <ul class="list-unstyled">
+        <li class="card mb-3">
+          <h2 class="card-header h5">
+            Organisation
+          </h2>
+          <p class="card-body mb-0">
+            <a href="{{ job_request.workspace.project.org.get_staff_url }}">{{ job_request.workspace.project.org.name }}</a>
+          </p>
+        </li>
+        <li class="card mb-3">
+          <h2 class="card-header h5">
+            Project
+          </h2>
+          <p class="card-body mb-0">
+            <a href="{{ job_request.workspace.project.get_staff_url }}">{{ job_request.workspace.project.title }}</a>
+          </p>
+        </li>
+        <li class="card mb-3">
+          <h2 class="card-header h5">
+            Workspace
+          </h2>
+          <p class="card-body mb-0">
+            <a href="{{ job_request.workspace.get_staff_url }}">{{ job_request.workspace.name }}</a>
+          </p>
+        </li>
+        <li class="card mb-3">
+          <h2 class="card-header h5">
+            Backend
+          </h2>
+          <p class="card-body mb-0">
+            <a href="{{ job_request.backend.get_staff_url }}">{{ job_request.backend.name }}</a>
+          </p>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/templates/staff/job_request_list.html
+++ b/templates/staff/job_request_list.html
@@ -1,0 +1,121 @@
+{% extends "staff/base.html" %}
+
+{% load humanize %}
+{% load querystring_tools %}
+{% load selected_filter %}
+
+{% block metatitle %}Job Requests: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:index' %}">Staff area</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        Job Requests
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
+  <div class="container">
+    <h1 class="display-4">Job Requests</h1>
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div class="col col-lg-3 col-xl-4">
+      <h2 class="h3">Filters</h2>
+
+      {% if request.GET %}
+      <div class="mb-3">
+        <a href="{% url 'staff:job-request-list' %}">Clear All</a>
+      </div>
+      {% endif %}
+
+    </div>
+
+    <div class="col col-lg-9 col-xl-8">
+      <form method="GET" class="mb-4">
+        <div class="form-inline w-100 d-flex flex-nowrap">
+          <label for="requestSearch" class="sr-only">Search by number, (partial) identifier, name of author, workspace, project, or org</label>
+          <input
+            class="form-control mr-sm-2 w-100"
+            id="requestSearch"
+            name="q"
+            placeholder="Search by number, (partial) identifier, name of author, workspace, project, or org"
+            type="search"
+            {% if q %}
+              value="{{ q }}"
+            {% endif %}
+          >
+          <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
+        </div>
+      </form>
+
+      <div class="list-group list-unstyled">
+        {% for job_request in object_list %}
+        <span class="list-group-item list-group-item-action">
+          {{ job_request.pk }} by {{ job_request.created_by }}
+          <small class="text-muted">(created {{ job_request.created_at|date }})</small>
+        </span>
+        {% endfor %}
+      </div>
+
+      <div class="d-flex justify-content-between align-items-center py-2">
+        <div>
+          {% with enabled=page_obj.has_previous %}
+          <a
+            {% if enabled %}href="?page=1"{% endif %}
+            class="
+              btn btn-sm btn-primary
+              {% if not enabled %}disabled{% endif %}
+            ">First</a>
+
+          <a
+            {% if enabled %}href="?page={{ page_obj.previous_page_number }}"{% endif %}
+            class="
+              btn btn-sm btn-primary
+              {% if not enabled %}disabled{% endif %}
+            ">Previous</a>
+
+          {% endwith %}
+        </div>
+
+        <div class="current">
+          Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+        </div>
+
+        <div>
+          {% with enabled=page_obj.has_next %}
+          <a
+            {% if enabled %}href="?page={{ page_obj.next_page_number }}"{% endif %}
+            class="
+              btn btn-sm btn-primary
+              {% if not enabled %}disabled{% endif %}
+            "
+            >Next</a>
+          <a
+            {% if enabled %}href="?page={{ page_obj.paginator.num_pages }}"{% endif %}
+            class="
+              btn btn-sm btn-primary
+              {% if not enabled %}disabled{% endif %}
+            "
+            >Last</a>
+          {% endwith %}
+        </div>
+      </div>
+
+    </div>
+
+  </div>
+</div>
+{% endblock content %}

--- a/templates/staff/job_request_list.html
+++ b/templates/staff/job_request_list.html
@@ -81,7 +81,9 @@
             ">First</a>
 
           <a
-            {% if enabled %}href="?page={{ page_obj.previous_page_number }}"{% endif %}
+            {% if enabled %}
+            href="{% url_with_querystring page=page_obj.previous_page_number %}"
+            {% endif %}
             class="
               btn btn-sm btn-primary
               {% if not enabled %}disabled{% endif %}
@@ -97,14 +99,18 @@
         <div>
           {% with enabled=page_obj.has_next %}
           <a
-            {% if enabled %}href="?page={{ page_obj.next_page_number }}"{% endif %}
+            {% if enabled %}
+            href="{% url_with_querystring page=page_obj.next_page_number %}"
+            {% endif %}
             class="
               btn btn-sm btn-primary
               {% if not enabled %}disabled{% endif %}
             "
             >Next</a>
           <a
-            {% if enabled %}href="?page={{ page_obj.paginator.num_pages }}"{% endif %}
+            {% if enabled %}
+            href="{% url_with_querystring page=page_obj.paginator.num_pages %}"
+            {% endif %}
             class="
               btn btn-sm btn-primary
               {% if not enabled %}disabled{% endif %}

--- a/templates/staff/job_request_list.html
+++ b/templates/staff/job_request_list.html
@@ -63,9 +63,13 @@
 
       <div class="list-group list-unstyled">
         {% for job_request in object_list %}
-        <a class="list-group-item list-group-item-action" href="{{ job_request.get_staff_url }}">
-          {{ job_request.pk }} by {{ job_request.created_by }}
-          <small class="text-muted">(created {{ job_request.created_at|date }})</small>
+        <a class="list-group-item list-group-item-action d-flex flex-column align-items-start"
+          href="{{ job_request.get_staff_url }}">
+          <div>
+            {{ job_request.pk }} by {{ job_request.created_by }}
+            <small class="text-muted">(created {{ job_request.created_at|date }})</small>
+          </div>
+          <small class="text-muted">{{ job_request.workspace.name }}</small>
         </a>
         {% endfor %}
       </div>

--- a/templates/staff/job_request_list.html
+++ b/templates/staff/job_request_list.html
@@ -46,12 +46,12 @@
     <div class="col col-lg-9 col-xl-8">
       <form method="GET" class="mb-4">
         <div class="form-inline w-100 d-flex flex-nowrap">
-          <label for="requestSearch" class="sr-only">Search by number, (partial) identifier, name of author, workspace, project, or org</label>
+          <label for="requestSearch" class="sr-only">Search by number, (partial) identifier, job (partial) identifier, name of author, workspace, project, or org</label>
           <input
             class="form-control mr-sm-2 w-100"
             id="requestSearch"
             name="q"
-            placeholder="Search by number, (partial) identifier, name of author, workspace, project, or org"
+            placeholder="Search by number, (partial) identifier, job (partial) identifier, name of author, workspace, project, or org"
             type="search"
             {% if q %}
               value="{{ q }}"

--- a/templates/staff/job_request_list.html
+++ b/templates/staff/job_request_list.html
@@ -63,10 +63,10 @@
 
       <div class="list-group list-unstyled">
         {% for job_request in object_list %}
-        <span class="list-group-item list-group-item-action">
+        <a class="list-group-item list-group-item-action" href="{{ job_request.get_staff_url }}">
           {{ job_request.pk }} by {{ job_request.created_by }}
           <small class="text-muted">(created {{ job_request.created_at|date }})</small>
-        </span>
+        </a>
         {% endfor %}
       </div>
 

--- a/templates/staff/workspace_detail.html
+++ b/templates/staff/workspace_detail.html
@@ -87,6 +87,23 @@
         </div>
       </section>
 
+      <div class="d-flex justify-content-between align-items-center">
+        <h2>Job Requests</h2>
+        <a class="btn btn-sm btn-primary"
+          href="{% url 'staff:job-request-list' %}?workspace={{ workspace.name }}"
+          >View all</a>
+      </div>
+      <div class="list-group mb-3">
+        {% for job_request in job_requests %}
+        <a href="{{ job_request.get_staff_url }}" class="list-group-item list-group-item-action">
+          {{ job_request.pk }} by {{ job_request.created_by.name }}
+          <small class="text-muted">(created {{ job_request.created_at|date }})</small>
+        </a>
+        {% empty %}
+          <p class="list-group-item">No job requests</p>
+        {% endfor %}
+      </div>
+
       <h2>Redirects</h2>
       <div class="list-group mb-3">
         {% for redirect in redirects %}

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -121,6 +121,19 @@ def test_jobrequest_get_repo_url_success():
     assert url == "http://example.com/opensafely/some_repo/tree/abc123"
 
 
+def test_jobrequest_get_staff_url():
+    job_request = JobRequestFactory()
+
+    url = job_request.get_staff_url()
+
+    assert url == reverse(
+        "staff:job-request-detail",
+        kwargs={
+            "pk": job_request.pk,
+        },
+    )
+
+
 def test_jobrequest_is_completed():
     job_request = JobRequestFactory()
     JobFactory(job_request=job_request, status="failed")

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -356,3 +356,9 @@ def test_jobrequest_status_without_prefetching_jobs(django_assert_num_queries):
     job_request.status
 
     assert "jobs" in job_request._prefetched_objects_cache
+
+
+def test_jobrequest_str():
+    job_request = JobRequestFactory()
+
+    assert str(job_request) == str(job_request.pk)

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -167,7 +167,7 @@ def test_jobrequest_runtime_one_job_missing_completed_at(freezer):
         completed_at=None,
     )
 
-    jr = JobRequest.objects.get(pk=job_request.pk)
+    jr = JobRequest.objects.with_started_at().get(pk=job_request.pk)
     assert jr.started_at
     assert not jr.completed_at
 
@@ -197,7 +197,7 @@ def test_jobrequest_runtime_one_job_missing_started_at(freezer):
         completed_at=timezone.now(),
     )
 
-    jr = JobRequest.objects.get(pk=job_request.pk)
+    jr = JobRequest.objects.with_started_at().get(pk=job_request.pk)
     assert jr.started_at
     assert jr.completed_at
 
@@ -211,7 +211,7 @@ def test_jobrequest_runtime_one_job_missing_started_at(freezer):
 
 def test_jobrequest_runtime_no_jobs():
     JobRequestFactory()
-    assert not JobRequest.objects.first().runtime
+    assert not JobRequest.objects.with_started_at().first().runtime
 
 
 def test_jobrequest_runtime_not_completed(freezer):
@@ -231,7 +231,7 @@ def test_jobrequest_runtime_not_completed(freezer):
         started_at=seconds_ago(now, 30),
     )
 
-    job_request = JobRequest.objects.first()
+    job_request = JobRequest.objects.with_started_at().first()
     assert job_request.started_at
     assert not job_request.completed_at
 
@@ -248,7 +248,7 @@ def test_jobrequest_runtime_not_started():
     JobFactory(job_request=jr, status="running")
     JobFactory(job_request=jr, status="pending")
 
-    assert not JobRequest.objects.first().runtime
+    assert not JobRequest.objects.with_started_at().first().runtime
 
 
 def test_jobrequest_runtime_success():
@@ -269,7 +269,7 @@ def test_jobrequest_runtime_success():
         completed_at=start + timedelta(minutes=3),
     )
 
-    job_request = JobRequest.objects.first()
+    job_request = JobRequest.objects.with_started_at().first()
     assert job_request.runtime
     assert job_request.runtime.hours == 0
     assert job_request.runtime.minutes == 2
@@ -344,7 +344,7 @@ def test_jobrequest_status_uses_prefetch_cache(django_assert_num_queries):
     with django_assert_num_queries(2):
         # 1. select JobRequests
         # 2. select Jobs for those JobRequests
-        [jr.status for jr in JobRequest.objects.all()]
+        [jr.status for jr in JobRequest.objects.with_started_at().all()]
 
 
 def test_jobrequest_status_without_prefetching_jobs(django_assert_num_queries):

--- a/tests/unit/staff/views/test_job_requests.py
+++ b/tests/unit/staff/views/test_job_requests.py
@@ -1,0 +1,155 @@
+import pytest
+from django.core.exceptions import PermissionDenied
+
+from jobserver.utils import set_from_qs
+from staff.views.job_requests import JobRequestList
+
+from ....factories import (
+    JobRequestFactory,
+    OrgFactory,
+    ProjectFactory,
+    UserFactory,
+    WorkspaceFactory,
+)
+
+
+def test_jobrequestlist_search_by_fullname(rf, core_developer):
+    JobRequestFactory.create_batch(5)
+
+    user = UserFactory(fullname="Ben Goldacre")
+    job_request = JobRequestFactory(created_by=user)
+
+    request = rf.get("/?q=ben")
+    request.user = core_developer
+
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 200
+    assert len(response.context_data["object_list"]) == 1
+    assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
+
+
+def test_jobrequestlist_search_by_identifier(rf, core_developer):
+    JobRequestFactory.create_batch(5)
+
+    job_request = JobRequestFactory(identifier="1234abcd")
+
+    request = rf.get("/?q=1234abcd")
+    request.user = core_developer
+
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 200
+    assert len(response.context_data["object_list"]) == 1
+    assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
+
+    request = rf.get("/?q=34ab")
+    request.user = core_developer
+
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 200
+    assert len(response.context_data["object_list"]) == 1
+    assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
+
+
+def test_jobrequestlist_search_by_org(rf, core_developer):
+    JobRequestFactory.create_batch(5)
+
+    org = OrgFactory(name="University of Testing")
+    project = ProjectFactory(org=org)
+    workspace = WorkspaceFactory(project=project)
+    job_request = JobRequestFactory(workspace=workspace)
+
+    request = rf.get("/?q=university")
+    request.user = core_developer
+
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 200
+    assert len(response.context_data["object_list"]) == 1
+    assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
+
+
+def test_jobrequestlist_search_by_pk(rf, core_developer):
+    JobRequestFactory.create_batch(5)
+
+    job_request = JobRequestFactory()
+
+    request = rf.get(f"/?q={job_request.pk}")
+    request.user = core_developer
+
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 200
+    assert len(response.context_data["object_list"]) == 1
+    assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
+
+
+def test_jobrequestlist_search_by_project(rf, core_developer):
+    JobRequestFactory.create_batch(5)
+
+    project = ProjectFactory(name="A Very Important Project")
+    workspace = WorkspaceFactory(project=project)
+    job_request = JobRequestFactory(workspace=workspace)
+
+    request = rf.get("/?q=important")
+    request.user = core_developer
+
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 200
+    assert len(response.context_data["object_list"]) == 1
+    assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
+
+
+def test_jobrequestlist_search_by_username(rf, core_developer):
+    JobRequestFactory.create_batch(5)
+
+    user = UserFactory(username="beng")
+    job_request = JobRequestFactory(created_by=user)
+
+    request = rf.get("/?q=ben")
+    request.user = core_developer
+
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 200
+    assert len(response.context_data["object_list"]) == 1
+    assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
+
+
+def test_jobrequestlist_search_by_workspace(rf, core_developer):
+    JobRequestFactory.create_batch(5)
+
+    workspace = WorkspaceFactory(name="workspace-testing-research")
+    job_request = JobRequestFactory(workspace=workspace)
+
+    request = rf.get("/?q=research")
+    request.user = core_developer
+
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 200
+    assert len(response.context_data["object_list"]) == 1
+    assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
+
+
+def test_jobrequestlist_success(rf, core_developer):
+    JobRequestFactory.create_batch(5)
+
+    request = rf.get("/")
+    request.user = core_developer
+
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 200
+    assert len(response.context_data["object_list"]) == 5
+
+
+def test_jobrequestlist_unauthorized(rf):
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    with pytest.raises(PermissionDenied):
+        JobRequestList.as_view()(request)

--- a/tests/unit/staff/views/test_job_requests.py
+++ b/tests/unit/staff/views/test_job_requests.py
@@ -43,6 +43,22 @@ def test_jobrequestdetail_unknown_job_request(rf, core_developer):
         JobRequestDetail.as_view()(request, pk=0)
 
 
+def test_jobrequestlist_filter_by_workspace(rf, core_developer):
+    JobRequestFactory.create_batch(5)
+
+    workspace = WorkspaceFactory(name="workspace-testing-research")
+    job_request = JobRequestFactory(workspace=workspace)
+
+    request = rf.get(f"/?workspace={workspace.name}")
+    request.user = core_developer
+
+    response = JobRequestList.as_view()(request)
+
+    assert response.status_code == 200
+    assert len(response.context_data["object_list"]) == 1
+    assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
+
+
 def test_jobrequestlist_search_by_fullname(rf, core_developer):
     JobRequestFactory.create_batch(5)
 


### PR DESCRIPTION
We can't lean on our typical filtering UI for JobRequests since we'd had to list nearly every User, Project, and Workspace.  I suspect we can add those in later with searchable dropdowns, however I didn't want this change to be bogged down by working out how to get those working in the staff area.

Fix: #3322 