### PR TITLE
Use the MD5 password hasher in tests

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -197,9 +197,12 @@ SOCIAL_AUTH_GITHUB_SCOPE = ["user:email"]
 
 # Passwords
 # https://docs.djangoproject.com/en/4.0/ref/settings/#password-hashers
-PASSWORD_HASHERS = [
-    "django.contrib.auth.hashers.Argon2PasswordHasher",
-]
+PASSWORD_HASHERS = env.list(
+    "PASSWORD_HASHERS",
+    default=[
+        "django.contrib.auth.hashers.Argon2PasswordHasher",
+    ],
+)
 
 
 # Messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ addopts = "--disable-network --tb=native --no-migrations --ignore=./release-hatc
 DJANGO_SETTINGS_MODULE = "jobserver.settings"
 env = [
   "GITHUB_TOKEN=empty",
+  "PASSWORD_HASHERS=django.contrib.auth.hashers.MD5PasswordHasher",
   "SECRET_KEY=12345",
   "SOCIAL_AUTH_GITHUB_KEY=test",
   "SOCIAL_AUTH_GITHUB_SECRET=test",


### PR DESCRIPTION
The argon2 hasher is more expensive to use and we don't need extra password security in tests, so lets optimise for speed in that context.

This currently affects 21 tests, which you can check by setting `PASSWORD_HASHERS=` in pyproject.toml and counting how many tests break (at least one password hasher is required).  Locally I'm seeing this shave a handful (2-3) of seconds off the test runtime, but I would expect to see a little more in CI.