### PR TITLE
Annotate started_at to the latest JobRequest when creating a job

### DIFF
--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -171,7 +171,11 @@ class JobRequestCreate(CreateView):
         return {"will_notify": self.workspace.should_notify}
 
     def get_latest_job_request(self):
-        return self.workspace.job_requests.order_by("-created_at").first()
+        return (
+            self.workspace.job_requests.with_started_at()
+            .order_by("-created_at")
+            .first()
+        )
 
 
 class JobRequestDetail(View):


### PR DESCRIPTION
This was missed in #3323 because of the missing check on the context data of this view.