### PR TITLE
Display search query in the filters sidebar of staff area list pages

### DIFF
--- a/staff/views/analysis_requests.py
+++ b/staff/views/analysis_requests.py
@@ -1,6 +1,3 @@
-import functools
-
-from django.db.models import Q
 from django.db.models.functions import Lower
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
@@ -12,6 +9,8 @@ from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_role
 from jobserver.github import _get_github_api
 from jobserver.models import Project, User
+
+from .qwargs_tools import qwargs
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
@@ -80,15 +79,7 @@ class AnalysisRequestList(ListView):
                 "created_by__username",
                 "title",
             ]
-
-            # build up Q objects OR'd together.  We need to build them with
-            # functools.reduce so we can optionally add the PK filter to the
-            # list
-            qwargs = functools.reduce(
-                Q.__or__, (Q(**{f"{f}__icontains": q}) for f in fields)
-            )
-
-            qs = qs.filter(qwargs)
+            qs = qs.filter(qwargs(fields, q))
 
         if self.request.GET.get("has_report") == "yes":
             qs = qs.exclude(report=None)

--- a/staff/views/orgs.py
+++ b/staff/views/orgs.py
@@ -15,6 +15,7 @@ from jobserver.models import Org, OrgMembership, Project, User
 
 from ..forms import OrgAddGitHubOrgForm, OrgAddMemberForm
 from ..htmx_tools import get_redirect_url
+from .qwargs_tools import qwargs
 
 
 @require_role(CoreDeveloper)
@@ -170,9 +171,11 @@ class OrgList(ListView):
     def get_queryset(self):
         qs = super().get_queryset()
 
-        q = self.request.GET.get("q")
-        if q:
-            qs = qs.filter(name__icontains=q)
+        if q := self.request.GET.get("q"):
+            fields = [
+                "name",
+            ]
+            qs = qs.filter(qwargs(fields, q))
 
         return qs
 

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -1,6 +1,5 @@
 from django.contrib import messages
 from django.db import transaction
-from django.db.models import Q
 from django.db.models.functions import Lower
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
@@ -34,6 +33,7 @@ from ..forms import (
     ProjectMembershipForm,
 )
 from ..htmx_tools import get_redirect_url
+from .qwargs_tools import qwargs
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
@@ -301,9 +301,12 @@ class ProjectList(ListView):
     def get_queryset(self):
         qs = super().get_queryset()
 
-        q = self.request.GET.get("q")
-        if q:
-            qs = qs.filter(Q(name__icontains=q) | Q(number__icontains=q))
+        if q := self.request.GET.get("q"):
+            fields = [
+                "name",
+                "number",
+            ]
+            qs = qs.filter(qwargs(fields, q))
 
         org = self.request.GET.get("org")
         if org:

--- a/staff/views/qwargs_tools.py
+++ b/staff/views/qwargs_tools.py
@@ -1,0 +1,14 @@
+import functools
+
+from django.db.models import Q
+
+
+def qwargs(fields, query, expression="icontains", operator=Q.__or__):
+    """
+    Build a Q object across the given fields with the given query
+
+    By default this ORs together a group of __icontains conditions.
+    """
+    return functools.reduce(
+        operator, (Q(**{f"{field}__{expression}": query}) for field in fields)
+    )

--- a/staff/views/redirects.py
+++ b/staff/views/redirects.py
@@ -1,7 +1,4 @@
-import functools
-
 from django.contrib import messages
-from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
 from django.views.generic import DetailView, ListView, View
@@ -9,6 +6,8 @@ from django.views.generic import DetailView, ListView, View
 from jobserver.authorization import CoreDeveloper
 from jobserver.authorization.decorators import require_role
 from redirects.models import Redirect
+
+from .qwargs_tools import qwargs
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
@@ -59,15 +58,7 @@ class RedirectList(ListView):
                 "project__name",
                 "workspace__name",
             ]
-
-            # build up Q objects OR'd together.  We need to build them with
-            # functools.reduce so we can optionally add the PK filter to the
-            # list
-            qwargs = functools.reduce(
-                Q.__or__, (Q(**{f"{f}__icontains": q}) for f in fields)
-            )
-
-            qs = qs.filter(qwargs)
+            qs = qs.filter(qwargs(fields, q))
 
         if object_type := self.request.GET.get("type"):
             qs = qs.filter(**{f"{object_type}__isnull": False})

--- a/staff/views/redirects.py
+++ b/staff/views/redirects.py
@@ -51,9 +51,11 @@ class RedirectList(ListView):
 
         if q := self.request.GET.get("q"):
             fields = [
+                "analysis_request__title",
                 "created_by__fullname",
                 "created_by__username",
                 "old_url",
+                "org__name",
                 "project__name",
                 "workspace__name",
             ]

--- a/staff/views/reports.py
+++ b/staff/views/reports.py
@@ -1,6 +1,4 @@
-import functools
-
-from django.db.models import OuterRef, Q, Subquery
+from django.db.models import OuterRef, Subquery
 from django.db.models.functions import Lower
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
@@ -16,6 +14,8 @@ from jobserver.models import (
     Report,
     User,
 )
+
+from .qwargs_tools import qwargs
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
@@ -111,15 +111,7 @@ class ReportList(ListView):
                 "created_by__username",
                 "title",
             ]
-
-            # build up Q objects OR'd together.  We need to build them with
-            # functools.reduce so we can optionally add the PK filter to the
-            # list
-            qwargs = functools.reduce(
-                Q.__or__, (Q(**{f"{f}__icontains": q}) for f in fields)
-            )
-
-            qs = qs.filter(qwargs)
+            qs = qs.filter(qwargs(fields, q))
 
         if state := self.request.GET.get("state"):
             # annotate the latest PublishRequest.decision value onto each

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -20,6 +20,8 @@ from jobserver.github import _get_github_api
 from jobserver.issues import create_switch_repo_to_public_request
 from jobserver.models import Job, Org, Project, Repo, User
 
+from .qwargs_tools import qwargs
+
 
 logger = structlog.get_logger(__name__)
 
@@ -170,7 +172,10 @@ class RepoList(ListView):
 
         # filter on the search query
         if q := self.request.GET.get("q"):
-            qs = qs.filter(url__icontains=q)
+            fields = [
+                "url",
+            ]
+            qs = qs.filter(qwargs(fields, q))
 
         if has_outputs := self.request.GET.get("has_outputs") == "yes":
             qs = qs.filter(has_github_outputs=has_outputs)

--- a/staff/views/workspaces.py
+++ b/staff/views/workspaces.py
@@ -1,5 +1,4 @@
 from django.db import transaction
-from django.db.models import Q
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.generic import DetailView, ListView, UpdateView
@@ -9,6 +8,7 @@ from jobserver.authorization.decorators import require_role
 from jobserver.models import Workspace
 
 from ..forms import WorkspaceEditForm
+from .qwargs_tools import qwargs
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
@@ -71,8 +71,11 @@ class WorkspaceList(ListView):
     def get_queryset(self):
         qs = super().get_queryset()
 
-        q = self.request.GET.get("q")
-        if q:
-            qs = qs.filter(Q(name__icontains=q) | Q(repo__url__icontains=q))
+        if q := self.request.GET.get("q"):
+            fields = [
+                "name",
+                "repo__url",
+            ]
+            qs = qs.filter(qwargs(fields, q))
 
         return qs

--- a/templates/staff/analysis_request_list.html
+++ b/templates/staff/analysis_request_list.html
@@ -41,6 +41,13 @@
       </div>
       {% endif %}
 
+      {% if request.GET.q %}
+      <div class="mb-3">
+        <h3 class="h4 mb-0">Search query</h3>
+        <code>{{ request.GET.q }}</code>
+      </div>
+      {% endif %}
+
       <h3 class="h4">Has Report</h3>
       <div class="btn-group-vertical w-100 mb-4" role="group" aria-label="Filter by having a report">
         {% is_filter_selected key="has_report" value="yes" as is_active %}

--- a/templates/staff/application_list.html
+++ b/templates/staff/application_list.html
@@ -41,6 +41,13 @@
       </div>
       {% endif %}
 
+      {% if request.GET.q %}
+      <div class="mb-3">
+        <h3 class="h4 mb-0">Search query</h3>
+        <code>{{ request.GET.q }}</code>
+      </div>
+      {% endif %}
+
       {% if statuses %}
       <h3 class="h4">Statuses</h3>
       <div class="btn-group-vertical w-100 mb-4" role="group" aria-label="Filter by status">

--- a/templates/staff/job_request_list.html
+++ b/templates/staff/job_request_list.html
@@ -51,6 +51,18 @@
         {% endif %}
       </div>
 
+      {% if request.GET.q %}
+      <div class="mb-4">
+        <div class="d-flex justify-content-between align-items-center mb-1">
+          <h3 class="h4 mb-0">Search query</h3>
+          <small>
+            <a href="{% url_without_querystring q="" %}">Clear</a>
+          </small>
+        </div>
+        <code>{{ request.GET.q }}</code>
+      </div>
+      {% endif %}
+
       <div class="mb-4">
         <div class="d-flex justify-content-between align-items-center mb-1">
           <h3 class="h4 mb-0">Filter by organisation</h3>

--- a/templates/staff/org_list.html
+++ b/templates/staff/org_list.html
@@ -42,6 +42,13 @@
         <a href="{% url 'staff:org-list' %}">Clear All</a>
       </div>
       {% endif %}
+
+      {% if request.GET.q %}
+      <div class="mb-3">
+        <h3 class="h4 mb-0">Search query</h3>
+        <code>{{ request.GET.q }}</code>
+      </div>
+      {% endif %}
     </div>
 
     <div class="col col-lg-9 col-xl-8">

--- a/templates/staff/org_list.html
+++ b/templates/staff/org_list.html
@@ -34,6 +34,16 @@
 {% block content %}
 <div class="container">
   <div class="row">
+    <div class="col col-lg-3 col-xl-4">
+      <h2 class="h3">Filters</h2>
+
+      {% if request.GET %}
+      <div class="mb-3">
+        <a href="{% url 'staff:org-list' %}">Clear All</a>
+      </div>
+      {% endif %}
+    </div>
+
     <div class="col col-lg-9 col-xl-8">
       <form method="GET" class="mb-4">
         <div class="form-inline w-100 d-flex flex-nowrap">

--- a/templates/staff/project_list.html
+++ b/templates/staff/project_list.html
@@ -41,6 +41,13 @@
     <div class="col col-lg-3 col-xl-4">
       <h2 class="sr-only">Filters</h2>
 
+      {% if request.GET.q %}
+      <div class="mb-3">
+        <h3 class="h4 mb-0">Search query</h3>
+        <code>{{ request.GET.q }}</code>
+      </div>
+      {% endif %}
+
       {% if orgs %}
       <h3 class="h4">Filter by organisation</h3>
       {% if request.GET %}

--- a/templates/staff/redirect_list.html
+++ b/templates/staff/redirect_list.html
@@ -40,6 +40,13 @@
       </div>
       {% endif %}
 
+      {% if request.GET.q %}
+      <div class="mb-3">
+        <h3 class="h4 mb-0">Search query</h3>
+        <code>{{ request.GET.q }}</code>
+      </div>
+      {% endif %}
+
       {% if backends %}
       <h3 class="h4">Backends</h3>
       <div class="btn-group-vertical w-100 mb-4" role="group" aria-label="Filter by backends">

--- a/templates/staff/redirect_list.html
+++ b/templates/staff/redirect_list.html
@@ -133,7 +133,7 @@
       <input
         class="form-control mr-2"
         type="search"
-        placeholder="Search by name or username"
+        placeholder="Search by old url, analysis, creator, org, project, or workspace"
         aria-label="Search"
         {% if q %}
         value="{{ q }}"

--- a/templates/staff/repo_list.html
+++ b/templates/staff/repo_list.html
@@ -40,6 +40,13 @@
       </div>
       {% endif %}
 
+      {% if request.GET.q %}
+      <div class="mb-3">
+        <h3 class="h4 mb-0">Search query</h3>
+        <code>{{ request.GET.q }}</code>
+      </div>
+      {% endif %}
+
       <h3 class="h4">Has Outputs on GitHub</h3>
       <div class="btn-group-vertical w-100 mb-4" role="group" aria-label="Filter by having outputs on GitHub">
         {% is_filter_selected key="has_outputs" value="yes" as is_active %}

--- a/templates/staff/report_list.html
+++ b/templates/staff/report_list.html
@@ -41,6 +41,13 @@
       </div>
       {% endif %}
 
+      {% if request.GET.q %}
+      <div class="mb-3">
+        <h3 class="h4 mb-0">Search query</h3>
+        <code>{{ request.GET.q }}</code>
+      </div>
+      {% endif %}
+
       <h3 class="h4">Published state</h3>
       <div class="btn-group-vertical w-100 mb-4" role="group" aria-label="Filter by state">
         {% for state in states %}

--- a/templates/staff/user_list.html
+++ b/templates/staff/user_list.html
@@ -46,6 +46,13 @@
       </div>
       {% endif %}
 
+      {% if request.GET.q %}
+      <div class="mb-3">
+        <h3 class="h4 mb-0">Search query</h3>
+        <code>{{ request.GET.q }}</code>
+      </div>
+      {% endif %}
+
       {% if backends %}
       <h3 class="h4">Backends</h3>
       <div class="btn-group-vertical w-100 mb-4" role="group" aria-label="Filter by backends">

--- a/templates/staff/workspace_list.html
+++ b/templates/staff/workspace_list.html
@@ -39,6 +39,13 @@
         <a href="{% url 'staff:workspace-list' %}">Clear All</a>
       </div>
       {% endif %}
+
+      {% if request.GET.q %}
+      <div class="mb-3">
+        <h3 class="h4 mb-0">Search query</h3>
+        <code>{{ request.GET.q }}</code>
+      </div>
+      {% endif %}
     </div>
 
     <div class="col-lg-9 col-xl-8">

--- a/templates/staff/workspace_list.html
+++ b/templates/staff/workspace_list.html
@@ -29,10 +29,19 @@
 {% endblock jumbotron %}
 
 {% block content %}
-
 <div class="container">
   <div class="row">
-    <div class="col-lg-8 col-xl-9">
+    <div class="col col-lg-3 col-xl-4">
+      <h2 class="h3">Filters</h2>
+
+      {% if request.GET %}
+      <div class="mb-3">
+        <a href="{% url 'staff:workspace-list' %}">Clear All</a>
+      </div>
+      {% endif %}
+    </div>
+
+    <div class="col-lg-9 col-xl-8">
       <form class="form d-flex align-items-center mb-3" method="GET">
         <input
           class="form-control mr-2"
@@ -55,5 +64,4 @@
     </div>
   </div>
 </div>
-
 {% endblock content %}

--- a/tests/unit/staff/views/test_redirects.py
+++ b/tests/unit/staff/views/test_redirects.py
@@ -112,6 +112,23 @@ def test_redirectlist_filter_by_object_type(rf, core_developer):
     assert set(response.context_data["object_list"]) == set(workspace_redirects)
 
 
+def test_redirectlist_search_by_analysis_request(rf, core_developer):
+    analysis_request = AnalysisRequestFactory()
+    redirect = RedirectFactory(analysis_request=analysis_request)
+
+    RedirectFactory(org=OrgFactory())
+    RedirectFactory(project=ProjectFactory())
+    RedirectFactory(workspace=WorkspaceFactory())
+
+    request = rf.get(f"/?q={analysis_request.title}")
+    request.user = core_developer
+
+    response = RedirectList.as_view()(request)
+
+    assert response.status_code == 200
+    assert set(response.context_data["object_list"]) == {redirect}
+
+
 def test_jobrequestlist_search_by_fullname(rf, core_developer):
     org = OrgFactory()
     user = UserFactory(fullname="Ben Goldacre")
@@ -135,6 +152,23 @@ def test_redirectlist_search_by_old_url(rf, core_developer):
     RedirectFactory.create_batch(5, org=org)
 
     request = rf.get("/?q=foo")
+    request.user = core_developer
+
+    response = RedirectList.as_view()(request)
+
+    assert response.status_code == 200
+    assert set(response.context_data["object_list"]) == {redirect}
+
+
+def test_redirectlist_search_by_org(rf, core_developer):
+    org = OrgFactory()
+    redirect = RedirectFactory(org=org)
+
+    RedirectFactory(analysis_request=AnalysisRequestFactory())
+    RedirectFactory(project=ProjectFactory())
+    RedirectFactory(workspace=WorkspaceFactory())
+
+    request = rf.get(f"/?q={org.name}")
     request.user = core_developer
 
     response = RedirectList.as_view()(request)

--- a/tests/unit/staff/views/test_redirects.py
+++ b/tests/unit/staff/views/test_redirects.py
@@ -8,7 +8,14 @@ from django.urls import reverse
 from redirects.models import Redirect
 from staff.views.redirects import RedirectDelete, RedirectDetail, RedirectList
 
-from ....factories import ProjectFactory, RedirectFactory, WorkspaceFactory
+from ....factories import (
+    AnalysisRequestFactory,
+    OrgFactory,
+    ProjectFactory,
+    RedirectFactory,
+    UserFactory,
+    WorkspaceFactory,
+)
 
 
 def test_redirectdelete_success(rf, core_developer):
@@ -105,11 +112,77 @@ def test_redirectlist_filter_by_object_type(rf, core_developer):
     assert set(response.context_data["object_list"]) == set(workspace_redirects)
 
 
-def test_redirectlist_search(rf, core_developer):
+def test_jobrequestlist_search_by_fullname(rf, core_developer):
+    org = OrgFactory()
+    user = UserFactory(fullname="Ben Goldacre")
+    redirect = RedirectFactory(org=org, created_by=user)
+
+    RedirectFactory.create_batch(5, org=org)
+
+    request = rf.get("/?q=ben")
+    request.user = core_developer
+
+    response = RedirectList.as_view()(request)
+
+    assert response.status_code == 200
+    assert set(response.context_data["object_list"]) == {redirect}
+
+
+def test_redirectlist_search_by_old_url(rf, core_developer):
+    org = OrgFactory()
+    redirect = RedirectFactory(org=org, old_url="/test/foo/bar/")
+
+    RedirectFactory.create_batch(5, org=org)
+
+    request = rf.get("/?q=foo")
+    request.user = core_developer
+
+    response = RedirectList.as_view()(request)
+
+    assert response.status_code == 200
+    assert set(response.context_data["object_list"]) == {redirect}
+
+
+def test_redirectlist_search_by_project(rf, core_developer):
     project = ProjectFactory()
     redirect = RedirectFactory(project=project)
 
+    RedirectFactory(analysis_request=AnalysisRequestFactory())
+    RedirectFactory(org=OrgFactory())
     RedirectFactory(project=ProjectFactory())
+    RedirectFactory(workspace=WorkspaceFactory())
+
+    request = rf.get(f"/?q={project.name}")
+    request.user = core_developer
+
+    response = RedirectList.as_view()(request)
+
+    assert response.status_code == 200
+    assert set(response.context_data["object_list"]) == {redirect}
+
+
+def test_redirectlist_search_by_username(rf, core_developer):
+    org = OrgFactory()
+    user = UserFactory(username="beng")
+    redirect = RedirectFactory(org=org, created_by=user)
+
+    RedirectFactory.create_batch(5, org=org)
+
+    request = rf.get("/?q=ben")
+    request.user = core_developer
+
+    response = RedirectList.as_view()(request)
+
+    assert response.status_code == 200
+    assert set(response.context_data["object_list"]) == {redirect}
+
+
+def test_redirectlist_search_by_workspace(rf, core_developer):
+    project = ProjectFactory()
+    redirect = RedirectFactory(project=project)
+
+    RedirectFactory(analysis_request=AnalysisRequestFactory())
+    RedirectFactory(org=OrgFactory())
     RedirectFactory(workspace=WorkspaceFactory())
 
     request = rf.get(f"/?q={project.name}")


### PR DESCRIPTION
This adds the current search query for a staff area list page into the sidebar above any possible filters.

Along the way I've added any missing bits to various list pages to try and bring them in line with each other.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/mXuGG995/ac453fbd-f818-4e88-8bad-003635071b57.jpg?v=ad895dcee722bc4f9de8f3660e6b0ea5)

Fix: #3326 