### PR TITLE
chore: permit access for Amazonbot

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,6 +1,3 @@
-User-agent: Amazonbot               # Amazon's user agent
-Disallow: /
-
 User-agent: *
 Crawl-delay: 1
 Disallow: /api/


### PR DESCRIPTION
* they've stopped scraping us, so have definitely read our most recent robots.txt (which told them not to scrape us at all)
* permit them to scrape us, but now with Crawl-delay set. We should have sufficient capacity to support this - and if we don't we should increase Crawl-delay
* fix https://github.com/opensafely-core/job-server/issues/3306
