### PR TITLE
Switch publishing to paths

### DIFF
--- a/jobserver/management/commands/publish_files.py
+++ b/jobserver/management/commands/publish_files.py
@@ -2,33 +2,44 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from furl import furl
 
-from jobserver import models
+from jobserver import models, releases
 
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument("username", type=str)
         parser.add_argument(
-            "ids", nargs="+", type=str, help="ReleaseFile IDs to add to Snapshot"
+            "username", type=str, help="Username to create the Snapshot with"
+        )
+        parser.add_argument(
+            "workspace", type=str, help="Workspace name to look up files under"
+        )
+        parser.add_argument(
+            "paths", nargs="+", type=str, help="File paths to add to Snapshot"
         )
 
     def handle(self, *args, **options):
-        ids = set(options["ids"])
+        paths = set(options["paths"])
         username = options["username"]
+        workspace = options["workspace"]
 
         try:
             user = models.User.objects.get(username=username)
         except models.User.DoesNotExist:
             raise CommandError(f"Unknown username: {username}")
 
-        rfiles = models.ReleaseFile.objects.filter(pk__in=ids)
+        try:
+            workspace = models.Workspace.objects.get(name=workspace)
+        except models.Workspace.DoesNotExist:
+            raise CommandError(f"Unknown workspace: {workspace}")
 
-        found = set(rfiles.values_list("pk", flat=True))
-        if unknown := ids - found:
-            raise CommandError(f"Unknown ReleaseFiles: {', '.join(unknown)}")
+        latest = set(releases.workspace_files(workspace).values())
+        requested = [f for f in latest if f.name in paths]
+
+        if missing := paths - {f.name for f in requested}:
+            raise CommandError(f"Unknown paths: {', '.join(missing)}")
 
         publish_request = models.PublishRequest.create_from_files(
-            files=rfiles, user=user
+            files=requested, user=user
         )
 
         url = furl(settings.BASE_URL) / publish_request.snapshot.get_absolute_url()

--- a/jobserver/models/outputs.py
+++ b/jobserver/models/outputs.py
@@ -423,6 +423,9 @@ class ReleaseFile(models.Model):
             ),
         ]
 
+    def __str__(self):
+        return f"{self.name} ({self.id})"
+
     def __format__(self, format_spec):
         match format_spec:
             case "b":

--- a/tests/unit/jobserver/models/test_outputs.py
+++ b/tests/unit/jobserver/models/test_outputs.py
@@ -290,6 +290,16 @@ def test_releasefile_constraints_missing_deleted_at_or_deleted_by():
         ReleaseFileFactory(deleted_at=timezone.now(), deleted_by=None)
 
 
+def test_releasefile_format():
+    size = 3.2 * 1024 * 1024  # 3.2Mb
+    rfile = ReleaseFileFactory(name="important/research.html", size=size)
+
+    assert f"{rfile:b}" == "3,355,443.2b"
+    assert f"{rfile:Kb}" == "3,276.8Kb"
+    assert f"{rfile:Mb}" == "3.2Mb"
+    assert f"{rfile}".startswith("important/research.html")
+
+
 def test_releasefile_get_absolute_url():
     rfile = ReleaseFileFactory(name="file1.txt")
 
@@ -363,19 +373,14 @@ def test_releasefile_get_api_url_with_is_published():
     )
 
 
+def test_releasefile_str():
+    rfile = ReleaseFileFactory(id="12345", name="important/research.html")
+
+    assert str(rfile) == "important/research.html (12345)"
+
+
 def test_releasefile_ulid():
     assert ReleaseFileFactory().ulid.timestamp
-
-
-def test_releasefile_format():
-    rfile = ReleaseFileFactory()
-    rfile.size = 3.2 * 1024 * 1024  # 3.2Mb
-    rfile.save()
-
-    assert f"{rfile:b}" == "3,355,443.2b"
-    assert f"{rfile:Kb}" == "3,276.8Kb"
-    assert f"{rfile:Mb}" == "3.2Mb"
-    assert f"{rfile}".startswith("ReleaseFile object")
 
 
 @pytest.mark.parametrize("field", ["created_at", "created_by"])


### PR DESCRIPTION
Louis has asked us to publish two sets of paths.  Rather than attempt to convert those to the relevant primary keys it seems more useful to have this command take paths instead.