### PR TITLE
Add views to trigger sentry error and message events

### DIFF
--- a/staff/urls.py
+++ b/staff/urls.py
@@ -1,5 +1,6 @@
 from django.urls import include, path
 
+from .views import sentry
 from .views.analysis_requests import (
     AnalysisRequestDetail,
     AnalysisRequestList,
@@ -203,6 +204,14 @@ researcher_urls = [
     path("<int:pk>/edit/", ResearcherEdit.as_view(), name="researcher-edit"),
 ]
 
+
+sentry_urls = [
+    path("", sentry.index, name="index"),
+    path("error", sentry.error, name="error"),
+    path("message", sentry.message, name="message"),
+]
+
+
 user_urls = [
     path("", UserList.as_view(), name="user-list"),
     path("add/", UserCreate.as_view(), name="user-create"),
@@ -229,6 +238,7 @@ urlpatterns = [
     path("repos/", include(repo_urls)),
     path("reports/", include(report_urls)),
     path("researchers/", include(researcher_urls)),
+    path("sentry/", include((sentry_urls, "sentry"), namespace="sentry")),
     path("users/", include(user_urls)),
     path("workspaces/", include(workspace_urls)),
 ]

--- a/staff/views/sentry.py
+++ b/staff/views/sentry.py
@@ -1,0 +1,21 @@
+import sentry_sdk
+from django.template.response import TemplateResponse
+
+from jobserver.authorization import CoreDeveloper
+from jobserver.authorization.decorators import require_role
+
+
+@require_role(CoreDeveloper)
+def error(request):
+    1 / 0
+
+
+@require_role(CoreDeveloper)
+def index(request):
+    return TemplateResponse(request, "staff/sentry/index.html")
+
+
+@require_role(CoreDeveloper)
+def message(request):
+    sentry_sdk.capture_message("testing")
+    return TemplateResponse(request, "staff/sentry/message.html")

--- a/templates/staff/index.html
+++ b/templates/staff/index.html
@@ -52,6 +52,7 @@
         <a href="{% url 'staff:redirect-list' %}" class="list-group-item list-group-item-action">Redirects</a>
         <a href="{% url 'staff:repo-list' %}" class="list-group-item list-group-item-action">Repos</a>
         <a href="{% url 'staff:report-list' %}" class="list-group-item list-group-item-action">Reports</a>
+        <a href="{% url 'staff:sentry:index' %}" class="list-group-item list-group-item-action">Sentry</a>
         <a href="{% url 'staff:user-list' %}" class="list-group-item list-group-item-action">Users</a>
         <a href="{% url 'staff:workspace-list' %}" class="list-group-item list-group-item-action">Workspaces</a>
       </div>

--- a/templates/staff/sentry/index.html
+++ b/templates/staff/sentry/index.html
@@ -1,0 +1,61 @@
+{% extends "staff/base.html" %}
+
+{% block metatitle %}Sentry: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:index' %}">Staff area</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        Sentry
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
+  <div class="container">
+    <h1 class="display-4">Sentry</h1>
+    <div class="lead">
+      <p>
+        A collection of views for manually testing events are sent to Sentry.
+      </p>
+    </div>
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8 col-xl-9">
+
+      <div class="card mb-3">
+        <div class="card-body">
+          <h5 class="card-title">Error</h5>
+          <p class="card-text">
+            Trigger an exception
+          </p>
+          <a href="{% url 'staff:sentry:error' %}" class="btn btn-primary">View</a>
+        </div>
+      </div>
+
+      <div class="card mb-3">
+        <div class="card-body">
+          <h5 class="card-title">Message</h5>
+          <p class="card-text">
+            Send a message to Sentry
+          </p>
+          <a href="{% url 'staff:sentry:message' %}" class="btn btn-primary">View</a>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/templates/staff/sentry/message.html
+++ b/templates/staff/sentry/message.html
@@ -1,0 +1,42 @@
+{% extends "staff/base.html" %}
+
+{% block metatitle %}Send a Sentry message: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+<nav class="breadcrumb-container breadcrumb--danger" aria-label="breadcrumb">
+  <div class="container">
+    <ol class="breadcrumb rounded-0 mb-0 px-0">
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:index' %}">Staff area</a>
+      </li>
+      <li class="breadcrumb-item">
+        <a href="{% url 'staff:sentry:index' %}">Sentry</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">
+        Message
+      </li>
+    </ol>
+  </div>
+</nav>
+{% endblock breadcrumbs %}
+
+{% block jumbotron %}
+<div class="jumbotron jumbotron-fluid jumbotron--danger pt-md-2">
+  <div class="container">
+    <h1 class="display-4">Message</h1>
+  </div>
+</div>
+{% endblock jumbotron %}
+
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div class="col">
+
+      <p>Check the message has <a href="https://ebm-datalab.sentry.io/issues/?project=5443358">arrived on Sentry</a>.</p>
+
+    </div>
+
+  </div>
+</div>
+{% endblock content %}

--- a/tests/unit/staff/views/test_sentry.py
+++ b/tests/unit/staff/views/test_sentry.py
@@ -1,0 +1,59 @@
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import PermissionDenied
+
+from staff.views import sentry
+from staff.views.sentry import sentry_sdk
+
+
+def test_error_success(rf, core_developer):
+    request = rf.get("/")
+    request.user = core_developer
+
+    with pytest.raises(ZeroDivisionError):
+        sentry.error(request)
+
+
+def test_error_unauthorized(rf):
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    with pytest.raises(PermissionDenied):
+        sentry.error(request)
+
+
+def test_index_success(rf, core_developer):
+    request = rf.get("/")
+    request.user = core_developer
+
+    response = sentry.index(request)
+
+    assert response.status_code == 200
+
+
+def test_index_unauthorized(rf):
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    with pytest.raises(PermissionDenied):
+        sentry.index(request)
+
+
+def test_message_success(rf, core_developer, mocker):
+    request = rf.get("/")
+    request.user = core_developer
+
+    spy = mocker.spy(sentry_sdk, "capture_message")
+
+    response = sentry.message(request)
+
+    assert response.status_code == 200
+    spy.assert_called_once_with("testing")
+
+
+def test_message_unauthorized(rf):
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    with pytest.raises(PermissionDenied):
+        sentry.message(request)


### PR DESCRIPTION
In #2667 we silently stopped Sentry events being sent.  Since it's tricky to test for the absense of a signal this adds some tools that let us manually fire those signals.