### PR TITLE
Bump pipeline to v2023.08.09.102223

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -15,7 +15,7 @@ djangorestframework
 environs[django]
 first
 furl
-https://github.com/opensafely-core/pipeline/archive/refs/tags/v0.0.3.zip#egg=opensafely-pipeline
+https://github.com/opensafely-core/pipeline/archive/refs/tags/v2023.08.09.102223.zip#egg=opensafely-pipeline
 gunicorn
 incuna-mail
 interactive_templates@https://github.com/opensafely-core/interactive-templates/archive/7eda2541137be0e04563c37e7cc813ddd93fa02f.zip

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -251,6 +251,10 @@ deprecated==1.2.13 \
     --hash=sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d \
     --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
     # via opentelemetry-api
+distro==1.8.0 \
+    --hash=sha256:02e111d1dc6a50abb8eed6bf31c3e48ed8b0830d1ea2a1b78c61765c2513fdd8 \
+    --hash=sha256:99522ca3e365cac527b44bde033f64c6945d90eb9f769703caaec52b09bbd3ff
+    # via ruyaml
 dj-database-url==1.3.0 \
     --hash=sha256:80a115bd7675c9fe14a900b2f8b5c8b1822b5a279b333bf9b2804de681656c7c \
     --hash=sha256:87be5f7c4c83d9b3d8ce94b834f96cea14b3986f3629aac097afdd9318d7b098
@@ -513,8 +517,8 @@ oauthlib==3.2.2 \
     # via
     #   requests-oauthlib
     #   social-auth-core
-opensafely-pipeline @ https://github.com/opensafely-core/pipeline/archive/refs/tags/v0.0.3.zip \
-    --hash=sha256:cefffa137f3fc380722eb07a5fefbd4b333b60c01b81503cb22c4ab7540ae9ac
+opensafely-pipeline @ https://github.com/opensafely-core/pipeline/archive/refs/tags/v2023.08.09.102223.zip \
+    --hash=sha256:d6caefd6292f7fa019738f47b32c7ce59865f412e94268a67e94bb6d4fe7717c
     # via -r requirements.prod.in
 opentelemetry-api==1.15.0 \
     --hash=sha256:79ab791b4aaad27acc3dc3ba01596db5b5aac2ef75c70622c6038051d6c2cded \
@@ -803,9 +807,9 @@ requests-oauthlib==1.3.1 \
     --hash=sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5 \
     --hash=sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a
     # via social-auth-core
-ruamel-yaml==0.17.21 \
-    --hash=sha256:742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7 \
-    --hash=sha256:8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af
+ruyaml==0.91.0 \
+    --hash=sha256:50e0ee3389c77ad340e209472e0effd41ae0275246df00cdad0a067532171755 \
+    --hash=sha256:6ce9de9f4d082d696d3bde264664d1bcdca8f5a9dff9d1a1f1a127969ab871ab
     # via opensafely-pipeline
 sentry-sdk==1.29.2 \
     --hash=sha256:3e17215d8006612e2df02b0e73115eb8376c37e3f586d8436fa41644e605074d \
@@ -952,3 +956,4 @@ setuptools==67.0.0 \
     #   opentelemetry-api
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
+    #   ruyaml

--- a/tests/unit/jobserver/models/test_job.py
+++ b/tests/unit/jobserver/models/test_job.py
@@ -82,7 +82,7 @@ def test_job_run_command_error_action():
       population_size: 1000
     actions:
       my_action:
-        run: cowsay research!
+        run: cowsay:latest research!
         outputs:
           moderately_sensitive:
             log: logs/cowsay.log
@@ -103,13 +103,13 @@ def test_job_run_command_invalid_project_definition():
       population_size: 1000
     actions:
       my_action:
-        run: cowsay research!
+        run: cowsay:latest research!
         outputs:
           moderately_sensitive:
             log: logs/cowsay.log
       another_action:
         needs: [my_action]
-        run: cowsay research!
+        run: cowsay:latest research!
         outputs:
           moderately_sensitive:
             log: logs/cowsay.log
@@ -130,9 +130,9 @@ def test_job_run_command_invalid_project_definition_yaml():
       population_size: 1000
     actions:
       my_action:
-        run: cowsay research!
+        run: cowsay:latest research!
       my_action:
-        run: cowsay research!
+        run: cowsay:latest research!
     """
 
     job_request = JobRequestFactory(project_definition=pipeline)
@@ -147,7 +147,7 @@ def test_job_run_command_success():
       population_size: 1000
     actions:
       my_action:
-        run: cowsay research!
+        run: cowsay:latest research!
         outputs:
           moderately_sensitive:
             log: logs/cowsay.log
@@ -156,7 +156,7 @@ def test_job_run_command_success():
     job_request = JobRequestFactory(project_definition=pipeline)
     job = JobFactory(job_request=job_request, action="my_action")
 
-    assert job.run_command == "cowsay research!"
+    assert job.run_command == "cowsay:latest research!"
 
 
 def test_job_runtime():

--- a/tests/unit/jobserver/test_pipeline_config.py
+++ b/tests/unit/jobserver/test_pipeline_config.py
@@ -42,11 +42,11 @@ def test_get_actions_missing_needs():
     dummy = Pipeline(
         **{
             "version": 3,
-            "expectations": {},
+            "expectations": {"population_size": 1000},
             "actions": {
                 "frobnicate": {
-                    "run": "test",
-                    "outputs": {"highly_sensitive": {"cohort": "/some/path"}},
+                    "run": "test:latest",
+                    "outputs": {"highly_sensitive": {"cohort": "some/path"}},
                 },
             },
         }
@@ -64,16 +64,16 @@ def test_get_actions_no_run_all():
     dummy = Pipeline(
         **{
             "version": 3,
-            "expectations": {},
+            "expectations": {"population_size": 1000},
             "actions": {
                 "frobnicate": {
-                    "run": "test1",
-                    "outputs": {"highly_sensitive": {"cohort": "/some/path"}},
+                    "run": "test1:latest",
+                    "outputs": {"highly_sensitive": {"cohort": "some/path1"}},
                 },
                 "run_all": {
                     "needs": ["frobnicate"],
-                    "run": "test2",
-                    "outputs": {"highly_sensitive": {"cohort": "/some/path"}},
+                    "run": "test2:latest",
+                    "outputs": {"highly_sensitive": {"cohort": "some/path2"}},
                 },
             },
         }
@@ -92,11 +92,11 @@ def test_get_actions_success():
     content = Pipeline(
         **{
             "version": 3,
-            "expectations": {},
+            "expectations": {"population_size": 1000},
             "actions": {
                 "frobnicate": {
-                    "run": "test",
-                    "outputs": {"highly_sensitive": {"cohort": "/some/path"}},
+                    "run": "test:latest",
+                    "outputs": {"highly_sensitive": {"cohort": "some/path"}},
                 },
             },
         }

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -161,10 +161,10 @@ def test_jobrequestcreate_get_success(ref, rf, mocker, user):
       population_size: 1000
     actions:
       twiddle:
-        run: test
+        run: test:latest
         outputs:
           moderately_sensitive:
-            cohort: /path/to/output.csv
+            cohort: path/to/output.csv
     """
     mocker.patch(
         "jobserver.views.job_requests.get_project",
@@ -230,10 +230,10 @@ def test_jobrequestcreate_get_with_permission(rf, mocker, user):
       population_size: 1000
     actions:
       twiddle:
-        run: test
+        run: test:latest
         outputs:
           moderately_sensitive:
-            cohort: /path/to/output.csv
+            cohort: path/to/output.csv
     """
     mocker.patch(
         "jobserver.views.job_requests.get_project",
@@ -347,10 +347,10 @@ def test_jobrequestcreate_post_success(ref, rf, mocker, monkeypatch, user):
       population_size: 1000
     actions:
       twiddle:
-        run: test
+        run: test:latest
         outputs:
           moderately_sensitive:
-            cohort: /path/to/output.csv
+            cohort: path/to/output.csv
     """
     mocker.patch(
         "jobserver.views.job_requests.get_project",
@@ -442,10 +442,10 @@ def test_jobrequestcreate_post_with_notifications_default(
       population_size: 1000
     actions:
       twiddle:
-        run: test
+        run: test:latest
         outputs:
           moderately_sensitive:
-            cohort: /path/to/output.csv
+            cohort: path/to/output.csv
     """
     mocker.patch(
         "jobserver.views.job_requests.get_project",
@@ -497,10 +497,10 @@ def test_jobrequestcreate_post_with_notifications_override(
       population_size: 1000
     actions:
       twiddle:
-        run: test
+        run: test:latest
         outputs:
           moderately_sensitive:
-            cohort: /path/to/output.csv
+            cohort: path/to/output.csv
     """
     mocker.patch(
         "jobserver.views.job_requests.get_project",


### PR DESCRIPTION
Now that pipeline has switched to [pip-hash-mode-compatible releases](https://github.com/opensafely-core/pipeline/pull/172) we can bump it here and update our tests for the improved validation the recent versions bring.