### PR TITLE
Fix JobRequest.objects.with_started_at

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -167,11 +167,8 @@ class Job(models.Model):
 
 class JobRequestManager(models.Manager):
     def with_started_at(self):
-        return (
-            super()
-            .get_queryset()
-            .prefetch_related("jobs")
-            .annotate(started_at=Min("jobs__started_at"))
+        return self.prefetch_related("jobs").annotate(
+            started_at=Min("jobs__started_at")
         )
 
 

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -154,7 +154,7 @@ def test_jobrequest_num_completed_no_jobs():
     assert JobRequestFactory().num_completed == 0
 
 
-def test_job_request_num_completed_success():
+def test_jobrequest_num_completed_success():
     job_request = JobRequestFactory()
 
     job1, job2 = JobFactory.create_batch(2, job_request=job_request, status="succeeded")
@@ -375,3 +375,13 @@ def test_jobrequest_str():
     job_request = JobRequestFactory()
 
     assert str(job_request) == str(job_request.pk)
+
+
+def test_jobrequestmanager_with_started_at():
+    JobRequestFactory.create_batch(5)
+
+    workspace = WorkspaceFactory()
+    JobRequestFactory(workspace=workspace)
+    JobRequestFactory(workspace=workspace)
+
+    assert JobRequest.objects.with_started_at().filter(workspace=workspace).count() == 2


### PR DESCRIPTION
with_started_at was previously overriding the default QuerySet for JobRequests, hence super().get_queryset() in the method.  However, with this left in it had the unexpected side-effect of removing any previous filtering.

So a QuerySet in the form

    some_workspace.job_requests.with_start_at()

ended up with all JobRequests instead of just those for some_workspace.

Fix: #3346