### PR TITLE
Select some related models to avoid many extra queries

### DIFF
--- a/jobserver/api/jobs.py
+++ b/jobserver/api/jobs.py
@@ -291,10 +291,13 @@ class JobRequestAPIList(ListAPIView):
                 jobs__completed_at__isnull=True,
             )
             .select_related(
+                "backend",
                 "created_by",
                 "workspace",
                 "workspace__created_by",
                 "workspace__project",
+                "workspace__project__org",
+                "workspace__repo",
             )
             .order_by("-created_at")
             .distinct()


### PR DESCRIPTION
With a recent copy of the database this dropped the page locally from 247 queries to 4.