### PR TITLE
Allow blank Job.run_command to handle __error__ jobs

### DIFF
--- a/jobserver/api/jobs.py
+++ b/jobserver/api/jobs.py
@@ -42,7 +42,7 @@ class JobAPIUpdate(APIView):
         job_request_id = serializers.CharField()
         identifier = serializers.CharField()
         action = serializers.CharField(allow_blank=True)
-        run_command = serializers.CharField()
+        run_command = serializers.CharField(allow_blank=True)
         status = serializers.CharField()
         status_code = serializers.CharField(allow_blank=True)
         status_message = serializers.CharField(allow_blank=True)

--- a/tests/unit/jobserver/api/test_jobs.py
+++ b/tests/unit/jobserver/api/test_jobs.py
@@ -440,7 +440,7 @@ def test_jobapiupdate_post_job_request_error(api_rf):
             "identifier": "job1",
             "job_request_id": job_request.identifier,
             "action": "__error__",
-            "run_command": "do-research",
+            "run_command": "",
             "status": "failed",
             "status_code": "",
             "status_message": "",


### PR DESCRIPTION
We encode a JobRequest failing to produce any jobs as a Job with the action "__error__", but it doesn't have a run_command.