### PR TITLE
Only select needed columns for the first run job query

### DIFF
--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -45,6 +45,7 @@ class ProjectDetail(View):
 
         job = (
             Job.objects.filter(job_request__workspace__project=project)
+            .only("pk", "job_request_id", "created_at", "started_at")
             .annotate(first_run=Min(Least("started_at", "created_at")))
             .order_by("first_run")
             .first()


### PR DESCRIPTION
Locally this ~halves the execution time for this query, the most expensive on the page.

Ref: #3393