### PR TITLE
Fix link to project

### DIFF
--- a/templates/job_request_detail.html
+++ b/templates/job_request_detail.html
@@ -99,7 +99,7 @@
             requested one or more actions to be run against real patient data
             in the
             {% spaceless %}
-              {% link text="project" href=job_request.workspace.project.title %}
+              {% link text="project" href=job_request.workspace.project.slug %}
             {% endspaceless %}, within a secure environment.
           </p>
           <p>


### PR DESCRIPTION
Previously, the href attribute used the project title. However, I think it should use the project slug.