### PR TITLE
Pull queries for JobRequestDetail from template

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -228,7 +228,7 @@ class JobRequest(models.Model):
     def __str__(self):
         return str(self.pk)
 
-    @property
+    @cached_property
     def completed_at(self):
         with queries_dangerously_enabled():
             # enable querying here because this property needs to use

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -21,6 +21,7 @@ from opentelemetry.trace import propagation
 from opentelemetry.trace.propagation import tracecontext
 from sentry_sdk import capture_message
 from xkcdpass import xkcd_password
+from zen_queries import queries_dangerously_enabled
 
 from ..authorization import InteractiveReporter
 from ..authorization.fields import RolesArrayField
@@ -1015,6 +1016,7 @@ class User(AbstractBaseUser):
         return token
 
     @cached_property
+    @queries_dangerously_enabled()
     def uses_social_auth(self):
         """
         Cache whether this user logs in via GitHub (using social auth)

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -230,7 +230,11 @@ class JobRequest(models.Model):
 
     @property
     def completed_at(self):
-        last_job = self.jobs.order_by("completed_at").last()
+        with queries_dangerously_enabled():
+            # enable querying here because this property needs to use
+            # self.status which we haven't found a way to push down into the
+            # database yet.
+            last_job = self.jobs.order_by("completed_at").last()
 
         if not last_job:
             return
@@ -312,6 +316,7 @@ class JobRequest(models.Model):
         return len([j for j in self.jobs.all() if j.status == "succeeded"])
 
     @property
+    @queries_dangerously_enabled()
     def runtime(self):
         """
         Combined runtime for all completed Jobs of this JobRequest

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -298,20 +298,6 @@ class JobRequest(models.Model):
         return self.status in ["failed", "succeeded"]
 
     @property
-    def is_invalid(self):
-        """
-        Is this JobRequest invalid?
-
-        JobRequests are a request for a given configuration to be run on a
-        Backend.  That configuration could be unprocessable for a variety of
-        reasons when the Backend looks at it.  We currently surface that to
-        job-server by job-runner creating a Job with the action `__error__`.
-        This property finds Jobs with that action so we can easily see if this
-        particular request was valid or not.
-        """
-        return self.jobs.filter(action="__error__").exists()
-
-    @property
     def num_completed(self):
         return len([j for j in self.jobs.all() if j.status == "succeeded"])
 

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -5,11 +5,11 @@ from django.db import transaction
 from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
-from django.template.response import TemplateResponse
 from django.utils.safestring import mark_safe
 from django.views.generic import CreateView, ListView, RedirectView, View
 from django.views.generic.edit import FormMixin
 from pipeline import load_pipeline
+from zen_queries import TemplateResponse
 
 from .. import honeycomb
 from ..authorization import CoreDeveloper, has_permission, has_role

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -9,7 +9,7 @@ from django.utils.safestring import mark_safe
 from django.views.generic import CreateView, ListView, RedirectView, View
 from django.views.generic.edit import FormMixin
 from pipeline import load_pipeline
-from zen_queries import TemplateResponse
+from zen_queries import TemplateResponse, fetch
 
 from .. import honeycomb
 from ..authorization import CoreDeveloper, has_permission, has_role
@@ -195,6 +195,8 @@ class JobRequestDetail(View):
         except (JobRequest.DoesNotExist, MultipleObjectsReturned):
             raise Http404
 
+        jobs = fetch(job_request.jobs.order_by("started_at"))
+
         can_cancel_jobs = job_request.created_by == request.user or has_permission(
             request.user, "job_cancel", project=job_request.workspace.project
         )
@@ -211,6 +213,7 @@ class JobRequestDetail(View):
             "honeycomb_can_view_links": honeycomb_can_view_links,
             "honeycomb_links": {},
             "job_request": job_request,
+            "jobs": jobs,
             "project_definition": project_definition,
             "project_yaml_url": job_request.get_file_url("project.yaml"),
             "user_can_cancel_jobs": can_cancel_jobs,

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -11,6 +11,7 @@ django-htmx
 django-permissions-policy
 django-structlog
 django-vite
+django-zen-queries
 djangorestframework
 environs[django]
 first

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -278,6 +278,7 @@ django==4.2.4 \
     #   django-permissions-policy
     #   django-structlog
     #   django-vite
+    #   django-zen-queries
     #   djangorestframework
     #   slippers
     #   social-auth-app-django
@@ -324,6 +325,10 @@ django-structlog==5.3.0 \
 django-vite==2.1.3 \
     --hash=sha256:97984ac495910b7b71039228ccddff52d132231fa6612d3d31c6c228c95b0217 \
     --hash=sha256:c59b3bbd85501bc1faf63c500df66542abed2951cfa10dfbf8be8ecf229f7652
+    # via -r requirements.prod.in
+django-zen-queries==2.1.0 \
+    --hash=sha256:255f6a1efd94974c5752af2ef60d2d1fa66466d74e7faf32a6ff46141e947e55 \
+    --hash=sha256:624dad6a10f04df4dc188ff4f27a875943c1708738bd9863388dd39861ac9614
     # via -r requirements.prod.in
 djangorestframework==3.14.0 \
     --hash=sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8 \

--- a/templates/job_request_detail.html
+++ b/templates/job_request_detail.html
@@ -218,7 +218,7 @@
         </ul>
         {% #card_footer %}
           <p class="text-sm font-medium text-slate-600">
-            These timestamps are generated and stored using the UTC timezone on the {{ job.job_request.backend|upper }} backend.
+            These timestamps are generated and stored using the UTC timezone on the {{ job_request.backend|upper }} backend.
           </p>
         {% /card_footer %}
       {% /card %}

--- a/templates/job_request_detail.html
+++ b/templates/job_request_detail.html
@@ -123,7 +123,7 @@
       {% if not job_request.is_invalid %}
         {% #card title="Jobs" %}
           <ul class="divide-y divide-slate-200 border-t border-t-slate-200">
-            {% for job in job_request.jobs.all %}
+            {% for job in jobs %}
               <li class="relative transition-colors hover:bg-oxford-50 group">
                 <dl class="flex flex-col gap-2 px-4 py-4 sm:px-6">
                   <div class="flex gap-x-2">

--- a/templates/job_request_detail.html
+++ b/templates/job_request_detail.html
@@ -120,7 +120,7 @@
         </div>
       {% /card %}
 
-      {% if not job_request.is_invalid %}
+      {% if not is_invalid %}
         {% #card title="Jobs" %}
           <ul class="divide-y divide-slate-200 border-t border-t-slate-200">
             {% for job in jobs %}

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -143,13 +143,6 @@ def test_jobrequest_is_completed():
     assert jr.is_completed
 
 
-def test_jobrequest_is_invalid():
-    job_request = JobRequestFactory()
-    JobFactory(job_request=job_request, action="__error__")
-
-    assert job_request.is_invalid
-
-
 def test_jobrequest_num_completed_no_jobs():
     assert JobRequestFactory().num_completed == 0
 

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -626,6 +626,24 @@ def test_jobrequestdetail_with_job_request_creator(rf):
     assert "Cancel" in response.rendered_content
 
 
+def test_jobrequestdetail_with_invalid_job_request(rf, django_assert_num_queries):
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, action="__error__")
+
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    response = JobRequestDetail.as_view()(
+        request,
+        project_slug=job_request.workspace.project.slug,
+        workspace_slug=job_request.workspace.name,
+        pk=job_request.pk,
+    )
+
+    assert response.status_code == 200
+    assert response.context_data["is_invalid"]
+
+
 def test_jobrequestdetail_with_permission(rf, django_assert_num_queries):
     job_request = JobRequestFactory()
 
@@ -647,6 +665,7 @@ def test_jobrequestdetail_with_permission(rf, django_assert_num_queries):
         )
 
     assert response.status_code == 200
+    assert not response.context_data["is_invalid"]
     assert "Cancel" in response.rendered_content
 
 

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -626,7 +626,7 @@ def test_jobrequestdetail_with_job_request_creator(rf):
     assert "Cancel" in response.rendered_content
 
 
-def test_jobrequestdetail_with_permission(rf):
+def test_jobrequestdetail_with_permission(rf, django_assert_num_queries):
     job_request = JobRequestFactory()
 
     user = UserFactory()
@@ -638,12 +638,13 @@ def test_jobrequestdetail_with_permission(rf):
     request = rf.get("/")
     request.user = user
 
-    response = JobRequestDetail.as_view()(
-        request,
-        project_slug=job_request.workspace.project.slug,
-        workspace_slug=job_request.workspace.name,
-        pk=job_request.pk,
-    )
+    with django_assert_num_queries(6):
+        response = JobRequestDetail.as_view()(
+            request,
+            project_slug=job_request.workspace.project.slug,
+            workspace_slug=job_request.workspace.name,
+            pk=job_request.pk,
+        )
 
     assert response.status_code == 200
     assert "Cancel" in response.rendered_content


### PR DESCRIPTION
This is an initial attempt to pull queries out of template rendering and into the view.  It uses [django-zen-queries](https://github.com/dabapps/django-zen-queries), from the ever wonderful folks over at dabapps, a nice set of utilities built around Django's [database instrumentation hooks](https://docs.djangoproject.com/en/4.2/topics/db/instrumentation/).

#### Implementation thoughts
zen-queries provides a great toolbox for opting in or out of render-time querying.  Getting clear errors from Django when we unexpectedly do it was our goal here and this gives it to us, with the offending query in the exception.

Some parts of zen-queries that I liked in particular:
* TemplateResponse is a drop-in replacement for Django's own response, allowing us to configure our CBVs ore return it directly.
* There are opt-outs allowing us to keep rendering in the template if the alternative is onerous (ie moving JobRequest's `status` and `completed_at` properties into QuerySet/Manager annotation methods)
* It includes the `fetch` wrapper, to force QuerySet evaluation.

#### Thoughts on the theory
There's been a clear tension while doing this work.  On the one hand we have some complex logic in places that's very non-trivial to move into the database (JobRequest.status and JobRequest.completed_at are the obvious candidates here), yet they're very necessary to keep template or view logic to a minimum.

Given the small, hard to track bugs we've had because of render-time queries I think we're headed in the right direction with this, despite the tensions.

Ref: #3347 