### PR TITLE
Use a more generic pending state

### DIFF
--- a/templates/partials/latest-jobs-tw.html
+++ b/templates/partials/latest-jobs-tw.html
@@ -76,11 +76,7 @@
                     {{ job_request.created_by.name }}
                   </td>
                   <td class="whitespace-nowrap px-2 py-2 text-sm text-slate-700">
-                    {% if job_request.started_at %}
-                      {{ job_request.started_at|naturaltime }}
-                    {% else %}
-                      Pending
-                    {% endif %}
+                    {{ job_request.started_at|naturaltime|default:"-" }}
                   </td>
                   <td
                     class="relative whitespace-nowrap py-2 pl-3 pr-4 text-right text-sm font-medium sm:pr-0"

--- a/templates/workspace_log.html
+++ b/templates/workspace_log.html
@@ -142,11 +142,7 @@
               {{ group.created_by.name }}
             </td>
             <td class="whitespace-nowrap px-2 py-2 text-sm text-slate-700">
-              {% if group.started_at %}
-                {{ group.started_at|naturaltime }}
-              {% else %}
-                Pending
-              {% endif %}
+              {{ group.started_at|naturaltime|default:"-" }}
             </td>
             <td
               class="relative whitespace-nowrap py-2 pl-3 pr-4 text-right text-sm font-medium"


### PR DESCRIPTION
JobRequests can have no started_at when all jobs have been cancelled, before any get started, so we can't use "Pending" here.

Fix: #3407