### PR TITLE
Fix the collect-me-maybe script regression.

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -163,9 +163,10 @@ STORAGES = {
 }
 
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
+# Note: these *must* be strings. If they are paths, we cannot cleanly extract them in ./scripts/collect-me-maybe.sh
 STATICFILES_DIRS = [
-    BASE_DIR / "static",
-    env.path("BUILT_ASSETS", default=BASE_DIR / "assets" / "dist"),
+    str(BASE_DIR / "static"),
+    str(env.path("BUILT_ASSETS", default=BASE_DIR / "assets" / "dist")),
 ]
 STATIC_ROOT = env.path("STATIC_ROOT", default=BASE_DIR / "staticfiles")
 STATIC_URL = "/static/"

--- a/scripts/collect-me-maybe.sh
+++ b/scripts/collect-me-maybe.sh
@@ -18,6 +18,11 @@ if ! test -f "$sentinel"; then
     run=true
 else
     staticdirs="$($python manage.py print_settings STATICFILES_DIRS --format value | sed -e "s/[]',[]//g")"
+
+    if [[ "$staticdirs" == *"PosixPath"* ]]; then
+        echo "ERROR: invalid STATICFILES_DIRS values - they should be strings not paths"
+        exit 1
+    fi
     # shellcheck disable=SC2086
     find $staticdirs -type f -newer "$sentinel" | grep -q . && run=true
 fi


### PR DESCRIPTION
This had been previously fixed, but was broken again in
6832a34e41b3ac5db021bd25a56d398bbc67f3b6, for 2+ months.

The collect-me-maybe.sh script relies on strings being output by
`manage.py print_settings`. If they are path objects, it outputs the
repr for them, which is not valid path.

To prevent this regressing again, I have added comment and a validation
check to the script.
