### PR TITLE
Switch will_notify back to the custom form of form_radio component

### DIFF
--- a/templates/job_request_create.html
+++ b/templates/job_request_create.html
@@ -188,15 +188,15 @@
 
           <div class="w-full grid grid-flow-row gap-y-2">
             {% if form.will_notify.value|stringformat:"s" == "True" %}
-              {% form_radio field=form.will_notify label="Notify me when each of the selected actions has completed" checked=True %}
+              {% form_radio custom_field=True id="id_will_notify" name="will_notify" value="True" label="Notify me when each of the selected actions has completed" checked=True %}
             {% else %}
-              {% form_radio field=form.will_notify label="Notify me when each of the selected actions has completed" checked=False %}
+              {% form_radio custom_field=True id="id_will_notify" name="will_notify" value="True" label="Notify me when each of the selected actions has completed" checked=False %}
             {% endif %}
 
             {% if form.will_notify.value|stringformat:"s" == "False" %}
-              {% form_radio field=form.will_notify label="Do not notify me" checked=True %}
+              {% form_radio custom_field=True id="id_will_notify" name="will_notify" value="False" label="Do not notify me" checked=True %}
             {% else %}
-              {% form_radio field=form.will_notify label="Do not notify me" checked=False %}
+              {% form_radio custom_field=True id="id_will_notify" name="will_notify" value="False" label="Do not notify me" checked=False %}
             {% endif %}
           </div>
         {% /form_fieldset %}


### PR DESCRIPTION
will_notify is a BooleanField under the hood, instead of a choices-supporting Field, so it doesn't provide the usual .choices() method from which to get some values from.  In moving this use of the component to use the BoundField instance I unwittingly used the static field.value (always either True/False depending on context the page was loaded in).

This reverts that change, explicitly using the strings True/False.

Fix: #3454