### PR TITLE
Run docker image as non-root user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ jobserver.dump
 node_modules/
 workspaces
 releases
-staticfiles
+/staticfiles
+/docker/staticfiles/*
 uploads
 /release-hatch
 /assets/src/scripts/outputs-viewer/coverage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -183,6 +183,9 @@ LABEL org.opencontainers.image.created=$BUILD_DATE
 ARG GITREF=unknown
 LABEL org.opencontainers.image.revision=$GITREF
 
+ARG USERID=10001
+ARG GROUPID=10001
+USER ${USERID}:${GROUPID}
 
 ##################################################
 #
@@ -202,3 +205,8 @@ RUN --mount=type=cache,target=/root/.cache \
 
 # Override ENTRYPOINT rather than CMD so we can pass arbitrary commands to the entrypoint script
 ENTRYPOINT ["/app/docker/entrypoints/dev.sh"]
+
+# Run as non root user. Required when building image.
+ARG USERID
+ARG GROUPID
+USER ${USERID}:${GROUPID}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -59,14 +59,18 @@ services:
     build:
       # the dev stage in the Dockerfile
       target: job-server-dev
+      args:
+        # user developer uid:gid in dev
+        - USERID=${DEV_USERID:-1000}
+        - GROUPID=${DEV_GROUPID:-1000}
     # paths relative to docker-compose.yaml file
     env_file:
       - ../.env
     volumes:
+      # Note: paths are relative to the *docker-compose* file
       - ..:/app
-      # this gives the dev containers a persistant cache for staticfiles, which
-      # allows us to avoid rerunning collectstatic if nothing has changed
-      - staticfiles:/opt/staticfiles
+      # provides a persistant inspectable cache for staticfiles
+      - ./staticfiles:/opt/staticfiles
 
   dev:
     extends:
@@ -84,7 +88,6 @@ services:
     env_file:
       - ../.test.env
     environment:
-      # override db hostname, so we can reach it within the container
       - GITHUB_TOKEN_TESTING
     command: bash -c "coverage run --branch --source=applications,interactive,jobserver,services,staff,tests --module pytest && coverage report || coverage html"
 

--- a/docker/justfile
+++ b/docker/justfile
@@ -1,6 +1,9 @@
 # Load .env files by default
 set dotenv-load := true
 
+export DEV_USERID := `id -u`
+export DEV_GROUPID := `id -g`
+
 
 build env="dev":
     #!/usr/bin/env bash
@@ -60,7 +63,8 @@ clean:
 clean-volumes: clean
     #!/bin/bash
     set -eux
-    docker volume rm -f job-server_postgres_data job-server_staticfiles
+    rm -rf staticfiles/*
+    docker volume rm -f job-server_postgres_data
 
 
 # restore the db from a dump file. Will wipe and reset your current docker dev db.

--- a/scripts/collect-me-maybe.sh
+++ b/scripts/collect-me-maybe.sh
@@ -12,6 +12,7 @@ fi
 
 staticfiles="$($python manage.py print_settings STATIC_ROOT --format value)"
 sentinel="$staticfiles/.written"
+gitkeep="$staticfiles/.keep"
 run=false
 
 if ! test -f "$sentinel"; then
@@ -30,6 +31,7 @@ fi
 if test "$run" = "true"; then
     echo "Run collectstatic, src file changes detected"
     $python manage.py collectstatic --no-input --clear | grep -v '^Deleting '
+    touch "$gitkeep"
     touch "$sentinel"
 else
     echo "Skipping collectstatic, no changes detected"


### PR DESCRIPTION
This user switch built in to the image, and thus decided at *build
time*. This means we can't accidentally misconfigure dokku and run it as
root again.

In dev, it uses the developers local uid:gid. Because we run
collectstatic in the dev entrypoint, that meant the dev volume set up
needed a slight tweak. Rather than a docker volume, it's now a bind
mount volume. This just ensures that the user has the correct
permissions to write collectstatic output there. It also means we can
easily poke around in the docker-built assets if needed.

In prod, this is an arbitrary uid:gid, currently 10001.
This uid:gid should be set up in the production environment and given
ownership/perimssions to appropriate directories. This is not for
collectstatic (which is built into the image) but instead for releases
and other files that may get written to disk.
