### PR TITLE
Pre event log tidy ups

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -394,7 +394,7 @@ class Org(models.Model):
         return self.name
 
     def get_absolute_url(self):
-        return reverse("org-detail", kwargs={"org_slug": self.slug})
+        return reverse("org-detail", kwargs={"slug": self.slug})
 
     def get_edit_url(self):
         return reverse("staff:org-edit", kwargs={"slug": self.slug})

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -144,7 +144,7 @@ files_urls = [
 
 org_urls = [
     path("", yours.OrgList.as_view(), name="your-orgs"),
-    path("<str:org_slug>/", OrgDetail.as_view(), name="org-detail"),
+    path("<slug:slug>/", OrgDetail.as_view(), name="org-detail"),
 ]
 
 outputs_urls = [

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -142,6 +142,11 @@ files_urls = [
     ),
 ]
 
+org_urls = [
+    path("", yours.OrgList.as_view(), name="your-orgs"),
+    path("<str:org_slug>/", OrgDetail.as_view(), name="org-detail"),
+]
+
 outputs_urls = [
     path("", WorkspaceOutputList.as_view(), name="workspace-output-list"),
     path(
@@ -291,8 +296,7 @@ urlpatterns = [
     path("login-with-token/", LoginWithToken.as_view(), name="login-with-token"),
     path("logout/", LogoutView.as_view(), name="logout"),
     path("organisations/", OrgList.as_view(), name="org-list"),
-    path("orgs/", yours.OrgList.as_view(), name="your-orgs"),
-    path("orgs/<str:org_slug>/", OrgDetail.as_view(), name="org-detail"),
+    path("orgs/", include(org_urls)),
     path("projects/", yours.ProjectList.as_view(), name="your-projects"),
     path("publish-repo/<repo_url>/", SignOffRepo.as_view(), name="repo-sign-off"),
     path("repo/<repo_url>/", RepoHandler.as_view(), name="repo-handler"),

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -66,10 +66,10 @@ from .views.workspaces import (
     WorkspaceCreate,
     WorkspaceDetail,
     WorkspaceEdit,
+    WorkspaceEventLog,
     WorkspaceFileList,
     WorkspaceLatestOutputsDetail,
     WorkspaceLatestOutputsDownload,
-    WorkspaceLog,
     WorkspaceNotificationsToggle,
     WorkspaceOutputList,
 )
@@ -234,7 +234,7 @@ workspace_urls = [
         name="workspace-archive-toggle",
     ),
     path("files/", include(files_urls)),
-    path("logs/", WorkspaceLog.as_view(), name="workspace-logs"),
+    path("logs/", WorkspaceEventLog.as_view(), name="workspace-logs"),
     path(
         "notifications-toggle/",
         WorkspaceNotificationsToggle.as_view(),

--- a/jobserver/views/orgs.py
+++ b/jobserver/views/orgs.py
@@ -6,7 +6,6 @@ from ..models import Org
 
 
 class OrgDetail(DetailView):
-    slug_url_kwarg = "org_slug"
     model = Org
     template_name = "org_detail.html"
 

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -403,6 +403,60 @@ class WorkspaceEdit(FormView):
         return {"purpose": self.workspace.purpose}
 
 
+class WorkspaceEventLog(ListView):
+    paginate_by = 25
+    template_name = "workspace_log.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        try:
+            self.workspace = Workspace.objects.get(
+                project__slug=self.kwargs["project_slug"],
+                name=self.kwargs["workspace_slug"],
+            )
+        except Workspace.DoesNotExist:
+            return redirect("/")
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        # limit backends to those the workspace uses
+        backends = Backend.objects.filter(
+            pk__in=JobRequest.objects.filter(workspace=self.workspace).values_list(
+                "backend_id", flat=True
+            )
+        )
+
+        return super().get_context_data(**kwargs) | {
+            "backends": backends,
+            "workspace": self.workspace,
+        }
+
+    def get_queryset(self):
+        qs = (
+            JobRequest.objects.with_started_at()
+            .filter(workspace=self.workspace)
+            .select_related("backend", "workspace", "workspace__project")
+            .order_by("-pk")
+        )
+
+        q = self.request.GET.get("q")
+        if q:
+            qwargs = Q(jobs__action__icontains=q) | Q(jobs__identifier__icontains=q)
+            try:
+                q = int(q)
+            except ValueError:
+                qs = qs.filter(qwargs)
+            else:
+                # if the query looks enough like a number for int() to handle
+                # it then we can look for a job number
+                qs = qs.filter(qwargs | Q(jobs__pk=q))
+
+        if backends := self.request.GET.getlist("backend"):
+            qs = qs.filter(backend__slug__in=backends)
+
+        return qs
+
+
 class WorkspaceFileList(View):
     def get(self, request, *args, **kwargs):
         workspace = get_object_or_404(
@@ -512,60 +566,6 @@ class WorkspaceLatestOutputsDownload(View):
             as_attachment=True,
             filename=f"workspace-{workspace.name}.zip",
         )
-
-
-class WorkspaceLog(ListView):
-    paginate_by = 25
-    template_name = "workspace_log.html"
-
-    def dispatch(self, request, *args, **kwargs):
-        try:
-            self.workspace = Workspace.objects.get(
-                project__slug=self.kwargs["project_slug"],
-                name=self.kwargs["workspace_slug"],
-            )
-        except Workspace.DoesNotExist:
-            return redirect("/")
-
-        return super().dispatch(request, *args, **kwargs)
-
-    def get_context_data(self, **kwargs):
-        # limit backends to those the workspace uses
-        backends = Backend.objects.filter(
-            pk__in=JobRequest.objects.filter(workspace=self.workspace).values_list(
-                "backend_id", flat=True
-            )
-        )
-
-        return super().get_context_data(**kwargs) | {
-            "backends": backends,
-            "workspace": self.workspace,
-        }
-
-    def get_queryset(self):
-        qs = (
-            JobRequest.objects.with_started_at()
-            .filter(workspace=self.workspace)
-            .select_related("backend", "workspace", "workspace__project")
-            .order_by("-pk")
-        )
-
-        q = self.request.GET.get("q")
-        if q:
-            qwargs = Q(jobs__action__icontains=q) | Q(jobs__identifier__icontains=q)
-            try:
-                q = int(q)
-            except ValueError:
-                qs = qs.filter(qwargs)
-            else:
-                # if the query looks enough like a number for int() to handle
-                # it then we can look for a job number
-                qs = qs.filter(qwargs | Q(jobs__pk=q))
-
-        if backends := self.request.GET.getlist("backend"):
-            qs = qs.filter(backend__slug__in=backends)
-
-        return qs
 
 
 class WorkspaceNotificationsToggle(View):

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -437,8 +437,7 @@ class WorkspaceEventLog(ListView):
             .order_by("-pk")
         )
 
-        q = self.request.GET.get("q")
-        if q:
+        if q := self.request.GET.get("q"):
             qwargs = Q(jobs__action__icontains=q) | Q(jobs__identifier__icontains=q)
             try:
                 q = int(q)

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -408,13 +408,11 @@ class WorkspaceEventLog(ListView):
     template_name = "workspace_log.html"
 
     def dispatch(self, request, *args, **kwargs):
-        try:
-            self.workspace = Workspace.objects.get(
-                project__slug=self.kwargs["project_slug"],
-                name=self.kwargs["workspace_slug"],
-            )
-        except Workspace.DoesNotExist:
-            return redirect("/")
+        self.workspace = get_object_or_404(
+            Workspace,
+            project__slug=self.kwargs["project_slug"],
+            name=self.kwargs["workspace_slug"],
+        )
 
         return super().dispatch(request, *args, **kwargs)
 

--- a/tests/unit/jobserver/models/test_org.py
+++ b/tests/unit/jobserver/models/test_org.py
@@ -22,7 +22,7 @@ def test_org_default_for_github_orgs():
 def test_org_get_absolute_url():
     org = OrgFactory()
     url = org.get_absolute_url()
-    assert url == reverse("org-detail", kwargs={"org_slug": org.slug})
+    assert url == reverse("org-detail", kwargs={"slug": org.slug})
 
 
 def test_org_get_edit_url():

--- a/tests/unit/jobserver/test_urls.py
+++ b/tests/unit/jobserver/test_urls.py
@@ -135,7 +135,7 @@ def test_url_redirects(client, url, redirect):
         ("/p/w/files/", workspaces.WorkspaceFileList),
         ("/p/w/files/tpp/", workspaces.WorkspaceBackendFiles),
         ("/p/w/files/tpp/file.txt", workspaces.WorkspaceBackendFiles),
-        ("/p/w/logs/", workspaces.WorkspaceLog),
+        ("/p/w/logs/", workspaces.WorkspaceEventLog),
         ("/p/w/notifications-toggle/", workspaces.WorkspaceNotificationsToggle),
         ("/p/w/outputs/", workspaces.WorkspaceOutputList),
         ("/p/w/outputs/latest/", workspaces.WorkspaceLatestOutputsDetail),

--- a/tests/unit/jobserver/views/test_orgs.py
+++ b/tests/unit/jobserver/views/test_orgs.py
@@ -13,7 +13,7 @@ def test_orgdetail_success(rf):
 
     request = rf.get("/")
     request.user = UserFactory()
-    response = OrgDetail.as_view()(request, org_slug=org.slug)
+    response = OrgDetail.as_view()(request, slug=org.slug)
 
     assert response.status_code == 200
 
@@ -23,7 +23,7 @@ def test_orgdetail_unknown_org(rf):
     request.user = UserFactory()
 
     with pytest.raises(Http404):
-        OrgDetail.as_view()(request, org_slug="")
+        OrgDetail.as_view()(request, slug="")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -850,14 +850,12 @@ def test_workspaceeventlog_unknown_workspace(rf):
     request = rf.get("/")
     request.user = user
 
-    response = WorkspaceEventLog.as_view()(
-        request,
-        project_slug=project.slug,
-        workspace_slug="test",
-    )
-
-    assert response.status_code == 302
-    assert response.url == "/"
+    with pytest.raises(Http404):
+        WorkspaceEventLog.as_view()(
+            request,
+            project_slug=project.slug,
+            workspace_slug="test",
+        )
 
 
 def test_workspaceeventlog_with_authenticated_user(rf):


### PR DESCRIPTION
We're planning to make some sweeping changes to the event log page, and add more contextually relevant event logs around the site.  While adding some of those I've found a selection of tidy ups that need doing.  Normally I would have added these to the event log pages but we're planning to carefully roll out the new pages so rather than complicate the review and deployment of those, I've pulled the changes out into a separate PR.