### PR TITLE
Add user list and detail pages

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -885,6 +885,9 @@ class User(AbstractBaseUser):
 
         return "".join(w[0].upper() for w in self.name.split(" "))
 
+    def get_absolute_url(self):
+        return reverse("user-detail", kwargs={"username": self.username})
+
     def get_all_permissions(self):
         """
         Get all Permissions for the current User

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -58,6 +58,7 @@ from .views.users import (
     LoginWithURL,
     RequireName,
     Settings,
+    UserList,
 )
 from .views.workspaces import (
     WorkspaceAnalysisRequestList,
@@ -264,6 +265,10 @@ project_urls = [
     path("<str:workspace_slug>/", include(workspace_urls)),
 ]
 
+user_urls = [
+    path("", UserList.as_view(), name="user-list"),
+]
+
 urlpatterns = [
     path("", Index.as_view(), name="home"),
     path(
@@ -304,6 +309,7 @@ urlpatterns = [
     path("staff/", include("staff.urls", namespace="staff")),
     path("status/", include(status_urls)),
     path("ui-components/", components),
+    path("users/", include(user_urls)),
     path("workspaces/", yours.WorkspaceList.as_view(), name="your-workspaces"),
     path("__debug__/", include(debug_toolbar.urls)),
     path("__reload__/", include("django_browser_reload.urls")),

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -58,6 +58,7 @@ from .views.users import (
     LoginWithURL,
     RequireName,
     Settings,
+    UserDetail,
     UserList,
 )
 from .views.workspaces import (
@@ -267,6 +268,7 @@ project_urls = [
 
 user_urls = [
     path("", UserList.as_view(), name="user-list"),
+    path("<str:username>/", UserDetail.as_view(), name="user-detail"),
 ]
 
 urlpatterns = [

--- a/jobserver/utils.py
+++ b/jobserver/utils.py
@@ -59,5 +59,11 @@ def strip_whitespace(text):
     return text.strip("\n")
 
 
+def set_from_list(lst, field="pk"):
+    """Build a set of fields from the given list"""
+    return {getattr(x, field) for x in lst}
+
+
 def set_from_qs(qs, field="pk"):
+    """Build a set of fields from the given QuerySet"""
     return set(qs.values_list(field, flat=True))

--- a/jobserver/views/users.py
+++ b/jobserver/views/users.py
@@ -13,7 +13,7 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.views.generic import FormView, ListView, View
+from django.views.generic import DetailView, FormView, ListView, View
 from furl import furl
 from opentelemetry import trace
 from social_django.utils import load_strategy
@@ -309,6 +309,21 @@ class Settings(View):
             "show_token_form": show_token_form,
         }
         return TemplateResponse(self.request, "settings.html", context)
+
+
+class UserDetail(DetailView):
+    model = User
+    slug_field = "username"
+    slug_url_kwarg = "username"
+    response_class = zTemplateResponse
+    template_name = "user_detail.html"
+
+    def get_context_data(self, **kwargs):
+        projects = fetch(self.object.projects.order_by(Lower("name")))
+
+        return super().get_context_data(**kwargs) | {
+            "projects": projects,
+        }
 
 
 class UserList(ListView):

--- a/templates/user_detail.html
+++ b/templates/user_detail.html
@@ -1,0 +1,78 @@
+{% extends "base-tw.html" %}
+
+{% block metatitle %}{{ user.name }} | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+  {% url "home" as home_url %}
+
+  {% #breadcrumbs %}
+    {% breadcrumb title="Home" url=home_url %}
+    {% breadcrumb title=user.name active=True %}
+  {% /breadcrumbs %}
+{% endblock breadcrumbs %}
+
+{% block content %}
+  {% article_header title=user.name class="mb-6" %}
+
+  {% if projects %}
+    {% #card title="Projects" %}
+      {% #list_group %}
+        {% for project in projects %}
+          <li>
+            <a href="{{ project.get_absolute_url }}" class="block transition-colors duration-200 hover:bg-oxford-50">
+              <div class="px-4 py-4 sm:px-6">
+                <div class="flex items-center justify-between">
+                  <p class="truncate text-base font-semibold text-oxford-600">
+                    {{ project.name }}
+                  </p>
+                  <div class="ml-2 flex flex-shrink-0">
+                    {% if project.status == "retired" %}
+                      {% pill sr_only="Status:" variant="warning" text=project.get_status_display %}
+                    {% elif project.status == "ongoing" %}
+                      {% pill sr_only="Status:" variant="primary" text=project.get_status_display %}
+                    {% elif project.status == "ongoing-and-linked" %}
+                      {% pill sr_only="Status:" variant="primary" text=project.get_status_display %}
+                    {% elif project.status == "postponed" %}
+                      {% pill sr_only="Status:" variant="danger" text=project.get_status_display %}
+                    {% elif project.status == "completed-and-linked" %}
+                      {% pill sr_only="Status:" variant="success" text=project.get_status_display %}
+                    {% elif project.status == "completed-and-awaiting" %}
+                      {% pill sr_only="Status:" variant="success" text=project.get_status_display %}
+                    {% endif %}
+                  </div>
+                </div>
+                <div class="mt-2 sm:flex sm:justify-between">
+                  <div class="sm:flex">
+                    <p class="flex items-center text-sm text-slate-600">
+                      {% icon_user_group_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
+                      {{ project.member_count }}
+                      user{{ project.member_count|pluralize }}
+                    </p>
+                    <p class="flex items-center text-sm text-slate-600 mt-2 sm:mt-0 sm:ml-6">
+                      {% icon_rectangle_stack_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
+                      {{ project.workspace_count }}
+                      workspace{{ project.workspace_count|pluralize }}
+                    </p>
+                  </div>
+                  <div class="mt-2 flex items-center text-sm text-slate-600 sm:mt-0">
+                    {% icon_calendar_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
+                    <time datetime="{{ project.created_at|date:"Y-m-d H:i:sO" }}">
+                      <span class="sr-only">Project created:</span>
+                      {{ project.created_at|date:"d M Y" }}
+                    </time>
+                  </div>
+                </div>
+              </div>
+            </a>
+          </li>
+        {% endfor %}
+      {% /list_group %}
+    {% /card %}
+  {% else %}
+    {% #card %}
+      {% #list_group %}
+        {% list_group_empty icon=True title="No projects" description="This user has been attached to any projects yet" %}
+      {% /list_group %}
+    {% /card %}
+  {% endif %}
+{% endblock %}

--- a/templates/user_list.html
+++ b/templates/user_list.html
@@ -1,0 +1,50 @@
+{% extends "base-tw.html" %}
+
+{% load querystring_tools %}
+
+{% block metatitle %}Users | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+  {% #breadcrumbs %}
+    {% url "home" as home_url %}
+    {% breadcrumb title="Home" url=home_url %}
+    {% breadcrumb title="Users" active=True %}
+  {% /breadcrumbs %}
+{% endblock breadcrumbs %}
+
+{% block content %}
+  {% article_header title="Users" text="Users using OpenSAFELY to deliver research projects" class="mb-6" %}
+
+  {% #card %}
+    {% #list_group %}
+      {% for user in object_list %}
+        {% #list_group_item href=user.get_absolute_url %}
+          <div class="flex flex-col md:flex-row min-w-0 md:justify-between md:flex-grow">
+            <p class="truncate text-base font-semibold text-oxford-600">
+              {{ user.name }}
+            </p>
+            <div class="mt-1 flex items-center text-sm text-slate-600 font-normal whitespace-nowrap md:mt-0 md:ml-2">
+              {% icon_rectangle_stack_outline class="mr-1.5 h-5 w-5 flex-shrink-0 text-slate-400" %}
+              {% if user.project_count %}
+                {{ user.project_count }} project{{ user.project_count|pluralize }}
+              {% else %}
+                No projects
+              {% endif %}
+            </div>
+          </div>
+        {% /list_group_item %}
+      {% endfor %}
+    {% /list_group %}
+
+    {% if page_obj.has_previous or page_obj.has_next %}
+      {% if page_obj.has_next %}
+        {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
+      {% endif %}
+      {% if page_obj.has_previous %}
+        {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
+      {% endif %}
+      {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+    {% endif %}
+  {% /card %}
+
+{% endblock %}

--- a/tests/integration/views/test_users.py
+++ b/tests/integration/views/test_users.py
@@ -1,3 +1,14 @@
+from tests.factories import UserFactory
+
+
+def test_userdetail(client):
+    user = UserFactory()
+
+    response = client.get(user.get_absolute_url())
+
+    assert response.status_code == 200
+
+
 def test_userlist(client):
     response = client.get("/users/")
 

--- a/tests/integration/views/test_users.py
+++ b/tests/integration/views/test_users.py
@@ -1,0 +1,4 @@
+def test_userlist(client):
+    response = client.get("/users/")
+
+    assert response.status_code == 200

--- a/tests/unit/jobserver/models/test_user.py
+++ b/tests/unit/jobserver/models/test_user.py
@@ -59,6 +59,14 @@ def test_user_constraints_missing_pat_token_or_pat_expires_at():
         UserFactory(pat_token="test", pat_expires_at=None)
 
 
+def test_user_get_absolute_url():
+    user = UserFactory()
+
+    url = user.get_absolute_url()
+
+    assert url == reverse("user-detail", kwargs={"username": user.username})
+
+
 def test_user_get_all_permissions():
     org = OrgFactory()
     project = ProjectFactory(org=org)

--- a/tests/unit/jobserver/test_urls.py
+++ b/tests/unit/jobserver/test_urls.py
@@ -125,6 +125,7 @@ def test_url_redirects(client, url, redirect):
         ("/projects/", yours.ProjectList),
         ("/settings/", users.Settings),
         ("/status/", status.Status),
+        ("/users/", users.UserList),
         ("/workspaces/", yours.WorkspaceList),
         ("/p/", projects.ProjectDetail),
         ("/p/new-workspace/", workspaces.WorkspaceCreate),

--- a/tests/unit/jobserver/test_urls.py
+++ b/tests/unit/jobserver/test_urls.py
@@ -126,6 +126,7 @@ def test_url_redirects(client, url, redirect):
         ("/settings/", users.Settings),
         ("/status/", status.Status),
         ("/users/", users.UserList),
+        ("/users/u/", users.UserDetail),
         ("/workspaces/", yours.WorkspaceList),
         ("/p/", projects.ProjectDetail),
         ("/p/new-workspace/", workspaces.WorkspaceCreate),


### PR DESCRIPTION
In preparation for adding a user-centric event log (#3433) this adds a list of detail page for users, leaning heavily on the design and layout of the relevant Org pages.

Note: mirroring the org pages the breadcrumbs for the detail page don't include the list page, is that desired here?

#### list
![](https://p198.p4.n0.cdn.getcloudapp.com/items/bLuZWO9e/a230c4c8-8ced-4433-8a54-b505bd6b60b7.jpg?v=1a68baec8e8c6fbc96a4d9efdb7c7ff2)

#### detail
![](https://p198.p4.n0.cdn.getcloudapp.com/items/E0uLxX2X/68d40fc3-8715-478a-8c1a-b4f1d58745a5.jpg?v=b1279ab36c7000fa5eeb02ae56d8ef4c)