### PR TITLE
Show the headers and content of failed repo deletions

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -271,6 +271,10 @@ class GitHubAPI:
         if r.status_code == 404:
             return
 
+        if not r.ok:
+            print(r.headers)
+            print(r.content)
+
         r.raise_for_status()
 
     def get_branch(self, org, repo, branch):


### PR DESCRIPTION
We're still getting intermittent failures when deleting a repo, but the plain 403 in the logs isn't very useful for debugging.