### PR TITLE
Only show the first jobs status message when the job request is invalid

### DIFF
--- a/templates/job_request_detail.html
+++ b/templates/job_request_detail.html
@@ -248,7 +248,7 @@
                 ">
                 {{ job_request.status|capfirst }}
               </span>
-              {% if job_request.status == "failed" %}
+              {% if is_invalid %}
                 <pre class="break-words whitespace-pre-wrap">{{ job_request.jobs.first.status_message }}</pre>
               {% endif %}
             </div>


### PR DESCRIPTION
This slipped in when the template was rebuilt and we have so few invalid JobRequests that it rarely ever gets exercised.

Fix: #3475