### PR TITLE
Don't set a static row start

### DIFF
--- a/templates/job_request_detail.html
+++ b/templates/job_request_detail.html
@@ -95,7 +95,7 @@
       {% /alert %}
     {% endif %}
 
-    <div class="space-y-6 md:space-y-6 lg:col-span-2 lg:row-start-3">
+    <div class="space-y-6 md:space-y-6 lg:col-span-2">
       {% #card container=True %}
         <div class="flex flex-col gap-y-4 text-slate-700">
           <p>


### PR DESCRIPTION
With the addition of the stale updates warning this pushes the main content area after the sidebar when there is no warning.