### PR TITLE
chore: configure dependabot group for opentelemetry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      otel-dependencies:
+        patterns:
+          - "opentelemetry*"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
* opentelemetry packages should be updated together
* see https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/ for more info