### PR TITLE
Enable filtering by multiple orgs in the backend of ProjectList

### DIFF
--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -272,10 +272,10 @@ class ProjectList(ListView):
             ]
             qs = qs.filter(qwargs(fields, q))
 
-        org = self.request.GET.get("org")
-        if org:
-            qs = qs.filter(org__slug=org)
-        return qs
+        if orgs := self.request.GET.getlist("orgs"):
+            qs = qs.filter(org__slug__in=orgs)
+
+        return qs.distinct()
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")

--- a/templates/staff/project/list.html
+++ b/templates/staff/project/list.html
@@ -32,7 +32,7 @@
       {% #button variant="success" type="submit" %}
         Apply filters
       {% /button %}
-      {% if request.GET.org %}
+      {% if request.GET %}
         {% #button variant="secondary-outline" type="link" href=staff_project_list_url %}
           Clear filters
         {% /button %}
@@ -40,9 +40,9 @@
     </div>
 
     {% #card title="Filter by organisation" container=True %}
-      {% #multiselect name="org" %}
+      {% #multiselect name="orgs" %}
         {% for org in orgs %}
-          {% is_filter_selected key="org" value=org.slug as is_org_active %}
+          {% is_filter_selected key="orgs" value=org.slug as is_org_active %}
           {% multiselect_option value=org.slug name=org.name is_active=is_org_active%}
         {% endfor %}
       {% /multiselect %}

--- a/templates/staff/project/list.html
+++ b/templates/staff/project/list.html
@@ -55,7 +55,7 @@
         {% if request.GET.q %}
           {% var value=request.GET.q|stringformat:"s" %}
         {% endif %}
-        {% form_input custom_field=True type="search" id="projectSearch" name="q" value=value label="Search for a project" label_class="sr-only" class="w-full" input_class="!m-0" %}
+        {% form_input custom_field=True type="search" id="projectSearch" name="q" value=value label="Search for a project" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by project name" show_placeholder=True %}
         {% #button type="submit" variant="primary" class="flex-shrink-0" %}Search{% /button %}
       </form>
       {% if request.GET.q %}

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -470,15 +470,16 @@ def test_projectlinkapplication_unknown_project(rf, core_developer):
 
 
 def test_projectlist_filter_by_org(rf, core_developer):
-    project = ProjectFactory()
+    org = OrgFactory()
+    project = ProjectFactory(org=org)
     ProjectFactory.create_batch(2)
 
-    request = rf.get(f"/?org={project.org.slug}")
+    request = rf.get(f"/?orgs={org.slug}")
     request.user = core_developer
 
     response = ProjectList.as_view()(request)
 
-    assert len(response.context_data["project_list"]) == 1
+    assert set_from_qs(response.context_data["project_list"]) == {project.pk}
 
 
 def test_projectlist_find_by_username(rf, core_developer):


### PR DESCRIPTION
In preparation for moving to Projects having multiple Orgs setting up this view to handle filtering the list of Projects by more than one.

Ref: #2827 