### PR TITLE
Stop building redirects when a Project's Org is changed

### DIFF
--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -199,7 +199,7 @@ class ProjectEdit(UpdateView):
         # new.project because self.object is mutated when ModelForm._post_clean
         # updates the instance it was passed.  This is because form.instance is
         # set from the passed in self.object.
-        if {"org", "slug"} & set(form.changed_data):
+        if "slug" in form.changed_data:
             new.redirects.create(
                 created_by=self.request.user,
                 old_url=old.get_absolute_url(),

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -315,9 +315,6 @@ def test_projectedit_post_success(rf, core_developer):
     Redirect.objects.count() == 1
     redirect = Redirect.objects.first()
     assert redirect.project_id == original.pk
-    assert redirect.old_url == original.get_absolute_url().replace(
-        updated.org.get_absolute_url(), old_org.get_absolute_url()
-    )
 
 
 def test_projectedit_post_success_when_not_changing_org_or_slug(rf, core_developer):


### PR DESCRIPTION
Orgs are no longer part of a Project's URL structure so we don't need to build redirects for them anymore.

Ref: #2827 