### PR TITLE
Fix disabled links in list_group_item component

### DIFF
--- a/templates/_components/list-group/list-group-item.html
+++ b/templates/_components/list-group/list-group-item.html
@@ -1,17 +1,23 @@
-<li>
+<li
+  {% if disabled %}
+    class="block px-4 py-3 font-semibold cursor-not-allowed text-slate-700 break-words sm:px-6 {{ class }}"
+  {% endif %}
+>
+  {% if not disabled %}
   <a
+
     class="
       block transition-colors duration-200 px-4 py-3 font-semibold text-oxford-600 break-words
       hover:bg-oxford-50
       focus:bg-oxford-50 focus:outline-none focus:ring-2 focus:ring-inset
       sm:px-6
-      {% if disabled %}
-      pointer-events-none cursor-not-allowed text-slate-700
-      {% endif %}
       {{ class }}
     "
     {% attrs aria-checked aria-labelled-by href role %}
   >
+  {% endif %}
     {{ children }}
+  {% if not disabled %}
   </a>
+  {% endif %}
 </li>


### PR DESCRIPTION
If the link is disabled, we should render an anchor element, as there is potential it could be clicked (and lead to a 404).

Instead we should make a list element with the required classes.