### PR TITLE
Set `database_name` based on project permissions

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -28,6 +28,7 @@ from zen_queries import queries_dangerously_enabled
 from ..authorization import InteractiveReporter
 from ..authorization.fields import RolesArrayField
 from ..hash_utils import hash_user_pat
+from ..permissions.t1oo import project_is_permitted_to_use_t1oo_data
 from ..runtime import Runtime
 
 
@@ -369,10 +370,10 @@ class JobRequest(models.Model):
 
     @property
     def database_name(self):
-        # TODO: We plan to make use of this property to control which set of patients'
-        # data a given job runs against. But until the relevant machinery is in place we
-        # hardcode this to the default value.
-        return "default"
+        if project_is_permitted_to_use_t1oo_data(self.workspace.project):
+            return "include_t1oo"
+        else:
+            return "default"
 
 
 class Org(models.Model):

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -372,7 +372,7 @@ class JobRequest(models.Model):
         # TODO: We plan to make use of this property to control which set of patients'
         # data a given job runs against. But until the relevant machinery is in place we
         # hardcode this to the default value.
-        return "full"
+        return "default"
 
 
 class Org(models.Model):

--- a/jobserver/permissions/t1oo.py
+++ b/jobserver/permissions/t1oo.py
@@ -1,0 +1,110 @@
+# ****************************************************************************
+# ANY ADDITIONS TO THE LIST BELOW MUST BE EXPLICITLY APPROVED BY THE IG TEAM *
+# ****************************************************************************
+
+# From Appendix 3 of DPIA document linked here:
+# https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/directions-and-data-provision-notices/data-provision-notices-dpns/opensafely-covid-19-service-data-provision-notice
+PROJECTS_WITH_T1OO_PERMISSION = {
+    2,  # https://jobs.opensafely.org/online-consultations/
+    4,  # https://jobs.opensafely.org/tncc-vaccine-efficacy/
+    8,  # https://jobs.opensafely.org/germdefence/
+    9,  # https://jobs.opensafely.org/impact-of-covid-19-on-long-term-healthcare-use-and-costs-in-children-and-young-people/
+    11,  # https://jobs.opensafely.org/antidepressants/
+    12,  # https://jobs.opensafely.org/investigating-events-following-sars-cov-2-infection/
+    16,  # https://jobs.opensafely.org/brit-antibiotic-research/
+    17,  # https://jobs.opensafely.org/effects-of-covid-19-on-people-with-diabetes/
+    18,  # https://jobs.opensafely.org/managing-the-long-term-effects-of-covid-19-study/
+    19,  # https://jobs.opensafely.org/evaluation-of-pandemic-associated-changes-in-bmi-and-metabolic-parameters/
+    21,  # https://jobs.opensafely.org/direct-oral-anticoagulant-doac-prescribing-during-covid-19/
+    22,  # https://jobs.opensafely.org/investigating-the-effectiveness-of-the-covid-19-vaccination-programme-in-the-uk/
+    24,  # https://jobs.opensafely.org/24-incidence-of-mental-illness-following-coronavirus-infection-in-the-community/
+    25,  # https://jobs.opensafely.org/tpp-representativeness/
+    26,  # https://jobs.opensafely.org/uptake-of-nhs-at-home-interventions-during-covid-19/
+    27,  # https://jobs.opensafely.org/the-effect-of-covid-19-on-pancreatic-cancer-diagnosis-and-care/
+    28,  # https://jobs.opensafely.org/adtinjectables/
+    29,  # https://jobs.opensafely.org/mainroute/
+    30,  # https://jobs.opensafely.org/pathology-comparators-short-report/
+    31,  # https://jobs.opensafely.org/long-covid-risk-factors/
+    34,  # https://jobs.opensafely.org/deaths-at-home-during-covid-19/
+    35,  # https://jobs.opensafely.org/impact-of-the-covid-19-pandemic-on-prevention-of-cardiovascular-disease/
+    36,  # https://jobs.opensafely.org/impact-of-the-covid-19-pandemic-on-anticoagulation-for-atrial-fibrillation/
+    57,  # https://jobs.opensafely.org/service-restoration-observatory/
+    61,  # https://jobs.opensafely.org/covid-19-vaccine-effectiveness/
+    65,  # https://jobs.opensafely.org/diabetes-test-levels/
+    66,  # https://jobs.opensafely.org/pincer/
+    67,  # https://jobs.opensafely.org/assessing-effectiveness-of-3rd-booster-covid-19-vaccine-doses-in-england/
+    70,  # https://jobs.opensafely.org/lone-households-and-mental-health/
+    71,  # https://jobs.opensafely.org/openprompt/
+    75,  # https://jobs.opensafely.org/long-covid-symptoms/
+    77,  # https://jobs.opensafely.org/investigating-the-impact-of-covid-19-on-childhood-immunisations-prototyping-a-dashboard/
+    78,  # https://jobs.opensafely.org/long-term-kidney-outcomes-after-sars-cov-2-infection/
+    84,  # https://jobs.opensafely.org/long-covid-19-sick-notes/
+    85,  # https://jobs.opensafely.org/85-flucats/
+    86,  # https://jobs.opensafely.org/impacts-of-healthcare-disruption-on-avoidable-hospitalisations/
+    87,  # https://jobs.opensafely.org/validation-of-the-opensafely-kidney-codes/
+    88,  # https://jobs.opensafely.org/88-reduced-kidney-function-dialysis-and-transplantation-on-c19-vaccination-efficacy/
+    91,  # https://jobs.opensafely.org/coverage-effectiveness-and-safety-of-neutralising-monoclonal-antibodies-or-antivirals-for-non-hospitalised-patients-with-covid-19/
+    92,  # https://jobs.opensafely.org/impact-of-covid-19-pandemic-on-services-for-people-with-asthma/
+    93,  # https://jobs.opensafely.org/lockdown-and-vulnerable-groups/
+    94,  # https://jobs.opensafely.org/postopcovid/
+    95,  # https://jobs.opensafely.org/covid-19-collateral/
+    97,  # https://jobs.opensafely.org/primary-care-covid-codes-research/
+    99,  # https://jobs.opensafely.org/suicide-deaths-after-healthcare-contact-in-primary-care/
+    100,  # https://jobs.opensafely.org/early-inflammatory-arthritis-during-covid-19/
+    101,  # https://jobs.opensafely.org/indians-in-india-and-the-uk/
+    102,  # https://jobs.opensafely.org/covid-19-antimicrobial-stewardship/
+    103,  # https://jobs.opensafely.org/covid-symptom-study-biobank-long-covid/
+    104,  # https://jobs.opensafely.org/predictors-of-asymptomatic-versus-symptomatic-infection-with-sars-cov-2/
+    105,  # https://jobs.opensafely.org/antidepressant-learning-disability-and-autism/
+    106,  # https://jobs.opensafely.org/effectiveness-safety-sotrovimab-molnupiravir/
+    108,  # https://jobs.opensafely.org/hepatitis-in-children-related-to-the-pandemic/
+    110,  # https://jobs.opensafely.org/covid-19-vaccine-coverage-and-effectiveness-in-chronic-kidney-disease-patients/
+    112,  # https://jobs.opensafely.org/112-coronavirus-pandemic-on-rheumatoid-arthritis-care-and-non-covid-outcomes/
+    113,  # https://jobs.opensafely.org/113-shared-care-monitoring-the-impact-of-covid-19-and-factors-associated-with-resilience/
+    114,  # https://jobs.opensafely.org/ethnicity-short-data-report/
+    115,  # https://jobs.opensafely.org/115-effectiveness-of-sotrovimabmolnupiravir-use-vs-non-use/
+    116,  # https://jobs.opensafely.org/further-analysis-of-doac-prescribing-for-patients-with-mechanical-heart-valves/
+    117,  # https://jobs.opensafely.org/understanding-and-adjusting-for-bias-in-opensafely-covid-testing-data/
+    118,  # https://jobs.opensafely.org/expected-background-rates-of-clinical-events-in-immunocompromised-patients/
+    119,  # https://jobs.opensafely.org/the-healthcare-utilisation-of-people-with-long-covid-openprompt/
+    120,  # https://jobs.opensafely.org/long-term-kidney-outcomes-following-hospitalisation-with-covid-19/
+    121,  # https://jobs.opensafely.org/phosp-mental-health/
+    122,  # https://jobs.opensafely.org/opioid-prescribing-trends-and-changes-during-covid-19/
+    125,  # https://jobs.opensafely.org/what-was-the-impact-of-the-covid-19-pandemic-on-medication-reviews/
+    126,  # https://jobs.opensafely.org/antipsychotics-prescribing-during-covid-19/
+    127,  # https://jobs.opensafely.org/prostate-cancer-incidence-and-prevalence-in-the-covid-19-pandemic/
+    128,  # https://jobs.opensafely.org/the-effect-of-covid-19-infection-and-vaccination-on-psa-levels-in-men/
+    129,  # https://jobs.opensafely.org/curation-of-gp-appointments-data-short-data-report/
+    130,  # https://jobs.opensafely.org/surveillance-of-psychiatric-emergencies-over-time-to-investigate-the-effect-of-covid-19-on-mental-health-a-cohort-study-using-opensafely/
+    131,  # https://jobs.opensafely.org/sle-and-covid-19/
+    132,  # https://jobs.opensafely.org/assessing-the-impact-of-covid-19-on-qof-registered-patients-and-health-groups-that-experience-inequalities/
+    133,  # https://jobs.opensafely.org/effect-of-covid-19-on-prescribing-of-dependence-forming-medicines-and-the-associated-health-utilisation/
+    134,  # https://jobs.opensafely.org/impact-of-covid-19-in-people-with-chronic-lymphocytic-leukaemia/
+    135,  # https://jobs.opensafely.org/impact-of-covid-19-on-diabetes-care-in-england/
+    136,  # https://jobs.opensafely.org/gp-appointments-during-covid/
+    137,  # https://jobs.opensafely.org/healthcare-needs-for-people-with-chronic-kidney-disease-in-the-covid-19-era/
+    138,  # https://jobs.opensafely.org/hypertension-and-blood-pressure-in-the-quality-and-outcomes-framework-qof/
+    139,  # https://jobs.opensafely.org/risk-factors-for-covid-19-disease-progression-in-immunocompromised-populations/
+    140,  # https://jobs.opensafely.org/incidence-and-management-of-gout-during-and-before-the-covid-19-pandemic/
+    141,  # https://jobs.opensafely.org/the-impact-of-covid-19-on-the-care-of-people-with-sickle-cell-disease/
+    142,  # https://jobs.opensafely.org/the-impact-of-covid-19-on-prescribing-of-antimicrobials/
+    143,  # https://jobs.opensafely.org/comparison-of-risk-factors-for-hospitalizations-and-death-from-winter-infections/
+    144,  # https://jobs.opensafely.org/covid-19-impact-on-anastrazole-use-by-post-menopausal-women-with-hormone-dependent-breast-cancer/
+    145,  # https://jobs.opensafely.org/association-between-ursodeoxycholic-acid-and-covid-19-outcomes/
+    146,  # https://jobs.opensafely.org/scarlet-fever-and-invasive-group-a-strep-cases-during-the-covid-19-pandemic/
+    147,  # https://jobs.opensafely.org/winter-pressures-in-primary-care-in-the-context-of-covid-19-recovery/
+    148,  # https://jobs.opensafely.org/the-impact-of-covid-19-on-pregnancy-treatment-pathways-and-outcomes/
+    149,  # https://jobs.opensafely.org/descriptive-cohort-analysis-of-long-covid-and-vaccination-status/
+    150,  # https://jobs.opensafely.org/evaluating-the-uk-shielding-policy-during-the-covid-19-pandemic/
+    151,  # https://jobs.opensafely.org/venous-thromboembolism-and-cardiovascular-events-in-inflammatory-rheumatic-diseases/
+    152,  # https://jobs.opensafely.org/digital-access-to-primary-care-for-older-people-during-covid/
+    153,  # https://jobs.opensafely.org/what-was-the-impact-of-covid-19-on-mortality-related-to-venous-thromboembolism-in-england/
+    154,  # https://jobs.opensafely.org/validation-of-isaric-sus-phosp-data-for-covid-related-hospital-admissions/
+    155,  # https://jobs.opensafely.org/the-effect-of-long-covid-on-quality-adjusted-life-years-using-openprompt/
+}
+
+
+def project_is_permitted_to_use_t1oo_data(project):
+    if not project.number:
+        return False
+    return project.number in PROJECTS_WITH_T1OO_PERMISSION

--- a/tests/unit/jobserver/api/test_jobs.py
+++ b/tests/unit/jobserver/api/test_jobs.py
@@ -808,7 +808,7 @@ def test_jobrequestapilist_success(api_rf):
             "project": project.slug,
             "requested_actions": ["frob", "wizzle"],
             "sha": "",
-            "database_name": "full",
+            "database_name": "default",
             "workspace": {
                 "name": workspace.name,
                 "repo": workspace.repo.url,
@@ -828,7 +828,7 @@ def test_jobrequestapilist_success(api_rf):
             "project": project.slug,
             "requested_actions": ["frobnicate", "wibble"],
             "sha": "",
-            "database_name": "full",
+            "database_name": "default",
             "workspace": {
                 "name": workspace.name,
                 "repo": workspace.repo.url,
@@ -848,7 +848,7 @@ def test_jobrequestapilist_success(api_rf):
             "project": project.slug,
             "requested_actions": ["analyse"],
             "sha": "",
-            "database_name": "full",
+            "database_name": "default",
             "workspace": {
                 "name": workspace.name,
                 "repo": workspace.repo.url,

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -7,7 +7,13 @@ from django.utils import timezone
 
 from jobserver.models import JobRequest
 
-from ....factories import JobFactory, JobRequestFactory, RepoFactory, WorkspaceFactory
+from ....factories import (
+    JobFactory,
+    JobRequestFactory,
+    ProjectFactory,
+    RepoFactory,
+    WorkspaceFactory,
+)
 from ....utils import minutes_ago, seconds_ago
 
 
@@ -378,3 +384,29 @@ def test_jobrequestmanager_with_started_at():
     JobRequestFactory(workspace=workspace)
 
     assert JobRequest.objects.with_started_at().filter(workspace=workspace).count() == 2
+
+
+def test_jobrequest_database_name_with_no_project_number(build_job_request):
+    job_request = build_job_request(project_number=None)
+    assert job_request.database_name == "default"
+
+
+def test_jobrequest_database_name_without_t1oo_permission(build_job_request):
+    job_request = build_job_request(project_number=1)
+    assert job_request.database_name == "default"
+
+
+def test_jobrequest_database_name_with_t1oo_permission(build_job_request):
+    # This is one of the project numbers hardcoded into `permissions/t1oo.py`
+    job_request = build_job_request(project_number=2)
+    assert job_request.database_name == "include_t1oo"
+
+
+@pytest.fixture
+def build_job_request():
+    def _build_job_request(project_number):
+        project = ProjectFactory(number=project_number)
+        workspace = WorkspaceFactory(project=project)
+        return JobRequestFactory(workspace=workspace)
+
+    return _build_job_request

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -33,7 +33,6 @@ def test_workspacecreateform_success():
     project = ProjectFactory()
     data = {
         "name": "test",
-        "db": "slice",
         "repo": "http://example.com/derp/test-repo",
         "branch": "test-branch",
         "purpose": "test",
@@ -54,7 +53,6 @@ def test_workspacecreateform_success_with_upper_case_names():
     project = ProjectFactory()
     data = {
         "name": "TeSt",
-        "db": "full",
         "repo": "http://example.com/derp/test-repo",
         "branch": "test-branch",
         "purpose": "test",
@@ -84,7 +82,6 @@ def test_workspacecreateform_unknown_branch():
     form = WorkspaceCreateForm(project, repos_with_branches)
     form.cleaned_data = {
         "name": "test",
-        "db": "slice",
         "repo": "http://example.com/derp/test-repo",
         "branch": "unknown-branch",
     }
@@ -107,7 +104,6 @@ def test_workspacecreateform_unknown_repo():
     form = WorkspaceCreateForm(project, repos_with_branches)
     form.cleaned_data = {
         "name": "test",
-        "db": "full",
         "repo": "unknown-repo",
         "branch": "test-branch",
     }


### PR DESCRIPTION
We've taken the deliberate decision here to use a hardcoded list of project numbers committed to the codebase, rather than storing a new set of permissions in the database. In the short-term we don't anticipate needing to add to this list. We can revist the implementation as and when that proves necessary.

As well as simplicity this approach has the advantage of creating a natural public audit trail in the form of the commit history, where changes to the database would be opaque.