### PR TITLE
fix: add more packages to the otel-dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,12 @@ updates:
     groups:
       otel-dependencies:
         patterns:
+          - "backoff"
+          - "deprecated"
+          - "googleapis-common-protos"
           - "opentelemetry*"
+          - "protobuf"
+          - "wrapt"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
* add some dependencies of opentelemetry* in the hopes of getting dependabot to bump the whole group correctly