### PR TITLE
Reduce number of queries in staff area

### DIFF
--- a/staff/views/job_requests.py
+++ b/staff/views/job_requests.py
@@ -18,10 +18,10 @@ class JobRequestDetail(DetailView):
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
 class JobRequestList(ListView):
-    model = JobRequest
     ordering = "-created_at"
     paginate_by = 25
     template_name = "staff/job_request/list.html"
+    queryset = JobRequest.objects.prefetch_related("workspace", "workspace__project")
 
     def get_context_data(self, **kwargs):
         backends = {

--- a/staff/views/redirects.py
+++ b/staff/views/redirects.py
@@ -30,10 +30,10 @@ class RedirectDetail(DetailView):
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
 class RedirectList(ListView):
-    model = Redirect
     ordering = "-old_url"
     paginate_by = 25
     template_name = "staff/redirect/list.html"
+    queryset = Redirect.objects.prefetch_related("project", "workspace", "org")
 
     def get_context_data(self, **kwargs):
         types = [

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -183,9 +183,9 @@ class UserDetailWithOAuth(UpdateView):
 
 @method_decorator(require_permission("user_manage"), name="dispatch")
 class UserList(ListView):
-    model = User
     paginate_by = 25
     template_name = "staff/user/list.html"
+    queryset = User.objects.prefetch_related("project_memberships", "org_memberships")
 
     def get_context_data(self, **kwargs):
         all_roles = [name for name, value in inspect.getmembers(roles, inspect.isclass)]


### PR DESCRIPTION
We recently added a call to `user.all_roles` in the template, which increased the number of queries from 7 to 57. This change reduces the number of queries down to 9. The same approach has been applied to a couple of other views that had a similar issue.