### PR TITLE
chore: remove dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    groups:
-      otel-dependencies:
-        patterns:
-          - "backoff"
-          - "deprecated"
-          - "googleapis-common-protos"
-          - "opentelemetry*"
-          - "protobuf"
-          - "wrapt"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
* doesn't appear to work as hoped
* does: try to update each dependency in turn, each one failing because of conflicts with the others
* does not: update all dependencies together