### PR TITLE
Fix grid overflow issues on mobile screens

### DIFF
--- a/templates/staff/analysis_request/list.html
+++ b/templates/staff/analysis_request/list.html
@@ -20,7 +20,7 @@
 {% block content %}
 {% url "staff:analysis-request-list" as staff_analysis_request_list_url %}
 
-<div class="grid lg:grid-cols-3 gap-8">
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
   <div class="flex flex-col gap-y-6">
     {% if request.GET.has_report or request.GET.project or request.GET.user %}
       {% #button variant="secondary-outline" type="link" href=staff_analysis_request_list_url %}

--- a/templates/staff/application/list.html
+++ b/templates/staff/application/list.html
@@ -21,7 +21,7 @@
 {% block content %}
 {% url "staff:application-list" as staff_application_list_url %}
 
-<div class="grid lg:grid-cols-3 gap-8">
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
   <div class="flex flex-col gap-y-6">
     {% if request.GET.status or request.GET.user %}
       {% #button variant="secondary-outline" type="link" href=staff_application_list_url %}

--- a/templates/staff/index.html
+++ b/templates/staff/index.html
@@ -17,7 +17,7 @@
 {% endblock hero %}
 
 {% block content %}
-<div class="grid lg:grid-cols-3 gap-8">
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
   {% #card title="Go to…" %}
     {% #list_group %}
       {% url "staff:analysis-request-list" as staff_analysis_request_list %}

--- a/templates/staff/project/list.html
+++ b/templates/staff/project/list.html
@@ -26,7 +26,7 @@
 {% block content %}
 {% url "staff:project-list" as staff_project_list_url %}
 
-<div class="grid lg:grid-cols-3 gap-8">
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
   <form class="flex flex-col gap-y-6">
     <div class="flex flex-row gap-2">
       {% #button variant="success" type="submit" %}

--- a/templates/staff/repo/list.html
+++ b/templates/staff/repo/list.html
@@ -19,7 +19,7 @@
 
 {% block content %}
   {% url "staff:repo-list" as staff_repo_list_url %}
-  <div class="grid lg:grid-cols-3 gap-8">
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
     <form class="flex flex-col gap-y-6">
       <div class="flex flex-row gap-2">
         {% if request.GET %}

--- a/templates/staff/report/list.html
+++ b/templates/staff/report/list.html
@@ -21,7 +21,7 @@
 {% block content %}
   {% url "staff:report-list" as staff_report_list_url %}
 
-  <div class="grid lg:grid-cols-3 gap-8">
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
     <form class="flex flex-col gap-y-6">
       <div class="flex flex-row gap-2">
         {% #button variant="success" type="submit" %}

--- a/templates/staff/user/list.html
+++ b/templates/staff/user/list.html
@@ -25,7 +25,7 @@
 
 {% block content %}
 {% url "staff:user-list" as staff_user_list_url %}
-<div class="grid lg:grid-cols-3 gap-8">
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
   <form class="flex flex-col gap-y-6">
     <div class="flex flex-row gap-2">
       {% #button variant="success" type="submit" %}

--- a/templates/staff/workspace/list.html
+++ b/templates/staff/workspace/list.html
@@ -20,7 +20,7 @@
 
 {% block content %}
   {% url "staff:workspace-list" as staff_workspace_list_url %}
-  <div class="grid lg:grid-cols-3 gap-8">
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
     <form class="flex flex-col gap-y-6">
       <div class="flex flex-row gap-2">
         {% #button variant="success" type="submit" %}


### PR DESCRIPTION
By not setting a base grid column with a minimum size, the cards can overflow the grid on mobile screen sizes.