### PR TITLE
Order by pk instead of created_by

### DIFF
--- a/jobserver/views/index.py
+++ b/jobserver/views/index.py
@@ -14,7 +14,7 @@ class Index(View):
                 "workspace__project",
                 "workspace__project__org",
             )
-            .order_by("-created_at")
+            .order_by("-pk")
         )
 
         if not self.request.user.is_authenticated:


### PR DESCRIPTION
This gives us an order of magnitude speed improvement over ordering by a datetime column.