### PR TITLE
Consistently order lists of users in the staff area

### DIFF
--- a/staff/forms.py
+++ b/staff/forms.py
@@ -37,7 +37,6 @@ class PickUsersMixin:
     def __init__(self, users, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        users = users.order_by(Lower("username"))
         self.fields["users"] = UserModelMultipleChoiceField(queryset=users)
 
 
@@ -146,7 +145,7 @@ class ProjectEditForm(forms.ModelForm):
         self.fields["number"].required = False
 
         self.fields["copilot"] = UserModelChoiceField(
-            queryset=User.objects.order_by(Lower("username")), required=False
+            queryset=User.objects.order_by_name(), required=False
         )
         self.fields["copilot_support_ends_at"].required = False
 

--- a/staff/views/orgs.py
+++ b/staff/views/orgs.py
@@ -108,7 +108,7 @@ class OrgDetail(FormView):
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {
             "github_orgs": sorted(self.object.github_orgs),
-            "members": self.object.members.order_by(Lower("username")),
+            "members": self.object.members.order_by_name(),
             "org": self.object,
             "projects": self.object.projects.order_by("number", Lower("name")),
             "redirects": self.object.redirects.order_by("-created_at"),
@@ -117,7 +117,7 @@ class OrgDetail(FormView):
     def get_form_kwargs(self):
         members = self.object.members.values_list("pk", flat=True)
         return super().get_form_kwargs() | {
-            "users": User.objects.exclude(pk__in=members),
+            "users": User.objects.exclude(pk__in=members).order_by_name(),
         }
 
     def get_initial(self):

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -77,7 +77,7 @@ class ProjectAddMember(FormView):
         members = self.project.members.values_list("pk", flat=True)
         return super().get_form_kwargs() | {
             "available_roles": roles_for(ProjectMembership),
-            "users": User.objects.exclude(pk__in=members),
+            "users": User.objects.exclude(pk__in=members).order_by_name(),
         }
 
     def get_initial(self):

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -111,7 +111,7 @@ class RepoDetail(View):
             users = list(
                 User.objects.filter(job_requests__workspace=workspace)
                 .distinct()
-                .order_by(Lower("username"), Lower("fullname"))
+                .order_by_name()
             )
             if workspace.created_by not in users:
                 users = [workspace.created_by, *users]


### PR DESCRIPTION
We don't have full names for all users yet so we can't consistently order by them, so we added order_by_name() in the interim to order users by fullname and fall back to username.  This uses that function consistently across the staff area.