### PR TITLE
Staff area list page improvements

### DIFF
--- a/staff/views/orgs.py
+++ b/staff/views/orgs.py
@@ -178,7 +178,7 @@ class OrgList(ListView):
             ]
             qs = qs.filter(qwargs(fields, q))
 
-        return qs
+        return qs.distinct()
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -3,7 +3,7 @@ import inspect
 import structlog
 from django.core.exceptions import FieldError
 from django.db import transaction
-from django.db.models import Exists, OuterRef, Q
+from django.db.models import Exists, OuterRef, Q, Sum
 from django.db.models.functions import Lower
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
@@ -246,10 +246,12 @@ class UserList(ListView):
             # build up a query that checks for any roles or no roles.  We have
             # to check for the presence of the *_memberships relations as well
             # as traversing to their roles fields
-            org_roles = Q(org_memberships=None) | Q(org_memberships__roles=[])
-            project_roles = Q(project_memberships=None) | Q(
-                project_memberships__roles=[]
+            qs = qs.annotate(
+                org_roles_count=Sum("org_memberships__roles__len"),
+                project_roles_count=Sum("project_memberships__roles__len"),
             )
+            org_roles = Q(org_memberships=None) | Q(org_roles_count=0)
+            project_roles = Q(project_memberships=None) | Q(project_roles_count=0)
             query = Q(roles=[]) & org_roles & project_roles
 
             if any_roles == "yes":

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -257,7 +257,7 @@ class UserList(ListView):
             elif any_roles == "no":
                 qs = qs.filter(query)
 
-        return qs
+        return qs.distinct()
 
 
 @method_decorator(require_permission("user_manage"), name="dispatch")

--- a/staff/views/workspaces.py
+++ b/staff/views/workspaces.py
@@ -88,4 +88,4 @@ class WorkspaceList(ListView):
         if projects := self.request.GET.getlist("projects"):
             qs = qs.filter(project__slug__in=projects)
 
-        return qs
+        return qs.distinct()

--- a/tests/unit/staff/views/test_users.py
+++ b/tests/unit/staff/views/test_users.py
@@ -485,7 +485,7 @@ def test_userlist_filter_by_invalid_role(rf, core_developer):
 
 def test_userlist_filter_by_any_roles_yes_includes_global_roles(rf, core_developer):
     UserFactory(roles=[OutputPublisher])
-    UserFactory(roles=[])
+    UserFactory()
 
     request = rf.get("/?any_roles=yes")
     request.user = core_developer
@@ -498,8 +498,9 @@ def test_userlist_filter_by_any_roles_yes_includes_global_roles(rf, core_develop
 
 
 def test_userlist_filter_by_any_roles_yes_includes_project(rf, core_developer):
-    UserFactory(roles=[])
-    user_with_project = UserFactory(roles=[])
+    UserFactory()
+
+    user_with_project = UserFactory()
     ProjectMembershipFactory(user=user_with_project, roles=[ProjectDeveloper])
 
     request = rf.get("/?any_roles=yes")
@@ -513,12 +514,12 @@ def test_userlist_filter_by_any_roles_yes_includes_project(rf, core_developer):
 
 
 def test_userlist_filter_by_any_roles_yes_includes_org(rf, core_developer):
-    UserFactory(roles=[])
+    UserFactory()
 
-    user_with_project = UserFactory(roles=[])
+    user_with_project = UserFactory()
     ProjectMembershipFactory(user=user_with_project, roles=[ProjectDeveloper])
 
-    user_with_org = UserFactory(roles=[])
+    user_with_org = UserFactory()
     OrgMembershipFactory(user=user_with_org, roles=[ProjectDeveloper])
 
     request = rf.get("/?any_roles=yes")
@@ -534,7 +535,7 @@ def test_userlist_filter_by_any_roles_yes_includes_org(rf, core_developer):
 def test_userlist_filter_by_any_roles_no_excludes_global_roles(rf, core_developer):
     UserFactory(roles=[OutputPublisher])
     UserFactory(roles=[ProjectDeveloper])
-    UserFactory(roles=[])
+    UserFactory()
 
     request = rf.get("/?any_roles=no")
     request.user = core_developer
@@ -547,13 +548,13 @@ def test_userlist_filter_by_any_roles_no_excludes_global_roles(rf, core_develope
 def test_userlist_filter_by_any_roles_no_excludes_project_roles(rf, core_developer):
     UserFactory(roles=[OutputPublisher])
     UserFactory(roles=[ProjectDeveloper])
-    UserFactory(roles=[])
+    UserFactory()
 
-    user_with_project = UserFactory(roles=[])
+    user_with_project = UserFactory()
     ProjectMembershipFactory(user=user_with_project, roles=[ProjectDeveloper])
 
-    user_with_project_and_no_roles = UserFactory(roles=[])
-    ProjectMembershipFactory(user=user_with_project_and_no_roles, roles=[])
+    user_with_project_and_no_roles = UserFactory()
+    ProjectMembershipFactory(user=user_with_project_and_no_roles)
 
     request = rf.get("/?any_roles=no")
     request.user = core_developer
@@ -566,13 +567,13 @@ def test_userlist_filter_by_any_roles_no_excludes_project_roles(rf, core_develop
 def test_userlist_filter_by_any_roles_no_excludes_org_roles(rf, core_developer):
     UserFactory(roles=[OutputPublisher])
     UserFactory(roles=[ProjectDeveloper])
-    UserFactory(roles=[])
+    UserFactory()
 
-    user_with_project = UserFactory(roles=[])
+    user_with_project = UserFactory()
     OrgMembershipFactory(user=user_with_project, roles=[ProjectDeveloper])
 
-    user_with_org_and_no_roles = UserFactory(roles=[])
-    OrgMembershipFactory(user=user_with_org_and_no_roles, roles=[])
+    user_with_org_and_no_roles = UserFactory()
+    OrgMembershipFactory(user=user_with_org_and_no_roles)
 
     request = rf.get("/?any_roles=no")
     request.user = core_developer

--- a/tests/unit/staff/views/test_users.py
+++ b/tests/unit/staff/views/test_users.py
@@ -484,7 +484,7 @@ def test_userlist_filter_by_invalid_role(rf, core_developer):
 
 
 def test_userlist_filter_by_any_roles_yes_includes_global_roles(rf, core_developer):
-    UserFactory(roles=[OutputPublisher])
+    user = UserFactory(roles=[OutputPublisher])
     UserFactory()
 
     request = rf.get("/?any_roles=yes")
@@ -492,9 +492,10 @@ def test_userlist_filter_by_any_roles_yes_includes_global_roles(rf, core_develop
 
     response = UserList.as_view()(request)
 
-    assert (
-        len(response.context_data["object_list"]) == 2
-    )  # this includes the core_developer
+    assert set_from_qs(response.context_data["object_list"]) == {
+        core_developer.pk,
+        user.pk,
+    }
 
 
 def test_userlist_filter_by_any_roles_yes_includes_project(rf, core_developer):
@@ -508,9 +509,10 @@ def test_userlist_filter_by_any_roles_yes_includes_project(rf, core_developer):
 
     response = UserList.as_view()(request)
 
-    assert (
-        len(response.context_data["object_list"]) == 2
-    )  # this includes the core_developer
+    assert set_from_qs(response.context_data["object_list"]) == {
+        core_developer.pk,
+        user_with_project.pk,
+    }
 
 
 def test_userlist_filter_by_any_roles_yes_includes_org(rf, core_developer):
@@ -527,28 +529,30 @@ def test_userlist_filter_by_any_roles_yes_includes_org(rf, core_developer):
 
     response = UserList.as_view()(request)
 
-    assert (
-        len(response.context_data["object_list"]) == 3
-    )  # this includes the core_developer
+    assert set_from_qs(response.context_data["object_list"]) == {
+        core_developer.pk,
+        user_with_org.pk,
+        user_with_project.pk,
+    }
 
 
 def test_userlist_filter_by_any_roles_no_excludes_global_roles(rf, core_developer):
     UserFactory(roles=[OutputPublisher])
     UserFactory(roles=[ProjectDeveloper])
-    UserFactory()
+    user = UserFactory()
 
     request = rf.get("/?any_roles=no")
     request.user = core_developer
 
     response = UserList.as_view()(request)
 
-    assert len(response.context_data["object_list"]) == 1
+    assert set_from_qs(response.context_data["object_list"]) == {user.pk}
 
 
 def test_userlist_filter_by_any_roles_no_excludes_project_roles(rf, core_developer):
     UserFactory(roles=[OutputPublisher])
     UserFactory(roles=[ProjectDeveloper])
-    UserFactory()
+    user = UserFactory()
 
     user_with_project = UserFactory()
     ProjectMembershipFactory(user=user_with_project, roles=[ProjectDeveloper])
@@ -561,13 +565,16 @@ def test_userlist_filter_by_any_roles_no_excludes_project_roles(rf, core_develop
 
     response = UserList.as_view()(request)
 
-    assert len(response.context_data["object_list"]) == 2
+    assert set_from_qs(response.context_data["object_list"]) == {
+        user.pk,
+        user_with_project_and_no_roles.pk,
+    }
 
 
 def test_userlist_filter_by_any_roles_no_excludes_org_roles(rf, core_developer):
     UserFactory(roles=[OutputPublisher])
     UserFactory(roles=[ProjectDeveloper])
-    UserFactory()
+    user = UserFactory()
 
     user_with_project = UserFactory()
     OrgMembershipFactory(user=user_with_project, roles=[ProjectDeveloper])
@@ -580,7 +587,10 @@ def test_userlist_filter_by_any_roles_no_excludes_org_roles(rf, core_developer):
 
     response = UserList.as_view()(request)
 
-    assert len(response.context_data["object_list"]) == 2
+    assert set_from_qs(response.context_data["object_list"]) == {
+        user.pk,
+        user_with_org_and_no_roles.pk,
+    }
 
 
 def test_userlist_filter_by_any_roles_invalid_does_nothing(rf, core_developer):

--- a/tests/unit/staff/views/test_users.py
+++ b/tests/unit/staff/views/test_users.py
@@ -560,6 +560,12 @@ def test_userlist_filter_by_any_roles_no_excludes_project_roles(rf, core_develop
     user_with_project_and_no_roles = UserFactory()
     ProjectMembershipFactory(user=user_with_project_and_no_roles)
 
+    user_with_mixture_of_project_roles = UserFactory()
+    ProjectMembershipFactory(user=user_with_mixture_of_project_roles)
+    ProjectMembershipFactory(
+        user=user_with_mixture_of_project_roles, roles=[ProjectDeveloper]
+    )
+
     request = rf.get("/?any_roles=no")
     request.user = core_developer
 
@@ -581,6 +587,10 @@ def test_userlist_filter_by_any_roles_no_excludes_org_roles(rf, core_developer):
 
     user_with_org_and_no_roles = UserFactory()
     OrgMembershipFactory(user=user_with_org_and_no_roles)
+
+    user_with_mixture_of_org_roles = UserFactory()
+    OrgMembershipFactory(user=user_with_mixture_of_org_roles)
+    OrgMembershipFactory(user=user_with_mixture_of_org_roles, roles=[ProjectDeveloper])
 
     request = rf.get("/?any_roles=no")
     request.user = core_developer


### PR DESCRIPTION
Catherine noticed we had some duplicate users on the user list page and what looked like a simple fix turned into a mildly-sisyphean task.

Duplicate users was because we were missing a `distinct()` call, an easy fix! The other bug will be just as easy! Dear reader, let me assure you, it was not.

Note: I checked for and fixed the other staff area list pages missing the `distinct()` call.

The "has any roles: y/n" filter was giving some rather confusing results, some users were being included when filtering on `no` when they clealry had roles.  After more time than I'd like to admit, and a full repro with raw SQL, I tracked this down to users who had any membership with `roles=[]`.  So even when they had other memberships of the same type with roles they were still getting included.