### PR TITLE
Correcting link to DAA

### DIFF
--- a/snippets/start_page.md
+++ b/snippets/start_page.md
@@ -25,6 +25,6 @@ We use data submitted by this form as described in [our privacy policy](https://
 
 ## Before you start your application
 
-Here is a copy of [our online application form](https://drive.google.com/file/d/169NEtgw8EdF5FO81TKYqsQS5n2wyboYN/view), including a checklist at the end.
+Here is a copy of [our online application form](https://docs.google.com/document/d/1ujG3OI2Q8zJz1kLPq6d2zMrBGX-zztEXghlsxn-0amk/edit), including a checklist at the end.
 This is only to be used as a guide to help you understand the information needed to assess our application.
 Do not use the PDF file to submit an application.


### PR DESCRIPTION
Link to our DAA located at the bottom of the PDF of the application form needed correcting, as pathway had been deleted. 