### PR TITLE
Update structlog to 23.2.0

### DIFF
--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -866,9 +866,9 @@ sqlparse==0.4.4 \
     # via
     #   django
     #   django-debug-toolbar
-structlog==21.5.0 \
-    --hash=sha256:68c4c29c003714fe86834f347cb107452847ba52414390a7ee583472bde00fc9 \
-    --hash=sha256:fd7922e195262b337da85c2a91c84be94ccab1f8fd1957bd6986f6904e3761c8
+structlog==23.2.0 \
+    --hash=sha256:16a167e87b9fa7fae9a972d5d12805ef90e04857a93eba479d4be3801a6a1482 \
+    --hash=sha256:334666b94707f89dbc4c81a22a8ccd34449f0201d5b1ee097a030b577fa8c858
     # via django-structlog
 typeguard==2.13.3 \
     --hash=sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4 \


### PR DESCRIPTION
More prep for #3617 

This isn't being updated by dependabot, but hasn't been a problem so far.  This bump covers some more deprecations in the datetime module.