### PR TITLE
Enable updates for sub-dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: "all"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
I've picked `all` here on the working theory that `production` will stop development updates being picked which is not the desired outcome, but ideally (I think?) we would have sub-deps of production dependencies updated where possible.

Related to #3655 where I was surprised to find we were using a 2yo structlog, because django-structlog has a very wide range for structlog.