### PR TITLE
Specify missing direct deps

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -36,6 +36,7 @@ requests
 sentry-sdk
 slack-sdk
 slippers
+social-auth-core
 social-auth-app-django
 structlog
 whitenoise[brotli]

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -37,5 +37,6 @@ sentry-sdk
 slack-sdk
 slippers
 social-auth-app-django
+structlog
 whitenoise[brotli]
 xkcdpass

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -858,7 +858,9 @@ sqlparse==0.4.4 \
 structlog==23.2.0 \
     --hash=sha256:16a167e87b9fa7fae9a972d5d12805ef90e04857a93eba479d4be3801a6a1482 \
     --hash=sha256:334666b94707f89dbc4c81a22a8ccd34449f0201d5b1ee097a030b577fa8c858
-    # via django-structlog
+    # via
+    #   -r requirements.prod.in
+    #   django-structlog
 typeguard==2.13.3 \
     --hash=sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4 \
     --hash=sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -844,7 +844,9 @@ social-auth-app-django==5.3.0 \
 social-auth-core==4.4.1 \
     --hash=sha256:29f5ea3174162797ccb9b849f7a38a9490bfb920304ecd9b7f63c6c3a5ceb7a3 \
     --hash=sha256:cff78e0707ed0f6bdd3beec6ce713591875492b98272ea6298cc173912e3234b
-    # via social-auth-app-django
+    # via
+    #   -r requirements.prod.in
+    #   social-auth-app-django
 soupsieve==2.5 \
     --hash=sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690 \
     --hash=sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7


### PR DESCRIPTION
Related to #3655 and #3656 

Structlog feels like an obvious win here, we're using it in `services/logging.py` to configure our formatter so it's effectively used everywhere.

social-auth-core feels slightly dubious though.  social-auth-django should, assuming no major architcture changes to it, always depend on social-auth-core and pull in the correct version.  However, we do directly import from the package which is why I've added it here.  Dearest reviewer, please have an opinion on this!