### PR TITLE
Change text on output viewer app buttons

### DIFF
--- a/assets/src/scripts/outputs-viewer/__tests__/App.test.jsx
+++ b/assets/src/scripts/outputs-viewer/__tests__/App.test.jsx
@@ -44,14 +44,16 @@ describe("<App />", () => {
   it("shows prepare button", async () => {
     fetch.mockResponseOnce(JSON.stringify({ files: fileList }));
     render(<App {...props} prepareUrl={prepareUrl} />);
-    expect(screen.getByRole("button", { name: "Publish" })).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Create a draft publication" }),
+    ).toBeVisible();
   });
 
   it("shows publish button", async () => {
     fetch.mockResponseOnce(JSON.stringify({ files: fileList }));
     render(<App {...props} publishUrl={publishUrl} />);
     expect(
-      screen.getByRole("button", { name: "Confirm Publish?" }),
+      screen.getByRole("button", { name: "Create a public published output" }),
     ).toBeVisible();
   });
 

--- a/assets/src/scripts/outputs-viewer/__tests__/components/Button/PrepareButton.test.jsx
+++ b/assets/src/scripts/outputs-viewer/__tests__/components/Button/PrepareButton.test.jsx
@@ -63,7 +63,9 @@ describe("<PrepareButton />", () => {
       />,
     );
 
-    expect(screen.getByRole("button")).toHaveTextContent("Publish");
+    expect(screen.getByRole("button")).toHaveTextContent(
+      "Create a draft publication",
+    );
   });
 
   it("triggers a mutation on click", async () => {
@@ -93,12 +95,14 @@ describe("<PrepareButton />", () => {
       />,
     );
 
-    expect(screen.getByRole("button")).toHaveTextContent("Publish");
+    expect(screen.getByRole("button")).toHaveTextContent(
+      "Create a draft publication",
+    );
 
     await user.click(screen.getByRole("button"));
 
     await waitFor(() =>
-      expect(screen.getByRole("button")).toHaveTextContent("Publishing…"),
+      expect(screen.getByRole("button")).toHaveTextContent("Creating…"),
     );
 
     await waitFor(() => {
@@ -128,7 +132,9 @@ describe("<PrepareButton />", () => {
       />,
     );
 
-    expect(screen.getByRole("button")).toHaveTextContent("Publish");
+    expect(screen.getByRole("button")).toHaveTextContent(
+      "Create a draft publication",
+    );
 
     await user.click(screen.getByRole("button"));
 
@@ -164,7 +170,9 @@ describe("<PrepareButton />", () => {
       />,
     );
 
-    expect(screen.getByRole("button")).toHaveTextContent("Publish");
+    expect(screen.getByRole("button")).toHaveTextContent(
+      "Create a draft publication",
+    );
 
     await user.click(screen.getByRole("button"));
 

--- a/assets/src/scripts/outputs-viewer/__tests__/components/Button/PublishButton.test.jsx
+++ b/assets/src/scripts/outputs-viewer/__tests__/components/Button/PublishButton.test.jsx
@@ -13,7 +13,9 @@ describe("<PublishButton />", () => {
   it("shows the button", () => {
     render(<PublishButton csrfToken={csrfToken} publishUrl={publishUrl} />);
 
-    expect(screen.getByRole("button")).toHaveTextContent("Publish");
+    expect(screen.getByRole("button")).toHaveTextContent(
+      "Create a public published output",
+    );
   });
 
   it("triggers a mutation on click", async () => {
@@ -28,11 +30,13 @@ describe("<PublishButton />", () => {
 
     render(<PublishButton csrfToken={csrfToken} publishUrl={publishUrl} />);
 
-    expect(screen.getByRole("button")).toHaveTextContent("Confirm Publish?");
+    expect(screen.getByRole("button")).toHaveTextContent(
+      "Create a public published output",
+    );
 
     await user.click(screen.getByRole("button"));
 
-    expect(screen.getByRole("button")).toHaveTextContent("Confirming…");
+    expect(screen.getByRole("button")).toHaveTextContent("Creating…");
 
     await waitFor(() => expect(fetch.requests().length).toEqual(1));
   });
@@ -48,7 +52,9 @@ describe("<PublishButton />", () => {
 
     render(<PublishButton csrfToken={csrfToken} publishUrl={publishUrl} />);
 
-    expect(screen.getByRole("button")).toHaveTextContent("Confirm Publish?");
+    expect(screen.getByRole("button")).toHaveTextContent(
+      "Create a public published output",
+    );
 
     await user.click(screen.getByRole("button"));
 
@@ -73,7 +79,9 @@ describe("<PublishButton />", () => {
 
     render(<PublishButton csrfToken={csrfToken} publishUrl={publishUrl} />);
 
-    expect(screen.getByRole("button")).toHaveTextContent("Confirm Publish?");
+    expect(screen.getByRole("button")).toHaveTextContent(
+      "Create a public published output",
+    );
 
     await user.click(screen.getByRole("button"));
 

--- a/assets/src/scripts/outputs-viewer/components/Button/PrepareButton.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Button/PrepareButton.jsx
@@ -59,7 +59,7 @@ function PrepareButton({ authToken, csrfToken, filesUrl, prepareUrl }) {
       type="button"
       variant={mutation.isPending ? "secondary" : "primary"}
     >
-      {mutation.isPending ? "Publishing…" : "Publish"}
+      {mutation.isPending ? "Creating…" : "Create a draft publication"}
     </Button>
   );
 }

--- a/assets/src/scripts/outputs-viewer/components/Button/PublishButton.jsx
+++ b/assets/src/scripts/outputs-viewer/components/Button/PublishButton.jsx
@@ -52,7 +52,7 @@ function PublishButton({ csrfToken, publishUrl }) {
       type="button"
       variant={mutation.isPending ? "secondary" : "primary"}
     >
-      {mutation.isPending ? "Confirming…" : "Confirm Publish?"}
+      {mutation.isPending ? "Creating…" : "Create a public published output"}
     </Button>
   );
 }


### PR DESCRIPTION
So that it is clearer what the button does.

- "Publish" changed to "Create a draft publication"
- "Confirm Publish?" changed to "Create a public published output"