### PR TITLE
Simplify interactive integration test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ filterwarnings = [
     "ignore::pytest.PytestUnraisableExceptionWarning:",
     "ignore:distutils Version classes are deprecated:DeprecationWarning:pytest_freezegun",
     "ignore:Call to deprecated method __init__:DeprecationWarning:",
-    "ignore:path is deprecated.:DeprecationWarning:opensafely",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:",
     "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning:",
     "ignore:The FORMS_URLFIELD_ASSUME_HTTPS transitional setting is deprecated.:django.utils.deprecation.RemovedInDjango60Warning:",

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -9,7 +9,6 @@ coverage[toml]
 coverage-enable-subprocess
 django-upgrade
 factory_boy
-opensafely
 pip-tools
 pre-commit
 pytest-django

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -258,10 +258,6 @@ nodeenv==1.8.0 \
     --hash=sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2 \
     --hash=sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec
     # via pre-commit
-opensafely==1.41.2 \
-    --hash=sha256:3ef9e0a4c8fb7ed00dd17f76ee2700090ee4aa00e159e48f08ccfea70e062c0f \
-    --hash=sha256:ff813ca0d161ed94d2ede95f9949e4a36de8f61ff103aa791728244003b1467a
-    # via -r requirements.dev.in
 packaging==23.2 \
     --hash=sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5 \
     --hash=sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7

--- a/tests/integration/test_interactive.py
+++ b/tests/integration/test_interactive.py
@@ -97,11 +97,8 @@ def test_interactive_submission_success(rf, local_repo, enable_network):
             "type": "event",
             "value": "pincer/ast/v1.8",
         },
-        "demographics": ["sex", "age"],
         "filterPopulation": "all",
         "purpose": "For… science!",
-        "timeScale": "years",
-        "timeValue": "5",
     }
     request = rf.post("/", data=json.dumps(data), content_type="appliation/json")
     request.user = user
@@ -113,36 +110,19 @@ def test_interactive_submission_success(rf, local_repo, enable_network):
     # check the view redirects, a 200 means we have validation errors
     assert response.status_code == 302, response.context_data["form"].errors
 
-    _, _, ar_pk = response.url.rpartition("/")[0].rpartition("/")
-    analysis_request = AnalysisRequest.objects.get(slug=ar_pk)
-
-    assert analysis_request.template_data["codelist_1"] == {
-        "path": None,
-        "slug": "opensafely/asthma-inhaler-salbutamol-medication/2020-04-15",
-        "type": "medication",
-        "label": "Asthma Inhaler Salbutamol Medication",
-        "description": None,
-    }
-    assert analysis_request.template_data["codelist_2"] == {
-        "path": None,
-        "slug": "pincer/ast/v1.8",
-        "type": "event",
-        "label": "Asthma",
-        "description": None,
-    }
-    assert analysis_request.template_data["demographics"] == ["sex", "age"]
-    assert analysis_request.template_data["filter_population"] == "all"
-    assert analysis_request.template_data["time_scale"] == "years"
-    assert analysis_request.template_data["time_value"] == 5
+    ar_slug = response.url.rpartition("/")[0].rpartition("/")[-1]
+    ar_pk = ar_slug.rpartition("-")[-1]
+    analysis_request = AnalysisRequest.objects.get(slug=ar_slug)
 
     # Setting the Git SHA is done as a result of calling
     # interactive_template's create_commit function. This renders the analysis
     # code based on the contents of the template data. So if the template data
-    # hasn't changed and we receive a SHA then we can assume everything is
-    # working.
+    # hasn't changed, all variables will be replaced in the project definition
+    # and a commit will be made with the SHA saved to the job request.
     assert isinstance(analysis_request.job_request.sha, str)
     assert (
-        "generate_study_population" in analysis_request.job_request.project_definition
+        f"generate_study_population_{ar_pk}"
+        in analysis_request.job_request.project_definition
     )
     assert "{{" not in analysis_request.job_request.project_definition
 


### PR DESCRIPTION
Now that the creation of the git commit has moved into interactive_templates, we no longer need to test the commit creation here. The interactive_templates tests are also checking run_all. We just need to confirm that we're constructing everything correctly and that we're triggering the commit to be created with the right information.

This should take around 40s off the test time and remove a fairly significant dependency.