### PR TITLE
Make flaky test more specific

### DIFF
--- a/tests/unit/staff/views/test_job_requests.py
+++ b/tests/unit/staff/views/test_job_requests.py
@@ -169,13 +169,12 @@ def test_jobrequestlist_search_using_fullname(rf, core_developer):
     user = UserFactory(fullname="Ben Goldacre")
     job_request = JobRequestFactory(created_by=user)
 
-    request = rf.get("/?q=ben")
+    request = rf.get("/?q=ben+goldacre")
     request.user = core_developer
 
     response = JobRequestList.as_view()(request)
 
     assert response.status_code == 200
-    assert len(response.context_data["object_list"]) == 1
     assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
 
 


### PR DESCRIPTION
This test failed because it was doing a search on the first name, which was very short, and happened to return back more than one result. This changes it to search for the fullname instead, which should only ever return back a single result.