### PR TITLE
chore: tidy up unused docker volume

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -93,4 +93,3 @@ services:
 
 volumes:
   postgres_data:
-  staticfiles:


### PR DESCRIPTION
* I believe this volume is unused since https://github.com/opensafely-core/job-server/pull/3456 - tidy it up!