### PR TITLE
Remove cancelled JobRequests from API

### DIFF
--- a/jobserver/api/jobs.py
+++ b/jobserver/api/jobs.py
@@ -3,6 +3,7 @@ import json
 import operator
 
 import structlog
+from django.db.models import Q
 from django.http import Http404
 from django.utils import timezone
 from rest_framework import serializers
@@ -287,7 +288,7 @@ class JobRequestAPIList(ListAPIView):
     def get_queryset(self):
         qs = (
             JobRequest.objects.filter(
-                jobs__completed_at__isnull=True,
+                Q(jobs__status__in=["pending", "running"]) | Q(jobs=None),
             )
             .select_related(
                 "backend",

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -14,6 +14,7 @@ pip-tools
 pre-commit
 pytest-django
 pytest-env
+pytest-icdiff
 pytest-mock
 pytest-network
 pytest-subtests

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -220,6 +220,10 @@ filelock==3.13.1 \
     --hash=sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e \
     --hash=sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c
     # via virtualenv
+icdiff==2.0.7 \
+    --hash=sha256:f05d1b3623223dd1c70f7848da7d699de3d9a2550b902a8234d9026292fb5762 \
+    --hash=sha256:f79a318891adbf59a45e3a7694f5e1f18c5407065264637072ac8363b759866f
+    # via pytest-icdiff
 identify==2.5.32 \
     --hash=sha256:0b7656ef6cba81664b783352c73f8c24b39cf82f926f78f4550eda928e5e0545 \
     --hash=sha256:5d9979348ec1a21c768ae07e0a652924538e8bce67313a73cb0f681cf08ba407
@@ -271,6 +275,10 @@ pluggy==1.3.0 \
     --hash=sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12 \
     --hash=sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7
     # via pytest
+pprintpp==0.4.0 \
+    --hash=sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d \
+    --hash=sha256:ea826108e2c7f49dc6d66c752973c3fc9749142a798d6b254e1e301cfdbc6403
+    # via pytest-icdiff
 pre-commit==3.5.0 \
     --hash=sha256:5804465c675b659b0862f07907f96295d490822a450c4c40e747d0b1c6ebcb32 \
     --hash=sha256:841dc9aef25daba9a0238cd27984041fa0467b4199fc4852e27950664919f660
@@ -303,6 +311,7 @@ pytest==7.4.3 \
     # via
     #   pytest-django
     #   pytest-env
+    #   pytest-icdiff
     #   pytest-mock
     #   pytest-network
     #   pytest-subtests
@@ -314,6 +323,10 @@ pytest-django==4.7.0 \
 pytest-env==1.1.1 \
     --hash=sha256:1efb8acce1f6431196150f3b30673443ff05a6fabff64539a9495cd2248adf9e \
     --hash=sha256:2b71b37c6810f28bec790a7b373c777af87352b3a359b3de0edb9d24df5cf8b3
+    # via -r requirements.dev.in
+pytest-icdiff==0.9 \
+    --hash=sha256:13aede616202e57fcc882568b64589002ef85438046f012ac30a8d959dac8b75 \
+    --hash=sha256:efee0da3bd1b24ef2d923751c5c547fbb8df0a46795553fba08ef57c3ca03d82
     # via -r requirements.dev.in
 pytest-mock==3.12.0 \
     --hash=sha256:0972719a7263072da3a21c7f4773069bcc7486027d7e8e1f81d98a47e701bc4f \


### PR DESCRIPTION
With a db dump from earlier today this takes the number of JobRequests served by the API locally from 100+ to 2.

Fix: #3770 