### PR TITLE
Fix coverage with `just test-dev`

### DIFF
--- a/justfile
+++ b/justfile
@@ -139,7 +139,7 @@ test *args: assets
 
 test-dev *args: assets
     #!/bin/bash
-    export COVERAGE_REPORT_ARGS="--omit=interactive/opencodelists.py,jobserver/github.py,tests/integration/test_interactive.py,tests/verification/*"
+    export COVERAGE_REPORT_ARGS="--omit=jobserver/github.py,jobserver/opencodelists.py,tests/integration/test_interactive.py,tests/verification/*"
     ./scripts/test-coverage.sh -m "not verification and not slow_test" {{ args }}
 
 


### PR DESCRIPTION
We moved the `opencodelists` module in a68ea25ef3d115ce9f2698278bcdce30e8f1c869, but missed the `--omit` path for `test-dev`.  We don't use this in CI so it's hard to get feedback that it happened.