### PR TITLE
Restore the application restore button

### DIFF
--- a/templates/applications/application_list.html
+++ b/templates/applications/application_list.html
@@ -58,8 +58,14 @@
       {% #card container=False title="Deleted applications" subtitle="OpenSAFELY applications that have been deleted by you" %}
         {% #list_group %}
           {% for application in deleted_applications %}
-            <li class="flex flex-col items-start gap-y-1 px-4 py-3 sm:px-6">
-              {% link href=application.get_absolute_url text="Application: "|add:application.pk_hash %}
+            <li class="flex flex-col gap-y-1 px-4 py-3 sm:px-6">
+              <div class="flex flex-row flex-wrap gap-2 justify-between">
+                {% link href=application.get_absolute_url text="Application: "|add:application.pk_hash %}
+                <form method="POST" action="{{ application.get_restore_url }}">
+                  {% csrf_token %}
+                  {% #button variant="danger" small=True type="submit" %}Restore{% /button %}
+                </form>
+              </div>
               <span class="text-sm text-slate-800 font-normal">
                 Started on: {{ application.created_at|date:"d F Y" }}
               </span>


### PR DESCRIPTION
This was accidentally removed as part of fa2bb9c.

I've mirrored the styles used in the application list above this section, but added in `justify-between` for the div wrapping the name&button row, rather than using `ml-auto`, since there's no status pill to account for.

Fix: #3650 