### PR TITLE
Don't render large project.yamls

### DIFF
--- a/templates/job_request_detail.html
+++ b/templates/job_request_detail.html
@@ -74,7 +74,7 @@
           View repo
         {% /button %}
 
-        {% #button href=project_yaml_url type="link" variant="secondary" %}
+        {% #button href=project_yaml.url type="link" variant="secondary" %}
           View project.yaml
         {% /button %}
 
@@ -175,7 +175,7 @@
         {% /card %}
       {% endif %}
 
-      {% if project_definition %}
+      {% if not project_yaml.is_empty %}
         {% #card title="Pipeline" container=True %}
           <details
             class="
@@ -192,7 +192,11 @@
             </summary>
 
             <div class="p-4 bg-[#f8f8f8] overflow-scroll">
-              {{ project_definition }}
+              {% if project_yaml.is_too_large %}
+                This file is too large to render, try {% link href=project_yaml.url text="viewing it on GitHub" %}.
+              {% else %}
+                {{ project_yaml.definition }}
+              {% endif %}
             </div>
           </details>
         {% /card %}

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -1008,7 +1008,7 @@ def test_jobrequestdetail_with_permission_with_completed_at(rf):
 
 
 def test_jobrequestdetail_with_unauthenticated_user(rf):
-    job_request = JobRequestFactory()
+    job_request = JobRequestFactory(project_definition="test")
 
     request = rf.get("/")
     request.user = AnonymousUser()


### PR DESCRIPTION
After a certain size it takes too long to render with pygments and for the particularly large examples (2.43MB) they crash the browser locally.

I've handled the too large outcome in the template so we can make use of our `link` component.

Fix: #3704 