### PR TITLE
Disable delete buttons for files which haven't been uploaded

### DIFF
--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -288,9 +288,10 @@ class WorkspaceReleaseList(View):
                     "pk": f.pk,
                     "name": f.name,
                     "is_deleted": f.is_deleted,
-                    "deleted_by": f.deleted_by,
                     "deleted_at": f.deleted_at,
+                    "deleted_by": f.deleted_by,
                     "detail_url": getattr(f, url_method_name),
+                    "get_delete_url": f.get_delete_url(),
                 }
                 for f in files
             ]

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -23,6 +23,23 @@ from ..releases import build_outputs_zip, serve_file, workspace_files
 from ..utils import build_spa_base_url
 
 
+def build_files(files, url_method_name):
+    return [
+        {
+            "pk": f.pk,
+            "name": f.name,
+            "is_deleted": f.is_deleted,
+            "disable_deletion": f.is_deleted or f.uploaded_at is None,
+            "not_uploaded": f.uploaded_at is None,
+            "deleted_at": f.deleted_at,
+            "deleted_by": f.deleted_by,
+            "detail_url": getattr(f, url_method_name),
+            "get_delete_url": f.get_delete_url(),
+        }
+        for f in files
+    ]
+
+
 class ProjectReleaseList(View):
     def get(self, request, *args, **kwargs):
         project = get_object_or_404(Project, slug=self.kwargs["project_slug"])
@@ -56,7 +73,7 @@ class ProjectReleaseList(View):
                 "created_at": r.created_at,
                 "created_by": r.created_by,
                 "download_url": r.get_download_url(),
-                "files": r.files.all(),
+                "files": build_files(r.files.all(), "get_absolute_url"),
                 "id": r.pk,
                 "view_url": r.get_absolute_url(),
                 "workspace": r.workspace,
@@ -281,20 +298,6 @@ class WorkspaceReleaseList(View):
             "release_file_view",
             project=workspace.project,
         )
-
-        def build_files(files, url_method_name):
-            return [
-                {
-                    "pk": f.pk,
-                    "name": f.name,
-                    "is_deleted": f.is_deleted,
-                    "deleted_at": f.deleted_at,
-                    "deleted_by": f.deleted_by,
-                    "detail_url": getattr(f, url_method_name),
-                    "get_delete_url": f.get_delete_url(),
-                }
-                for f in files
-            ]
 
         latest_files = list(
             sorted(workspace_files(workspace).values(), key=lambda rf: rf.name)

--- a/templates/project_release_list.html
+++ b/templates/project_release_list.html
@@ -75,7 +75,7 @@
           >
             {% #list_group small %}
               {% for file in release.files %}
-                {% #list_group_item href=file.detail_url disabled=file.is_deleted class="flex flex-row justify-between items-center flex-wrap gap-2" %}
+                {% #list_group_item href=file.detail_url disabled=file.disable_deletion class="flex flex-row justify-between items-center flex-wrap gap-2" %}
                   <code class="truncate">{{ file.name }}</code>
 
                   {% if file.is_deleted %}
@@ -84,7 +84,13 @@
                   </span>
                   {% endif %}
 
-                  {% if user_can_delete_files and not file.is_deleted %}
+                  {% if file.not_uploaded %}
+                  <span class="text-xs text-slate-600 font-normal mr-auto">
+                    (Not yet uploaded)
+                  </span>
+                  {% endif %}
+
+                  {% if user_can_delete_files and not file.disable_deletion %}
                   <form
                     action="{{ file.get_delete_url }}"
                     class="ml-auto"

--- a/templates/project_release_list.html
+++ b/templates/project_release_list.html
@@ -86,7 +86,7 @@
 
                   {% if user_can_delete_files and not file.is_deleted %}
                   <form
-                    action="{% url "release-file-delete" project_slug=project.slug workspace_slug=release.workspace.name pk=release.id release_file_id=file.pk %}"
+                    action="{{ file.get_delete_url }}"
                     class="ml-auto"
                     method="POST"
                   >

--- a/templates/workspace_release_list.html
+++ b/templates/workspace_release_list.html
@@ -59,7 +59,7 @@
         >
           {% #list_group small %}
             {% for file in latest_release.files %}
-              {% #list_group_item href=file.detail_url disabled=file.is_deleted class="flex flex-row justify-between items-center flex-wrap gap-2" %}
+              {% #list_group_item href=file.detail_url disabled=file.disable_deletion class="flex flex-row justify-between items-center flex-wrap gap-2" %}
                 <code class="truncate">{{ file.name }}</code>
 
                 {% if file.is_deleted %}
@@ -68,7 +68,13 @@
                 </span>
                 {% endif %}
 
-                {% if user_can_delete_files and not file.is_deleted %}
+                {% if file.not_uploaded %}
+                <span class="text-xs text-slate-600 font-normal mr-auto">
+                  (Not yet uploaded)
+                </span>
+                {% endif %}
+
+                {% if user_can_delete_files and not file.disable_deletion %}
                 <form
                   action="{{ file.get_delete_url }}"
                   class="ml-auto"
@@ -120,7 +126,7 @@
           >
             {% #list_group small %}
               {% for file in release.files %}
-                {% #list_group_item href=file.detail_url disabled=file.is_deleted class="flex flex-row justify-between items-center flex-wrap gap-2" %}
+                {% #list_group_item href=file.detail_url disabled=file.disable_deletion class="flex flex-row justify-between items-center flex-wrap gap-2" %}
                   <code class="truncate">{{ file.name }}</code>
 
                   {% if file.is_deleted %}
@@ -129,7 +135,13 @@
                   </span>
                   {% endif %}
 
-                  {% if user_can_delete_files and not file.is_deleted %}
+                  {% if file.not_uploaded %}
+                  <span class="text-xs text-slate-600 font-normal mr-auto">
+                    (Not yet uploaded)
+                  </span>
+                  {% endif %}
+
+                  {% if user_can_delete_files and not file.disable_deletion %}
                   <form
                     action="{{ file.get_delete_url }}"
                     class="ml-auto"

--- a/templates/workspace_release_list.html
+++ b/templates/workspace_release_list.html
@@ -70,14 +70,14 @@
 
                 {% if user_can_delete_files and not file.is_deleted %}
                 <form
-                  action="{% url "release-file-delete" project_slug=workspace.project.slug workspace_slug=workspace.name pk=latest_release.id release_file_id=file.pk %}"
+                  action="{{ file.get_delete_url }}"
                   class="ml-auto"
                   method="POST"
                 >
                   {% csrf_token %}
 
                   {% #button class="flex-shrink-0 whitespace-nowrap" small type="submit" variant="danger" %}
-                   Delete file
+                  Delete file
                   {% /button %}
                 </form>
                 {% endif %}
@@ -131,7 +131,7 @@
 
                   {% if user_can_delete_files and not file.is_deleted %}
                   <form
-                    action="{% url "release-file-delete" project_slug=workspace.project.slug workspace_slug=workspace.name pk=release.id release_file_id=file.pk %}"
+                    action="{{ file.get_delete_url }}"
                     class="ml-auto"
                     method="POST"
                   >


### PR DESCRIPTION
Similar to when a file has been deleted this hides the delete button, and adds an explanatory message next to the filename:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/Z4upQL8v/b88e8dbb-b009-4855-b789-bfd45b8e0670.jpg?v=766525da05f44e3838da18060b0aeac9)

Fix: #3875