### PR TITLE
Show alerts when a job or job request has been cancelled

### DIFF
--- a/jobserver/views/jobs.py
+++ b/jobserver/views/jobs.py
@@ -103,6 +103,7 @@ class JobDetail(View):
             ] = honeycomb.previous_actions_link(job)
 
         context = {
+            "cancellation_requested": job.action in job.job_request.cancelled_actions,
             "job": job,
             "log_path": log_path,
             "log_path_url": log_path_url,

--- a/templates/job_detail.html
+++ b/templates/job_detail.html
@@ -29,6 +29,12 @@
   {% /alert %}
 {% endif %}
 
+{% if cancellation_requested and not job.is_completed %}
+  {% #alert variant="info" title="Cancellation requested" class="mb-4" %}
+    A User has requested this job is cancelled.
+  {% /alert %}
+{% endif %}
+
 <div class="md:flex md:items-center md:justify-between md:space-x-5">
   <h1 class="min-w-0 text-3xl break-words md:text-4xl font-bold text-slate-900">
     {% if job.action == "__error__" %}

--- a/templates/job_request_detail.html
+++ b/templates/job_request_detail.html
@@ -33,6 +33,12 @@
     {% /alert %}
   {% endif %}
 
+  {% if job_request.cancelled_actions and not job_request.is_completed %}
+    {% #alert variant="info" title="Cancellation requested" class="mb-4" %}
+      A User has requested this job is cancelled.
+    {% /alert %}
+  {% endif %}
+
   <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
     <div class="flex flex-col text-center items-center gap-y-2 lg:text-left lg:items-start lg:col-span-full">
       <div class="flex flex-col items-center gap-y-2 w-full lg:flex-row lg:justify-between lg:items-start">
@@ -81,7 +87,7 @@
         {% if user_can_cancel_jobs %}
           <form class="d-inline-block" method="POST" action="{{ job_request.get_cancel_url }}">
             {% csrf_token %}
-            {% if job_request.is_completed %}
+            {% if job_request.is_completed or job_request.cancelled_actions %}
               {% #button type="submit" disabled=True tooltip="This job request can no longer be cancelled" %}
                 Cancel this job
               {% /button %}


### PR DESCRIPTION
This adds info alerts to the JobRequestDetail and JobDetail pages when a Job[Request] is still running but a user has requested they are cancelled, and sets the cancel buttons to disabled.

Fix: #3701 
Fix: #3702