### PR TITLE
Add a cancel button to the staff area's JobRequestDetail page

### DIFF
--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -297,6 +297,14 @@ class JobRequest(models.Model):
             },
         )
 
+    def get_staff_cancel_url(self):
+        return reverse(
+            "staff:job-request-cancel",
+            kwargs={
+                "pk": self.pk,
+            },
+        )
+
     @property
     def is_completed(self):
         return self.status in ["failed", "succeeded"]

--- a/jobserver/models/core.py
+++ b/jobserver/models/core.py
@@ -305,6 +305,18 @@ class JobRequest(models.Model):
     def num_completed(self):
         return len([j for j in self.jobs.all() if j.status == "succeeded"])
 
+    def request_cancellation(self):
+        # Exclude succeeded jobs (failed or succeeded status, consistent with Job.is_completed method)
+        actions = list(
+            set(
+                self.jobs.exclude(status__in=["failed", "succeeded"]).values_list(
+                    "action", flat=True
+                )
+            )
+        )
+        self.cancelled_actions = actions
+        self.save(update_fields=["cancelled_actions"])
+
     @property
     @queries_dangerously_enabled()
     def runtime(self):

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -46,17 +46,7 @@ class JobRequestCancel(View):
         if job_request.is_completed:
             return redirect(job_request)
 
-        # Exclude succeeded jobs (failed or succeeded status, consistent with Job.is_completed method)
-        actions = list(
-            set(
-                job_request.jobs.exclude(
-                    status__in=["failed", "succeeded"]
-                ).values_list("action", flat=True)
-            )
-        )
-
-        job_request.cancelled_actions = actions
-        job_request.save()
+        job_request.request_cancellation()
 
         messages.success(request, "The requested actions have been cancelled")
 

--- a/staff/urls.py
+++ b/staff/urls.py
@@ -26,7 +26,7 @@ from .views.dashboards.index import DashboardIndex
 from .views.dashboards.projects import ProjectsDashboard
 from .views.dashboards.repos import PrivateReposDashboard, ReposWithMultipleProjects
 from .views.index import Index
-from .views.job_requests import JobRequestDetail, JobRequestList
+from .views.job_requests import JobRequestCancel, JobRequestDetail, JobRequestList
 from .views.orgs import (
     OrgCreate,
     OrgDetail,
@@ -132,6 +132,7 @@ dashboard_urls = [
 job_request_urls = [
     path("", JobRequestList.as_view(), name="job-request-list"),
     path("<int:pk>/", JobRequestDetail.as_view(), name="job-request-detail"),
+    path("<int:pk>/cancel/", JobRequestCancel.as_view(), name="job-request-cancel"),
 ]
 
 org_urls = [

--- a/templates/staff/job_request/detail.html
+++ b/templates/staff/job_request/detail.html
@@ -15,9 +15,23 @@
 {% block hero %}
   {% with id=job_request.pk|stringformat:"s" %}
     {% #staff_hero title="Job request: "|add:id %}
-      {% #button variant="primary" type="link" href=job_request.get_absolute_url %}
-        View on site
-      {% /button %}
+      <div class="flex flex-row gap-2">
+        {% #button variant="primary" type="link" href=job_request.get_absolute_url %}
+          View on site
+        {% /button %}
+        <form class="d-inline-block" method="POST" action="{{ job_request.get_staff_cancel_url }}">
+          {% csrf_token %}
+          {% if job_request.is_completed or job_request.cancelled_actions %}
+            {% #button type="submit" disabled=True tooltip="This job request can no longer be cancelled" %}
+              Cancel this job
+            {% /button %}
+          {% else %}
+            {% #button type="submit" variant="danger" %}
+              Cancel this job
+            {% /button %}
+          {% endif %}
+        </form>
+      </div>
     {% /staff_hero %}
   {% endwith %}
 {% endblock hero %}

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -140,6 +140,19 @@ def test_jobrequest_get_staff_url():
     )
 
 
+def test_jobrequest_get_staff_cancel_url():
+    job_request = JobRequestFactory()
+
+    url = job_request.get_staff_cancel_url()
+
+    assert url == reverse(
+        "staff:job-request-cancel",
+        kwargs={
+            "pk": job_request.pk,
+        },
+    )
+
+
 def test_jobrequest_is_completed():
     job_request = JobRequestFactory()
     JobFactory(job_request=job_request, status="failed")

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -161,6 +161,19 @@ def test_jobrequest_num_completed_success():
     assert job_request.num_completed == 2
 
 
+def test_jobrequest_request_cancellation():
+    job_request = JobRequestFactory(cancelled_actions=[])
+    JobFactory(job_request=job_request, action="job1", status="pending")
+    JobFactory(job_request=job_request, action="job2", status="running")
+    JobFactory(job_request=job_request, action="job3", status="failed")
+    JobFactory(job_request=job_request, action="job4", status="succeeded")
+
+    job_request.request_cancellation()
+
+    job_request.refresh_from_db()
+    assert set(job_request.cancelled_actions) == {"job1", "job2"}
+
+
 def test_jobrequest_runtime_one_job_missing_completed_at(time_machine):
     job_request = JobRequestFactory()
 


### PR DESCRIPTION
This pulls the cancelling logic out to a method on the JobRequest model, and adds a view to the staff area to call it.

We don't have jobs in the staff area so no cancel button there.

Fix: #3700