### PR TITLE
Only send report notifications if we create one successfully

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -382,14 +382,15 @@ class ReleaseAPI(APIView):
         slacks.notify_release_file_uploaded(rfile)
 
         if analysis_request := is_interactive_report(rfile):
-            create_report(
-                analysis_request=analysis_request,
-                rfile=rfile,
-                user=analysis_request.created_by,
-            )
+            with transaction.atomic():
+                create_report(
+                    analysis_request=analysis_request,
+                    rfile=rfile,
+                    user=analysis_request.created_by,
+                )
 
-            send_report_uploaded_notification(analysis_request)
-            notify_report_uploaded(analysis_request)
+                send_report_uploaded_notification(analysis_request)
+                notify_report_uploaded(analysis_request)
 
         response = Response(status=201)
         response.headers["File-Id"] = rfile.id


### PR DESCRIPTION
Should the creation of a report fail we want to avoid sending out notifications about the analysis request.

create_report() is also wrapped in a transaction since it touches more than one DB object.  This change leaves that transaction alone so any caller of it does not need to worry about it happening correctly, and Django will handle the stacked transactions for us.

Fix: #3708