### PR TITLE
Fix smart quotes in reports

### DIFF
--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -236,6 +236,14 @@ def serve_file(request, rfile):
         # bypass DRFs renderer framework and just serve bytes
         response = FileResponse(path.open("rb"))
 
+        content_type = response.headers.get("Content-Type")
+        if content_type.startswith("text"):
+            # for text-based files append a charset to the existing
+            # content-type header, being careful just in case the existing
+            # value is empty
+            joiner = "; " if content_type else ""
+            response.headers["Content-Type"] = f"{content_type}{joiner}charset=utf-8"
+
     # set Last-Modified header as per:
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified
     response.headers["Last-Modified"] = http_date(rfile.created_at.timestamp())

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -998,7 +998,7 @@ def test_releasefileapi_with_permission(api_rf, build_release_with_files):
 
     assert response.status_code == 200
     assert b"".join(response.streaming_content) == rfile.absolute_path().read_bytes()
-    assert response.headers["Content-Type"] == "text/plain"
+    assert response.headers["Content-Type"] == "text/plain; charset=utf-8"
 
 
 def test_releasefileapi_without_permission(api_rf):

--- a/tests/unit/jobserver/test_releases.py
+++ b/tests/unit/jobserver/test_releases.py
@@ -293,6 +293,17 @@ def test_serve_file(rf):
         releases.serve_file(request, rfile)
 
 
+def test_serve_file_with_non_text_file(build_release, build_release_file, rf):
+    release = build_release(["bennett.json"])
+    rfile = build_release_file(release, "bennett.json")
+
+    request = rf.get("/")
+    response = releases.serve_file(request, rfile)
+
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/json"
+
+
 def test_workspace_files_no_releases():
     workspace = WorkspaceFactory()
 

--- a/tests/unit/jobserver/views/test_releases.py
+++ b/tests/unit/jobserver/views/test_releases.py
@@ -113,7 +113,7 @@ def test_publishedsnapshotfile_success(rf, release):
 
     assert response.status_code == 200
     assert b"".join(response.streaming_content) == rfile.absolute_path().read_bytes()
-    assert response.headers["Content-Type"] == "text/plain"
+    assert response.headers["Content-Type"] == "text/plain; charset=utf-8"
     assert response.headers["Last-Modified"]
 
 


### PR DESCRIPTION
Well, this was an absolute doozy.

To recap, we have two views of the same file:
- Reports: quotes are mangled
- outputs-viewer: quotes are fine

Viewing the endpoint directly also rendered mangled quotes.  I'm still not sure why outputs-viewer was displaying them correctly, possibly something to do with the iframe? @tomodwyer – any ideas? (not relevant to this PR as all three contexts still work after this change).

I've kept FileResponse here since it sets a few values for us and recreating that, accurately, with HttpResponse wasn't worth the effort, so instead I've updated the Content-Type header to include an explicit charset.

Interestingly, `response.charset` was already correctly set to utf-8 before this change.

Fix: opensafely-core/reports#550