### PR TITLE
Remove the previous code path for releasing files

### DIFF
--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -106,17 +106,8 @@ def check_not_already_uploaded(filename, filehash, backend):
 
 @transaction.atomic
 def create_release(workspace, backend, created_by, requested_files, **kwargs):
-    # we infer a new style payload from it being a dict or list.  Once the new
-    # style release UI is completed and in use, we can remove the old way of
-    # doing things from here.
-    new_style = isinstance(requested_files, list)
-
-    if new_style:
-        for f in requested_files:
-            check_not_already_uploaded(f["name"], f["sha256"], backend)
-    else:
-        for filename, filehash in requested_files.items():
-            check_not_already_uploaded(filename, filehash, backend)
+    for f in requested_files:
+        check_not_already_uploaded(f["name"], f["sha256"], backend)
 
     release = Release.objects.create(
         workspace=workspace,
@@ -126,18 +117,17 @@ def create_release(workspace, backend, created_by, requested_files, **kwargs):
         **kwargs,
     )
 
-    if new_style:
-        for f in requested_files:
-            ReleaseFile.objects.create(
-                release=release,
-                workspace=release.workspace,
-                created_by=created_by,
-                name=f["name"],
-                filehash=f["sha256"],
-                size=f["size"],
-                mtime=f["date"],
-                metadata=f["metadata"],
-            )
+    for f in requested_files:
+        ReleaseFile.objects.create(
+            release=release,
+            workspace=release.workspace,
+            created_by=created_by,
+            name=f["name"],
+            filehash=f["sha256"],
+            size=f["size"],
+            mtime=f["date"],
+            metadata=f["metadata"],
+        )
 
     return release
 

--- a/tests/unit/jobserver/test_releases.py
+++ b/tests/unit/jobserver/test_releases.py
@@ -109,7 +109,7 @@ def test_build_outputs_zip_with_missing_files(build_release_with_files):
             assert "This file was redacted by" in zipped_contents, zipped_contents
 
 
-def test_create_release_new_style_reupload():
+def test_create_release_reupload():
     rfile = ReleaseFileFactory(name="file1.txt", filehash="hash")
 
     files = [
@@ -133,7 +133,7 @@ def test_create_release_new_style_reupload():
         )
 
 
-def test_create_release_new_style_success():
+def test_create_release_success():
     backend = BackendFactory()
     workspace = WorkspaceFactory()
     user = UserFactory()
@@ -157,27 +157,6 @@ def test_create_release_new_style_success():
     rfile = release.files.first()
     rfile.filehash == "hash"
     rfile.size == 7
-
-
-def test_create_release_success():
-    backend = BackendFactory()
-    workspace = WorkspaceFactory()
-    user = UserFactory()
-    files = {"file1.txt": "hash"}
-    release = releases.create_release(workspace, backend, user, files)
-    assert release.requested_files == files
-
-
-def test_create_release_reupload():
-    rfile = ReleaseFileFactory(name="file1.txt", filehash="hash")
-    files = {"file1.txt": "hash"}
-    with pytest.raises(releases.ReleaseFileAlreadyExists):
-        releases.create_release(
-            rfile.release.workspace,
-            rfile.release.backend,
-            rfile.release.created_by,
-            files,
-        )
 
 
 def test_handle_release_upload_file_created(build_release, file_content):


### PR DESCRIPTION
We've been using the new style path in production for the best part of a year at this point, so osrelease is fully moved over.

Fix: #3876 