### PR TITLE
Explain what a user should do when just check-migrations fails

### DIFF
--- a/justfile
+++ b/justfile
@@ -158,7 +158,8 @@ check: black django-upgrade ruff
 
 
 check-migrations: devenv
-    $BIN/python manage.py makemigrations --dry-run --check
+    $BIN/python manage.py makemigrations --dry-run --check \
+    || echo "There is model state unaccounted for in the migrations, run python manage.py migrations to fix."
 
 
 # fix formatting and import sort ordering


### PR DESCRIPTION
This check failed on the [audit-trail branch](https://github.com/opensafely-core/job-server/actions/runs/7251262874/job/19753252846?pr=3607) and it took me a few minutes to realise what was going on.  The check is certainly useful, and once I realised what was going on I realised what needed fixing.

This error message will hopefully point future users at the problem a little faster.