### PR TITLE
Fix auto-merging of dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,7 @@ name: Approve and enable auto-merge for Dependabot updates
 on: pull_request
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
We're seeing failures [1] with the error

    GraphQL: Resource not accessible by integration (mergePullRequest)

I couldn't find any resources on the permissions necessary for GraphQL mutations, however the docs for auto-merging dependabot PRs [2] use `contents: write` in their example.  Looking at the permissions docs for jobs [3] they have a section on permissions for contents [4] which lists merging [5] as covered by that permission.

1: https://github.com/opensafely-core/job-server/actions/runs/7377983549/job/20097209870#step:2:11
2: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
3: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
4: https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents
5: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#merge-a-pull-request