### PR TITLE
Revert grouping of dependabot dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,6 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "all"
-    groups:
-      prod-minor:
-        dependency-type: "production"
-        update-types: ["minor"]
-      prod-patch:
-        dependency-type: "production"
-        update-types: ["patch"]
-      dev-minor-patch:
-        dependency-type: "development"
-        update-types: ["minor", "patch"]
 
   - package-ecosystem: "npm"
     directory: "/"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,8 +13,7 @@ jobs:
     steps:
       - name: Auto-merge Dependabot PRs
         if: |
-          startsWith(github.head_ref, 'dependabot/pip/dev-minor-patch-') ||
-          startsWith(github.head_ref, 'dependabot/pip/prod-patch-') ||
+          startsWith(github.head_ref, 'dependabot/pip/') ||
           startsWith(github.head_ref, 'dependabot/github_actions/')
         run: |
           set -eu


### PR DESCRIPTION
We're reverting grouping of updates here because it's so much harder to debug errors in the groups, back to the drawing board with this one 😞 