### PR TITLE
Add First and Last buttons to the pagination component

### DIFF
--- a/templates/_partials/card-pagination.html
+++ b/templates/_partials/card-pagination.html
@@ -1,6 +1,7 @@
 {% load querystring_tools %}
 
 {% if page_obj.has_next %}
+  {% url_with_querystring page=page_obj.paginator.num_pages as last_page_url %}
   {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
 {% endif %}
 
@@ -28,6 +29,9 @@
       {% endif %}
       {% if next_page_url %}
         {% #button type="link" href=next_page_url variant="secondary-outline" %}Next{% /button %}
+      {% endif %}
+      {% if last_page_url %}
+        {% #button type="link" href=last_page_url variant="secondary-outline" %}Last{% /button %}
       {% endif %}
     </div>
   </nav>

--- a/templates/_partials/card-pagination.html
+++ b/templates/_partials/card-pagination.html
@@ -6,6 +6,7 @@
 {% endif %}
 
 {% if page_obj.has_previous %}
+  {% url_with_querystring page=1 as first_page_url %}
   {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
 {% endif %}
 
@@ -24,6 +25,9 @@
     </div>
 
     <div class="flex flex-1 justify-between gap-2 sm:justify-end">
+      {% if first_page_url %}
+        {% #button type="link" href=first_page_url variant="secondary-outline" %}First{% /button %}
+      {% endif %}
       {% if previous_page_url %}
         {% #button type="link" href=previous_page_url variant="secondary-outline" %}Previous{% /button %}
       {% endif %}

--- a/templates/_partials/card-pagination.html
+++ b/templates/_partials/card-pagination.html
@@ -1,5 +1,16 @@
 {% load querystring_tools %}
 
+{% if page_obj.has_next %}
+  {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
+{% endif %}
+
+{% if page_obj.has_previous %}
+  {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
+{% endif %}
+
+{% var page_number=page_obj.number  %}
+{% var total_pages=page_obj.paginator.num_pages %}
+
 {% #card_footer no_container=no_container %}
   <nav class="flex items-center justify-between" aria-label="Pagination">
     <div class="hidden sm:block">

--- a/templates/_partials/card-pagination.html
+++ b/templates/_partials/card-pagination.html
@@ -15,6 +15,14 @@
 
 {% #card_footer no_container=no_container %}
   <nav class="flex items-center justify-between" aria-label="Pagination">
+    <div class="flex flex-1 gap-2">
+      {% if first_page_url %}
+        {% #button type="link" href=first_page_url variant="secondary-outline" %}First{% /button %}
+      {% endif %}
+      {% if previous_page_url %}
+        {% #button type="link" href=previous_page_url variant="secondary-outline" %}Previous{% /button %}
+      {% endif %}
+    </div>
     <div class="hidden sm:block">
       <p class="text-sm text-gray-700">
         Page
@@ -23,14 +31,7 @@
         <span class="font-medium">{{ total_pages }}</span>
       </p>
     </div>
-
-    <div class="flex flex-1 justify-between gap-2 sm:justify-end">
-      {% if first_page_url %}
-        {% #button type="link" href=first_page_url variant="secondary-outline" %}First{% /button %}
-      {% endif %}
-      {% if previous_page_url %}
-        {% #button type="link" href=previous_page_url variant="secondary-outline" %}Previous{% /button %}
-      {% endif %}
+    <div class="flex flex-1 gap-2 justify-end">
       {% if next_page_url %}
         {% #button type="link" href=next_page_url variant="secondary-outline" %}Next{% /button %}
       {% endif %}

--- a/templates/staff/analysis_request/list.html
+++ b/templates/staff/analysis_request/list.html
@@ -139,13 +139,7 @@
       {% /list_group %}
 
       {% if page_obj.has_previous or page_obj.has_next %}
-        {% if page_obj.has_next %}
-          {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-        {% endif %}
-        {% if page_obj.has_previous %}
-          {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-        {% endif %}
-        {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+        {% card_pagination page_obj=page_obj request=request no_container=True %}
       {% endif %}
     {% /card %}
   </div>

--- a/templates/staff/application/list.html
+++ b/templates/staff/application/list.html
@@ -135,13 +135,7 @@
       {% /list_group %}
 
       {% if page_obj.has_previous or page_obj.has_next %}
-        {% if page_obj.has_next %}
-          {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-        {% endif %}
-        {% if page_obj.has_previous %}
-          {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-        {% endif %}
-        {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+        {% card_pagination page_obj=page_obj request=request no_container=True %}
       {% endif %}
     {% /card %}
   </div>

--- a/templates/staff/backend/list.html
+++ b/templates/staff/backend/list.html
@@ -32,13 +32,7 @@
   {% /list_group %}
 
   {% if page_obj.has_previous or page_obj.has_next %}
-    {% if page_obj.has_next %}
-      {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-    {% endif %}
-    {% if page_obj.has_previous %}
-      {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-    {% endif %}
-    {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+    {% card_pagination page_obj=page_obj request=request no_container=True %}
   {% endif %}
 {% /card %}
 {% endblock content %}

--- a/templates/staff/job_request/list.html
+++ b/templates/staff/job_request/list.html
@@ -129,13 +129,7 @@
         {% /list_group %}
 
         {% if page_obj.has_previous or page_obj.has_next %}
-          {% if page_obj.has_next %}
-            {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-          {% endif %}
-          {% if page_obj.has_previous %}
-            {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-          {% endif %}
-          {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+          {% card_pagination page_obj=page_obj request=request no_container=True %}
         {% endif %}
       {% /card %}
     </div>

--- a/templates/staff/org/list.html
+++ b/templates/staff/org/list.html
@@ -51,13 +51,7 @@
         {% /list_group %}
 
         {% if page_obj.has_previous or page_obj.has_next %}
-          {% if page_obj.has_next %}
-            {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-          {% endif %}
-          {% if page_obj.has_previous %}
-            {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-          {% endif %}
-          {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+          {% card_pagination page_obj=page_obj request=request no_container=True %}
         {% endif %}
       {% /card %}
     </div>

--- a/templates/staff/project/list.html
+++ b/templates/staff/project/list.html
@@ -76,13 +76,7 @@
         {% /list_group %}
 
         {% if page_obj.has_previous or page_obj.has_next %}
-          {% if page_obj.has_next %}
-            {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-          {% endif %}
-          {% if page_obj.has_previous %}
-            {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-          {% endif %}
-          {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+          {% card_pagination page_obj=page_obj request=request no_container=True %}
         {% endif %}
       {% else %}
         {% list_group_empty icon=True title="No projects found" description="Try a new search or clearing the filters" %}

--- a/templates/staff/redirect/list.html
+++ b/templates/staff/redirect/list.html
@@ -79,13 +79,7 @@
         {% /list_group %}
 
         {% if page_obj.has_previous or page_obj.has_next %}
-          {% if page_obj.has_next %}
-            {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-          {% endif %}
-          {% if page_obj.has_previous %}
-            {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-          {% endif %}
-          {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+          {% card_pagination page_obj=page_obj request=request no_container=True %}
         {% endif %}
       {% /card %}
     </div>

--- a/templates/staff/repo/list.html
+++ b/templates/staff/repo/list.html
@@ -112,13 +112,7 @@
         {% /list_group %}
 
         {% if page_obj.has_previous or page_obj.has_next %}
-          {% if page_obj.has_next %}
-            {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-          {% endif %}
-          {% if page_obj.has_previous %}
-            {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-          {% endif %}
-          {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+          {% card_pagination page_obj=page_obj request=request no_container=True %}
         {% endif %}
       {% /card %}
     </div>

--- a/templates/staff/report/list.html
+++ b/templates/staff/report/list.html
@@ -90,13 +90,7 @@
           {% /list_group %}
 
           {% if page_obj.has_previous or page_obj.has_next %}
-            {% if page_obj.has_next %}
-              {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-            {% endif %}
-            {% if page_obj.has_previous %}
-              {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-            {% endif %}
-            {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+            {% card_pagination page_obj=page_obj request=request no_container=True %}
           {% endif %}
         {% else %}
           {% list_group_empty icon=True title="No reports found" description="Try a new search or clearing the filters" %}

--- a/templates/staff/user/list.html
+++ b/templates/staff/user/list.html
@@ -152,13 +152,7 @@
       {% /list_group %}
 
       {% if page_obj.has_previous or page_obj.has_next %}
-        {% if page_obj.has_next %}
-          {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-        {% endif %}
-        {% if page_obj.has_previous %}
-          {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-        {% endif %}
-        {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+        {% card_pagination page_obj=page_obj request=request no_container=True %}
       {% endif %}
     {% /card %}
   </div>

--- a/templates/staff/workspace/list.html
+++ b/templates/staff/workspace/list.html
@@ -80,13 +80,7 @@
         {% /list_group %}
 
         {% if page_obj.has_previous or page_obj.has_next %}
-          {% if page_obj.has_next %}
-            {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-          {% endif %}
-          {% if page_obj.has_previous %}
-            {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-          {% endif %}
-          {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+          {% card_pagination page_obj=page_obj request=request no_container=True %}
         {% endif %}
       {% /card %}
     </div>

--- a/templates/user/list.html
+++ b/templates/user/list.html
@@ -37,13 +37,7 @@
     {% /list_group %}
 
     {% if page_obj.has_previous or page_obj.has_next %}
-      {% if page_obj.has_next %}
-        {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-      {% endif %}
-      {% if page_obj.has_previous %}
-        {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-      {% endif %}
-      {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+      {% card_pagination page_obj=page_obj request=request no_container=True %}
     {% endif %}
   {% /card %}
 

--- a/templates/yours/org_list.html
+++ b/templates/yours/org_list.html
@@ -42,13 +42,7 @@
     {% /list_group %}
 
     {% if page_obj.has_previous or page_obj.has_next %}
-      {% if page_obj.has_next %}
-        {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-      {% endif %}
-      {% if page_obj.has_previous %}
-        {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-      {% endif %}
-      {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+      {% card_pagination page_obj=page_obj request=request no_container=True %}
     {% endif %}
   {% /card %}
 {% endblock content %}

--- a/templates/yours/project_list.html
+++ b/templates/yours/project_list.html
@@ -33,13 +33,7 @@
     {% /list_group %}
 
     {% if page_obj.has_previous or page_obj.has_next %}
-      {% if page_obj.has_next %}
-        {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-      {% endif %}
-      {% if page_obj.has_previous %}
-        {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-      {% endif %}
-      {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+      {% card_pagination page_obj=page_obj request=request no_container=True %}
     {% endif %}
   {% /card %}
 {% endblock content %}

--- a/templates/yours/workspace_list.html
+++ b/templates/yours/workspace_list.html
@@ -42,13 +42,7 @@
 
 
     {% if page_obj.has_previous or page_obj.has_next %}
-      {% if page_obj.has_next %}
-        {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-      {% endif %}
-      {% if page_obj.has_previous %}
-        {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-      {% endif %}
-      {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+      {% card_pagination page_obj=page_obj request=request no_container=True %}
     {% endif %}
   {% /card %}
 {% endblock content %}


### PR DESCRIPTION
Add first and last buttons to our card_pagination component.  In a view where I have 3 pages of content, this looks like so:

**First page**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/nOuJB6DW/09345567-999c-4754-823e-522d79bae423.jpg?v=3ece2543a2271ebc088fdd30b8e1b6f1)

**Second page**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/bLuQo1gG/c425a00b-02c7-402d-9a06-fc793046ac67.jpg?v=366c14f801fb29395c212155ac6657e1)

**Third page**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/YEuJlqXO/e643989a-15b2-4573-8ee3-4ff0fa3ce25e.jpg?v=e4cc7b6ce165374d3730ac0f01fe4fa4)

Fix: #3804 

---

This also reworks the card_pagination component so we compute the various page URLs inside the component, from the given `page_obj`, so save each calling template having to care about it.  Unfortunately, we also have to pass in the `request` so we can build the URLs, but that's a small price to pay for all the centralised config we've gained IMO.