### PR TITLE
Remove ignore freezegun warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ env = [
 filterwarnings = [
     "error",
     "ignore::pytest.PytestUnraisableExceptionWarning:",
-    "ignore:distutils Version classes are deprecated:DeprecationWarning:pytest_freezegun",
     "ignore:Call to deprecated method __init__:DeprecationWarning:",
     "ignore:path is deprecated.:DeprecationWarning:opensafely",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:",


### PR DESCRIPTION
We're no longer using freezegun, so we don't need to ignore any warnings about it in tests.