### PR TITLE
Remove default argument of bash for docker/run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /.ipynb_checkpoints
 /.pytest_cache
 /.venv/
-/__pycache__
+__pycache__
 /assets/dist
 /assets/stats.html
 /coverage

--- a/docker/justfile
+++ b/docker/justfile
@@ -30,7 +30,7 @@ serve env="dev" *args="":
     docker-compose up {{ args }} {{ env }}
 
 # run command in dev|prod container
-run env="dev" *args="bash":
+run env="dev" *args="":
     {{ just_executable() }} build {{ env }}
     docker-compose run --rm {{ env }} {{ args }}
 

--- a/justfile
+++ b/justfile
@@ -269,7 +269,7 @@ docker-serve env="dev" *args="": _env
 
 
 # run cmd in dev or prod docker container
-docker-run env="dev" *args="bash": _env
+docker-run env="dev" *args="": _env
     {{ just_executable() }} docker/run {{ env }} {{ args }}
 
 


### PR DESCRIPTION
This makes it match `just run`
