### PR TITLE
Remove references to "datalab" org

### DIFF
--- a/jobserver/issues.py
+++ b/jobserver/issues.py
@@ -91,7 +91,7 @@ def create_copilot_publish_report_request(report, github_api):
 
 
 def create_output_checking_request(release, github_api):
-    is_internal = release.created_by.orgs.filter(slug="datalab").exists()
+    is_internal = release.created_by.orgs.filter(pk=settings.BENNETT_ORG_PK).exists()
 
     files = release.files.all()
     number = len(files)

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -392,3 +392,8 @@ BACKEND_IP_MAP = {
     # uncomment to pretend your browser is on tpp
     # "127.0.0.1": "tpp",
 }
+
+# These orgs are not copiloted
+BENNETT_ORG_PK = 3
+LSHTM_ORG_PK = 4
+UNIVERSITY_OF_BRISTOL_ORG_PK = 9

--- a/tests/unit/jobserver/test_issues.py
+++ b/tests/unit/jobserver/test_issues.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from first import first
 
 from jobserver.issues import (
@@ -90,7 +91,7 @@ def test_create_github_issue_external_success(build_release_with_files, github_a
 
 
 def test_create_github_issue_internal_success(build_release_with_files, github_api):
-    org = OrgFactory(slug="datalab")
+    org = OrgFactory(pk=settings.BENNETT_ORG_PK)
     user = UserFactory()
     OrgMembershipFactory(org=org, user=user)
     release = build_release_with_files(["file1.txt", "graph.png"], created_by=user)


### PR DESCRIPTION
This removes references to the "datalab" org, selecting this org with the PK rather than the slug. For consistency, it does the same for two other orgs: "lshtm" and "university-of-bristol".

Closes #3946