### PR TITLE
Remove load file from sqlite migration

### DIFF
--- a/sqlite.load
+++ b/sqlite.load
@@ -1,5 +1,0 @@
-load database
-     from sqlite://db.sqlite3
-     into postgresql://localhost/jobserver
-
- with include drop, reset sequences;


### PR DESCRIPTION
It's been 3 years, we don't need to hang on to this anymore.