### PR TITLE
Add `dump-co-pilot-reporting-data.sh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__
 /docker/staticfiles/*
 /htmlcov
 /jobserver.dump
+/jobserver.sqlite.zip
 /node_modules
 /release-hatch
 /releases

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -376,27 +376,9 @@ Alternatively, the `osi_release` command can be used without running an analysis
 Co-pilots [have a report](https://github.com/ebmdatalab/copiloting/tree/copiloting-report) they run every few months, building on data from this service.
 
 To produce a dump in the format they need you will need to install [db-to-sqlite](https://pypi.org/project/db-to-sqlite/) via pip, pipx, or your installer of choice.
+You will also need to set the `DATABASE_URL` environment variable.
 
-Then run the following, replacing `<database URL>` with the URL to your database, this is likely in the `DATABASE_URL` environment variable.
-
-```
-db-to-sqlite \
-    --progress \
-    --table applications_application \
-    --table jobserver_project \
-    --table jobserver_projectmembership \
-    --table jobserver_workspace \
-    --table jobserver_user \
-    --table jobserver_org \
-    --table jobserver_orgmembership \
-    --table jobserver_job \
-    --table jobserver_jobrequest \
-    --table jobserver_release \
-    --table jobserver_releasefile \
-    <database URL> \
-    jobserver.sqlite
-```
-
+Then run `just dump-co-pilot-reporting-data`.
 
 ## Ensuring paired field state with CheckConstraints
 We have various paired fields in our database models.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -375,7 +375,7 @@ Alternatively, the `osi_release` command can be used without running an analysis
 ## Dumping co-pilot reporting data
 Co-pilots [have a report](https://github.com/ebmdatalab/copiloting/tree/copiloting-report) they run every few months, building on data from this service.
 
-To produce a dump in the format they need you will need to install [db-to-sqlite](https://pypi.org/project/db-to-sqlite/) via pip, pipx, brew, or your installer of choice.
+To produce a dump in the format they need you will need to install [db-to-sqlite](https://pypi.org/project/db-to-sqlite/) via pip, pipx, or your installer of choice.
 
 Then run the following, replacing `<database URL>` with the URL to your database, this is likely in the `DATABASE_URL` environment variable.
 

--- a/justfile
+++ b/justfile
@@ -251,6 +251,10 @@ assets-test: assets-install
 release-hatch:
     ./scripts/local-release-hatch.sh
 
+# dump data for co-pilot reporting to a compressed SQLite database
+dump-co-pilot-reporting-data:
+    ./scripts/dump-co-pilot-reporting-data.sh
+
 # note these are just aliases for the docker/justfile commands. We add them just for autocompletion from the root dir
 
 # build docker image env=dev|prod

--- a/scripts/collect-me-maybe.sh
+++ b/scripts/collect-me-maybe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # allow just file to pass current venv python through

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 target="$1"
 

--- a/scripts/dump-co-pilot-reporting-data.sh
+++ b/scripts/dump-co-pilot-reporting-data.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v db-to-sqlite &>/dev/null; then
+    echo 'db-to-sqlite was not found'
+    exit 1
+fi
+
+if test -z "${DATABASE_URL:-}"; then
+    echo 'DATABASE_URL was not set'
+    exit 1
+fi
+
+rm -f jobserver.sqlite.zip
+
+db-to-sqlite \
+    --progress \
+    --table applications_application \
+    --table jobserver_project \
+    --table jobserver_projectmembership \
+    --table jobserver_workspace \
+    --table jobserver_user \
+    --table jobserver_org \
+    --table jobserver_orgmembership \
+    --table jobserver_job \
+    --table jobserver_jobrequest \
+    --table jobserver_release \
+    --table jobserver_releasefile \
+    ${DATABASE_URL} \
+    jobserver.sqlite
+
+# `--move` deletes the uncompressed file after compressing it
+zip --move jobserver.sqlite.zip jobserver.sqlite

--- a/scripts/local-release-hatch.sh
+++ b/scripts/local-release-hatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu -o pipefail
 
 RELEASE_HATCH_REPO=${RELEASE_HATCH_REPO:-./release-hatch}

--- a/scripts/test-coverage.sh
+++ b/scripts/test-coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if command -v coverage; then


### PR DESCRIPTION
After completing #3958, Millie asked for a dump of co-pilot reporting data. Whilst the snippet in `DEVELOPERS.md` is almost complete, I realized I needed to remove a pre-existing dump before running the snippet and zip the dump before sharing it. For convenience, then, I decided to move the snippet into a script.