### PR TITLE
Remove temporary coverage files

### DIFF
--- a/scripts/test-coverage.sh
+++ b/scripts/test-coverage.sh
@@ -20,4 +20,6 @@ set -x
 # shellcheck disable=SC2086
 "$coverage" report ${COVERAGE_REPORT_ARGS:-} || { rc=$?; "$coverage" html ${COVERAGE_REPORT_ARGS:-}; }
 
+"$coverage" erase
+
 exit $rc


### PR DESCRIPTION
We can safely remove them at the end of a run to prevent the build up of lots of local temp files.