### PR TITLE
Add template_name to responses

### DIFF
--- a/assets/src/scripts/_plausible.js
+++ b/assets/src/scripts/_plausible.js
@@ -1,5 +1,6 @@
 const isLoggedIn = document.head.querySelector(`meta[name="is_logged_in"]`);
 const isStaff = document.head.querySelector(`meta[name="is_staff"]`);
+const templateName = document.head.querySelector(`meta[name="template"]`);
 
 if (document.location.hostname === "jobs.opensafely.org") {
   const script = document.createElement("script");
@@ -14,6 +15,10 @@ if (document.location.hostname === "jobs.opensafely.org") {
 
   if (isStaff) {
     script.setAttribute("event-is_staff", isStaff.content);
+  }
+
+  if (templateName) {
+    script.setAttribute("event-template", templateName.content);
   }
 
   document.head.appendChild(script);

--- a/jobserver/middleware.py
+++ b/jobserver/middleware.py
@@ -15,8 +15,31 @@ class XSSFilteringMiddleware:
         return response
 
 
+class TemplateNameMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_template_response(self, request, response):
+        if response.context_data is None:
+            # no context data, so fail fast
+            return response
+
+        if "template_name" in response.context_data:
+            # application's page.html uses template_name to include custom
+            # templates for it's Form instances.  This is only used for the
+            # researchers page so could potentially be removed in favour of
+            # simplifying this check.
+            return response
+
+        response.context_data["template_name"] = response.template_name
+        return response
+
+
 class ClientAddressIdentification:
-    """Detect if client IP address is commng from a Level 4 IP address.
+    """Detect if client IP address is coming from a Level 4 IP address.
 
     In the simple local dev case, there is no proxy, so we just use
     REMOTE_ADDR. When we are behind nginx, we use the standard X-Forwarded-For

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -85,6 +85,7 @@ MIDDLEWARE = [
     "csp.middleware.CSPMiddleware",
     "jobserver.middleware.XSSFilteringMiddleware",
     "jobserver.middleware.ClientAddressIdentification",
+    "jobserver.middleware.TemplateNameMiddleware",
 ]
 
 ROOT_URLCONF = "jobserver.urls"

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,6 +24,7 @@
 
     <meta name="is_logged_in" content="{% if user.is_authenticated %}true{% else %}false{% endif %}">
     <meta name="is_staff" content="{% if user_can_view_staff_area %}true{% else %}false{% endif %}">
+    {% if template_name %}<meta name="template" content="{{ template_name }}">{% endif %}
 
     {% vite_hmr_client %}
     {% vite_asset "assets/src/scripts/base.js" %}


### PR DESCRIPTION
Add the response's `template_name` to the template context.

We can't do this on every invocation because we're [making use of the `template_name` context variable in applications' `page` view](https://github.com/opensafely-core/job-server/blob/caaf4f8c330714f5e0be3b3a7d6f65232cc0c5db/applications/form_spec_helpers.py#L35).

This happens to only be used for the Researcher page so could potentially be changed to something else if necessary.

Fix: #3984 