### PR TITLE
Fix logout link

### DIFF
--- a/templates/_components/header.html
+++ b/templates/_components/header.html
@@ -82,7 +82,10 @@
               {% endif %}
               <li><a href="{% url 'settings' %}" class="{{ link_class }}">Settings</a></li>
               <li><a href="{% url 'applications:list' %}" class="{{ link_class }}">Applications</a></li>
-              <li><a href="{% url 'logout' %}" class="{{ link_class }}">Logout</a></li>
+              <form action="{% url 'logout' %}" method="POST">
+                {% csrf_token %}
+                <button class="{{ link_class }} w-full text-left" type="submit">Logout</button>
+              </form>
             </ul>
           </li>
           {% endif %}
@@ -164,7 +167,10 @@
                 {% endif %}
                 <li><a class="{{ link_class }}" href="{% url 'settings' %}">Settings</a></li>
                 <li><a class="{{ link_class }}" href="{% url 'applications:list' %}">Applications</a></li>
-                <li><a class="{{ link_class }}" href="{% url 'logout' %}">Logout</a></li>
+                <form action="{% url 'logout' %}" method="POST">
+                  {% csrf_token %}
+                  <button class="{{ link_class }} w-full text-left" type="submit">Logout</button>
+                </form>
               </ul>
             </div>
           </details>

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,7 +38,7 @@
 
   <body class="preload flex flex-col min-h-screen text-slate bg-white">
     {% skip_link %}
-    {% header login_url=login_url nav=nav user=user request=request user_can_view_staff_area=user_can_view_staff_area %}
+    {% header csrf_token=csrf_token login_url=login_url nav=nav user=user request=request user_can_view_staff_area=user_can_view_staff_area %}
 
     {% block breadcrumbs %}{% endblock %}
 


### PR DESCRIPTION
Logout link now must be a POST request:

> Support for logging out via GET requests in the django.contrib.auth.views.LogoutView and django.contrib.auth.views.logout_then_login() is removed

**Source:** [docs.djangoproject.com/en/5.0/releases/5.0/](https://docs.djangoproject.com/en/5.0/releases/5.0/#features-removed-in-5-0)