### PR TITLE
Use free 4-vCPU runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
         run: just check
 
   test:
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-22.04
 
     services:
       postgres:
@@ -98,7 +98,7 @@ jobs:
         if: ${{ failure() }}  # only upload when the previous step, run tests, fails
 
   lint-dockerfile:
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -107,7 +107,7 @@ jobs:
           dockerfile: docker/Dockerfile
 
   docker-test:
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -147,7 +147,7 @@ jobs:
   deploy:
     needs: [check, test, docker-test, lint-dockerfile]
 
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: read


### PR DESCRIPTION
GitHub have announced that they've made 4-vCPU runners available for free for open source projects. This means we no longer need to use the paid-for larger runners to get the same benefit.

https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/

I've run this twice and if anything it's slightly faster than the paid-for larger runners...
First run: 4m8s
Second run: 3m58s