### PR TITLE
Display per-job metrics on Job Detail page

### DIFF
--- a/templates/job/detail.html
+++ b/templates/job/detail.html
@@ -188,6 +188,50 @@
       </dl>
     {% /card %}
 
+    {% if request.user.all_roles %}
+    {% #card title="Job metrics" subtitle="Computed for the time spent running on the backend" %}
+      <dl class="border-t border-slate-200 sm:divide-y sm:divide-slate-200">
+        {% #description_item title="Mean CPU usage" %}
+          {% if job.metrics %}
+          <span class="relative group cursor-pointer">
+          {{ job.metrics.cpu_mean|floatformat:"0" }}%
+          {% tooltip content="Values are reported across all CPU cores" %}
+          </span>
+          {% else %}
+          -
+          {% endif %}
+        {% /description_item %}
+
+        {% #description_item title="Peak CPU usage" %}
+          {% if job.metrics %}
+          <span class="relative group cursor-pointer">
+          {{ job.metrics.cpu_peak|floatformat:"0" }}%
+          {% tooltip content="Values are reported across all CPU cores" %}
+          </span>
+          {% else %}
+          -
+          {% endif %}
+        {% /description_item %}
+
+        {% #description_item title="Mean memory usage" %}
+          {% if job.metrics %}
+          {{ job.metrics.mem_mb_mean|floatformat:"0g" }} MB
+          {% else %}
+          -
+          {% endif %}
+        {% /description_item %}
+
+        {% #description_item title="Peak memory usage" %}
+          {% if job.metrics %}
+          {{ job.metrics.mem_mb_peak|floatformat:"0g" }} MB
+          {% else %}
+          -
+          {% endif %}
+        {% /description_item %}
+      </dl>
+    {% /card %}
+    {% endif %}
+
     {% if honeycomb_links %}
       {% #card title="Monitoring" subtitle="Honeycomb login required" container %}
         <ul class="flex flex-col gap-y-1.5 list-disc text-sm">


### PR DESCRIPTION
This adds a "Job metrics" card to the Job Detail page for users with one or more roles. This card displays CPU and memory usage statistics, when available (see below).

In addition to mean and peak, which are displayed here, Job Runner collects sample and cumsum for both CPU and memory usage statistics (opensafely-core/job-runner#686). However, I don't think sample and cumsum usage statistics are useful to users: sample, because we (and so they) don't know when the sample was taken; cumsum, because we (and so they) don't know how many samples were taken (and if we did, then all we would be able to compute would be the mean, which Job Runner has computed for us).

As #3998 states, usage statistics are not available for historic jobs (i.e. prior to 17/01/2024). In this case, `job.metrics == None`. They are also not available for some other types of job. In these cases, `job.metrics == {}`. We don't distinguish these cases, displaying "-" to users in both cases.

Closes #3998

---

Thanks, @ghickman and @lucyb for suggesting different approaches to determine whether the "Job metrics" card should be displayed. I've opted for `request.user.all_roles` for simplicity. We do something similar, here:

https://github.com/opensafely-core/job-server/blob/624b6b9c8ebba387c2d3e8c5805ae7c6966009a0/templates/staff/user/list.html#L145-L147