### PR TITLE
chore: refactor justfile dotenv for docker

### DIFF
--- a/docker/justfile
+++ b/docker/justfile
@@ -4,8 +4,12 @@ set dotenv-load := true
 export DEV_USERID := `id -u`
 export DEV_GROUPID := `id -g`
 
+# an alias to allow us to use this recipe from the justfile in the parent directory
+_dotenv:
+    {{ just_executable() }} --justfile {{ justfile_directory() }}/../justfile _dotenv
 
-build env="dev":
+
+build env="dev": _dotenv
     #!/usr/bin/env bash
     test -z "${SKIP_BUILD:-}" || { echo "SKIP_BUILD set"; exit 0; }
 
@@ -18,31 +22,31 @@ build env="dev":
 
 
 # run tests in dev container
-test *pytest_args="": build
+test *pytest_args="": _dotenv build
     #!/bin/bash
     # Note, we do *not* run coverage in docker, as we want to use xdist, and coverage does not seem to work reliably.
     docker-compose run --rm test pytest {{ pytest_args }}
 
 
 # run server in dev|prod container
-serve env="dev" *args="":
+serve env="dev" *args="": _dotenv
     {{ just_executable() }} build {{ env }}
     docker-compose up {{ args }} {{ env }}
 
 # run command in dev|prod container
-run env="dev" *args="":
+run env="dev" *args="": _dotenv
     {{ just_executable() }} build {{ env }}
     docker-compose run --rm {{ env }} {{ args }}
 
 
 # exec command in existing dev|prod container
-exec env="dev" *args="bash":
+exec env="dev" *args="bash": _dotenv
     {{ just_executable() }} build {{ env }}
     docker-compose exec {{ env }} {{ args }}
 
 
 # run a basic functional smoke test against a running job-server
-smoke-test host="http://localhost:8000":
+smoke-test host="http://localhost:8000": _dotenv
     #!/bin/bash
     set -eu
     curl -I {{ host }} -s --compressed --fail --retry 20 --retry-delay 1 --retry-all-errors

--- a/justfile
+++ b/justfile
@@ -33,11 +33,15 @@ virtualenv: _env
     test -e $BIN/pip-compile || $PIP install pip-tools
 
 
-_env:
+# create a default .env file
+_dotenv:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    test -f .env || cp dotenv-sample .env
+    if [[ ! -f .env ]]; then
+      echo "No '.env' file found; creating a default '.env' from 'dotenv-sample'"
+      cp dotenv-sample .env
+    fi
 
 
 _compile src dst *args: virtualenv

--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ clean:
 
 
 # ensure valid virtualenv
-virtualenv: _env
+virtualenv: _dotenv
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -256,33 +256,34 @@ release-hatch:
 dump-co-pilot-reporting-data:
     ./scripts/dump-co-pilot-reporting-data.sh
 
-# note these are just aliases for the docker/justfile commands. We add them just for autocompletion from the root dir
+# The docker-* commands are simply aliases for the docker/justfile commands.
+# We add them for autocompletion from the root dir.
 
 # build docker image env=dev|prod
-docker-build env="dev": _env
+docker-build env="dev":
     {{ just_executable() }} docker/build {{ env }}
 
 
 # run tests in the dev docker container
-docker-test *args="": _env
+docker-test *args="":
     {{ just_executable() }} docker/test {{ args }}
 
 
 # run server in dev or prod docker container
-docker-serve env="dev" *args="": _env
+docker-serve env="dev" *args="":
     {{ just_executable() }} docker/serve {{ env }} {{ args }}
 
 
 # run cmd in dev or prod docker container
-docker-run env="dev" *args="": _env
+docker-run env="dev" *args="":
     {{ just_executable() }} docker/run {{ env }} {{ args }}
 
 
 # exec command in an existing dev docker container
-docker-exec env="dev" *args="bash": _env
+docker-exec env="dev" *args="bash":
     {{ just_executable() }} docker/exec {{ env }} {{ args }}
 
 
 # run basic smoke test against a running job-server
-docker-smoke-test host="http://localhost:8000": _env
+docker-smoke-test host="http://localhost:8000":
     {{ just_executable() }} docker/smoke-test {{ host }}


### PR DESCRIPTION
* rename _env just target to _dotenv
  * to reduce the naming collision with arguments named env and programs called env
* refactor the .env dependency for docker targets
  * some docker/justfile targets require an .env file, a better place to specify this dependency is in /docker/justfile rather than /justfile