### PR TITLE
Fix flaky test

### DIFF
--- a/tests/unit/staff/views/test_job_requests.py
+++ b/tests/unit/staff/views/test_job_requests.py
@@ -238,7 +238,8 @@ def test_jobrequestlist_search_using_fullname(rf, core_developer):
 
 
 def test_jobrequestlist_search_using_identifier(rf, core_developer):
-    JobRequestFactory.create_batch(5)
+    for i in range(5):
+        JobRequestFactory.create(identifier=f"{i:016}")
 
     job_request = JobRequestFactory(identifier="1234abcd")
 
@@ -260,7 +261,8 @@ def test_jobrequestlist_search_using_identifier(rf, core_developer):
 
 
 def test_jobrequestlist_search_using_job_identifier(rf, core_developer):
-    JobRequestFactory.create_batch(5)
+    for i in range(5):
+        JobRequestFactory.create(identifier=f"{i:016}")
 
     job_request = JobRequestFactory()
     JobFactory(job_request=job_request, identifier="1234abcd")
@@ -325,7 +327,8 @@ def test_jobrequestlist_search_using_project(rf, core_developer):
 
 
 def test_jobrequestlist_search_using_username(rf, core_developer):
-    JobRequestFactory.create_batch(5)
+    for i in range(5):
+        JobRequestFactory.create(identifier=f"{i:016}")
 
     user = UserFactory(username="beng")
     job_request = JobRequestFactory(created_by=user)


### PR DESCRIPTION
`test_jobrequestlist_search_using_username` is a flaky test (it can either pass or fail without the code under test, or the test code itself, changing). This flakiness is caused by factories that occasionally create instances with values that match the query string. Most values are obviously not going to match the query string (e.g. values of `Workspace.name` will be `workspace-0`, `workspace-1`, `workspace-2`, etc.). However, `JobRequest.identifier` might match the query string, because by default it contains a string of random, lower case, alphanumeric characters. Instead, we use a string of non-random characters with the same characteristics.

As well as `test_jobrequestlist_search_using_username`, this fixes a couple of other flaky tests.[^1] However, it doesn't fix all tests that call `JobRequestFactory.create_batch`; it fixes only those tests where the query string is four characters or fewer.

Closes #4003 

[^1]: I've reviewed the tests that execute a search (i.e. those that contain `?q=`).