### PR TITLE
Get first template name

### DIFF
--- a/jobserver/middleware.py
+++ b/jobserver/middleware.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from first import first
 
 from jobserver.models import Backend
 
@@ -34,7 +35,13 @@ class TemplateNameMiddleware:
             # simplifying this check.
             return response
 
-        response.context_data["template_name"] = response.template_name
+        template_name = response.template_name
+
+        # flatten template_name to a string
+        if isinstance(template_name, list):
+            template_name = first(template_name)
+
+        response.context_data["template_name"] = template_name
         return response
 
 

--- a/tests/unit/jobserver/test_middleware.py
+++ b/tests/unit/jobserver/test_middleware.py
@@ -1,8 +1,12 @@
+from django.http import HttpResponse
+from django.template.response import TemplateResponse
 from django.test.utils import override_settings
+from django.views.generic import DetailView, View
 
-from jobserver.middleware import ClientAddressIdentification
+from jobserver.middleware import ClientAddressIdentification, TemplateNameMiddleware
+from jobserver.models import Project
 
-from ...factories import BackendFactory
+from ...factories import BackendFactory, ProjectFactory
 
 
 @override_settings(BACKEND_IP_MAP={"1.2.3.4": "tpp"})
@@ -84,3 +88,63 @@ def test_client_ip_middleware_get_forwarded_ip_no_ips():
         )
         == "172.17.0.2"
     )
+
+
+def test_template_name_middleware_with_no_context_data(rf):
+    def dummy_view(request):
+        response = HttpResponse()
+        response.context_data = None
+        return response
+
+    request = rf.get("/")
+    response = dummy_view(request)
+
+    assert response.context_data is None
+
+    TemplateNameMiddleware(None).process_template_response(request, response)
+
+    # context_data is None should be a no-op for the middleware
+    assert response.context_data is None
+
+
+def test_template_name_middleware_with_template_name_already_in_context(rf):
+    def dummy_view(request):
+        return TemplateResponse(request, "")
+
+    request = rf.get("/")
+    response = dummy_view(request)
+
+    template_name = getattr(response, "template_name", "already set")
+
+    TemplateNameMiddleware(None).process_template_response(request, response)
+
+    # when template_name is already set it should not be changed by the middleware
+    assert response.template_name == template_name
+
+
+def test_template_name_middleware_with_template_name_as_a_list(rf):
+    project = ProjectFactory()
+
+    class DummyView(DetailView):
+        model = Project
+        template_name = "my_template"
+
+    request = rf.get("/")
+    response = DummyView.as_view()(request, pk=project.pk)
+
+    TemplateNameMiddleware(None).process_template_response(request, response)
+
+    assert response.context_data["template_name"] == "my_template"
+
+
+def test_template_name_middleware_with_template_name_as_a_string(rf):
+    class DummyView(View):
+        def get(self, request, *args, **kwargs):
+            return TemplateResponse(request, "my_template", context={})
+
+    request = rf.get("/")
+    response = DummyView.as_view()(request)
+
+    TemplateNameMiddleware(None).process_template_response(request, response)
+
+    assert response.context_data["template_name"] == "my_template"


### PR DESCRIPTION
`TemplateResponseMixin`, used in several GCBVs, returns a list of templates.  The first template in that list is the one used when rendering the response, so we want to use that for plausible.