### PR TITLE
Order projects when creating interactive users by just name

### DIFF
--- a/staff/forms.py
+++ b/staff/forms.py
@@ -234,7 +234,7 @@ class UserCreateForm(forms.Form):
     project = forms.ModelChoiceField(
         queryset=Project.objects.filter(workspaces__name__endswith="interactive")
         .distinct()
-        .order_by(Lower("org__name"), Lower("name"))
+        .order_by("-number", Lower("name"))
     )
     name = forms.CharField()
     email = forms.EmailField()


### PR DESCRIPTION
Now that Projects can have more than one Org this doesn't make a lot of sense to order by them.  Elsewhere around the site we also order orgs by number then name, so this makes the drop-down for new users consistent with that.

This was missed when rebasing #2208 over the changes from #3571