### PR TITLE
Use backend token rather than API for auth endpoint

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -578,9 +578,9 @@ class TokenAuthenticationAPI(APIView):
         staff = serializers.BooleanField()
 
     def post(self, request):
-        if getattr(request, "backend", None) is None:
-            logger.info("API Login with token failed because request not from backend")
-            raise NotAuthenticated()
+        # Only allow requests from backend (this function raises the appropriate
+        # exceptions)
+        get_backend_from_token(request.headers.get("Authorization"))
 
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
This matches what we do for most the rest of the API endpoints here. It's only for requests that come direct from the user that we have to resort to checking the IP.