### PR TITLE
Label the Sentry release action with version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,7 +201,7 @@ jobs:
           ./honeymarker --writekey ${{ secrets.HC_MARKER_APIKEY }} --dataset __all__ add --type deploy --msg "job-server deploy $GITHUB_SHA"
 
       - name: Create Sentry release
-        uses: getsentry/action-release@c1b57ce473178fd036cf1133b163b6324c0064a8
+        uses: getsentry/action-release@c1b57ce473178fd036cf1133b163b6324c0064a8 # v1.6.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_RELEASE_INTEGRATION_TOKEN }}
           SENTRY_ORG: ebm-datalab


### PR DESCRIPTION
To make this clearer and aid debugging, should we need to do so.