### PR TITLE
Tweak `just docker/run` command

### DIFF
--- a/docker/justfile
+++ b/docker/justfile
@@ -27,21 +27,19 @@ test *pytest_args="": _dotenv build
     # Note, we do *not* run coverage in docker, as we want to use xdist, and coverage does not seem to work reliably.
     docker-compose run --rm test pytest {{ pytest_args }}
 
-
-# run server in dev|prod container
+# run as service in dev|prod container
 serve env="dev" *args="": _dotenv
     {{ just_executable() }} build {{ env }}
     docker-compose up {{ args }} {{ env }}
 
-# run command in dev|prod container
-run env="dev" *args="": _dotenv
-    {{ just_executable() }} build {{ env }}
-    docker-compose run --rm {{ env }} {{ args }}
+
+# run command in dev|prod container, runserver by default
+run env="dev" *args="": (build env)
+    docker-compose run --service-ports --rm {{ env }} {{ args }}
 
 
 # exec command in existing dev|prod container
-exec env="dev" *args="bash": _dotenv
-    {{ just_executable() }} build {{ env }}
+exec env="dev" *args="bash": (build env)
     docker-compose exec {{ env }} {{ args }}
 
 


### PR DESCRIPTION
It now properly maps ports when used, which sometimes caught people out.

Now we've fixed that, we can drop the old `docker/serve` command
(keeping an alias) which was a bit awkward to use, as `docker compose
up` is really intended for production services.

Also added some clean ups using the parameterised dependency syntax
`(build env)`, which is much nicer than explicit `just_executable()`
calls.
