### PR TITLE
Disable Run Jobs button on workspace detail if user unable to run jobs

### DIFF
--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -298,6 +298,7 @@ class WorkspaceDetail(View):
         can_toggle_notifications = has_permission(
             request.user, "workspace_toggle_notifications", project=workspace.project
         )
+        has_backends = request.user.is_authenticated and request.user.backends.exists()
 
         # should we show the admin section in the UI?
         show_admin = (
@@ -337,6 +338,7 @@ class WorkspaceDetail(View):
             "user_can_archive_workspace": can_archive_workspace,
             "user_can_run_jobs": can_run_jobs,
             "user_can_toggle_notifications": can_toggle_notifications,
+            "user_has_backends": has_backends,
             "workspace": workspace,
         }
         return TemplateResponse(

--- a/templates/workspace/detail.html
+++ b/templates/workspace/detail.html
@@ -80,18 +80,26 @@
           {% /button %}
         {% endif %}
 
-        {% if user_can_run_jobs %}
-          {% if workspace.is_archived %}
-            {% #button type="button" variant="info" disabled=True tooltip="Jobs cannot be run on an archived workspace" %}
-              Run jobs
-              {% icon_play_outline class="h-4 w-4 ml-2 -mr-2" %}
-            {% /button %}
-          {% else %}
-            {% #button href=workspace.get_jobs_url type="link" variant="success" %}
-              Run jobs
-              {% icon_play_outline class="h-4 w-4 ml-2 -mr-2" %}
-            {% /button %}
-          {% endif %}
+        {% if workspace.is_archived %}
+          {% #button type="button" variant="info" disabled=True tooltip="Jobs cannot be run on an archived workspace" %}
+            Run jobs
+            {% icon_play_outline class="h-4 w-4 ml-2 -mr-2" %}
+          {% /button %}
+        {% elif not user_can_run_jobs %}
+          {% #button type="button" variant="info" disabled=True tooltip="You do not have permission to run jobs on this workspace" %}
+            Run jobs
+            {% icon_play_outline class="h-4 w-4 ml-2 -mr-2" %}
+          {% /button %}
+        {% elif not user_has_backends %}
+          {% #button type="button" variant="info" disabled=True tooltip="You do not have permission to run jobs on any OpenSAFELY backends" %}
+            Run jobs
+            {% icon_play_outline class="h-4 w-4 ml-2 -mr-2" %}
+          {% /button %}
+        {% else %}
+          {% #button href=workspace.get_jobs_url type="link" variant="success" %}
+            Run jobs
+            {% icon_play_outline class="h-4 w-4 ml-2 -mr-2" %}
+          {% /button %}
         {% endif %}
 
         {% if show_interactive_button %}


### PR DESCRIPTION
(Partially) fixes #3989 

* displays a disabled run job button if user has inadequate permissions to run jobs in this workspace (with explanatory hover text) instead of not displaying button at all
* displays a disabled run job button if user has permissions but has not been assigned backend permissions (with explanatory hover text)