### PR TITLE
Correct orgs and projects URLs in user detail area

### DIFF
--- a/templates/staff/user/detail_with_email.html
+++ b/templates/staff/user/detail_with_email.html
@@ -51,7 +51,7 @@
   {% #card title="Organisations" button=True button_text="Add to organisation" button_href=staff_user_set_orgs_url %}
     {% #list_group %}
       {% for org in orgs %}
-        {% #list_group_item href=org.get_staff_url %}
+        {% #list_group_item href=org.staff_url %}
           {{ org.name }}
         {% /list_group_item %}
       {% empty %}
@@ -63,7 +63,7 @@
   {% #card title="Projects" %}
     {% #list_group %}
       {% for project in projects %}
-        {% #list_group_item href=project.get_staff_url %}
+        {% #list_group_item href=project.staff_url %}
           {{ project.name }}
         {% /list_group_item %}
       {% empty %}


### PR DESCRIPTION
Fixes #4042.

These were broken in the staff "user with detail" view.