### PR TITLE
Add create_backend command

### DIFF
--- a/jobserver/management/commands/create_backend.py
+++ b/jobserver/management/commands/create_backend.py
@@ -1,0 +1,58 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from jobserver.models import Backend, User
+
+
+class Command(BaseCommand):
+    """
+    Create or update a backend
+
+    Designed to be used to automate development setup.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("slug", default="local-dev", help="The id for backend")
+        parser.add_argument("--name", default=None, help="The name will be set to this")
+        parser.add_argument(
+            "--url", default=None, help="level_4_url will be set to this"
+        )
+        parser.add_argument(
+            "--user", default=None, help="Username to add to the backend"
+        )
+        parser.add_argument(
+            "--quiet",
+            action="store_true",
+            help="only print the auth token (useful for scripts)",
+        )
+
+    @transaction.atomic()
+    def handle(self, *args, **options):
+        backend, created = Backend.objects.get_or_create(
+            slug=options["slug"],
+            defaults={
+                "name": options["name"] or options["slug"],
+                "level_4_url": options["url"] or "",
+            },
+        )
+        if created:
+            if not options["quiet"]:  # pragma: nocover
+                print(f"Created backend {options['name']}")
+        else:
+            if options["name"]:
+                backend.name = options["name"]
+            if options["url"]:
+                backend.level_4_url = options["url"]
+            backend.save()
+            if not options["quiet"]:  # pragma: nocover
+                print(f"Updated backend {options['name']}")
+
+        if options["user"]:
+            user = User.objects.get(username=options["user"])
+            if backend not in user.backends.all():
+                user.backends.add(backend)
+                if not options["quiet"]:  # pragma: nocover
+                    print(f"User {options['user']} added to backend")
+                user.save()
+
+        print(backend.auth_token)

--- a/scripts/local-release-hatch.sh
+++ b/scripts/local-release-hatch.sh
@@ -16,18 +16,7 @@ fi
 # set VIRTUAL_ENV explicitly so we don't use job-server's venv
 env -C "$RELEASE_HATCH_REPO" VIRTUAL_ENV=".venv" just devenv
 
-JOB_SERVER_TOKEN="$("$VIRTUAL_ENV/bin/python" manage.py shell << EOF
-from jobserver.models.backends import Backend
-
-backend, created = Backend.objects.get_or_create(
-    slug="local-dev",
-    name="Local Dev"
-)
-backend.level_4_url = "$RELEASE_HATCH_URL"
-backend.save()
-print(backend.auth_token)
-EOF
-)"
+JOB_SERVER_TOKEN="$("$VIRTUAL_ENV/bin/python" manage.py create_backend local-dev --name 'Local Dev' --url "$RELEASE_HATCH_URL" --quiet)"
 
 JOB_SERVER="$("$VIRTUAL_ENV/bin/python" manage.py shell -c 'from django.conf import settings; print(settings.BASE_URL)')"
 

--- a/tests/unit/jobserver/management/commands/test_create_backend.py
+++ b/tests/unit/jobserver/management/commands/test_create_backend.py
@@ -1,0 +1,45 @@
+from django.core.management import call_command
+
+from jobserver.models import Backend, User
+from tests.factories.user import UserFactory
+
+
+def test_create_backend(capsys):
+    call_command("create_backend", "testslug", "--quiet")
+
+    token = capsys.readouterr().out.strip()
+    backend = Backend.objects.get(slug="testslug")
+    assert backend.slug == "testslug"
+    assert backend.name == "testslug"
+    assert backend.level_4_url == ""
+    assert backend.auth_token == token
+
+    # calling again doesn't create new backend, but does update metadata
+    call_command(
+        "create_backend", "testslug", "--name=testname", "--url=url", "--quiet"
+    )
+    backend = Backend.objects.get(slug="testslug")
+    assert backend.slug == "testslug"
+    assert backend.name == "testname"
+    assert backend.level_4_url == "url"
+    assert backend.auth_token == token  # same token
+
+
+def test_create_backend_user():
+    user = UserFactory()
+    user.save()
+    call_command(
+        "create_backend",
+        "testslug",
+        f"--user={user.username}",
+    )
+    backend = Backend.objects.get(slug="testslug")
+    # refresh user
+    user = User.objects.get(username=user.username)
+    assert backend in user.backends.all()
+
+    call_command(
+        "create_backend",
+        "testslug",
+        f"--user={user.username}",
+    )


### PR DESCRIPTION
It prints the auth token. Motivating use case was to set up a test
backend from cli for local tests.

Replaced the janky scripot in the local release-hatch setup.

We want to use to automate setting up a local job-server in airlock.
