### PR TITLE
Ensure bw sync is run in dev-env.sh

### DIFF
--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -12,12 +12,11 @@ fi
 
 session_from_env=${BW_SESSION-"not-found"}
 
-if (test $session_from_env = "not-found"); then
+if test "$session_from_env" = "not-found"; then
     echo "Unlocking bitwarden..."
     BW_SESSION=$(bw unlock --raw)
     export BW_SESSION
 fi
-
 SOCIAL_AUTH_BW_ID=d48e3e3f-07ed-4865-b348-ace700ee004
 GH_DEV_TOKEN_BW_ID=10242708-234a-4162-982f-ace700ee5c53
 
@@ -26,6 +25,9 @@ write() {
     local value="$2"
     sed -i"" -e "s/$name=.*/$name=$value/" "$target"
 }
+
+# ensure we have latest passwords
+bw sync
 
 write GITHUB_TOKEN "$(bw get password $GH_DEV_TOKEN_BW_ID)"
 write SOCIAL_AUTH_GITHUB_KEY "$(bw get username $SOCIAL_AUTH_BW_ID)"


### PR DESCRIPTION
So that we have the latest passwords.

This scripts is only run occasionally, so is ok that it adds a couple of
seconds
