### PR TITLE
Update application email text

### DIFF
--- a/applications/emails.py
+++ b/applications/emails.py
@@ -9,12 +9,14 @@ def send_submitted_application_email(email, application):
 
     context = {
         "url": f.url,
+        "applicant": application.submitted_by.name,
+        "reference": application.pk_hash,
     }
 
     send(
         to=email,
         sender="notifications@jobs.opensafely.org",
-        subject="Thank you for applying to use OpenSAFELY",
+        subject="Acknowledgement of New COVID-19 Project Application",
         template_name="applications/emails/submission_confirmation.txt",
         html_template_name="applications/emails/submission_confirmation.html",
         context=context,

--- a/templates/applications/emails/submission_confirmation.html
+++ b/templates/applications/emails/submission_confirmation.html
@@ -1,9 +1,11 @@
 {% extends "emails/base.html" %}
 
 {% block content %}
-<p>Thank you for applying to use the OpenSAFELY platform.</p>
-
-<p>You can view your <a href="{{ url }}">submitted application here</a>.</p>
-
-<p>We are a very committed, but still small and busy team, so feel free to email us at team@opensafely.org if you haven't had any response after three weeks from the date of application submission.</p>
+<p>Dear {{ applicant }},</p>
+<p>Thank you for submitting your project application (ref: {{ reference }}) to OpenSAFELY.</p>
+<p>You can now view your <a href="{{ url }}">submitted application here</a>.</p>
+<p>We are working with NHS England to agree a date to reopen OpenSAFELY to new research projects. As a result we cannot guarantee when your project will be assessed, but we will keep you updated about our timescales on a regular basis.</p>
+<p>We will be in touch if we have any questions regarding your application.</p>
+<p>In the meantime, please know that we appreciate your patience and understanding during this transition period.</p>
+<p>If you have any questions or require further assistance, please don't hesitate to reach out to us at applications@opensafely.org and quote your project application reference (shown above) in the subject of the email.</p>
 {% endblock content %}

--- a/templates/applications/emails/submission_confirmation.txt
+++ b/templates/applications/emails/submission_confirmation.txt
@@ -1,11 +1,18 @@
 {% extends "emails/base.txt" %}
 
 {% block content %}
-Thank you for applying to use the OpenSAFELY platform.
+Dear {{ applicant }},
 
-You can view your submitted application here:
+Thank you for submitting your project application (ref: {{ reference }}) to OpenSAFELY.
+You can now view your submitted application here:
 
 {{ url }}
 
-We are a very committed, but still small and busy team, so feel free to email us at team@opensafely.org if you haven't had any response after three weeks from the date of application submission.
+We are working with NHS England to agree a date to reopen OpenSAFELY to new research projects. As a result we cannot guarantee when your project will be assessed, but we will keep you updated about our timescales on a regular basis.
+
+We will be in touch if we have any questions regarding your application.
+
+In the meantime, please know that we appreciate your patience and understanding during this transition period.
+
+If you have any questions or require further assistance, please don't hesitate to reach out to us at applications@opensafely.org and quote your project application reference (shown above) in the subject of the email.
 {% endblock content %}

--- a/tests/unit/applications/test_emails.py
+++ b/tests/unit/applications/test_emails.py
@@ -5,11 +5,18 @@ from ...factories import ApplicationFactory
 
 def test_send_finished_notification(mailoutbox):
     application = ApplicationFactory()
+    application.submitted_by = application.created_by
 
     send_submitted_application_email("test@example.com", application)
 
     m = mailoutbox[0]
-
-    assert application.get_absolute_url() in m.body
+    text_content = m.body
+    html_content = m.alternatives[0][0]
 
     assert list(m.to) == ["test@example.com"]
+    assert application.get_absolute_url() in text_content
+    assert application.get_absolute_url() in html_content
+    assert application.submitted_by.name in text_content
+    assert application.submitted_by.name in html_content
+    assert f"ref: {application.pk_hash}" in text_content
+    assert f"ref: {application.pk_hash}" in html_content


### PR DESCRIPTION
We're not currently open to research projects, although we will be soon, and we are accepting applications. So this change updates the information emailed to applicants when they submit an application to use OpenSAFELY.

I'm also curious to find out if there's a better way to write the assertions. I couldn't think of one at the time, but would welcome opinions.

Fixes #4060