### PR TITLE
Add assertions for the html content of emails

### DIFF
--- a/tests/unit/interactive/test_emails.py
+++ b/tests/unit/interactive/test_emails.py
@@ -10,9 +10,13 @@ def test_send_report_uploaded_notification(mailoutbox):
     send_report_uploaded_notification(analysis_request)
 
     m = mailoutbox[0]
+    text_content = m.body
+    html_content = m.alternatives[0][0]
 
-    assert analysis_request.get_absolute_url() in m.body
-    assert analysis_request.report.title in m.body
+    assert analysis_request.get_absolute_url() in text_content
+    assert analysis_request.get_absolute_url() in html_content
+    assert analysis_request.report.title in text_content
+    assert analysis_request.report.title in html_content
     assert list(m.to) == [analysis_request.created_by.email]
 
 
@@ -22,7 +26,9 @@ def test_welcome_email(mailoutbox):
     send_welcome_email(user)
 
     m = mailoutbox[0]
+    text_content = m.body
+    html_content = m.alternatives[0][0]
 
-    assert user.name in m.body
-
+    assert user.name in text_content
+    assert user.name in html_content
     assert list(m.to) == [user.email]

--- a/tests/unit/staff/views/test_reports.py
+++ b/tests/unit/staff/views/test_reports.py
@@ -224,9 +224,7 @@ def test_reportpublishrequestapprove_success(
     publish_request_with_report.refresh_from_db()
     assert publish_request_with_report.decision_at
 
-    m = mailoutbox[0]
-    assert m.subject == "Your report has been published"
-    assert report.get_absolute_url() in m.body
+    assert len(mailoutbox) == 1
 
 
 def test_reportpublishrequestapprove_unauthorized(rf):


### PR DESCRIPTION
As part of working on another [ticket](https://github.com/opensafely-core/job-server/pull/4084), I noticed that we weren't testing the html content of email templates, only the plain text version. I updated those tests while working on that ticket, but now I've gone back and changed the remaining tests too.

In one case, I also moved the email test out of the test for the Reports View and into its own `test_send_report_published_email` test.