### PR TITLE
Fix created/deleted

### DIFF
--- a/templates/staff/application/list.html
+++ b/templates/staff/application/list.html
@@ -105,7 +105,7 @@
               {% #list_group_rich_item type="Application" title=title url=application.get_staff_url status_text=application.status %}
                 <dl class="text-sm -mt-2">
                   <div class="flex flex-row gap-1">
-                    <dt class="font-semibold">Submitted:</dt>
+                    <dt class="font-semibold">Created:</dt>
                     <dd>{{ application.created_at|date:"d F Y" }}</dd>
                   </div>
                 </dl>
@@ -114,8 +114,8 @@
               {% #list_group_rich_item type="Deleted application" title=title class="cursor-not-allowed bg-bn-ribbon-100/25 opacity-80" status_text="deleted" %}
                 <dl class="text-sm -mt-2">
                   <div class="flex flex-row gap-1">
-                    <dt class="font-semibold">Submitted:</dt>
-                    <dd>{{ application.created_at|date:"d F Y" }}</dd>
+                    <dt class="font-semibold">Deleted:</dt>
+                    <dd>{{ application.deleted_at|date:"d F Y" }}</dd>
                   </div>
                   <div class="flex flex-row gap-1 mt-2">
                     <form method="POST" action="{{ application.get_staff_restore_url }}">


### PR DESCRIPTION
Previously, all applications were labelled "Submitted" in the applications list. However, in each case, the datetime recorded when the application was _created_.

Here, we change "Submitted" to either "Created" or "Deleted". In the former case, we (still) use the creation datetime. In the latter case, we use the deletion datetime.

Thanks for spotting this, @CLStables!

## Before

![applications_before](https://github.com/opensafely-core/job-server/assets/477263/c5b13ecb-a874-4f19-8c8d-779f1109c603)

## After

![applications_after](https://github.com/opensafely-core/job-server/assets/477263/0cc01bd7-12ba-4f87-827e-f2c37b311ff7)