### PR TITLE
Disable auto-reload middleware on POST

### DIFF
--- a/jobserver/middleware.py
+++ b/jobserver/middleware.py
@@ -1,3 +1,4 @@
+import django_browser_reload.middleware
 from django.conf import settings
 from first import first
 
@@ -98,3 +99,13 @@ class ClientAddressIdentification:
                 return ip
 
         return ip
+
+
+class BrowserReloadMiddleware(django_browser_reload.middleware.BrowserReloadMiddleware):
+
+    def __call__(self, request):
+        # Reloading should only be enabled for GET requests
+        if request.method == "GET":
+            return super().__call__(request)
+        else:
+            return self.get_response(request)

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -69,7 +69,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "redirects.middleware.RedirectsMiddleware",
-    "django_browser_reload.middleware.BrowserReloadMiddleware",
+    "jobserver.middleware.BrowserReloadMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django_permissions_policy.PermissionsPolicyMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",

--- a/tests/integration/test_middleware.py
+++ b/tests/integration/test_middleware.py
@@ -1,0 +1,16 @@
+def test_browser_reload_middleware_with_get(client, settings):
+    settings.DEBUG = True
+    response = client.get("/login/")
+    assert (
+        b'django-browser-reload/reload-listener.js" data-worker-script-path'
+        in response.content
+    )
+
+
+def test_browser_reload_middleware_with_post(client, settings):
+    settings.DEBUG = True
+    response = client.post("/login/")
+    assert (
+        b'django-browser-reload/reload-listener.js" data-worker-script-path'
+        not in response.content
+    )


### PR DESCRIPTION
In development, this causes the single-use token page to be unexpectedly reloaded, thus generating a new token and causing confusion.

This is a (hopefully) temporary workaround in advance of this being a configurable option in `django-browser-reload`:
https://github.com/adamchainz/django-browser-reload/issues/243