### PR TITLE
Add submitted fields to application detail page

### DIFF
--- a/staff/views/applications.py
+++ b/staff/views/applications.py
@@ -102,7 +102,7 @@ class ApplicationDetail(View):
     def dispatch(self, request, *args, **kwargs):
         self.application = get_object_or_404(
             Application.objects.select_related(
-                "approved_by", "created_by", "deleted_by", "project"
+                "approved_by", "created_by", "deleted_by", "project", "submitted_by"
             ),
             pk=unhash_or_404(self.kwargs["pk_hash"]),
         )

--- a/templates/staff/application/detail.html
+++ b/templates/staff/application/detail.html
@@ -30,6 +30,20 @@
       </div>
     </div>
     <div>
+      {% if application.submitted_by %}
+      <div class="flex flex-row flex-wrap gap-1">
+        <dt class="font-semibold">Submitted by:</dt>
+        <dd>{% link href=application.submitted_by.get_staff_url text=application.submitted_by.name %}</dd>
+      </div>
+      {% endif %}
+      {% if application.submitted_at %}
+      <div class="flex flex-row flex-wrap gap-1">
+        <dt class="font-semibold">Submitted at:</dt>
+        <dd>{{ application.submitted_at|date:"d F Y" }} at {{ application.submitted_at|date:"H:i" }}</dd>
+      </div>
+      {% endif %}
+    </div>
+    <div>
       {% if application.deleted_by %}
       <div class="flex flex-row flex-wrap gap-1">
         <dt class="font-semibold">Deleted by:</dt>

--- a/templates/staff/application/detail.html
+++ b/templates/staff/application/detail.html
@@ -17,8 +17,8 @@
 {% block hero %}
 {% #staff_hero title="Application "|add:application.pk_hash %}
   <dl class="flex flex-col gap-2 mt-1">
-    {% if application.created_by %}
     <div>
+      {% if application.created_by %}
       <div class="flex flex-row flex-wrap gap-1">
         <dt class="font-semibold">Created by:</dt>
         <dd>{% link href=application.created_by.get_staff_url text=application.created_by.name %}</dd>


### PR DESCRIPTION
Add both `submitted_by` and `submitted_at` to the application detail page, just as we have approved, created, and deleted fields.