### PR TITLE
Replace `clear_all_roles` method with command

### DIFF
--- a/jobserver/commands/__init__.py
+++ b/jobserver/commands/__init__.py
@@ -1,6 +1,7 @@
-from . import project_members
+from . import org_members, project_members
 
 
 __all__ = [
+    "org_members",
     "project_members",
 ]

--- a/jobserver/commands/__init__.py
+++ b/jobserver/commands/__init__.py
@@ -1,7 +1,8 @@
-from . import org_members, project_members
+from . import org_members, project_members, users
 
 
 __all__ = [
     "org_members",
     "project_members",
+    "users",
 ]

--- a/jobserver/commands/org_members.py
+++ b/jobserver/commands/org_members.py
@@ -1,0 +1,7 @@
+from django.db import transaction
+
+
+@transaction.atomic()
+def update_roles(*, member, by, roles):
+    member.roles = roles
+    member.save(update_fields=["roles"])

--- a/jobserver/commands/users.py
+++ b/jobserver/commands/users.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 from django.utils import timezone
 from xkcdpass import xkcd_password
 
+from jobserver.commands import org_members, project_members
 from jobserver.emails import (
     send_token_login_generated_email,
     send_token_login_used_email,
@@ -96,3 +97,14 @@ def validate_login_token(username, token):
 def update_roles(*, user, by, roles):
     user.roles = roles
     user.save(update_fields=["roles"])
+
+
+@transaction.atomic()
+def clear_all_roles(*, user, by):
+    update_roles(user=user, by=by, roles=[])
+
+    for org_membership in user.org_memberships.all():
+        org_members.update_roles(member=org_membership, by=by, roles=[])
+
+    for project_membership in user.project_memberships.all():
+        project_members.update_roles(member=project_membership, by=by, roles=[])

--- a/jobserver/commands/users.py
+++ b/jobserver/commands/users.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.contrib.auth.hashers import check_password, make_password
+from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 from xkcdpass import xkcd_password
@@ -89,3 +90,9 @@ def validate_login_token(username, token):
     send_token_login_used_email(user)
 
     return user
+
+
+@transaction.atomic()
+def update_roles(*, user, by, roles):
+    user.roles = roles
+    user.save(update_fields=["roles"])

--- a/jobserver/models/project_membership.py
+++ b/jobserver/models/project_membership.py
@@ -20,6 +20,13 @@ class ProjectMembershipManager(models.Manager):
         )
         raise TypeError(msg)
 
+    def update(self, *args, **kwargs):
+        msg = (
+            "Direct update of ProjectMemberships via this method is disabled, "
+            "please use commands.project_memberships.update_roles"
+        )
+        raise TypeError(msg)
+
 
 class ProjectMembership(models.Model):
     """

--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -6,7 +6,7 @@ import structlog
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.models import UserManager as DjangoUserManager
 from django.contrib.auth.validators import UnicodeUsernameValidator
-from django.db import models, transaction
+from django.db import models
 from django.db.models import Q
 from django.db.models.functions import Lower, NullIf
 from django.urls import reverse
@@ -192,14 +192,6 @@ class User(AbstractBaseUser):
     def clean(self):
         super().clean()
         self.email = self.__class__.objects.normalize_email(self.email)
-
-    @transaction.atomic()
-    def clear_all_roles(self):
-        self.org_memberships.update(roles=[])
-        self.project_memberships.update(roles=[])
-
-        self.roles = []
-        self.save(update_fields=["roles"])
 
     @property
     def initials(self):

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -20,6 +20,7 @@ from jobserver.authorization import roles
 from jobserver.authorization.decorators import require_permission
 from jobserver.authorization.forms import RolesForm
 from jobserver.authorization.utils import roles_for, strings_to_roles
+from jobserver.commands import users
 from jobserver.models import (
     AuditableEvent,
     Backend,
@@ -91,7 +92,7 @@ class UserClearRoles(View):
     def post(self, request, *args, **kwargs):
         user = get_object_or_404(User, username=self.kwargs["username"])
 
-        user.clear_all_roles()
+        users.clear_all_roles(user=user, by=request.user)
 
         return redirect(get_next_url(request.GET, user.get_staff_roles_url()))
 

--- a/tests/unit/jobserver/commands/test_org_members.py
+++ b/tests/unit/jobserver/commands/test_org_members.py
@@ -1,0 +1,15 @@
+from jobserver.authorization import ProjectDeveloper
+from jobserver.commands import org_members as members
+from tests.factories import OrgMembershipFactory, UserFactory
+
+
+def test_update_roles():
+    updator = UserFactory()
+    membership = OrgMembershipFactory()
+
+    assert membership.roles == []
+
+    members.update_roles(member=membership, by=updator, roles=[ProjectDeveloper])
+
+    membership.refresh_from_db()
+    assert membership.roles == [ProjectDeveloper]

--- a/tests/unit/jobserver/commands/test_users.py
+++ b/tests/unit/jobserver/commands/test_users.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import pytest
 from django.utils import timezone
 
+from jobserver.authorization import ProjectDeveloper
 from jobserver.commands import users
 
 from ....factories import (
@@ -77,3 +78,15 @@ def test_user_validate_login_token_wrong(token_login_user):
 
     with pytest.raises(users.BadLoginToken):
         users.validate_login_token(token_login_user.username, "bad token")
+
+
+def test_update_roles():
+    updator = UserFactory()
+    user = UserFactory()
+
+    assert user.roles == []
+
+    users.update_roles(user=user, by=updator, roles=[ProjectDeveloper])
+
+    user.refresh_from_db()
+    assert user.roles == [ProjectDeveloper]

--- a/tests/unit/jobserver/commands/test_users.py
+++ b/tests/unit/jobserver/commands/test_users.py
@@ -5,9 +5,12 @@ from django.utils import timezone
 
 from jobserver.authorization import ProjectDeveloper
 from jobserver.commands import users
+from jobserver.models import AuditableEvent
 
 from ....factories import (
     BackendMembershipFactory,
+    OrgMembershipFactory,
+    ProjectFactory,
     UserFactory,
     UserSocialAuthFactory,
 )
@@ -90,3 +93,40 @@ def test_update_roles():
 
     user.refresh_from_db()
     assert user.roles == [ProjectDeveloper]
+
+
+def test_clear_all_roles(project_membership):
+    updator = UserFactory()
+    project = ProjectFactory()
+    user = UserFactory(roles=[ProjectDeveloper])
+
+    OrgMembershipFactory(user=user, roles=[ProjectDeveloper])
+    membership = project_membership(
+        project=project, user=user, roles=[ProjectDeveloper]
+    )
+
+    assert len(user.roles) == 1
+    assert len(user.org_memberships.get().roles) == 1
+    assert len(user.project_memberships.get().roles) == 1
+
+    # these are the "user added" and the "user's roles updated" events
+    assert AuditableEvent.objects.count() == 2
+
+    users.clear_all_roles(user=user, by=updator)
+
+    user.refresh_from_db()
+    assert len(user.roles) == 0
+    assert len(user.org_memberships.get().roles) == 0
+    assert len(user.project_memberships.get().roles) == 0
+
+    # this is the "user's roles updated" event
+    assert AuditableEvent.objects.count() == 3
+
+    event = AuditableEvent.objects.last()
+    assert event.type == AuditableEvent.Type.PROJECT_MEMBER_UPDATED_ROLES
+    assert event.target_model == "jobserver.ProjectMembership"
+    assert event.target_id == str(membership.pk)
+    assert event.target_user == user.username
+    assert event.parent_model == "jobserver.Project"
+    assert event.parent_id == str(project.pk)
+    assert event.created_by == updator.username

--- a/tests/unit/jobserver/models/test_project_membership.py
+++ b/tests/unit/jobserver/models/test_project_membership.py
@@ -11,6 +11,11 @@ def test_projectmembership_direct_use_of_create():
         ProjectMembership.objects.create()
 
 
+def test_projectmembership_direct_use_of_update():
+    with pytest.raises(TypeError):
+        ProjectMembership.objects.update()
+
+
 def test_projectmembership_get_staff_edit_url(project_membership):
     project = ProjectFactory()
     membership = project_membership(project=project)

--- a/tests/unit/jobserver/models/test_user.py
+++ b/tests/unit/jobserver/models/test_user.py
@@ -57,21 +57,6 @@ def test_user_constraints_missing_pat_token_or_pat_expires_at():
         UserFactory(pat_token="test", pat_expires_at=None)
 
 
-def test_user_clear_all_roles(project_membership):
-    user = UserFactory(roles=[CoreDeveloper])
-
-    OrgMembershipFactory(user=user, roles=[InteractiveReporter])
-    project_membership(user=user, roles=[ProjectCollaborator, ProjectDeveloper])
-
-    user.clear_all_roles()
-
-    user.refresh_from_db()
-
-    assert user.roles == []
-    assert not set(*user.org_memberships.values_list("roles", flat=True))
-    assert not set(*user.project_memberships.values_list("roles", flat=True))
-
-
 def test_user_get_absolute_url():
     user = UserFactory()
 


### PR DESCRIPTION
This PR replaces the `User.clear_all_roles` method with the `users.clear_all_roles` command in the `UserClearRoles` view. It also removes the method, which is no longer used. Along the way, it introduces a couple of additional commands. Because the `users.clear_all_roles` command calls the existing `project_members.update_roles` command, we can be confident that clearing a user's roles is -- for project-membership roles -- audited.

Fixes #4093