### PR TITLE
Custom create_superuser

### DIFF
--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -15,7 +15,7 @@ from django.utils.functional import cached_property
 from sentry_sdk import capture_message
 from zen_queries import queries_dangerously_enabled
 
-from ..authorization import InteractiveReporter
+from ..authorization import CoreDeveloper, InteractiveReporter
 from ..authorization.fields import RolesArrayField
 from ..hash_utils import hash_user_pat
 
@@ -47,6 +47,12 @@ class UserQuerySet(models.QuerySet):
 
 class UserManager(DjangoUserManager.from_queryset(UserQuerySet)):
     use_in_migrations = True
+
+    def create_superuser(self, email, password, **extra_fields):
+        username = email
+        return super().create_superuser(
+            username, email, password, roles=[CoreDeveloper]
+        )
 
 
 def get_or_create_user(username, email, fullname, update_fields=None):

--- a/tests/unit/jobserver/models/test_user.py
+++ b/tests/unit/jobserver/models/test_user.py
@@ -354,3 +354,12 @@ def test_get_or_create_user_update_fields(update_fields):
     assert not created
     assert user.email == expected_email + "@example.com"
     assert user.fullname == expected_fullname
+
+
+def test_create_superuser():
+    su = User.objects.create_superuser(email="test@test.test", password="hunter2")
+    assert su.username == "test@test.test"
+    assert su.email == "test@test.test"
+    assert su.is_staff
+    assert su.is_superuser
+    assert CoreDeveloper in su.roles


### PR DESCRIPTION
Fixes #4076 

django uses `User.USERNAME_FIELD` to derive what fields are required for `manage.py createsuperuser` but not for the built-in `UserManager.create_superuser()` which expects a `username` regardless, so if this is changed to not include `username` then one will encounter a missing argument error.

Since we set the username field to `email` to support OSI user creation we can/must set the username to email for superusers created with the createsuperuser management command.

This also allows us to set the staff and superuser boolean flags (which may soon be retired) and also assign the `CoreDeveloper` role to ensure an adequately permissioned "staff" user is created by this command.