### PR TITLE
Fix missing file from Outputs Viewer file list

### DIFF
--- a/assets/src/scripts/outputs-viewer/hooks/use-file-list.js
+++ b/assets/src/scripts/outputs-viewer/hooks/use-file-list.js
@@ -41,6 +41,7 @@ export function sortedFiles(files) {
     return filesSorted.map((file) => ({
       ...file,
       shortName: file.name,
+      visible: true,
     }));
   }
 


### PR DESCRIPTION
On initial load, the visible state was not being set to true. This meant files would not show up in the file list sidebar component, until the file filter was triggered.

## Example

[Link to source](https://jobs.opensafely.org/opensafely-internal/test-age-distribution/releases/01HP7ESXTT0PJ0776XFV2QF2CF/output/count_by_age.csv)

![CleanShot 2024-02-13 at 12 58 01@2x](https://github.com/opensafely-core/job-server/assets/24863179/c07f4653-fd37-4c14-bfbb-5e5fc3957cc6)
