### PR TITLE
Custom endpoint for dokku health checks

### DIFF
--- a/CHECKS
+++ b/CHECKS
@@ -2,4 +2,4 @@ WAIT=30
 TIMEOUT=60
 ATTEMPTS=5
 
-/
+/health-check/

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -26,6 +26,7 @@ from jobserver.api.releases import (
     TokenAuthenticationAPI,
     WorkspaceStatusAPI,
 )
+from jobserver.views.health_check import HealthCheck
 
 from .views import yours
 from .views.components import components
@@ -306,6 +307,7 @@ urlpatterns = [
     path("enter-your-name/", RequireName.as_view(), name="require-name"),
     path("event-log/", JobRequestList.as_view(), name="job-list"),
     path("event-list/", RedirectView.as_view(url="/event-log/")),
+    path("health-check/", HealthCheck.as_view(), name="health-check"),
     path("jobs/", RedirectView.as_view(query_string=True, pattern_name="job-list")),
     path(
         "job-requests/<pk>/",

--- a/jobserver/views/health_check.py
+++ b/jobserver/views/health_check.py
@@ -1,0 +1,7 @@
+from django.http import HttpResponse
+from django.views import View
+
+
+class HealthCheck(View):
+    def get(self, request, *args, **kwargs):
+        return HttpResponse()

--- a/tests/unit/jobserver/test_urls.py
+++ b/tests/unit/jobserver/test_urls.py
@@ -26,6 +26,7 @@ from jobserver.api.releases import (
 )
 from jobserver.utils import dotted_path
 from jobserver.views import (
+    health_check,
     index,
     job_requests,
     jobs,
@@ -95,6 +96,7 @@ def test_url_redirects(client, url, redirect):
         ("/applications/42/researchers/42/edit/", applications.ResearcherEdit),
         ("/enter-your-name/", users.RequireName),
         ("/event-log/", job_requests.JobRequestList),
+        ("/health-check/", health_check.HealthCheck),
         ("/staff/applications/", staff_applications.ApplicationList),
         ("/staff/applications/42/", staff_applications.ApplicationDetail),
         ("/staff/applications/42/approve/", staff_applications.ApplicationApprove),

--- a/tests/unit/jobserver/views/test_health_check.py
+++ b/tests/unit/jobserver/views/test_health_check.py
@@ -1,0 +1,12 @@
+from django.contrib.auth.models import AnonymousUser
+
+from jobserver.views.health_check import HealthCheck
+
+
+def test_health_check_successful(rf):
+    request = rf.get("/")
+    request.user = AnonymousUser()
+
+    response = HealthCheck.as_view()(request)
+
+    assert response.status_code == 200


### PR DESCRIPTION
When we deploy Job Server, Dokku starts each container and performs a health check to ensure the container has come up properly before routing traffic to it. These health checks are customisable (see
[docs](https://dokku.com/docs/deployment/zero-downtime-deploys/)). Dokku only uses this health check when deploying new containers, it does not use it once the container has been deployed (we do have Freshping checking the site every few minutes though to make sure it's still working okay).

This change moves away from using the homepage as the health check endpoint and to a specific endpoint that will return 200 when the app starts and nothing else. Using the homepage as a health check is slower and makes a number of database connections, whereas this in theory decouples the app health check from the database. Currently, the app does depend on a database connection for all requests due to the middleware that's used, however that could change in future.

We could also use this endpoint for other, more frequent liveness checks.

Fixes #3990