### PR TITLE
Change username and email display

### DIFF
--- a/templates/staff/project/membership_edit.html
+++ b/templates/staff/project/membership_edit.html
@@ -26,7 +26,10 @@
 
 {% block hero %}
   {% #staff_hero title="Edit member: "|add:membership.user.name %}
-    <p><strong>GitHub Username:</strong> {{ membership.user.username }}</p>
+    {% if membership.user.social_auth.exists %}
+      <p><strong>GitHub Username:</strong> {{ membership.user.username }}</p>
+    {% endif %}
+    <p><strong>Email address:</strong> {{ membership.user.email }}</p>
   {% /staff_hero %}
 {% endblock hero %}
 


### PR DESCRIPTION
In the "edit member of project" form, in the staff area.

Fixes #4043.

This commit:

* displays both email address and GitHub username, for users with a GitHub-backed login
* only displays email address for users without a GitHub-backed login (currently, Interactive users), and corrects the text to refer to "email" instead of "GitHub username"