### PR TITLE
Show lead org as default for projects

### DIFF
--- a/tests/unit/jobserver/models/test_project.py
+++ b/tests/unit/jobserver/models/test_project.py
@@ -5,7 +5,12 @@ from django.utils import timezone
 
 from jobserver.models import Project
 
-from ....factories import ProjectFactory, UserFactory
+from ....factories import (
+    OrgFactory,
+    ProjectCollaborationFactory,
+    ProjectFactory,
+    UserFactory,
+)
 
 
 def test_project_constraints_created_at_and_created_by_both_set():
@@ -158,3 +163,11 @@ def test_project_title():
 
     project = ProjectFactory(name="test", number=123)
     assert project.title == "123 - test"
+
+
+def test_project_org():
+    project = ProjectFactory()
+    ProjectCollaborationFactory(org=OrgFactory(), project=project, is_lead=False)
+    lead_org = OrgFactory()
+    ProjectCollaborationFactory(org=lead_org, project=project, is_lead=True)
+    assert project.org == lead_org


### PR DESCRIPTION
`Project.org` was replaced by `Project.orgs` when we moved from a one-to-many to a many-to-many relationship between orgs and projects. However, we need `Project.org` in several locations. For convenience, it makes sense to show the lead org in these locations.

We expose `Project.org` as a property, meaning that an extra query is executed each time a project's lead org is requested. Hooking properties into [`prefetch_related`][1], which would reduce the number of extra queries, is non-trivial. Should we bother?

The answer depends on how many extra queries we expect. Let's take the `yours.ProjectList` view as an example
(https://jobs.opensafely.org/projects/). At present, the maximum number of projects per user is 20 - held jointly by @alexwalkerepi and @LFISHER7. For these users, this view executes 26 queries: five for page setup, one for the list of projects, and 20 for the lead org for each project. Locally, these queries execute in roughly 40ms. If we don't expose the property, then this view executes six queries in roughly 10ms. So, the worst case for this view is a four-fold increase in execution time.

20 projects per user is the maximum, though. At present, the median is two projects per user (for users that are associated with at least one project). So, hooking the property into `prefetch_related` wouldn't change much for many users. We shouldn't bother!

[1]: https://docs.djangoproject.com/en/5.0/ref/models/querysets/#prefetch-related

Fixes #4136