### PR TITLE
Fix staff area project edit screen

### DIFF
--- a/templates/staff/project/edit.html
+++ b/templates/staff/project/edit.html
@@ -77,7 +77,7 @@
     {% #form_fieldset class="w-full items-stretch gap-y-6" %}
       {% form_legend text="Status" class="sr-only" %}
 
-      {% form_select field=form.fields.status choices=form.fields.status.choices selected=form.copilot.value id="id_status" name="status" label="Project status" %}
+      {% form_select field=form.status choices=form.fields.status.choices selected=form.status.value %}
       {% form_textarea field=form.status_description label="Status description" %}
     {% /form_fieldset %}
   {% /card %}

--- a/templates/staff/project/edit.html
+++ b/templates/staff/project/edit.html
@@ -23,12 +23,27 @@
 <form method="POST" class="max-w-3xl flex flex-col gap-y-6">
   {% csrf_token %}
 
-  {% if form.non_field_errors %}
-    {% for error in form.non_field_errors %}
-      {% #alert variant="danger" class="mb-6" %}
-        {{ error }}
-      {% /alert %}
-    {% endfor %}
+  {% if form.non_field_errors or form.errors %}
+    {% #alert variant="danger" %}
+      <ul>
+        {% for error in form.non_field_errors %}
+          <li>{{ error }}</li>
+        {% endfor %}
+
+        {% for field in form %}
+          {% if field.errors %}
+            <li>
+              <strong>{{ field.label }}:</strong>
+              <ul>
+                {% for error in field.errors %}
+                  <li>{{ error }}</li>
+                {% endfor %}
+              </ul>
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    {% /alert %}
   {% endif %}
 
   {% #card title="Project info" container=True %}

--- a/templates/staff/project/edit.html
+++ b/templates/staff/project/edit.html
@@ -82,7 +82,7 @@
     {% #form_fieldset class="w-full items-stretch gap-y-6" %}
       {% form_legend text="Internal co-pilot details" class="sr-only" %}
 
-      {% form_select field=form.fields.copilot choices=form.fields.copilot.choices selected=form.copilot.value id="id_copilot" name="copilot" label="Select a co-pilot" %}
+      {% form_select field=form.copilot choices=form.fields.copilot.choices selected=form.copilot.value label="Select a co-pilot" %}
       {% form_input custom_field=True id="id_copilot_support_ends_at" name="copilot_support_ends_at" value=form.copilot_support_ends_at.value|date:"Y-m-d" errors=form.copilot_support_ends_at.errors type="date" label="Co-pilot support ends at" %}
       {% form_textarea field=form.copilot_notes label="Co-pilot notes" %}
     {% /form_fieldset %}

--- a/templates/staff/project/edit.html
+++ b/templates/staff/project/edit.html
@@ -58,7 +58,7 @@
   {% #card title="Organisations" container=True %}
     {% #form_fieldset class="w-full items-stretch gap-y-6" %}
       {% form_legend text="Organisations" class="sr-only" %}
-      {% multiselect field=form.orgs placeholder="Select one or more orgs" %}
+      {% form_select field=form.fields.orgs choices=form.fields.orgs.choices selected=form.orgs.value id="id_orgs" name="orgs" label="Select an organisation" required %}
     {% /form_fieldset %}
   {% /card %}
 

--- a/templates/staff/project/edit.html
+++ b/templates/staff/project/edit.html
@@ -49,8 +49,8 @@
   {% #card title="Project info" container=True %}
     {% #form_fieldset class="w-full items-stretch gap-y-6" %}
       {% form_legend text="Project info" class="sr-only" %}
-      {% form_input field=form.name label="Project name" %}
-      {% form_input field=form.slug label="URL slug" %}
+      {% form_input field=form.name label="Project name" required %}
+      {% form_input field=form.slug label="URL slug" required %}
       {% form_input field=form.number label="Project number" inputmode="numeric" %}
     {% /form_fieldset %}
   {% /card %}
@@ -92,7 +92,7 @@
     {% #form_fieldset class="w-full items-stretch gap-y-6" %}
       {% form_legend text="Status" class="sr-only" %}
 
-      {% form_select field=form.status choices=form.fields.status.choices selected=form.status.value %}
+      {% form_select field=form.status choices=form.fields.status.choices selected=form.status.value label="Project status" required %}
       {% form_textarea field=form.status_description label="Status description" %}
     {% /form_fieldset %}
   {% /card %}


### PR DESCRIPTION
The staff area project edit screen had multiple issues:

- The org multiselect was not set up correctly, this meant the form did not validate
- The error messages were not showing at the top of the screen, or for the muliselect element
- The project status field was receiving incorrect values

This PR changes that so:

- The org select is instead a single selection option which will display an error as it is required
- The error messages for each field show at the top of the form
- The values passed to the status field is now correct

This should resolve https://github.com/opensafely-core/job-server/issues/4144 but we should confirm after deployment.