### PR TITLE
Fixes for Markdown project status description field

### DIFF
--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -1,3 +1,4 @@
+import nh3
 from django.contrib import messages
 from django.db import transaction
 from django.db.models.functions import Lower
@@ -14,6 +15,7 @@ from django.views.generic import (
 )
 from django_htmx.http import HttpResponseClientRedirect
 from furl import furl
+from markdown import markdown
 from zen_queries import TemplateResponse as zTemplateResponse
 from zen_queries import fetch
 
@@ -213,6 +215,9 @@ class ProjectDetail(DetailView):
             ),
             "orgs": self.object.orgs.order_by(Lower("name")),
             "redirects": self.object.redirects.order_by("old_url"),
+            "status_description_html": nh3.clean(
+                markdown(self.object.status_description)
+            ),
             "workspaces": self.object.workspaces.order_by("name"),
         }
 

--- a/templates/project/edit.html
+++ b/templates/project/edit.html
@@ -25,7 +25,7 @@
 
       {% #card title="Edit "|add:project.name class="w-full" container_class="flex flex-col gap-y-4 items-start" container=True %}
         {% form_select class="min-w-[50%]" field=form.status choices=form.fields.status.choices selected=form.status.value %}
-        {% form_textarea class="w-full max-w-[65ch]" field=form.status_description resize=False rows="8" %}
+        {% form_textarea class="w-full max-w-[65ch]" custom_field errors=form.status_description.errors hint_text="You can format the status description text using Markdown" id="id_status_description" label="Status description" name="status_description" resize rows="12" value=form.status_description.value  %}
         {% #button class="mt-2" type="submit" variant="primary" %}
           Submit
         {% /button %}

--- a/templates/staff/project/detail.html
+++ b/templates/staff/project/detail.html
@@ -65,10 +65,10 @@
 
         {% #description_item title="Status" %}
           {% pill_project_status status=project.status text=project.get_status_display %}
-          {% if project.status_description %}
-            <p class="mt-2">
-              {{ project.status_description }}
-            </p>
+          {% if status_description_html %}
+            <div class="prose prose-sm prose-oxford mt-4">
+              {{ status_description_html|safe }}
+            </div>
           {% endif %}
         {% /description_item %}
       {% /description_list %}

--- a/templates/staff/project/edit.html
+++ b/templates/staff/project/edit.html
@@ -92,8 +92,8 @@
     {% #form_fieldset class="w-full items-stretch gap-y-6" %}
       {% form_legend text="Status" class="sr-only" %}
 
-      {% form_select field=form.status choices=form.fields.status.choices selected=form.status.value label="Project status" required %}
-      {% form_textarea field=form.status_description label="Status description" %}
+      {% form_select field=form.status choices=form.fields.status.choices selected=form.status.value %}
+      {% form_textarea custom_field name="status_description" id="id_status_description" hint_text="You can format the status description text using Markdown" label="Status description" resize rows="12" value=form.status_description.value errors=form.status_description.errors %}
     {% /form_fieldset %}
   {% /card %}
 


### PR DESCRIPTION
- Show the Markdown-ified version of the status in the staff area
- Tell users and staff they can use Markdown when entering a status description