### PR TITLE
Test atomicity of project-members commands

### DIFF
--- a/tests/unit/jobserver/commands/test_project_members.py
+++ b/tests/unit/jobserver/commands/test_project_members.py
@@ -1,8 +1,15 @@
+import pytest
+from django.db import IntegrityError
+
 from jobserver.authorization import ProjectDeveloper
 from jobserver.commands import project_members as members
-from jobserver.models import AuditableEvent
+from jobserver.models import AuditableEvent, ProjectMembership
 from jobserver.utils import set_from_list, set_from_qs
 from tests.factories import ProjectFactory, UserFactory
+
+
+def raise_integrity_error(*args, **kwargs):
+    raise IntegrityError
 
 
 def test_add():
@@ -28,6 +35,27 @@ def test_add():
         assert event.parent_id == str(project.pk)
         assert event.created_by == creator.username
         assert event.created_at
+
+
+def test_add_with_integrity_error(monkeypatch):
+    project = ProjectFactory()
+    user, creator = UserFactory.create_batch(2)
+
+    assert ProjectMembership.objects.count() == 0
+    assert AuditableEvent.objects.count() == 0
+
+    with monkeypatch.context() as mp, pytest.raises(IntegrityError):
+        # We patch AuditableEvent.objects.create because it is called after
+        # Project.memberships.create. In other words, we test that a ProjectMembership
+        # isn't created if creating an AuditableEvent fails.
+        mp.setattr(
+            "jobserver.models.AuditableEvent.objects.create", raise_integrity_error
+        )
+        members.add(project=project, user=user, roles=[], by=creator)
+
+    # nothing has changed
+    assert ProjectMembership.objects.count() == 0
+    assert AuditableEvent.objects.count() == 0
 
 
 def test_add_with_roles():
@@ -99,6 +127,26 @@ def test_update_roles(project_membership):
     assert event.created_by == updator.username
 
 
+def test_update_roles_with_integrity_error(monkeypatch, project_membership):
+    project = ProjectFactory()
+    user, updator = UserFactory.create_batch(2)
+    membership = project_membership(project=project, user=user, roles=[])
+
+    assert ProjectMembership.objects.count() == 1
+    assert AuditableEvent.objects.count() == 1
+
+    with monkeypatch.context() as mp, pytest.raises(IntegrityError):
+        # We patch ProjectMembership.save because it is called after
+        # AuditableEvent.objects.create. In other words, we test that an AuditableEvent
+        # isn't created if updating a ProjectMembership fails.
+        mp.setattr("jobserver.models.ProjectMembership.save", raise_integrity_error)
+        members.update_roles(member=membership, by=updator, roles=[ProjectDeveloper])
+
+    # nothing has changed
+    assert ProjectMembership.objects.count() == 1
+    assert AuditableEvent.objects.count() == 1
+
+
 def test_remove(project_membership):
     deletor = UserFactory()
     project = ProjectFactory()
@@ -123,3 +171,23 @@ def test_remove(project_membership):
     assert event.parent_model == "jobserver.Project"
     assert event.parent_id == str(project.pk)
     assert event.created_by == deletor.username
+
+
+def test_remove_with_integrity_error(monkeypatch, project_membership):
+    project = ProjectFactory()
+    user, deletor = UserFactory.create_batch(2)
+    membership = project_membership(project=project, user=user, roles=[])
+
+    assert ProjectMembership.objects.count() == 1
+    assert AuditableEvent.objects.count() == 1
+
+    with monkeypatch.context() as mp, pytest.raises(IntegrityError):
+        # We patch ProjectMembership.delete because it is called after
+        # AuditableEvent.objects.create. In other words, we test that an AuditableEvent
+        # isn't created if deleting a ProjectMembership fails.
+        mp.setattr("jobserver.models.ProjectMembership.delete", raise_integrity_error)
+        members.remove(membership=membership, by=deletor)
+
+    # nothing has changed
+    assert ProjectMembership.objects.count() == 1
+    assert AuditableEvent.objects.count() == 1


### PR DESCRIPTION
The commands in `jobserver.commands.project_members` are decorated with `atomic` to ensure that writing to the DB results in either complete success or complete failure. Generally, we'd rely on Django to test `atomic`. However, because these commands are also adding entries to the audit log, and because the semantics of the audit log are especially important to us, we also test their atomicity.

We use `monkeypatch.context()` to be very specific about when we raise `IntegrityError`s. We don't, for example, want to interfere with the factories. Whilst we could locate `raise_integrity_error` in a utils module, we don't because we still need to import `IntegrityError` wherever the function is called.

Closes #4127