### PR TITLE
Update some UI components

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -39,7 +39,10 @@ class JobRequestCreateForm(forms.ModelForm):
 
         # bulid the backends field based on the backends passed in
         self.fields["backend"] = forms.ChoiceField(
-            choices=backends, initial=initial, widget=forms.RadioSelect
+            choices=backends,
+            initial=initial,
+            widget=forms.RadioSelect,
+            label="Select a backend",
         )
 
     def clean(self):

--- a/jobserver/views/components.py
+++ b/jobserver/views/components.py
@@ -1,51 +1,42 @@
 from datetime import UTC, datetime
 
+from django import forms
 from django.template.response import TemplateResponse
 
 
-def components(request):
-    example_date = datetime.fromtimestamp(1667317153, tz=UTC)
-    example_form_email = {
-        "auto_id": "id_email",
-        "errors": {"This email is registered to a different account"},
-        "html_name": "email",
-        "id_for_label": "id_email",
-        "label": "Email address",
-        "value": "you@example.com",
-    }
+class ExampleForm(forms.Form):
 
-    example_form_select = {
-        "auto_id": "id_language_select",
-        "choices": [
+    example_select = forms.ChoiceField(
+        choices=[
             ["", "Please select a language"],
             ["english", "English"],
             ["french", "French"],
             ["german", "German"],
             ["spanish", "Spanish"],
         ],
-        "errors": {},
-        "html_name": "language-select",
-        "id_for_label": "id_language_select",
-        "label": "Language select",
-        "value": "french",
-    }
+        label="Language select",
+        initial="french",
+    )
 
-    example_form_textarea = {
-        "auto_id": "id_project_description",
-        "errors": {},
-        "html_name": "project-description",
-        "id_for_label": "id_project_description",
-        "label": "Notification email address",
-        "value": "",
-    }
+    example_email = forms.EmailField()
 
+    example_textarea = forms.Textarea()
+
+    def clean_example_email(self):
+        self.add_error(
+            "example_email", "This email is registered to a different account"
+        )
+
+
+def components(request):
+    example_date = datetime.fromtimestamp(1667317153, tz=UTC)
+    form = ExampleForm({"example_select": "french", "example_email": "you@example.com"})
+    form.is_valid()
     return TemplateResponse(
         request,
         "_components/index.html",
         context={
             "example_date": example_date,
-            "example_form_email": example_form_email,
-            "example_form_select": example_form_select,
-            "example_form_textarea": example_form_textarea,
+            "example_form": form,
         },
     )

--- a/jobserver/views/components.py
+++ b/jobserver/views/components.py
@@ -22,6 +22,18 @@ class ExampleForm(forms.Form):
 
     example_textarea = forms.Textarea()
 
+    example_radios = forms.ChoiceField(
+        choices=[
+            ["english", "English"],
+            ["french", "French"],
+            ["german", "German"],
+            ["spanish", "Spanish"],
+        ],
+        label="Language select",
+        initial="french",
+        widget=forms.RadioSelect,
+    )
+
     def clean_example_email(self):
         self.add_error(
             "example_email", "This email is registered to a different account"

--- a/templates/_components/button.html
+++ b/templates/_components/button.html
@@ -1,6 +1,6 @@
 {% if type == "link" %}
   <a
-    {% attrs data-table-pagination href %}
+    {% attrs data-table-pagination href id %}
     {% if external %}
       rel="noopener noreferrer"
       target="_blank"

--- a/templates/_components/form/radio_list.html
+++ b/templates/_components/form/radio_list.html
@@ -1,3 +1,42 @@
+{% if id %}
+  {% var label_for=id %}
+  {% var radios_id=id %}
+  {% var radios_name=name %}
+{% else %}
+  {% var label_for=field.id_for_label %}
+  {% var radios_id=field.auto_id %}
+  {% var radios_name=field.html_name %}
+{% endif %}
+
+{% if label %}
+  {% var radios_label=label %}
+{% elif field.label %}
+  {% var radios_label=label %}
+{% else  %}
+  {% var radios_label="" %}
+{% endif %}
+
+<div {% attrs class %}>
+  {% if radios_label %}
+    <label
+        class="inline-block font-semibold text-lg text-slate-900 cursor-pointer"
+        for="{{ label_for }}"
+      >
+        {{ radios_label }}
+
+        {% if required %}
+          <span
+            aria-hidden="true"
+            class="text-bn-ribbon-700 font-bold"
+          >*</span>
+        {% endif %}
+      </label>
+  {% endif %}
+
+  {% if hint_text %}
+    <p class="mb-2 text-sm text-gray-700">{{ hint_text }}</p>
+  {% endif %}
+
 {% for value, label in field.field.choices %}
 
   {% if field.value == value %}
@@ -7,7 +46,8 @@
   {% endif %}
 
   {% with id=forloop.counter|stringformat:"s" %}
-  {% form_radio id="id_backend"|add:id name="backend" value=value label=label checked=checked %}
+  {% form_radio id="id_"|add:radios_name|add:id name=radios_name value=value label=label checked=checked %}
   {% endwith %}
 
 {% endfor %}
+</div>

--- a/templates/_components/index.html
+++ b/templates/_components/index.html
@@ -332,6 +332,14 @@
       <h3>Checkbox</h3>
       <ul>
         <li><code>checked</code>: [boolean] - if true, checkbox is checked</li>
+        <li><code>field</code>: a Django form field
+          <ul>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.auto_id"><code>auto_id</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.html_name"><code>html_name</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.id_for_label"><code>id_for_label</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.label"><code>label</code></a></li>
+          </ul>
+        </li>
         <li><code>custom_field</code>: [boolean] - set to true if field does not directly map to a Django Form field</li>
         <li><code>id</code>: [string] - set the HTML id for the input element</li>
         <li><code>label_class</code>: [string] - add HTML classes to the label tag</li>
@@ -370,7 +378,7 @@
         <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#autocorrect"><code>autocorrect</code></a></li>
         <li><code>class</code>: [string] - add HTML classes to the component</li>
         <li><code>errors</code>: [object] - object for Django to map over for individual errors</li>
-        <li><code>field</code> - passed from Django
+        <li><code>field</code>: a Django form field
           <ul>
             <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.auto_id"><code>auto_id</code></a></li>
             <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.errors"><code>errors</code></a></li>
@@ -394,7 +402,7 @@
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border border-slate-500 rounded">
         <div class="flex flex-col gap-y-4 items-start max-w-xl w-full mx-auto">
-          {% form_input type="email" label="Email address" required=True field=example_form_email hint_text="Must be an opensafely.org account" %}
+          {% form_input type="email" label="Email address" required=True field=example_form.example_email hint_text="Must be an opensafely.org account" %}
           {% form_input type="text" label="Phone number" inputmode="number" autocapitalize=False autocomplete=False autocorrect=False %}
           {% form_input type="search" label="Search the site"%}
         </div>
@@ -453,7 +461,7 @@
       <ul>
         <li><code>choices</code>: [dict] - dict of [value, label] for the options</li>
         <li><code>class</code>: [string] - add HTML classes to the component</li>
-        <li><code>field</code>
+        <li><code>field</code>: a Django form field
           <ul>
             <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.auto_id"><code>auto_id</code></a></li>
             <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.errors"><code>errors</code></a></li>
@@ -470,8 +478,8 @@
         <li><code>selected</code>: [string] - matches value of choice for preselected option</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border border-slate-500 rounded">
-        {% form_select class="w-full max-w-lg mx-auto" label="Select a language" required=True field=example_form_select choices=example_form_select.choices selected=example_form_select.value %}
-        <pre><code class="language-django">{% verbatim %}{% form_select class="w-full max-w-lg mx-auto" label="Select a language" required=True field=example_form_select choices=example_form_select.choices selected=example_form_select.value %}{% endverbatim %}</code></pre>
+        {% form_select class="w-full max-w-lg mx-auto" label="Select a language" required=True field=example_form.example_select choices=example_form.example_select.field.choices selected=example_form.example_select.value %}
+        <pre><code class="language-django">{% verbatim %}{% form_select class="w-full max-w-lg mx-auto" label="Select a language" required=True field=example_form.example_select choices=example_form.example_select.field.choices selected=example_form.example_select.value %}{% endverbatim %}</code></pre>
       </div>
 
       <h3>Textarea</h3>
@@ -481,7 +489,7 @@
         <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#autocorrect"><code>autocorrect</code></a></li>
         <li><code>class</code>: [string] - add HTML classes to the component</li>
         <li><code>errors</code>: [object] - object for Django to map over for individual errors</li>
-        <li><code>field</code>
+        <li><code>field</code>: a Django form field
           <ul>
             <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.auto_id"><code>auto_id</code></a></li>
             <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.errors"><code>errors</code></a></li>
@@ -504,8 +512,8 @@
         <li><code>value</code>: [string] - set the HTML value for the input element</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border border-slate-500 rounded">
-        {% form_textarea class="max-w-lg w-full mx-auto" field=example_form_textarea label="Enter a short description of the project" resize=True rows=8 %}
-        <pre><code class="language-django">{% verbatim %}{% form_textarea class="max-w-lg w-full mx-auto" field=example_form_textarea label="Enter a short description of the project" resize=True rows=8 %}{% endverbatim %}</code></pre>
+        {% form_textarea class="max-w-lg w-full mx-auto" field=example_form.example_textarea label="Enter a short description of the project" resize=True rows=8 %}
+        <pre><code class="language-django">{% verbatim %}{% form_textarea class="max-w-lg w-full mx-auto" field=example_form.example_textarea label="Enter a short description of the project" resize=True rows=8 %}{% endverbatim %}</code></pre>
       </div>
     </section>
 

--- a/templates/_components/index.html
+++ b/templates/_components/index.html
@@ -455,7 +455,30 @@
       </div>
 
       <h3>Radio list</h3>
-      <p>Pass Django radio fields in to a list of radios</p>
+      <p>Pass Django choice fields in to a list of radios</p>
+      <ul>
+        <li><code>choices</code>: [dict] - dict of [value, label] for the options</li>
+        <li><code>class</code>: [string] - add HTML classes to the component</li>
+        <li><code>field</code>: a Django form field
+          <ul>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.auto_id"><code>auto_id</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.Form.errors"><code>errors</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.html_name"><code>html_name</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.id_for_label"><code>id_for_label</code></a></li>
+            <li><a href="https://devdocs.io/django~4.1/ref/forms/api#django.forms.BoundField.label"><code>label</code></a></li>
+          </ul>
+        </li>
+        <li><code>hint_text</code>: [string] - add a subtitle as hint text for the select</li>
+        <li><code>id</code>: [string] - set the HTML id for the select element</li>
+        <li><code>label</code>: [string] - overwrite the label passed from Django</li>
+        <li><code>name</code>: [string] - set the HTML name for the select element</li>
+        <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required"><code>required</code></a></li>
+        <li><code>selected</code>: [string] - matches value of choice for preselected option</li>
+      </ul>
+      <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border border-slate-500 rounded">
+        {% form_radios class="w-full max-w-lg mx-auto" label="Choose a language" required=True field=example_form.example_radios choices=example_form.example_radios.field.choices selected=example_form.example_radios.value %}
+        <pre><code class="language-django">{% form_radios class="w-full max-w-lg mx-auto" label="Choose a language" required=True field=example_form.example_radios choices=example_form.example_radios.field.choices selected=example_form.example_radios.value %}{% endverbatim %}</code></pre>
+      </div>
 
       <h3>Select</h3>
       <ul>

--- a/templates/_components/index.html
+++ b/templates/_components/index.html
@@ -477,7 +477,7 @@
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border border-slate-500 rounded">
         {% form_radios class="w-full max-w-lg mx-auto" label="Choose a language" required=True field=example_form.example_radios choices=example_form.example_radios.field.choices selected=example_form.example_radios.value %}
-        <pre><code class="language-django">{% form_radios class="w-full max-w-lg mx-auto" label="Choose a language" required=True field=example_form.example_radios choices=example_form.example_radios.field.choices selected=example_form.example_radios.value %}{% endverbatim %}</code></pre>
+        <pre><code class="language-django">{% verbatim %}{% form_radios class="w-full max-w-lg mx-auto" label="Choose a language" required=True field=example_form.example_radios choices=example_form.example_radios.field.choices selected=example_form.example_radios.value %}{% endverbatim %}</code></pre>
       </div>
 
       <h3>Select</h3>


### PR DESCRIPTION
3 updates to UI components that have come up while using these in Airlock:

1) Pass through id for a button component that is a link type
It was surprising that the docs said `id` was an available attribute, but i couldn't get it to appear (because my button was of type=link)

2) There were a couple of places in the docs for form components where a component was documenting using a django form field, but didn't quite work with a real django form. The main one was using `choices=<field>.choices` for a `form_select` component, whereas with a real django form field it should be `choices=<field>.field.choices`.  I've replaced the dicts that pretended to be django form fields with an actual django form.

3) Updated `form_radios` - only did this one because there was a heading for it in the docs without any content. It needed some minimal changes to make it more generic. We're currently stealing all of job-server's components for Airlock, so if we wanted to use a radio select element, the hard-coded ids would be a problem. Have checked that the create job request page is the only place it's used in job-server, and that everything looks the same after these changes.