### PR TITLE
Rationalize logging event-types

### DIFF
--- a/jobserver/commands/project_members.py
+++ b/jobserver/commands/project_members.py
@@ -66,7 +66,7 @@ def update_roles(*, member, by, roles):
     )
 
     member.roles = roles
-    member.save(update_fields=["roles"])
+    member.save(update_fields=["roles"], override=True)
 
 
 @transaction.atomic()
@@ -89,4 +89,4 @@ def remove(*, membership, by):
         created_by=by.username,
     )
 
-    membership.delete()
+    membership.delete(override=True)

--- a/jobserver/commands/project_members.py
+++ b/jobserver/commands/project_members.py
@@ -2,17 +2,18 @@ from django.db import transaction
 from django.utils import timezone
 
 from ..authorization.utils import dotted_path
-from ..models import AuditableEvent
+from ..models import AuditableEvent, ProjectMembership
 
 
 @transaction.atomic()
 def add(*, project, user, roles, by):
-    membership = project.memberships.create(
+    membership = ProjectMembership(
+        project=project,
         user=user,
         created_by=by,
         roles=roles,
-        override=True,
     )
+    membership.save(override=True)
 
     # use a single timestamp in case we're also setting roles below and
     # want to match up records in the future

--- a/jobserver/model_utils.py
+++ b/jobserver/model_utils.py
@@ -1,4 +1,19 @@
+from django.apps import apps
 from django.db import models
+
+
+_SKIP_APP_LABELS = {"auth", "contenttypes", "sessions", "social_django"}
+
+
+def get_models():
+    """
+    Return a list of all installed, project-specific models.
+    """
+    return [
+        model
+        for model in apps.get_models()
+        if model._meta.app_label not in _SKIP_APP_LABELS
+    ]
 
 
 class ImmutableError(TypeError):

--- a/jobserver/model_utils.py
+++ b/jobserver/model_utils.py
@@ -1,0 +1,19 @@
+class ImmutableError(TypeError):
+    pass
+
+
+def _raise_error(model):
+    model_name = model._meta.label.split(".")[1]
+    raise ImmutableError(f"Direct access to {model_name} is disabled")
+
+
+class ImmutableModelMixin:
+    def delete(self, *args, override=False, **kwargs):
+        if not override:
+            _raise_error(self)
+        super().delete(*args, **kwargs)
+
+    def save(self, *args, override=False, **kwargs):
+        if not override:
+            _raise_error(self)
+        super().save(*args, **kwargs)

--- a/jobserver/model_utils.py
+++ b/jobserver/model_utils.py
@@ -1,3 +1,6 @@
+from django.db import models
+
+
 class ImmutableError(TypeError):
     pass
 
@@ -17,3 +20,30 @@ class ImmutableModelMixin:
         if not override:
             _raise_error(self)
         super().save(*args, **kwargs)
+
+
+class ImmutableQuerySet(models.QuerySet):
+    # We don't override get_or_create, because we don't want to disable the get part.
+    # The create part delegates to create.
+
+    def bulk_create(self, *args, **kwargs):
+        _raise_error(self.model)
+
+    def bulk_update(self, *args, **kwargs):
+        _raise_error(self.model)
+
+    def create(self, *args, **kwargs):
+        _raise_error(self.model)
+
+    def delete(self, *args, **kwargs):
+        _raise_error(self.model)
+
+    def update(self, *args, **kwargs):
+        _raise_error(self.model)
+
+    def update_or_create(self, *args, **kwargs):
+        _raise_error(self.model)
+
+
+class ImmutableManager(models.Manager.from_queryset(ImmutableQuerySet)):
+    pass

--- a/jobserver/models/project_membership.py
+++ b/jobserver/models/project_membership.py
@@ -4,29 +4,10 @@ from django.urls import reverse
 from django.utils import timezone
 
 from ..authorization.fields import RolesArrayField
-from ..model_utils import ImmutableModelMixin
+from ..model_utils import ImmutableManager, ImmutableModelMixin
 
 
 logger = structlog.get_logger(__name__)
-
-
-class ProjectMembershipManager(models.Manager):
-    def create(self, *args, override=False, **kwargs):
-        if override:
-            return super().create(*args, **kwargs)
-
-        msg = (
-            "Direct creation of ProjectMemberships via this method is disabled, "
-            "please use commands.project_members.add"
-        )
-        raise TypeError(msg)
-
-    def update(self, *args, **kwargs):
-        msg = (
-            "Direct update of ProjectMemberships via this method is disabled, "
-            "please use commands.project_memberships.update_roles"
-        )
-        raise TypeError(msg)
 
 
 class ProjectMembership(ImmutableModelMixin, models.Model):
@@ -58,7 +39,7 @@ class ProjectMembership(ImmutableModelMixin, models.Model):
 
     created_at = models.DateTimeField(default=timezone.now)
 
-    objects = ProjectMembershipManager()
+    objects = ImmutableManager()
 
     class Meta:
         unique_together = ["project", "user"]

--- a/jobserver/models/project_membership.py
+++ b/jobserver/models/project_membership.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from ..authorization.fields import RolesArrayField
+from ..model_utils import ImmutableModelMixin
 
 
 logger = structlog.get_logger(__name__)
@@ -28,7 +29,7 @@ class ProjectMembershipManager(models.Manager):
         raise TypeError(msg)
 
 
-class ProjectMembership(models.Model):
+class ProjectMembership(ImmutableModelMixin, models.Model):
     """
     Membership of a Project for a User
 

--- a/tests/paired_fields_utils.py
+++ b/tests/paired_fields_utils.py
@@ -3,27 +3,16 @@ import inspect
 from django.apps import apps
 from factory.django import DjangoModelFactory
 
+from jobserver.model_utils import get_models
+
 from . import factories
 
-
-_SKIP_APP_LABELS = {"auth", "contenttypes", "sessions", "social_django"}
 
 _MODEL_TO_FACTORY = {
     f._meta.model: f
     for f in vars(factories).values()
     if inspect.isclass(f) and issubclass(f, DjangoModelFactory)
 }
-
-
-def get_models():
-    """
-    Return a list of all installed, project-specific models.
-    """
-    return [
-        model
-        for model in apps.get_models()
-        if model._meta.app_label not in _SKIP_APP_LABELS
-    ]
 
 
 class MissingFactoryError(Exception):

--- a/tests/unit/jobserver/models/test_mutability.py
+++ b/tests/unit/jobserver/models/test_mutability.py
@@ -1,8 +1,7 @@
 import pytest
 from django.apps import apps
 
-from jobserver.model_utils import ImmutableError
-from tests.paired_fields_utils import get_models
+from jobserver.model_utils import ImmutableError, get_models
 
 
 MUTABLE_MODELS = [

--- a/tests/unit/jobserver/models/test_mutability.py
+++ b/tests/unit/jobserver/models/test_mutability.py
@@ -1,0 +1,79 @@
+from django.apps import apps
+
+from tests.paired_fields_utils import get_models
+
+
+MUTABLE_MODELS = [
+    apps.get_model(x)
+    for x in [
+        "applications.Application",
+        "applications.CmoPriorityListPage",
+        "applications.CommercialInvolvementPage",
+        "applications.ContactDetailsPage",
+        "applications.DatasetsPage",
+        "applications.LegalBasisPage",
+        "applications.PreviousEhrExperiencePage",
+        "applications.RecordLevelDataPage",
+        "applications.ReferencesPage",
+        "applications.ResearcherDetailsPage",
+        "applications.ResearcherRegistration",
+        "applications.SharingCodePage",
+        "applications.SoftwareDevelopmentExperiencePage",
+        "applications.SponsorDetailsPage",
+        "applications.StudyDataPage",
+        "applications.StudyFundingPage",
+        "applications.StudyInformationPage",
+        "applications.StudyPurposePage",
+        "applications.TeamDetailsPage",
+        "applications.TypeOfStudyPage",
+        "interactive.AnalysisRequest",
+        "jobserver.AuditableEvent",
+        "jobserver.Backend",
+        "jobserver.BackendMembership",
+        "jobserver.Job",
+        "jobserver.JobRequest",
+        "jobserver.Org",
+        "jobserver.OrgMembership",
+        "jobserver.Project",
+        "jobserver.ProjectCollaboration",
+        "jobserver.ProjectMembership",
+        "jobserver.PublishRequest",
+        "jobserver.Release",
+        "jobserver.ReleaseFile",
+        "jobserver.ReleaseFileReview",
+        "jobserver.Repo",
+        "jobserver.Report",
+        "jobserver.Snapshot",
+        "jobserver.Stats",
+        "jobserver.User",
+        "jobserver.Workspace",
+        "redirects.Redirect",
+    ]
+]
+
+IMMUTABLE_MODELS = [apps.get_model(x) for x in []]
+
+
+MODEL_METHODS = ["delete", "save"]
+
+QUERYSET_METHODS = [
+    "bulk_create",
+    "bulk_update",
+    "create",
+    "delete",
+    "get_or_create",
+    "update",
+    "update_or_create",
+]
+
+
+def test_all_models_are_listed():
+    assert set(MUTABLE_MODELS) | set(IMMUTABLE_MODELS) == set(
+        get_models()
+    ), "The lists of mutable and immutable models are incomplete"
+
+
+def test_all_models_are_listed_as_either_mutable_or_immutable():
+    assert (
+        set(MUTABLE_MODELS) & set(IMMUTABLE_MODELS) == set()
+    ), "A model must be listed as either mutable or immutable"

--- a/tests/unit/jobserver/models/test_mutability.py
+++ b/tests/unit/jobserver/models/test_mutability.py
@@ -100,3 +100,21 @@ def test_mutable_model_methods(Model, method):
 def test_immutable_model_methods(Model, method):
     with pytest.raises(ImmutableError):
         getattr(Model(), method)()
+
+
+@pytest.mark.parametrize("Model", MUTABLE_MODELS)
+@pytest.mark.parametrize("method", QUERYSET_METHODS)
+def test_mutable_queryset_methods(Model, method):
+    try:
+        getattr(Model.objects.all(), method)()
+    except Exception as e:
+        assert type(e) != ImmutableError
+    else:
+        assert True
+
+
+@pytest.mark.parametrize("Model", IMMUTABLE_MODELS)
+@pytest.mark.parametrize("method", QUERYSET_METHODS)
+def test_immutable_queryset_methods(Model, method):
+    with pytest.raises(ImmutableError):
+        getattr(Model.objects.all(), method)()

--- a/tests/unit/jobserver/models/test_paired_fields.py
+++ b/tests/unit/jobserver/models/test_paired_fields.py
@@ -2,10 +2,10 @@ import pytest
 from django.db import IntegrityError
 from django.utils import timezone
 
+from jobserver.model_utils import get_models
 from tests.factories import UserFactory
 from tests.paired_fields_utils import (
     get_all_paired_fields,
-    get_models,
     get_optional_paired_fields,
 )
 


### PR DESCRIPTION
This is part one of a two-part attempt to rationalize logging event-types (#4128). Here, we add `ImmutableModelMixin` and `ImmutableManager` to prevent us from accidentally mutating `ProjectMembership` outside `jobserver.commands.project_members` and, hence, outside an audited workflow.

Adding these models has already highlighted one location where we mutated `ProjectMembership` in this way. This location was removed in #4178.

The tests should help us add, delete, and update existing models safely. It is for this reason that we add `ImmutableError`: it's hard to test that an existing model has been updated from a mutable to an immutable model without it. `ImmutableError` is a child of `TypeError` because

> This exception may be raised by user code to indicate that an attempted operation on an object is not supported, and is not meant to be.[^1]

I've got a follow up PR in mind that will complete #4128. It will involve some refactoring, to make the code in `jobserver.commands` easier to generalize to other models and other logging event-types.

[^1]: https://docs.python.org/3.12/library/exceptions.html#TypeError