### PR TITLE
Releases authn/z api improvments

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -560,19 +560,49 @@ class WorkspaceStatusAPI(RetrieveAPIView):
         uses_new_release_flow = serializers.BooleanField()
 
 
-class TokenAuthenticationAPI(APIView):
+class Level4AuthenticatedUser(serializers.Serializer):
+    username = serializers.CharField()
+    fullname = serializers.CharField()
+    workspaces = serializers.DictField(default={})
+    output_checker = serializers.BooleanField()
+    staff = serializers.BooleanField()
+
+
+def build_level4_user(user):
+    workspaces = {}
+    # this is 1 or 2 queries per project, not ideal, but we permissions are not stored in the db
+    for project in user.projects.all():
+        if has_permission(user, "unreleased_outputs_view", project=project):
+            for workspace in project.workspaces.all().values("name"):
+                workspaces[workspace["name"]] = {"project": project.name}
+
+    # using a DRF serializer for now, so we've *some* schema definition
+    level4_user = Level4AuthenticatedUser(
+        data=dict(
+            username=user.username,
+            fullname=user.fullname,
+            workspaces=workspaces,
+            # note, we use a generic role check here rather than a permissions
+            # as its currently a global role. In future, if output checking
+            # permissions applies to different projects/orgs, we'll need to
+            # list the explicit workspaces that the user has this permission
+            # for.
+            output_checker=has_role(user, OutputChecker),
+            staff=user.is_staff,
+        )
+    )
+    # we must validate this or DRF will refuse to serializer it.
+    level4_user.is_valid()
+
+    return level4_user
+
+
+class Level4TokenAuthenticationAPI(APIView):
     authentication_classes = []
 
     class serializer_class(serializers.Serializer):
         user = serializers.CharField()
         token = serializers.CharField()
-
-    class Level4AuthenticatedUser(serializers.Serializer):
-        username = serializers.CharField()
-        fullname = serializers.CharField()
-        workspaces = serializers.DictField(default={})
-        output_checker = serializers.BooleanField()
-        staff = serializers.BooleanField()
 
     def post(self, request):
         # Only allow requests from backend (this function raises the appropriate
@@ -596,29 +626,36 @@ class TokenAuthenticationAPI(APIView):
 
         logger.info(f"User {user} logged in with login token via API")
 
-        workspaces = {}
-        # this is 1 or 2 queries per project, not ideal, but we permissions are not stored in the db
-        for project in user.projects.all():
-            if has_permission(user, "unreleased_outputs_view", project=project):
-                for workspace in project.workspaces.all().values("name"):
-                    workspaces[workspace["name"]] = {"project": project.name}
+        level4_user = build_level4_user(user)
 
-        # using a DRF serializer for now, so we've *some* schema definition
-        level4_user = self.Level4AuthenticatedUser(
-            data=dict(
-                username=user.username,
-                fullname=user.fullname,
-                workspaces=workspaces,
-                # note, we use a generic role check here rather than a permissions
-                # as its currently a global role. In future, if output checking
-                # permissions applies to different projects/orgs, we'll need to
-                # list the explicit workspaces that the user has this permission
-                # for.
-                output_checker=has_role(user, OutputChecker),
-                staff=user.is_staff,
-            )
-        )
-        # we must validate this or DRF will refuse to serializer it.
-        level4_user.is_valid()
+        return Response(level4_user.data)
+
+
+class Level4AuthorisationAPI(APIView):
+    authentication_classes = []
+
+    class serializer_class(serializers.Serializer):
+        user = serializers.CharField()
+
+    def post(self, request):
+        # Only allow requests from backend (this function raises the appropriate
+        # exceptions)
+        get_backend_from_token(request.headers.get("Authorization"))
+
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.data
+
+        try:
+            user = get_object_or_404(User, username=data["user"])
+            users.validate_token_login_allowed(user)
+        except users.TokenLoginException as exc:
+            logger.info(f"User {data['user']} is not a valid Level 4 user")
+            trace.get_current_span().record_exception(exc)
+            raise NotAuthenticated()
+
+        logger.info(f"Provided authorization information for {user} via API")
+
+        level4_user = build_level4_user(user)
 
         return Response(level4_user.data)

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -622,7 +622,7 @@ class Level4TokenAuthenticationAPI(APIView):
         ) as exc:
             logger.info(f"API Login with token failed for user {data['user']}: {exc}")
             trace.get_current_span().record_exception(exc)
-            raise NotAuthenticated()
+            raise NotAuthenticated(str(exc))
 
         logger.info(f"User {user} logged in with login token via API")
 
@@ -652,7 +652,7 @@ class Level4AuthorisationAPI(APIView):
         except users.TokenLoginException as exc:
             logger.info(f"User {data['user']} is not a valid Level 4 user")
             trace.get_current_span().record_exception(exc)
-            raise NotAuthenticated()
+            raise NotAuthenticated(str(exc))
 
         logger.info(f"Provided authorization information for {user} via API")
 

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -15,6 +15,8 @@ from jobserver.api.jobs import (
     WorkspaceStatusesAPI,
 )
 from jobserver.api.releases import (
+    Level4AuthorisationAPI,
+    Level4TokenAuthenticationAPI,
     ReleaseAPI,
     ReleaseFileAPI,
     ReleaseNotificationAPICreate,
@@ -23,7 +25,6 @@ from jobserver.api.releases import (
     SnapshotAPI,
     SnapshotCreateAPI,
     SnapshotPublishAPI,
-    TokenAuthenticationAPI,
     WorkspaceStatusAPI,
 )
 from jobserver.views.health_check import HealthCheck
@@ -137,9 +138,14 @@ api_urls = [
         name="release-file",
     ),
     path(
-        "releases/auth",
-        TokenAuthenticationAPI.as_view(),
-        name="token-auth",
+        "releases/authenticate",
+        Level4TokenAuthenticationAPI.as_view(),
+        name="level4-authenticate",
+    ),
+    path(
+        "releases/authorise",
+        Level4AuthorisationAPI.as_view(),
+        name="level4-authorise",
     ),
 ]
 

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1571,10 +1571,10 @@ def test_tokenauthenticationapi_success(api_rf, project_membership, token_login_
     assert response.data == {
         "username": token_login_user.username,
         "fullname": token_login_user.fullname,
-        "workspaces": [
-            workspace1.name,
-            workspace2.name,
-        ],  # should not include workspace3
+        "workspaces": {
+            workspace1.name: {"project": project1.name},
+            workspace2.name: {"project": project1.name},
+        },  # should not include workspace3
         "output_checker": False,
         "staff": False,
     }
@@ -1613,7 +1613,10 @@ def test_tokenauthenticationapi_success_privileged(
     assert response.data == {
         "username": token_login_user.username,
         "fullname": token_login_user.fullname,
-        "workspaces": [workspace1.name, workspace2.name],
+        "workspaces": {
+            workspace1.name: {"project": project.name},
+            workspace2.name: {"project": project.name},
+        },  # should not include workspace3
         "output_checker": True,
         "staff": True,
     }

--- a/tests/unit/jobserver/test_urls.py
+++ b/tests/unit/jobserver/test_urls.py
@@ -14,6 +14,8 @@ from jobserver.api.jobs import (
     WorkspaceStatusesAPI,
 )
 from jobserver.api.releases import (
+    Level4AuthorisationAPI,
+    Level4TokenAuthenticationAPI,
     ReleaseAPI,
     ReleaseFileAPI,
     ReleaseNotificationAPICreate,
@@ -21,7 +23,6 @@ from jobserver.api.releases import (
     SnapshotAPI,
     SnapshotCreateAPI,
     SnapshotPublishAPI,
-    TokenAuthenticationAPI,
     WorkspaceStatusAPI,
 )
 from jobserver.utils import dotted_path
@@ -82,7 +83,8 @@ def test_url_redirects(client, url, redirect):
         ("/api/v2/releases/workspace/w", ReleaseWorkspaceAPI),
         ("/api/v2/releases/release/42", ReleaseAPI),
         ("/api/v2/releases/file/42", ReleaseFileAPI),
-        ("/api/v2/releases/auth", TokenAuthenticationAPI),
+        ("/api/v2/releases/authenticate", Level4TokenAuthenticationAPI),
+        ("/api/v2/releases/authorise", Level4AuthorisationAPI),
         ("/apply/", TemplateView),
         ("/apply/sign-in", applications.sign_in),
         ("/apply/terms/", applications.terms),


### PR DESCRIPTION
This is a slew of small changes needed for the releases authentication/authorisation API.

We needed some more information, and also the ability to refresh authorisation w/o re-authenticating.

Also added a quick fix to expose a little more information about failed logins, as it is hard to diagnose failures with out it.


