### PR TITLE
Upgrade Django to 5.0.3

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -11,6 +11,11 @@ services:
       - "6543:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data/
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
 
   # base service, exists to hold common config, but is not actually used directly
   base:
@@ -40,7 +45,9 @@ services:
     image: job-server
     extends:
       service: base
-    depends_on: [db]
+    depends_on:
+      db:
+        condition: service_healthy
     environment:
       - GITHUB_TOKEN=
       - GITHUB_WRITEABLE_TOKEN=
@@ -75,7 +82,9 @@ services:
   dev:
     extends:
       service: dev-base
-    depends_on: [db]
+    depends_on:
+      db:
+        condition: service_healthy
     # override command
     command: /app/manage.py runserver 0.0.0.0:8000
 
@@ -83,7 +92,9 @@ services:
   test:
     extends:
       service: dev-base
-    depends_on: [db]
+    depends_on:
+      db:
+        condition: service_healthy
     # different default test env
     env_file:
       - ../.test.env

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -356,9 +356,9 @@ dj-email-url==1.0.6 \
     --hash=sha256:55ffe3329e48f54f8a75aa36ece08f365e09d61f8a209773ef09a1d4760e699a \
     --hash=sha256:cbd08327fbb08b104eac160fb4703f375532e4c0243eb230f5b960daee7a96db
     # via environs
-django==5.0.2 \
-    --hash=sha256:56ab63a105e8bb06ee67381d7b65fe6774f057e41a8bab06c8020c8882d8ecd4 \
-    --hash=sha256:b5bb1d11b2518a5f91372a282f24662f58f66749666b0a286ab057029f728080
+django==5.0.3 \
+    --hash=sha256:5c7d748ad113a81b2d44750ccc41edc14e933f56581683db548c9257e078cc83 \
+    --hash=sha256:5fb37580dcf4a262f9258c1f4373819aacca906431f505e4688e37f3a99195df
     # via
     #   -r requirements.prod.in
     #   dj-database-url


### PR DESCRIPTION
This is a substitute for #4191, which fails due to the database not being accessible in the Docker tests.