### PR TITLE
Allow `OLD_SECRET_KEY` for secret key rotation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,7 +70,6 @@ There are three steps to this process.
 ### 1. Duplicate the existing secret key
 
 ```bash
-dokku config:get job-server SECRET_KEY
 dokku config:set job-server OLD_SECRET_KEY="$(dokku config:get job-server SECRET_KEY)"
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,3 +56,44 @@ dokku$ sudo mkdir -p /var/log/journal
 dokku$ dokku enter job-server
 container$ python manage.py sendtestemail me@myemail.org
 ```
+
+## Rotating the Django secret key
+
+If this is a *routine rotation* of the secret key
+— and not a compromised secret key —
+you can temporarily leave the secret key to be rotated alongside the new secret key.
+
+This allows for changing the secret key without logging out all users at once.
+
+There are three steps to this process.
+
+### 1. Duplicate the existing secret key
+
+```bash
+dokku config:get job-server SECRET_KEY
+dokku config:set job-server OLD_SECRET_KEY="$(dokku config:get job-server SECRET_KEY)"
+```
+
+### 2. Replace the existing secret key
+
+```bash
+# Prefix the command with a space to avoid saving the input to shell history:
+ dokku config:set job-server SECRET_KEY='xxx'
+```
+
+### 3. Remove the previous secret key
+
+A suitable expiry time is given by adding the `SESSION_COOKIE_AGE` duration
+to the time at which the secret key was replaced.
+Once that expiry time is reached,
+any sessions created before the secret key was replaced will have then expired anyway.
+
+If this is not set in the code,
+Django's default [`SESSION_COOKIE_AGE`](https://docs.djangoproject.com/en/dev/ref/settings/#session-cookie-age) is *two weeks*.
+
+Set a Slack reminder for this time,
+and then remove `OLD_SECRET_KEY` as soon as possible when reminded:
+
+```bash
+dokku config:unset job-server OLD_SECRET_KEY
+```

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -34,6 +34,14 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env.str("SECRET_KEY")
 
+# Optional fallback for rotating the secret key.
+# Any OLD_SECRET_KEY that is added should then be removed
+# after the time in SESSION_COOKIE_AGE elapses.
+# Refer to DEVELOPERS.md for guidance.
+OLD_SECRET_KEY = env.str("OLD_SECRET_KEY", default=None)
+if OLD_SECRET_KEY is not None:
+    SECRET_KEY_FALLBACKS = [OLD_SECRET_KEY]
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DEBUG", default=False)
 


### PR DESCRIPTION
This PR allows the use of Django's `SECRET_KEY_FALLBACKS` by configuring the `OLD_SECRET_KEY` environment variable to use the previous key.

This avoids users all getting logged out at once. Instead, we can:

1. Leave the previous secret key active, side-by-side with the new key.
1. Give some time for active users to access the site running the new secret key which updates their sessions.
1. Remove the previous secret key entirely.