### PR TITLE
Fix audit log card pagination

### DIFF
--- a/templates/staff/project/audit_log.html
+++ b/templates/staff/project/audit_log.html
@@ -61,13 +61,7 @@
         {% /list_group %}
 
         {% if page_obj.has_previous or page_obj.has_next %}
-          {% if page_obj.has_next %}
-            {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-          {% endif %}
-          {% if page_obj.has_previous %}
-            {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-          {% endif %}
-          {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+          {% card_pagination page_obj=page_obj request=request no_container=True %}
         {% endif %}
       {% else %}
         {% list_group_empty icon=True title="No logs found" %}

--- a/templates/staff/user/audit_log.html
+++ b/templates/staff/user/audit_log.html
@@ -61,13 +61,7 @@
         {% /list_group %}
 
         {% if page_obj.has_previous or page_obj.has_next %}
-          {% if page_obj.has_next %}
-            {% url_with_querystring page=page_obj.next_page_number as next_page_url %}
-          {% endif %}
-          {% if page_obj.has_previous %}
-            {% url_with_querystring page=page_obj.previous_page_number as previous_page_url %}
-          {% endif %}
-          {% card_pagination page_number=page_obj.number total_pages=page_obj.paginator.num_pages next_page_url=next_page_url previous_page_url=previous_page_url no_container=True %}
+          {% card_pagination page_obj=page_obj request=request no_container=True %}
         {% endif %}
       {% else %}
         {% list_group_empty icon=True title="No logs found" %}


### PR DESCRIPTION
The project view and user view of the audit log use a (possibly) outdated form of the card_pagination UI component. This updates these pages to use the form of this component that we use elsewhere.

Before:

![](https://github.com/opensafely-core/job-server/assets/477263/d41c3d06-d375-4d68-888e-9f2ed1c0dc54)

After:

![](https://github.com/opensafely-core/job-server/assets/477263/45dafb64-d1af-425b-9e37-36cf97e9be78)