### PR TITLE
Remove roles before removing membership

### DIFF
--- a/jobserver/commands/project_members.py
+++ b/jobserver/commands/project_members.py
@@ -72,6 +72,12 @@ def update_roles(*, membership, by, roles):
 
 @transaction.atomic()
 def remove(*, membership, by):
+    # We remove the roles from the membership before we remove the membership to ensure
+    # the audit log is complete: the membership may have been created before the audit
+    # log existed, so may not contain an entry that records the roles associated with
+    # the membership.
+    update_roles(membership=membership, by=by, roles=[])
+
     # We're removing the membership here so we need to save some details for
     # displaying that this happened as we won't be able to look them up at
     # render time.

--- a/jobserver/commands/project_members.py
+++ b/jobserver/commands/project_members.py
@@ -52,22 +52,22 @@ def add(*, project, user, roles, by):
 
 
 @transaction.atomic()
-def update_roles(*, member, by, roles):
+def update_roles(*, membership, by, roles):
     AuditableEvent.objects.create(
         type=AuditableEvent.Type.PROJECT_MEMBER_UPDATED_ROLES,
-        old=",".join([dotted_path(r) for r in member.roles]),
-        target_model=member._meta.label,
+        old=",".join([dotted_path(r) for r in membership.roles]),
+        target_model=membership._meta.label,
         target_field="roles",
-        target_id=member.pk,
-        target_user=member.user.username,
-        parent_model=member.project._meta.label,
-        parent_id=member.project.pk,
+        target_id=membership.pk,
+        target_user=membership.user.username,
+        parent_model=membership.project._meta.label,
+        parent_id=membership.project.pk,
         created_by=by.username,
         new=",".join([dotted_path(r) for r in roles]),
     )
 
-    member.roles = roles
-    member.save(update_fields=["roles"], override=True)
+    membership.roles = roles
+    membership.save(update_fields=["roles"], override=True)
 
 
 @transaction.atomic()

--- a/jobserver/commands/users.py
+++ b/jobserver/commands/users.py
@@ -107,4 +107,4 @@ def clear_all_roles(*, user, by):
         org_members.update_roles(member=org_membership, by=by, roles=[])
 
     for project_membership in user.project_memberships.all():
-        project_members.update_roles(member=project_membership, by=by, roles=[])
+        project_members.update_roles(membership=project_membership, by=by, roles=[])

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -314,7 +314,7 @@ class ProjectMembershipEdit(UpdateView):
 
     def form_valid(self, form):
         members.update_roles(
-            member=self.object,
+            membership=self.object,
             by=self.request.user,
             roles=form.cleaned_data["roles"],
         )

--- a/tests/unit/jobserver/commands/test_project_members.py
+++ b/tests/unit/jobserver/commands/test_project_members.py
@@ -160,9 +160,9 @@ def test_remove(project_membership):
     members.remove(membership=membership, by=deletor)
 
     assert not project.memberships.exists()
-    assert AuditableEvent.objects.count() == 3
+    assert AuditableEvent.objects.count() == 4
 
-    # we created the first and second when arranging this test
+    # we created the first, second, and third when arranging this test
     event = AuditableEvent.objects.last()
     assert event.type == AuditableEvent.Type.PROJECT_MEMBER_REMOVED
     assert event.target_model == "jobserver.ProjectMembership"

--- a/tests/unit/jobserver/commands/test_project_members.py
+++ b/tests/unit/jobserver/commands/test_project_members.py
@@ -108,7 +108,7 @@ def test_update_roles(project_membership):
 
     assert membership.roles == []
 
-    members.update_roles(member=membership, by=updator, roles=[ProjectDeveloper])
+    members.update_roles(membership=membership, by=updator, roles=[ProjectDeveloper])
 
     membership.refresh_from_db()
     assert membership.roles == [ProjectDeveloper]
@@ -140,7 +140,9 @@ def test_update_roles_with_integrity_error(monkeypatch, project_membership):
         # AuditableEvent.objects.create. In other words, we test that an AuditableEvent
         # isn't created if updating a ProjectMembership fails.
         mp.setattr("jobserver.models.ProjectMembership.save", raise_integrity_error)
-        members.update_roles(member=membership, by=updator, roles=[ProjectDeveloper])
+        members.update_roles(
+            membership=membership, by=updator, roles=[ProjectDeveloper]
+        )
 
     # nothing has changed
     assert ProjectMembership.objects.count() == 1

--- a/tests/unit/jobserver/commands/test_project_members.py
+++ b/tests/unit/jobserver/commands/test_project_members.py
@@ -150,22 +150,18 @@ def test_update_roles_with_integrity_error(monkeypatch, project_membership):
 
 
 def test_remove(project_membership):
-    deletor = UserFactory()
     project = ProjectFactory()
-    user = UserFactory()
-
+    user, deletor = UserFactory.create_batch(2)
     membership = project_membership(project=project, user=user)
     membership_pk = str(membership.pk)
 
     members.remove(membership=membership, by=deletor)
 
     assert not project.memberships.exists()
-
     assert AuditableEvent.objects.count() == 2
 
-    # first one is the membership we added while staging this test
+    # we created the first when arranging this test
     event = AuditableEvent.objects.last()
-
     assert event.type == AuditableEvent.Type.PROJECT_MEMBER_REMOVED
     assert event.target_model == "jobserver.ProjectMembership"
     assert event.target_id == membership_pk

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -94,7 +94,7 @@ def test_projectauditlog_filter_by_type(rf, core_developer, project_membership):
         by=actor,
     )
     project_members.update_roles(
-        member=project.memberships.first(),
+        membership=project.memberships.first(),
         by=actor,
         roles=[ProjectCollaborator, ProjectDeveloper],
     )
@@ -123,7 +123,7 @@ def test_projectauditlog_success(rf, core_developer, project_membership):
         by=actor,
     )
     project_members.update_roles(
-        member=project.memberships.first(),
+        membership=project.memberships.first(),
         by=actor,
         roles=[ProjectCollaborator, ProjectDeveloper],
     )

--- a/tests/unit/staff/views/test_users.py
+++ b/tests/unit/staff/views/test_users.py
@@ -47,7 +47,7 @@ def test_userauditlog_filter_by_type(rf, core_developer, project_membership):
         by=actor,
     )
     project_members.update_roles(
-        member=project.memberships.first(),
+        membership=project.memberships.first(),
         by=actor,
         roles=[ProjectCollaborator, ProjectDeveloper],
     )
@@ -76,7 +76,7 @@ def test_userauditlog_success(rf, core_developer, project_membership):
         by=actor,
     )
     project_members.update_roles(
-        member=project.memberships.first(),
+        membership=project.memberships.first(),
         by=actor,
         roles=[ProjectCollaborator, ProjectDeveloper],
     )


### PR DESCRIPTION
The substantive commit in this PR is 04a5069. Previously, removing a membership resulted in an entry like this in the audit log:

![](https://github.com/opensafely-core/job-server/assets/477263/61a22de5-a448-4d5e-9286-2bcb9d5602a6)

Notice that because the user (Alex) was added to the project (TNCC Vaccine Efficacy) before the audit log existed, there isn't an entry in the audit log that describes the user's roles.

Now, removing a membership results in entries like this in the audit log:

![](https://github.com/opensafely-core/job-server/assets/477263/9e92262b-40ca-414f-9702-8b0d600899f0)

The remaining commits do some light refactoring (7d88878 and d0c4482) and prepare the ground (1a1f93b).