### PR TITLE
Strings to symbols

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.generic import CreateView, RedirectView, UpdateView, View
 
-from jobserver.authorization import CoreDeveloper, has_permission, has_role
+from jobserver.authorization import CoreDeveloper, has_permission, has_role, permissions
 from jobserver.hash_utils import unhash_or_404
 from jobserver.slacks import notify_application
 
@@ -21,7 +21,7 @@ from .wizard import Wizard
 
 
 def validate_application_access(user, application):
-    if has_permission(user, "application_manage"):
+    if has_permission(user, permissions.application_manage):
         return
 
     if application.created_by == user:

--- a/interactive/views.py
+++ b/interactive/views.py
@@ -236,7 +236,7 @@ class ReportEdit(FormView):
 
         if not has_permission(
             request.user,
-            "analysis_request_view",
+            permissions.analysis_request_view,
             project=self.analysis_request.project,
         ):
             raise PermissionDenied

--- a/interactive/views.py
+++ b/interactive/views.py
@@ -11,7 +11,7 @@ from django.views.generic import DetailView, FormView, View
 from interactive_templates.dates import END_DATE, START_DATE, WEEK_OF_LATEST_EXTRACT
 from interactive_templates.schema import Codelist, v2
 
-from jobserver.authorization import has_permission
+from jobserver.authorization import has_permission, permissions
 from jobserver.models import Backend, Project
 from jobserver.opencodelists import _get_opencodelists_api
 from jobserver.reports import process_html
@@ -81,7 +81,7 @@ class AnalysisRequestCreate(View):
         self.project = get_object_or_404(Project, slug=self.kwargs["project_slug"])
 
         if not has_permission(
-            request.user, "analysis_request_create", project=self.project
+            request.user, permissions.analysis_request_create, project=self.project
         ):
             raise PermissionDenied
 

--- a/interactive/views.py
+++ b/interactive/views.py
@@ -205,7 +205,7 @@ class AnalysisRequestDetail(DetailView):
             return redirect_to_login(path, resolved_login_url)
 
         if not has_permission(
-            request.user, "release_file_view", project=self.object.project
+            request.user, permissions.release_file_view, project=self.object.project
         ):
             raise PermissionDenied
 

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -502,7 +502,7 @@ class SnapshotCreateAPI(APIView):
         data = serializer.data
 
         if not has_permission(
-            request.user, "snapshot_create", project=workspace.project
+            request.user, permissions.snapshot_create, project=workspace.project
         ):
             raise NotAuthenticated
 

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -28,7 +28,7 @@ from interactive.models import AnalysisRequest
 from interactive.slacks import notify_report_uploaded
 from jobserver import releases, slacks
 from jobserver.api.authentication import get_backend_from_token
-from jobserver.authorization import OutputChecker, has_permission, has_role
+from jobserver.authorization import OutputChecker, has_permission, has_role, permissions
 from jobserver.commands import users
 from jobserver.models import (
     PublishRequest,
@@ -201,7 +201,9 @@ def validate_upload_access(request, workspace):
         raise NotAuthenticated
 
     # check the user has permission to upload release files
-    if not has_permission(user, "release_file_upload", project=workspace.project):
+    if not has_permission(
+        user, permissions.release_file_upload, project=workspace.project
+    ):
         raise NotAuthenticated
 
     return backend, user

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -578,7 +578,7 @@ def build_level4_user(user):
     workspaces = {}
     # this is 1 or 2 queries per project, not ideal, but we permissions are not stored in the db
     for project in user.projects.all():
-        if has_permission(user, "unreleased_outputs_view", project=project):
+        if has_permission(user, permissions.unreleased_outputs_view, project=project):
             for workspace in project.workspaces.all().values("name"):
                 workspaces[workspace["name"]] = {"project": project.name}
 

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -229,7 +229,9 @@ def validate_release_access(request, workspace):
     if request.user.is_anonymous:
         raise NotAuthenticated("Invalid user or token")
 
-    if not has_permission(request.user, "release_file_view", project=workspace.project):
+    if not has_permission(
+        request.user, permissions.release_file_view, project=workspace.project
+    ):
         raise NotAuthenticated(f"Invalid user or token for workspace {workspace.name}")
 
 
@@ -246,7 +248,7 @@ def validate_snapshot_access(request, snapshot):
         raise NotAuthenticated("Invalid user or token")
 
     if not has_permission(
-        request.user, "release_file_view", project=snapshot.workspace.project
+        request.user, permissions.release_file_view, project=snapshot.workspace.project
     ):
         raise NotAuthenticated(f"Invalid user or token for snapshot pk={snapshot.pk}")
 

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -533,7 +533,9 @@ class SnapshotPublishAPI(APIView):
         )
 
         if not has_permission(
-            request.user, "snapshot_publish", project=snapshot.workspace.project
+            request.user,
+            permissions.snapshot_publish,
+            project=snapshot.workspace.project,
         ):
             raise NotAuthenticated
 

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -68,7 +68,9 @@ class JobRequestCreate(CreateView):
         except Workspace.DoesNotExist:
             return redirect("/")
 
-        if not has_permission(request.user, "job_run", project=self.workspace.project):
+        if not has_permission(
+            request.user, permissions.job_run, project=self.workspace.project
+        ):
             raise Http404
 
         if self.workspace.is_archived:

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -14,7 +14,7 @@ from pipeline import load_pipeline
 from zen_queries import TemplateResponse, fetch
 
 from .. import honeycomb
-from ..authorization import CoreDeveloper, has_permission, has_role
+from ..authorization import CoreDeveloper, has_permission, has_role, permissions
 from ..backends import backends_to_choices
 from ..forms import JobRequestCreateForm
 from ..github import _get_github_api
@@ -38,7 +38,7 @@ class JobRequestCancel(View):
             raise Http404
 
         can_cancel_jobs = job_request.created_by == request.user or has_permission(
-            request.user, "job_cancel", project=job_request.workspace.project
+            request.user, permissions.job_cancel, project=job_request.workspace.project
         )
         if not can_cancel_jobs:
             raise Http404
@@ -217,7 +217,7 @@ class JobRequestDetail(View):
         is_invalid = jobs.filter(action="__error__").exists()
 
         can_cancel_jobs = job_request.created_by == request.user or has_permission(
-            request.user, "job_cancel", project=job_request.workspace.project
+            request.user, permissions.job_cancel, project=job_request.workspace.project
         )
         honeycomb_can_view_links = has_role(self.request.user, CoreDeveloper)
 

--- a/jobserver/views/jobs.py
+++ b/jobserver/views/jobs.py
@@ -9,7 +9,7 @@ from django.views.generic import RedirectView, View
 from furl import furl
 
 from .. import honeycomb
-from ..authorization import CoreDeveloper, has_permission, has_role
+from ..authorization import CoreDeveloper, has_permission, has_role, permissions
 from ..models import Job, JobRequest
 
 
@@ -18,7 +18,9 @@ class JobCancel(View):
         job = get_object_or_404(Job, identifier=self.kwargs["identifier"])
 
         can_cancel_job = job.job_request.created_by == request.user or has_permission(
-            request.user, "job_cancel", project=job.job_request.workspace.project
+            request.user,
+            permissions.job_cancel,
+            project=job.job_request.workspace.project,
         )
         if not can_cancel_job:
             raise Http404
@@ -55,7 +57,9 @@ class JobDetail(View):
             return redirect(job)
 
         can_cancel_jobs = job.job_request.created_by == request.user or has_permission(
-            request.user, "job_cancel", project=job.job_request.workspace.project
+            request.user,
+            permissions.job_cancel,
+            project=job.job_request.workspace.project,
         )
 
         honeycomb_can_view_links = has_role(self.request.user, CoreDeveloper)

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -38,7 +38,7 @@ class ProjectDetail(View):
         project.status_description = nh3.clean(markdown(project.status_description))
 
         can_create_workspaces = has_permission(
-            request.user, "workspace_create", project=project
+            request.user, permissions.workspace_create, project=project
         )
 
         is_member = project.members.filter(username=request.user.username).exists()

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -249,7 +249,7 @@ class ProjectReportList(ListView):
         self.project = get_object_or_404(Project, slug=self.kwargs["project_slug"])
 
         self.can_view_unpublished_reports = has_permission(
-            self.request.user, "release_file_view", project=self.project
+            self.request.user, permissions.release_file_view, project=self.project
         )
 
         return super().dispatch(request, *args, **kwargs)

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -18,7 +18,7 @@ from zen_queries import fetch
 
 from jobserver.utils import set_from_qs
 
-from ..authorization import has_permission
+from ..authorization import has_permission, permissions
 from ..github import _get_github_api
 from ..models import Job, JobRequest, Project, PublishRequest, Repo, Snapshot
 
@@ -84,7 +84,7 @@ class ProjectDetail(View):
             )
 
         is_interactive_user = has_permission(
-            request.user, "analysis_request_create", project=project
+            request.user, permissions.analysis_request_create, project=project
         )
 
         with self.tracer.start_as_current_span("reports"):

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -241,7 +241,9 @@ class SnapshotDetail(View):
         }
 
         can_publish = has_permission(
-            request.user, "snapshot_publish", project=snapshot.workspace.project
+            request.user,
+            permissions.snapshot_publish,
+            project=snapshot.workspace.project,
         )
         if can_publish and snapshot.is_draft:
             context["publish_url"] = snapshot.get_publish_api_url()

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.views.generic import View
 
-from ..authorization import has_permission
+from ..authorization import has_permission, permissions
 from ..models import (
     Project,
     PublishRequest,
@@ -60,7 +60,7 @@ class ProjectReleaseList(View):
             raise Http404
 
         can_delete_files = has_permission(
-            request.user, "release_file_delete", project=project
+            request.user, permissions.release_file_delete, project=project
         )
         can_view_files = has_permission(
             request.user, "release_file_view", project=project
@@ -191,7 +191,7 @@ class ReleaseFileDelete(View):
 
         if not has_permission(
             request.user,
-            "release_file_delete",
+            permissions.release_file_delete,
             project=rfile.release.workspace.project,
         ):
             raise Http404
@@ -291,7 +291,7 @@ class WorkspaceReleaseList(View):
             raise Http404
 
         can_delete_files = has_permission(
-            request.user, "release_file_delete", project=workspace.project
+            request.user, permissions.release_file_delete, project=workspace.project
         )
         can_view_files = has_permission(
             request.user,

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -63,7 +63,7 @@ class ProjectReleaseList(View):
             request.user, permissions.release_file_delete, project=project
         )
         can_view_files = has_permission(
-            request.user, "release_file_view", project=project
+            request.user, permissions.release_file_view, project=project
         )
 
         releases = [
@@ -130,7 +130,7 @@ class ReleaseDetail(View):
 
         if not has_permission(
             request.user,
-            "release_file_view",
+            permissions.release_file_view,
             project=release.workspace.project,
         ):
             raise Http404
@@ -163,7 +163,7 @@ class ReleaseDownload(View):
 
         if not has_permission(
             request.user,
-            "release_file_view",
+            permissions.release_file_view,
             project=release.workspace.project,
         ):
             raise Http404
@@ -218,7 +218,9 @@ class SnapshotDetail(View):
         )
 
         has_permission_to_view = has_permission(
-            request.user, "release_file_view", project=snapshot.workspace.project
+            request.user,
+            permissions.release_file_view,
+            project=snapshot.workspace.project,
         )
         if snapshot.is_draft and not has_permission_to_view:
             raise Http404
@@ -265,7 +267,7 @@ class SnapshotDownload(View):
 
         can_view_unpublished_files = has_permission(
             request.user,
-            "release_file_view",
+            permissions.release_file_view,
             project=snapshot.workspace.project,
         )
         if snapshot.is_draft and not can_view_unpublished_files:
@@ -295,7 +297,7 @@ class WorkspaceReleaseList(View):
         )
         can_view_files = has_permission(
             request.user,
-            "release_file_view",
+            permissions.release_file_view,
             project=workspace.project,
         )
 

--- a/jobserver/views/reports.py
+++ b/jobserver/views/reports.py
@@ -7,7 +7,7 @@ from django.views.generic import View
 
 from interactive.models import AnalysisRequest
 
-from ..authorization import has_permission
+from ..authorization import has_permission, permissions
 from ..github import _get_github_api
 from ..issues import create_copilot_publish_report_request
 from ..models import PublishRequest
@@ -26,7 +26,7 @@ class PublishRequestCreate(View):
 
         if not has_permission(
             self.request.user,
-            "analysis_request_view",
+            permissions.analysis_request_view,
             project=self.analysis_request.project,
         ):
             raise PermissionDenied

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -17,7 +17,7 @@ from furl import furl
 
 from interactive.models import AnalysisRequest
 
-from ..authorization import CoreDeveloper, has_permission, has_role
+from ..authorization import CoreDeveloper, has_permission, has_role, permissions
 from ..forms import (
     WorkspaceArchiveToggleForm,
     WorkspaceCreateForm,
@@ -52,7 +52,9 @@ class WorkspaceAnalysisRequestList(ListView):
         )
 
         if not has_permission(
-            request.user, "analysis_request_create", project=self.workspace.project
+            request.user,
+            permissions.analysis_request_create,
+            project=self.workspace.project,
         ):
             raise PermissionDenied
 
@@ -308,7 +310,7 @@ class WorkspaceDetail(View):
         honeycomb_can_view_links = has_role(self.request.user, CoreDeveloper)
 
         is_interactive_user = has_permission(
-            request.user, "analysis_request_create", project=workspace.project
+            request.user, permissions.analysis_request_create, project=workspace.project
         )
         show_interactive_button = is_interactive_user and workspace.is_interactive
 

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -165,7 +165,7 @@ class WorkspaceCreate(CreateView):
 
         can_create_workspaces = has_permission(
             self.request.user,
-            "workspace_create",
+            permissions.workspace_create,
             project=self.project,
         )
         if not can_create_workspaces:
@@ -386,7 +386,7 @@ class WorkspaceEdit(FormView):
 
         can_create_workspaces = has_permission(
             self.request.user,
-            "workspace_create",
+            permissions.workspace_create,
             project=self.workspace.project,
         )
         if not can_create_workspaces:

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -353,7 +353,7 @@ class WorkspaceDetail(View):
         # a user can see backend files if they have access to at least one
         # backend and the permissions required to see outputs
         is_privileged_user = has_permission(
-            user, "release_file_view", project=workspace.project
+            user, permissions.release_file_view, project=workspace.project
         )
         has_backends = (
             user.is_authenticated and user.backends.exclude(level_4_url="").exists()
@@ -509,7 +509,7 @@ class WorkspaceLatestOutputsDetail(View):
 
         # only a privileged user can view the current files
         if not has_permission(
-            request.user, "release_file_view", project=workspace.project
+            request.user, permissions.release_file_view, project=workspace.project
         ):
             raise Http404
 
@@ -555,7 +555,7 @@ class WorkspaceLatestOutputsDownload(View):
 
         # only a privileged user can view the current files
         if not has_permission(
-            request.user, "release_file_view", project=workspace.project
+            request.user, permissions.release_file_view, project=workspace.project
         ):
             raise Http404
 
@@ -610,7 +610,7 @@ class WorkspaceOutputList(ListView):
         snapshots = workspace.snapshots.order_by("-created_at")
 
         can_view_all_files = has_permission(
-            request.user, "release_file_view", project=workspace.project
+            request.user, permissions.release_file_view, project=workspace.project
         )
         if not can_view_all_files:
             snapshots = snapshots.filter(

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -295,7 +295,7 @@ class WorkspaceDetail(View):
             request.user, "workspace_archive", project=workspace.project
         )
         can_run_jobs = has_permission(
-            request.user, "job_run", project=workspace.project
+            request.user, permissions.job_run, project=workspace.project
         )
         can_toggle_notifications = has_permission(
             request.user, "workspace_toggle_notifications", project=workspace.project

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -516,7 +516,7 @@ class WorkspaceLatestOutputsDetail(View):
         # only show the publish button if the user has permission to publish
         # ouputs
         can_publish = has_permission(
-            request.user, "snapshot_create", project=workspace.project
+            request.user, permissions.snapshot_create, project=workspace.project
         )
         prepare_url = workspace.get_create_snapshot_api_url() if can_publish else ""
 

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -121,7 +121,7 @@ class WorkspaceBackendFiles(View):
 
         if not has_permission(
             request.user,
-            "unreleased_outputs_view",
+            permissions.unreleased_outputs_view,
             project=workspace.project,
         ):
             raise Http404
@@ -469,7 +469,7 @@ class WorkspaceFileList(View):
 
         if not has_permission(
             request.user,
-            "unreleased_outputs_view",
+            permissions.unreleased_outputs_view,
             project=workspace.project,
         ):
             raise Http404

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -298,7 +298,9 @@ class WorkspaceDetail(View):
             request.user, permissions.job_run, project=workspace.project
         )
         can_toggle_notifications = has_permission(
-            request.user, "workspace_toggle_notifications", project=workspace.project
+            request.user,
+            permissions.workspace_toggle_notifications,
+            project=workspace.project,
         )
         has_backends = request.user.is_authenticated and request.user.backends.exists()
 
@@ -579,7 +581,9 @@ class WorkspaceNotificationsToggle(View):
         )
 
         if not has_permission(
-            request.user, "workspace_toggle_notifications", project=workspace.project
+            request.user,
+            permissions.workspace_toggle_notifications,
+            project=workspace.project,
         ):
             raise Http404
 

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -83,7 +83,7 @@ class WorkspaceArchiveToggle(View):
         )
 
         if not has_permission(
-            request.user, "workspace_archive", project=workspace.project
+            request.user, permissions.workspace_archive, project=workspace.project
         ):
             raise Http404
 
@@ -292,7 +292,7 @@ class WorkspaceDetail(View):
         )
 
         can_archive_workspace = has_permission(
-            request.user, "workspace_archive", project=workspace.project
+            request.user, permissions.workspace_archive, project=workspace.project
         )
         can_run_jobs = has_permission(
             request.user, permissions.job_run, project=workspace.project

--- a/staff/views/orgs.py
+++ b/staff/views/orgs.py
@@ -9,7 +9,7 @@ from django.views.generic import CreateView, FormView, ListView, UpdateView, Vie
 from django_htmx.http import HttpResponseClientRedirect
 from furl import furl
 
-from jobserver.authorization import CoreDeveloper
+from jobserver.authorization import CoreDeveloper, permissions
 from jobserver.authorization.decorators import require_permission, require_role
 from jobserver.models import Org, OrgMembership, User
 
@@ -42,7 +42,7 @@ def org_add_github_org(request, slug):
     return redirect(org.get_staff_url())
 
 
-@method_decorator(require_permission("org_create"), name="dispatch")
+@method_decorator(require_permission(permissions.org_create), name="dispatch")
 class OrgCreate(CreateView):
     fields = ["name"]
     model = Org

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -15,7 +15,7 @@ from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
 from django.views.generic import ListView, View
 
-from jobserver.authorization import CoreDeveloper, has_permission
+from jobserver.authorization import CoreDeveloper, has_permission, permissions
 from jobserver.authorization.decorators import require_role
 from jobserver.github import _get_github_api
 from jobserver.issues import create_switch_repo_to_public_request
@@ -75,7 +75,7 @@ class RepoDetail(View):
         }
 
     def build_disabled(self, repo, user):
-        can_sign_off = has_permission(user, "repo_sign_off_with_outputs")
+        can_sign_off = has_permission(user, permissions.repo_sign_off_with_outputs)
         return Disabled(
             already_signed_off=repo.internal_signed_off_at is not None,
             no_permission=repo.has_github_outputs and not can_sign_off,
@@ -199,7 +199,7 @@ class RepoSignOff(View):
         repo = get_object_or_404(Repo, url=unquote(self.kwargs["repo_url"]))
 
         if repo.has_github_outputs and not has_permission(
-            request.user, "repo_sign_off_with_outputs"
+            request.user, permissions.repo_sign_off_with_outputs
         ):
             msg = "The SignOffRepoWithOutputs role is required to sign off repos with outputs hosted on GitHub"
             messages.error(request, msg)

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -16,7 +16,7 @@ from zen_queries import fetch
 from interactive.commands import create_user
 from interactive.emails import send_welcome_email
 from jobserver.auditing.presenters.lookup import get_presenter
-from jobserver.authorization import roles
+from jobserver.authorization import permissions, roles
 from jobserver.authorization.decorators import require_permission
 from jobserver.authorization.forms import RolesForm
 from jobserver.authorization.utils import roles_for, strings_to_roles
@@ -39,7 +39,7 @@ from .qwargs_tools import qwargs
 logger = structlog.get_logger(__name__)
 
 
-@method_decorator(require_permission("user_manage"), name="dispatch")
+@method_decorator(require_permission(permissions.user_manage), name="dispatch")
 class UserAuditLog(ListView):
     paginate_by = 25
     template_name = "staff/user/audit_log.html"
@@ -87,7 +87,7 @@ class UserAuditLog(ListView):
         return fetch(qs.distinct())
 
 
-@method_decorator(require_permission("user_manage"), name="dispatch")
+@method_decorator(require_permission(permissions.user_manage), name="dispatch")
 class UserClearRoles(View):
     def post(self, request, *args, **kwargs):
         user = get_object_or_404(User, username=self.kwargs["username"])
@@ -97,7 +97,7 @@ class UserClearRoles(View):
         return redirect(get_next_url(request.GET, user.get_staff_roles_url()))
 
 
-@method_decorator(require_permission("user_manage"), name="dispatch")
+@method_decorator(require_permission(permissions.user_manage), name="dispatch")
 class UserCreate(FormView):
     form_class = UserCreateForm
     template_name = "staff/user/create.html"
@@ -132,7 +132,7 @@ class UserCreate(FormView):
         return redirect(get_next_url(self.request.GET, user.get_staff_url()))
 
 
-@method_decorator(require_permission("user_manage"), name="dispatch")
+@method_decorator(require_permission(permissions.user_manage), name="dispatch")
 class UserDetail(SingleObjectMixin, View):
     model = User
     slug_field = "username"
@@ -145,7 +145,7 @@ class UserDetail(SingleObjectMixin, View):
         return view.as_view()(request, *args, **kwargs)
 
 
-@method_decorator(require_permission("user_manage"), name="dispatch")
+@method_decorator(require_permission(permissions.user_manage), name="dispatch")
 class UserDetailWithEmail(UpdateView):
     fields = [
         "fullname",
@@ -184,7 +184,7 @@ class UserDetailWithEmail(UpdateView):
         return self.object.get_staff_url()
 
 
-@method_decorator(require_permission("user_manage"), name="dispatch")
+@method_decorator(require_permission(permissions.user_manage), name="dispatch")
 class UserDetailWithOAuth(UpdateView):
     form_class = UserForm
     model = User
@@ -240,7 +240,7 @@ class UserDetailWithOAuth(UpdateView):
         }
 
 
-@method_decorator(require_permission("user_manage"), name="dispatch")
+@method_decorator(require_permission(permissions.user_manage), name="dispatch")
 class UserList(ListView):
     paginate_by = 25
     template_name = "staff/user/list.html"
@@ -321,7 +321,7 @@ class UserList(ListView):
         return qs.distinct()
 
 
-@method_decorator(require_permission("user_manage"), name="dispatch")
+@method_decorator(require_permission(permissions.user_manage), name="dispatch")
 class UserRoleList(FormView):
     form_class = RolesForm
     template_name = "staff/user/role_list.html"
@@ -359,7 +359,7 @@ class UserRoleList(FormView):
         return super().get_initial() | {"roles": self.user.roles}
 
 
-@method_decorator(require_permission("user_manage"), name="dispatch")
+@method_decorator(require_permission(permissions.user_manage), name="dispatch")
 class UserSetOrgs(FormView):
     form_class = UserOrgsForm
     template_name = "staff/user/set_orgs.html"


### PR DESCRIPTION
This PR replaces permissions encoded as strings with their corresponding symbols. (I hope that's the right word for them; if not, then sorry computer scientists 🙁.) For example, it replaces `"workspace_toggle_notifications"` with `permissions.workspace_toggle_notifications`. Doing so makes it much easier to look up where, and how, permissions are used.

I've not replaced strings with symbols when the strings are expected values in the test suite. This gives me greater confidence that I've not made an error, and also avoids having to come up with another name for the concept of permissions, as a variable with that name often clobbers the module with that name.

One permission is unused. For more information, see #4255.