### PR TITLE
Fix backdrop blur causing outlines in Firefox

### DIFF
--- a/templates/index-unauthenticated.html
+++ b/templates/index-unauthenticated.html
@@ -11,7 +11,7 @@
 
 {% block full_width_content %}
 <div class="isolate sm:bg-bn-blush-50 relative overflow-hidden -mt-5 md:-mt-9">
-  <div class="hidden sm:block absolute inset-x-0 -z-10 transform-gpu overflow-hidden blur-3xl opacity-25">
+  <div class="hidden sm:block absolute inset-x-0 -z-10 overflow-hidden opacity-25">
     <svg class="relative -z-10 max-w-none -top-1/2" viewBox="0 0 1155 678">
       <path fill="url(#45de2b6b-92d5-4d68-a6a0-9b9b2abad533)" d="M317.219 518.975L203.852 678 0 438.341l317.219 80.634 204.172-286.402c1.307 132.337 45.083 346.658 209.733 145.248C936.936 126.058 882.053-94.234 1031.02 41.331c119.18 108.451 130.68 295.337 121.53 375.223L855 299l21.173 362.054-558.954-142.079z" />
       <defs>
@@ -22,7 +22,7 @@
       </defs>
     </svg>
   </div>
-  <div class="bg-bn-blush-50 sm:bg-transparent relative px-6 lg:px-8">
+  <div class="bg-bn-blush-50 sm:bg-transparent relative px-6 lg:px-8 backdrop-blur-3xl">
     <div class="mx-auto max-w-2xl py-16 sm:py-24 lg:py-32">
       <div class=" grid gap-y-6 text-center text-lg leading-relaxed text-oxford-800">
         <h1 class="text-4xl font-bold tracking-tight text-oxford-900 sm:text-6xl">


### PR DESCRIPTION
## Steps to replicate

1. Using Firefox, go to the home page as a logged out user
2. Click around in the hero header section of the home page
3. Weird background blocks show up

## Screenshot

![CleanShot 2024-04-17 at 10 12 31@2x](https://github.com/opensafely-core/job-server/assets/24863179/5197555c-2a62-4a22-aca6-00233908b33b)

## Resolution

Move the blur on the SVG background to the content element using [Backdrop Blur](https://tailwindcss.com/docs/backdrop-blur).