### PR TITLE
Simplify the `role_factory` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -352,16 +352,20 @@ def role_factory():
 
         name = f"Role_{permission}"
         assert name.isidentifier(), f"{name} is not a valid Python identifier"
-        Role = type(
-            name,
-            (object,),
-            {
-                "__module__": jobserver.authorization.roles.__name__,
-                "models": [],
-                "permissions": [permission],
-            },
-        )
-        setattr(jobserver.authorization.roles, name, Role)
+
+        Role = getattr(jobserver.authorization.roles, name, None)
+        if Role is None:
+            Role = type(
+                name,
+                (object,),
+                {
+                    "__module__": jobserver.authorization.roles.__name__,
+                    "models": [],
+                    "permissions": [permission],
+                },
+            )
+            setattr(jobserver.authorization.roles, name, Role)
+
         return Role
 
     return _role_factory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -338,9 +338,9 @@ def project_memberships(project_membership):
 
 @pytest.fixture
 def role_factory():
-    """A fixture for dynamically creating a role with a given set of permissions."""
+    """A fixture for dynamically creating a role with a given permission."""
 
-    def _role_factory(*, permissions):
+    def _role_factory(*, permission):
         # By using `type` as a class factory, we ensure `Role.permissions` is a class
         # attribute rather than an instance attribute.
 
@@ -350,7 +350,7 @@ def role_factory():
         # them using their dotted path. To accommodate the check and the import, we move
         # this role class into place with __module__ and setattr.
 
-        name = f"Role_{'_'.join(permissions)}"
+        name = f"Role_{permission}"
         assert name.isidentifier(), f"{name} is not a valid Python identifier"
         Role = type(
             name,
@@ -358,7 +358,7 @@ def role_factory():
             {
                 "__module__": jobserver.authorization.roles.__name__,
                 "models": [],
-                "permissions": permissions,
+                "permissions": [permission],
             },
         )
         setattr(jobserver.authorization.roles, name, Role)

--- a/tests/unit/applications/test_views.py
+++ b/tests/unit/applications/test_views.py
@@ -672,9 +672,7 @@ def test_validate_application_access_error():
 
 def test_validate_application_access_with_permission(role_factory):
     application = ApplicationFactory()
-    user = UserFactory(
-        roles=[role_factory(permissions=[permissions.application_manage])]
-    )
+    user = UserFactory(roles=[role_factory(permission=permissions.application_manage)])
     assert validate_application_access(user, application) is None
 
 

--- a/tests/unit/interactive/test_views.py
+++ b/tests/unit/interactive/test_views.py
@@ -39,7 +39,7 @@ def test_analysisrequestcreate_get_success(rf, project_membership, role_factory)
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_create])],
+        roles=[role_factory(permission=permissions.analysis_request_create)],
     )
 
     request = rf.get("/")
@@ -66,7 +66,7 @@ def test_analysisrequestcreate_post_failure(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_create])],
+        roles=[role_factory(permission=permissions.analysis_request_create)],
     )
 
     data = {
@@ -97,7 +97,7 @@ def test_analysisrequestcreate_post_success(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_create])],
+        roles=[role_factory(permission=permissions.analysis_request_create)],
     )
     add_codelist("bennett/event-codelist/event123")
     add_codelist("bennett/medication-codelist/medication123")
@@ -160,7 +160,7 @@ def test_analysisrequestdetail_success(rf, project_membership, role_factory):
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.release_file_view])],
+        roles=[role_factory(permission=permissions.release_file_view)],
     )
 
     request = rf.get("/")
@@ -196,7 +196,7 @@ def test_analysisrequestdetail_with_global_release_file_view(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = AnalysisRequestDetail.as_view()(
@@ -215,7 +215,7 @@ def test_analysisrequestdetail_with_release_file_view_on_another_project(
 
     user = UserFactory()
     project_membership(
-        user=user, roles=[role_factory(permissions=[permissions.release_file_view])]
+        user=user, roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     request = rf.get("/")
@@ -262,7 +262,7 @@ def test_analysisrequestdetail_login_redirect_with_different_domain(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.release_file_view])],
+        roles=[role_factory(permission=permissions.release_file_view)],
     )
 
     analysis_request = AnalysisRequestFactory(project=project, created_by=user)
@@ -288,7 +288,7 @@ def test_analysisrequestdetail_login_redirect_with_normal_settings(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.release_file_view])],
+        roles=[role_factory(permission=permissions.release_file_view)],
     )
 
     analysis_request = AnalysisRequestFactory(project=project, created_by=user)
@@ -314,7 +314,7 @@ def test_analysisrequestdetail_with_published_report(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.release_file_view])],
+        roles=[role_factory(permission=permissions.release_file_view)],
     )
 
     rfile = ReleaseFileFactory()
@@ -367,7 +367,7 @@ def test_reportedit_get_success(rf, project_membership, role_factory):
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_view])],
+        roles=[role_factory(permission=permissions.analysis_request_view)],
     )
     analysis_request = AnalysisRequestFactory(
         project=project,
@@ -394,7 +394,7 @@ def test_reportedit_no_report(rf, project_membership, role_factory):
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_view])],
+        roles=[role_factory(permission=permissions.analysis_request_view)],
     )
     analysis_request = AnalysisRequestFactory(
         project=project,
@@ -423,7 +423,7 @@ def test_reportedit_post_invalid(rf, project_membership, role_factory):
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_view])],
+        roles=[role_factory(permission=permissions.analysis_request_view)],
     )
     analysis_request = AnalysisRequestFactory(
         project=project,
@@ -455,7 +455,7 @@ def test_reportedit_post_success(rf, project_membership, role_factory):
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_view])],
+        roles=[role_factory(permission=permissions.analysis_request_view)],
     )
     analysis_request = AnalysisRequestFactory(
         project=project,
@@ -523,7 +523,7 @@ def test_reportedit_locked_with_approved_decision(rf, project_membership, role_f
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_view])],
+        roles=[role_factory(permission=permissions.analysis_request_view)],
     )
 
     PublishRequestFactory(
@@ -564,7 +564,7 @@ def test_reportedit_locked_with_pending_decision(rf, project_membership, role_fa
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_view])],
+        roles=[role_factory(permission=permissions.analysis_request_view)],
     )
     PublishRequestFactory(report=report, snapshot=snapshot)
 
@@ -600,7 +600,7 @@ def test_reportedit_unlocked_with_rejected_decision(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_view])],
+        roles=[role_factory(permission=permissions.analysis_request_view)],
     )
 
     PublishRequestFactory(

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1263,7 +1263,7 @@ def test_snapshotcreate_unknown_files(api_rf, project_membership, role_factory):
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.snapshot_create])],
+        roles=[role_factory(permission=permissions.snapshot_create)],
     )
 
     request = api_rf.post("/", data={"file_ids": ["test"]})
@@ -1288,7 +1288,7 @@ def test_snapshotcreate_with_existing_snapshot(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.snapshot_create])],
+        roles=[role_factory(permission=permissions.snapshot_create)],
     )
 
     request = api_rf.post("/", data={"file_ids": [release.files.first().pk]})
@@ -1319,7 +1319,7 @@ def test_snapshotcreate_with_permission(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.snapshot_create])],
+        roles=[role_factory(permission=permissions.snapshot_create)],
     )
 
     data = {
@@ -1369,7 +1369,7 @@ def test_snapshotpublishapi_already_published(api_rf, role_factory):
 
     request = api_rf.post("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.snapshot_publish])]
+        roles=[role_factory(permission=permissions.snapshot_publish)]
     )
 
     response = SnapshotPublishAPI.as_view()(
@@ -1392,7 +1392,7 @@ def test_snapshotpublishapi_success(api_rf, role_factory):
 
     request = api_rf.post("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.snapshot_publish])]
+        roles=[role_factory(permission=permissions.snapshot_publish)]
     )
 
     response = SnapshotPublishAPI.as_view()(
@@ -1412,7 +1412,7 @@ def test_snapshotpublishapi_unknown_snapshot(api_rf, role_factory):
 
     request = api_rf.post("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.snapshot_publish])]
+        roles=[role_factory(permission=permissions.snapshot_publish)]
     )
 
     response = SnapshotPublishAPI.as_view()(
@@ -1429,7 +1429,7 @@ def test_snapshotpublishapi_with_missing_publish_request(api_rf, role_factory):
 
     request = api_rf.post("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.snapshot_publish])]
+        roles=[role_factory(permission=permissions.snapshot_publish)]
     )
 
     with pytest.raises(Exception, match="Snapshot is missing publish request"):
@@ -1515,9 +1515,7 @@ def test_validate_upload_access_no_permission(rf):
 
 def test_validate_upload_access_not_a_backend_member(rf, role_factory):
     backend = BackendFactory()
-    user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_upload])]
-    )
+    user = UserFactory(roles=[role_factory(permission=permissions.release_file_upload)])
     workspace = WorkspaceFactory()
 
     request = rf.get(
@@ -1574,7 +1572,7 @@ def test_level4tokenauthenticationapi_success(
     project_membership(
         user=token_login_user,
         project=project1,
-        roles=[role_factory(permissions=[permissions.unreleased_outputs_view])],
+        roles=[role_factory(permission=permissions.unreleased_outputs_view)],
     )
 
     # another project, where user does *not* have permissions
@@ -1619,7 +1617,7 @@ def test_level4tokenauthenticationapi_success_privileged(
     project_membership(
         user=token_login_user,
         project=project,
-        roles=[role_factory(permissions=[permissions.unreleased_outputs_view])],
+        roles=[role_factory(permission=permissions.unreleased_outputs_view)],
     )
     workspace1 = WorkspaceFactory(project=project)
     workspace2 = WorkspaceFactory(project=project)
@@ -1655,7 +1653,7 @@ def test_level4tokenauthenticationapi_fails_not_backend(
     project_membership(
         user=token_login_user,
         project=project,
-        roles=[role_factory(permissions=[permissions.unreleased_outputs_view])],
+        roles=[role_factory(permission=permissions.unreleased_outputs_view)],
     )
 
     token = generate_login_token(token_login_user)
@@ -1677,7 +1675,7 @@ def test_level4tokenauthenticationapi_fails_invalid_token(
     project_membership(
         user=token_login_user,
         project=project,
-        roles=[role_factory(permissions=[permissions.unreleased_outputs_view])],
+        roles=[role_factory(permission=permissions.unreleased_outputs_view)],
     )
 
     generate_login_token(token_login_user)
@@ -1726,7 +1724,7 @@ def test_level4tokenauthenticationapi_fails_invalid_user(
     project_membership(
         user=user,
         project=project,
-        roles=[role_factory(permissions=[permissions.unreleased_outputs_view])],
+        roles=[role_factory(permission=permissions.unreleased_outputs_view)],
     )
 
     backend = BackendFactory()
@@ -1754,7 +1752,7 @@ def test_level4authorisationapi_success(
     project_membership(
         user=token_login_user,
         project=project1,
-        roles=[role_factory(permissions=[permissions.unreleased_outputs_view])],
+        roles=[role_factory(permission=permissions.unreleased_outputs_view)],
     )
 
     # another project, where user does *not* have permissions

--- a/tests/unit/jobserver/models/test_user.py
+++ b/tests/unit/jobserver/models/test_user.py
@@ -67,15 +67,15 @@ def test_user_get_absolute_url():
 def test_user_get_all_permissions(role_factory, project_membership):
     org = OrgFactory()
     project = ProjectFactory(orgs=[org])
-    user = UserFactory(roles=[role_factory(permissions=["a_global_permission"])])
+    user = UserFactory(roles=[role_factory(permission="a_global_permission")])
 
     OrgMembershipFactory(
-        org=org, user=user, roles=[role_factory(permissions=["an_org_permission"])]
+        org=org, user=user, roles=[role_factory(permission="an_org_permission")]
     )
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=["a_project_permission"])],
+        roles=[role_factory(permission="a_project_permission")],
     )
 
     output = user.get_all_permissions()

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -57,7 +57,7 @@ def test_jobrequestcancel_already_completed(rf, project_membership, role_factory
     project_membership(
         project=job_request.workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_cancel])],
+        roles=[role_factory(permission=permissions.job_cancel)],
     )
 
     request = rf.post("/")
@@ -82,7 +82,7 @@ def test_jobrequestcancel_success(rf, project_membership, role_factory):
     project_membership(
         project=job_request.workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_cancel])],
+        roles=[role_factory(permission=permissions.job_cancel)],
     )
 
     request = rf.post("/")
@@ -119,7 +119,7 @@ def test_jobrequestcancel_partially_completed(rf, project_membership, role_facto
     project_membership(
         project=job_request.workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_cancel])],
+        roles=[role_factory(permission=permissions.job_cancel)],
     )
 
     request = rf.post("/")
@@ -203,7 +203,7 @@ def test_jobrequestcreate_get_success(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     dummy_yaml = """
@@ -257,7 +257,7 @@ def test_jobrequestcreate_get_with_all_backends_removed(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     request = rf.get("/")
@@ -280,7 +280,7 @@ def test_jobrequestcreate_get_with_permission(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     dummy_yaml = """
@@ -327,7 +327,7 @@ def test_jobrequestcreate_get_with_project_yaml_errors(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     mocker.patch(
@@ -368,7 +368,7 @@ def test_jobrequestcreate_get_with_some_backends_removed(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     dummy_yaml = """
@@ -409,7 +409,7 @@ def test_jobrequestcreate_get_with_out_of_date_codelist(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     dummy_yaml = """
@@ -469,7 +469,7 @@ def test_jobrequestcreate_post_success(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     dummy_yaml = """
@@ -528,7 +528,7 @@ def test_jobrequestcreate_post_with_invalid_backend(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     dummy_yaml = """
@@ -571,7 +571,7 @@ def test_jobrequestcreate_post_with_notifications_default(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     dummy_yaml = """
@@ -628,7 +628,7 @@ def test_jobrequestcreate_post_with_notifications_override(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     dummy_yaml = """
@@ -686,7 +686,7 @@ def test_jobrequestcreate_post_cohortextractor_without_permission(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     dummy_yaml = """
@@ -733,7 +733,7 @@ def test_jobrequestcreate_post_sqlrunner_without_permission(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     dummy_yaml = """
@@ -798,7 +798,7 @@ def test_jobrequestcreate_post_with_codelists_error(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     dummy_yaml = """
@@ -892,7 +892,7 @@ def test_jobrequestcreate_with_archived_workspace(rf, project_membership, role_f
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     request = rf.get("/")
@@ -917,7 +917,7 @@ def test_jobrequestcreate_with_no_backends(rf, project_membership, role_factory)
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     request = rf.get("/")
@@ -992,7 +992,7 @@ def test_jobrequestdetail_with_permission(
     project_membership(
         project=job_request.workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_cancel])],
+        roles=[role_factory(permission=permissions.job_cancel)],
     )
 
     request = rf.get("/")
@@ -1060,7 +1060,7 @@ def test_jobrequestdetail_with_permission_with_completed_at(
     project_membership(
         project=job_request.workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_cancel])],
+        roles=[role_factory(permission=permissions.job_cancel)],
     )
 
     request = rf.get("/")

--- a/tests/unit/jobserver/views/test_jobs.py
+++ b/tests/unit/jobserver/views/test_jobs.py
@@ -24,7 +24,7 @@ def test_jobcancel_already_cancelled(rf, user, project_membership, role_factory)
     project_membership(
         project=job_request.workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_cancel])],
+        roles=[role_factory(permission=permissions.job_cancel)],
     )
 
     request = rf.post("/")
@@ -46,7 +46,7 @@ def test_jobcancel_already_completed(rf, user, project_membership, role_factory)
     project_membership(
         project=job_request.workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_cancel])],
+        roles=[role_factory(permission=permissions.job_cancel)],
     )
 
     request = rf.post("/")
@@ -69,7 +69,7 @@ def test_jobcancel_success(rf, project_membership, role_factory):
     project_membership(
         project=job_request.workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_cancel])],
+        roles=[role_factory(permission=permissions.job_cancel)],
     )
 
     request = rf.post("/")
@@ -161,7 +161,7 @@ def test_jobdetail_with_permission(rf, project_membership, role_factory):
     project_membership(
         project=job.job_request.workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_cancel])],
+        roles=[role_factory(permission=permissions.job_cancel)],
     )
 
     request = rf.get("/")

--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -69,7 +69,7 @@ def test_projectdetail_for_interactive_button(
 ):
     project = ProjectFactory()
     user = UserFactory(
-        roles=[role_factory(permissions=[permissions.analysis_request_create])]
+        roles=[role_factory(permission=permissions.analysis_request_create)]
     )
     project_membership(project=project, user=user)
 
@@ -87,7 +87,7 @@ def test_projectdetail_for_interactive_button(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_create])],
+        roles=[role_factory(permission=permissions.analysis_request_create)],
     )
 
     request = rf.get("/")
@@ -245,7 +245,7 @@ def test_projectedit_get_success(rf, project_membership, role_factory):
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.project_manage])],
+        roles=[role_factory(permission=permissions.project_manage)],
     )
 
     request = rf.get("/")
@@ -263,7 +263,7 @@ def test_projectedit_post_success(rf, project_membership, role_factory):
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.project_manage])],
+        roles=[role_factory(permission=permissions.project_manage)],
     )
 
     data = {
@@ -290,7 +290,7 @@ def test_projectedit_post_success_with_next(rf, project_membership, role_factory
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.project_manage])],
+        roles=[role_factory(permission=permissions.project_manage)],
     )
 
     data = {
@@ -336,7 +336,7 @@ def test_projectedit_user_has_global_project_manage(
     rf, project_membership, role_factory
 ):
     project = ProjectFactory()
-    user = UserFactory(roles=[role_factory(permissions=[permissions.project_manage])])
+    user = UserFactory(roles=[role_factory(permission=permissions.project_manage)])
     project_membership(project=project, user=user)
     request = rf.get("/")
     request.user = user
@@ -412,7 +412,7 @@ def test_projectreportlist_success(rf, project_membership, release, role_factory
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.release_file_view])],
+        roles=[role_factory(permission=permissions.release_file_view)],
     )
 
     request = rf.get("/")

--- a/tests/unit/jobserver/views/test_releases.py
+++ b/tests/unit/jobserver/views/test_releases.py
@@ -33,7 +33,7 @@ def test_projectreleaselist_no_releases(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     with pytest.raises(Http404):
@@ -81,12 +81,8 @@ def test_projectreleaselist_with_delete_permission(
     request = rf.get("/")
     request.user = UserFactory(
         roles=[
-            role_factory(
-                permissions=[
-                    permissions.release_file_delete,
-                    permissions.release_file_view,
-                ]
-            )
+            role_factory(permission=permissions.release_file_delete),
+            role_factory(permission=permissions.release_file_view),
         ]
     )
 
@@ -179,7 +175,7 @@ def test_releasedetail_unknown_release(rf):
 def test_releasedetail_with_path_success(rf, release, role_factory):
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = ReleaseDetail.as_view()(
@@ -211,7 +207,7 @@ def test_releasedetail_without_files(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     with pytest.raises(Http404):
@@ -228,7 +224,7 @@ def test_releasedownload_release_with_no_files(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     with pytest.raises(Http404):
@@ -243,7 +239,7 @@ def test_releasedownload_release_with_no_files(rf, role_factory):
 def test_releasedownload_success(rf, release, role_factory):
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = ReleaseDownload.as_view()(
@@ -261,7 +257,7 @@ def test_releasedownload_unknown_release(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     with pytest.raises(Http404):
@@ -291,7 +287,7 @@ def test_releasefiledelete_deleted_file(rf, role_factory):
 
     request = rf.post("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_delete])]
+        roles=[role_factory(permission=permissions.release_file_delete)]
     )
 
     with pytest.raises(Http404):
@@ -309,7 +305,7 @@ def test_releasefiledelete_no_file_on_disk(rf, role_factory):
 
     request = rf.post("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_delete])]
+        roles=[role_factory(permission=permissions.release_file_delete)]
     )
 
     with pytest.raises(Http404):
@@ -327,9 +323,7 @@ def test_releasefiledelete_success(rf, time_machine, release, role_factory):
     time_machine.move_to(now, tick=False)
 
     rfile = release.files.first()
-    user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_delete])]
-    )
+    user = UserFactory(roles=[role_factory(permission=permissions.release_file_delete)])
 
     request = rf.post("/")
     request.user = user
@@ -416,7 +410,7 @@ def test_snapshotdetail_published_with_permission(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = SnapshotDetail.as_view()(
@@ -458,12 +452,8 @@ def test_snapshotdetail_unpublished_with_permission_to_publish(rf, role_factory)
     request = rf.get("/")
     request.user = UserFactory(
         roles=[
-            role_factory(
-                permissions=[
-                    permissions.release_file_view,
-                    permissions.snapshot_publish,
-                ]
-            )
+            role_factory(permission=permissions.release_file_view),
+            role_factory(permission=permissions.snapshot_publish),
         ]
     )
 
@@ -484,7 +474,7 @@ def test_snapshotdetail_unpublished_without_permission_to_publish(rf, role_facto
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = SnapshotDetail.as_view()(
@@ -504,7 +494,7 @@ def test_snapshotdetail_unpublished_with_permission_to_view(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = SnapshotDetail.as_view()(
@@ -560,7 +550,7 @@ def test_snapshotdownload_published_with_permission(rf, release, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = SnapshotDownload.as_view()(
@@ -602,7 +592,7 @@ def test_snapshotdownload_unknown_snapshot(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     with pytest.raises(Http404):
@@ -622,7 +612,7 @@ def test_snapshotdownload_unpublished_with_permission(rf, release, role_factory)
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = SnapshotDownload.as_view()(
@@ -658,7 +648,7 @@ def test_snapshotdownload_with_no_files(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     with pytest.raises(Http404):
@@ -678,7 +668,7 @@ def test_workspacereleaselist_authenticated_to_view_not_delete(
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = WorkspaceReleaseList.as_view()(
@@ -711,12 +701,8 @@ def test_workspacereleaselist_authenticated_to_view_and_delete(
     request = rf.get("/")
     request.user = UserFactory(
         roles=[
-            role_factory(
-                permissions=[
-                    permissions.release_file_delete,
-                    permissions.release_file_view,
-                ]
-            )
+            role_factory(permission=permissions.release_file_delete),
+            role_factory(permission=permissions.release_file_view),
         ]
     )
 
@@ -741,7 +727,7 @@ def test_workspacereleaselist_no_releases(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     with pytest.raises(Http404):
@@ -792,12 +778,8 @@ def test_workspacereleaselist_build_files_for_latest(rf, build_release, role_fac
     request = rf.get("/")
     request.user = UserFactory(
         roles=[
-            role_factory(
-                permissions=[
-                    permissions.release_file_delete,
-                    permissions.release_file_view,
-                ]
-            )
+            role_factory(permission=permissions.release_file_delete),
+            role_factory(permission=permissions.release_file_view),
         ]
     )
 
@@ -820,12 +802,8 @@ def test_workspacereleaselist_build_files_for_releases(rf, build_release, role_f
     request = rf.get("/")
     request.user = UserFactory(
         roles=[
-            role_factory(
-                permissions=[
-                    permissions.release_file_delete,
-                    permissions.release_file_view,
-                ]
-            )
+            role_factory(permission=permissions.release_file_delete),
+            role_factory(permission=permissions.release_file_view),
         ]
     )
 

--- a/tests/unit/jobserver/views/test_reports.py
+++ b/tests/unit/jobserver/views/test_reports.py
@@ -26,7 +26,7 @@ def test_publishrequestcreate_get_success(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.analysis_request_view])]
+        roles=[role_factory(permission=permissions.analysis_request_view)]
     )
 
     response = PublishRequestCreate.as_view()(
@@ -46,7 +46,7 @@ def test_publishrequestcreate_locked_with_approved_decision(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_view])],
+        roles=[role_factory(permission=permissions.analysis_request_view)],
     )
 
     rfile = ReleaseFileFactory()
@@ -57,7 +57,7 @@ def test_publishrequestcreate_locked_with_approved_decision(
 
     request = rf.post("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.analysis_request_view])]
+        roles=[role_factory(permission=permissions.analysis_request_view)]
     )
 
     PublishRequestFactory(
@@ -89,7 +89,7 @@ def test_publishrequestcreate_locked_with_pending_decision(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_view])],
+        roles=[role_factory(permission=permissions.analysis_request_view)],
     )
 
     rfile = ReleaseFileFactory()
@@ -121,7 +121,7 @@ def test_publishrequestcreate_unlocked_with_rejected_decision(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.analysis_request_view])],
+        roles=[role_factory(permission=permissions.analysis_request_view)],
     )
 
     rfile = ReleaseFileFactory()
@@ -157,7 +157,7 @@ def test_publishrequestcreate_post_success(rf, slack_messages, role_factory):
 
     request = rf.post("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.analysis_request_view])]
+        roles=[role_factory(permission=permissions.analysis_request_view)]
     )
 
     # set up messages framework

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -55,7 +55,7 @@ def test_workspacearchivetoggle_success(rf, project_membership, role_factory):
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_archive])],
+        roles=[role_factory(permission=permissions.workspace_archive)],
     )
 
     request = rf.post("/", {"is_archived": "True"})
@@ -111,7 +111,7 @@ def test_workspacebackendfiles_success(rf, project_membership, role_factory):
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.unreleased_outputs_view])],
+        roles=[role_factory(permission=permissions.unreleased_outputs_view)],
     )
 
     request = rf.get("/")
@@ -167,7 +167,7 @@ def test_workspacebackendfiles_with_permission(rf, project_membership, role_fact
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.unreleased_outputs_view])],
+        roles=[role_factory(permission=permissions.unreleased_outputs_view)],
     )
 
     request = rf.get("/")
@@ -193,7 +193,7 @@ def test_workspacebackendfiles_without_backend_access(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.unreleased_outputs_view])],
+        roles=[role_factory(permission=permissions.unreleased_outputs_view)],
     )
 
     request = rf.get("/")
@@ -232,7 +232,7 @@ def test_workspacecreate_get_success(rf, project_membership, user, role_factory)
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_create])],
+        roles=[role_factory(permission=permissions.workspace_create)],
     )
 
     request = rf.get("/")
@@ -263,7 +263,7 @@ def test_workspacecreate_post_success(rf, project_membership, user, role_factory
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_create])],
+        roles=[role_factory(permission=permissions.workspace_create)],
     )
 
     data = {
@@ -291,7 +291,7 @@ def test_workspacecreate_without_github(rf, project_membership, user, role_facto
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_create])],
+        roles=[role_factory(permission=permissions.workspace_create)],
     )
 
     request = rf.get("/")
@@ -336,7 +336,7 @@ def test_workspacecreate_without_github_orgs(rf, project_membership, role_factor
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_create])],
+        roles=[role_factory(permission=permissions.workspace_create)],
     )
 
     request = rf.get("/")
@@ -355,7 +355,7 @@ def test_workspacecreate_without_org(rf, project_membership, role_factory):
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_create])],
+        roles=[role_factory(permission=permissions.workspace_create)],
     )
 
     request = rf.get("/")
@@ -386,7 +386,7 @@ def test_workspacedetail_authorized_archive_workspaces(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_archive])],
+        roles=[role_factory(permission=permissions.workspace_archive)],
     )
 
     request = rf.get("/")
@@ -424,7 +424,7 @@ def test_workspacedetail_authorized_public_repo_hide_change_visibility_banner(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_archive])],
+        roles=[role_factory(permission=permissions.workspace_archive)],
     )
 
     # this is what defines "private"
@@ -467,7 +467,7 @@ def test_workspacedetail_authorized_private_repo_show_change_visibility_banner(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_archive])],
+        roles=[role_factory(permission=permissions.workspace_archive)],
     )
 
     # this is what defines "private"
@@ -490,7 +490,7 @@ def test_workspacedetail_authorized_private_repo_show_change_visibility_banner(
 
 def test_workspacedetail_authorized_toggle_notifications(rf, role_factory):
     user = UserFactory(
-        roles=[role_factory(permissions=[permissions.workspace_toggle_notifications])]
+        roles=[role_factory(permission=permissions.workspace_toggle_notifications)]
     )
     workspace = WorkspaceFactory()
 
@@ -511,9 +511,7 @@ def test_workspacedetail_authorized_toggle_notifications(rf, role_factory):
 
 def test_workspacedetail_authorized_view_outputs(rf, role_factory):
     backend = BackendFactory(level_4_url="http://test/")
-    user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
-    )
+    user = UserFactory(roles=[role_factory(permission=permissions.release_file_view)])
     workspace = WorkspaceFactory()
     ReleaseFactory(workspace=workspace)
     snapshot = SnapshotFactory(workspace=workspace)
@@ -549,7 +547,7 @@ def test_workspacedetail_authorized_run_jobs(rf, project_membership, role_factor
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
     BackendMembershipFactory(backend=backend, user=user)
 
@@ -576,7 +574,7 @@ def test_workspacedetail_authorized_run_jobs_no_backends(
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.job_run])],
+        roles=[role_factory(permission=permissions.job_run)],
     )
 
     request = rf.get("/")
@@ -623,7 +621,7 @@ def test_workspacedetail_authorized_honeycomb(rf):
 def test_workspacedetail_for_interactive_button(rf, user, role_factory):
     workspace = WorkspaceFactory(name="testing-interactive")
     user = UserFactory(
-        roles=[role_factory(permissions=[permissions.analysis_request_create])]
+        roles=[role_factory(permission=permissions.analysis_request_create)]
     )
 
     request = rf.get("/")
@@ -727,7 +725,7 @@ def test_workspaceedit_get_success(rf, project_membership, role_factory):
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_create])],
+        roles=[role_factory(permission=permissions.workspace_create)],
     )
 
     request = rf.get("/")
@@ -762,7 +760,7 @@ def test_workspaceedit_post_success(rf, project_membership, role_factory):
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_create])],
+        roles=[role_factory(permission=permissions.workspace_create)],
     )
 
     request = rf.post("/", {"purpose": "test"})
@@ -973,7 +971,7 @@ def test_workspacefilelist_success(rf, project_membership, role_factory):
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.unreleased_outputs_view])],
+        roles=[role_factory(permission=permissions.unreleased_outputs_view)],
     )
 
     request = rf.get("/")
@@ -1010,7 +1008,7 @@ def test_workspacefilelist_without_backends(rf, project_membership, role_factory
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.unreleased_outputs_view])],
+        roles=[role_factory(permission=permissions.unreleased_outputs_view)],
     )
 
     request = rf.get("/")
@@ -1042,15 +1040,13 @@ def test_workspacefilelist_without_permission(rf):
 
 
 def test_workspacelatestoutputsdetail_success(rf, project_membership, role_factory):
-    user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
-    )
+    user = UserFactory(roles=[role_factory(permission=permissions.release_file_view)])
     workspace = WorkspaceFactory()
 
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.snapshot_create])],
+        roles=[role_factory(permission=permissions.snapshot_create)],
     )
 
     request = rf.get("/")
@@ -1085,7 +1081,7 @@ def test_workspacelatestoutputsdetail_without_publish_permission(rf, role_factor
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = WorkspaceLatestOutputsDetail.as_view()(
@@ -1116,7 +1112,7 @@ def test_workspacelatestoutputsdownload_no_files(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     with pytest.raises(Http404):
@@ -1136,7 +1132,7 @@ def test_workspacelatestoutputsdownload_success(
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = WorkspaceLatestOutputsDownload.as_view()(
@@ -1159,7 +1155,7 @@ def test_workspacelatestoutputsdownload_unknown_workspace(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     with pytest.raises(Http404):
@@ -1192,7 +1188,7 @@ def test_workspacenotificationstoggle_success(rf, project_membership, role_facto
     project_membership(
         project=workspace.project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_toggle_notifications])],
+        roles=[role_factory(permission=permissions.workspace_toggle_notifications)],
     )
 
     request = rf.post("/", {"should_notify": ""})
@@ -1236,7 +1232,7 @@ def test_workspacenotificationstoggle_unknown_workspace(
     project_membership(
         project=project,
         user=user,
-        roles=[role_factory(permissions=[permissions.workspace_toggle_notifications])],
+        roles=[role_factory(permission=permissions.workspace_toggle_notifications)],
     )
 
     request = rf.post("/")
@@ -1275,7 +1271,7 @@ def test_workspaceoutputlist_success(
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = WorkspaceOutputList.as_view()(
@@ -1334,7 +1330,7 @@ def test_workspaceoutputlist_without_snapshots(rf, time_machine, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.release_file_view])]
+        roles=[role_factory(permission=permissions.release_file_view)]
     )
 
     response = WorkspaceOutputList.as_view()(
@@ -1375,7 +1371,7 @@ def test_workspaceanalaysisrequestlist_success(rf, role_factory):
 
     request = rf.get("/")
     request.user = UserFactory(
-        roles=[role_factory(permissions=[permissions.analysis_request_create])]
+        roles=[role_factory(permission=permissions.analysis_request_create)]
     )
 
     response = WorkspaceAnalysisRequestList.as_view()(


### PR DESCRIPTION
Rather than associating a role with zero or many permissions, this associates a role with zero or one permission, making the implementation less error-prone. In the handful of cases where a function/method under test requires a user to have two permissions, we now assign the user two roles with one permission each. Previously, we would have assigned them one role with two permissions.

Thank you, @lucyb for suggesting this change when reviewing #4277.