### PR TITLE
Fix project templates

### DIFF
--- a/templates/staff/project/detail.html
+++ b/templates/staff/project/detail.html
@@ -150,7 +150,6 @@
           {% else %}
             {% list_group_empty class="w-full -ml-4" description="No organisations" %}
           {% endif %}
-          {% link href=project.org.get_staff_url text=project.org.name %}
         {% /description_item %}
 
         {% #description_item stacked=True title="Workspaces" %}

--- a/templates/staff/project/edit.html
+++ b/templates/staff/project/edit.html
@@ -58,7 +58,7 @@
   {% #card title="Organisations" container=True %}
     {% #form_fieldset class="w-full items-stretch gap-y-6" %}
       {% form_legend text="Organisations" class="sr-only" %}
-      {% form_select field=form.fields.orgs choices=form.fields.orgs.choices selected=form.orgs.value id="id_orgs" name="orgs" label="Select an organisation" required %}
+      {% form_select field=form.fields.orgs choices=form.fields.orgs.choices selected=form.orgs.value.0 id="id_orgs" name="orgs" label="Select an organisation" required %}
     {% /form_fieldset %}
   {% /card %}
 


### PR DESCRIPTION
Two fixes for project templates in the staff area. The first is cosmetic. The second, unfortunately, isn't.