### PR TITLE
Read output checking org and repo for airlock notifications from received payload

### DIFF
--- a/airlock/issues.py
+++ b/airlock/issues.py
@@ -54,11 +54,7 @@ def close_output_checking_issue(
 
 def update_output_checking_issue(release_request_id, updates, org, repo, github_api):
     updates_string = "\n".join([f"- {update}" for update in updates])
-    body = f"""
-        Release request updated:
-        {updates_string}
-    """
-    body = strip_whitespace(body)
+    body = f"Release request updated:\n{updates_string}"
 
     data = github_api.create_issue_comment(
         org=org,

--- a/airlock/issues.py
+++ b/airlock/issues.py
@@ -9,7 +9,7 @@ def get_issue_title(workspace_name, release_request_id):
 
 
 def create_output_checking_issue(
-    workspace, release_request_id, request_author, github_api
+    workspace, release_request_id, request_author, org, repo, github_api
 ):
     is_internal = request_author.orgs.filter(pk=settings.BENNETT_ORG_PK).exists()
 
@@ -29,8 +29,8 @@ def create_output_checking_issue(
     body = strip_whitespace(body)
 
     data = github_api.create_issue(
-        org="ebmdatalab",
-        repo="opensafely-output-review",
+        org=org,
+        repo=repo,
         title=get_issue_title(workspace.name, release_request_id),
         body=body,
         labels=["internal" if is_internal else "external"],
@@ -39,10 +39,12 @@ def create_output_checking_issue(
     return data["html_url"]
 
 
-def close_output_checking_issue(release_request_id, user, reason, github_api):
+def close_output_checking_issue(
+    release_request_id, user, reason, org, repo, github_api
+):
     data = github_api.close_issue(
-        org="ebmdatalab",
-        repo="opensafely-output-review",
+        org=org,
+        repo=repo,
         title_text=release_request_id,
         comment=f"Issue closed: {reason} by {user.username}",
     )
@@ -50,7 +52,7 @@ def close_output_checking_issue(release_request_id, user, reason, github_api):
     return data["html_url"]
 
 
-def update_output_checking_issue(release_request_id, user, updates, github_api):
+def update_output_checking_issue(release_request_id, updates, org, repo, github_api):
     updates_string = "\n".join([f"- {update}" for update in updates])
     body = f"""
         Release request updated:
@@ -59,8 +61,8 @@ def update_output_checking_issue(release_request_id, user, updates, github_api):
     body = strip_whitespace(body)
 
     data = github_api.create_issue_comment(
-        org="ebmdatalab",
-        repo="opensafely-output-review",
+        org=org,
+        repo=repo,
         title_text=release_request_id,
         body=body,
     )

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -42,6 +42,8 @@ class AirlockEvent:
     release_request_id: str
     request_author: User
     user: User
+    org: str
+    repo: str
 
     @classmethod
     def from_payload(cls, data):
@@ -63,6 +65,8 @@ class AirlockEvent:
             release_request_id=data.get("request"),
             request_author=request_author,
             user=user,
+            org=data.get("org"),
+            repo=data.get("repo"),
         )
 
     def describe_event(self):
@@ -85,6 +89,8 @@ def create_issue(airlock_event: AirlockEvent, github_api=None):
             airlock_event.workspace,
             airlock_event.release_request_id,
             airlock_event.request_author,
+            airlock_event.org,
+            airlock_event.repo,
             github_api,
         )
     except HTTPError:
@@ -99,6 +105,8 @@ def close_issue(airlock_event: AirlockEvent, github_api=None):
             airlock_event.release_request_id,
             airlock_event.user,
             reason,
+            airlock_event.org,
+            airlock_event.repo,
             github_api,
         )
     except HTTPError:
@@ -111,8 +119,9 @@ def update_issue(airlock_event: AirlockEvent, github_api=None):
     try:
         update_output_checking_issue(
             airlock_event.release_request_id,
-            airlock_event.user,
             updates,
+            airlock_event.org,
+            airlock_event.repo,
             github_api,
         )
     except HTTPError:

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -200,7 +200,7 @@ class GitHubAPI:
 
     def create_issue(self, org, repo, title, body, labels):
         if settings.DEBUG:  # pragma: no cover
-            logger.info("Issue created", title=title)
+            logger.info("Issue created", title=title, org=org, repo=repo, body=body)
             print("")
             print(f"Repo: https://github.com/{org}/{repo}/")
             print(f"Title: {title}")
@@ -208,7 +208,6 @@ class GitHubAPI:
             print(body)
             print("")
             return {"html_url": "http://example.com"}
-
         path_segments = [
             "repos",
             org,
@@ -278,7 +277,13 @@ class GitHubAPI:
         self, org, repo, title_text, body, latest=True, issue_number=None
     ):
         if settings.DEBUG:  # pragma: no cover
-            logger.info("Issue comment created", title_text=title_text, body=body)
+            logger.info(
+                "Issue comment created",
+                title_text=title_text,
+                org=org,
+                repo=repo,
+                body=body,
+            )
             print("")
             print(f"Repo: https://github.com/{org}/{repo}/")
             print(f"Title text: {title_text}")
@@ -321,7 +326,13 @@ class GitHubAPI:
 
     def close_issue(self, org, repo, title_text, comment=None, latest=True):
         if settings.DEBUG:  # pragma: no cover
-            logger.info("Issue closed", title_text=title_text, comment=comment)
+            logger.info(
+                "Issue closed",
+                title_text=title_text,
+                comment=comment,
+                org=org,
+                repo=repo,
+            )
             print("")
             print(f"Repo: https://github.com/{org}/{repo}/")
             print(f"Title text: {title_text}")

--- a/tests/unit/airlock/test_issues.py
+++ b/tests/unit/airlock/test_issues.py
@@ -21,7 +21,12 @@ def test_create_output_checking_request_external(github_api):
 
     assert (
         create_output_checking_issue(
-            workspace, "01AAA1AAAAAAA1AAAAA11A1AAA", user, github_api
+            workspace,
+            "01AAA1AAAAAAA1AAAAA11A1AAA",
+            user,
+            "ebmdatalab",
+            "opensafely-output-review",
+            github_api,
         )
         == "http://example.com"
     )
@@ -48,7 +53,12 @@ def test_create_output_checking_request_internal(github_api):
 
     assert (
         create_output_checking_issue(
-            workspace, "01AAA1AAAAAAA1AAAAA11A1AAA", user, github_api
+            workspace,
+            "01AAA1AAAAAAA1AAAAA11A1AAA",
+            user,
+            "ebmdatalab",
+            "opensafely-output-review",
+            github_api,
         )
         == "http://example.com"
     )
@@ -73,7 +83,12 @@ def test_close_output_checking_request(github_api):
     OrgMembershipFactory(org=org, user=user)
     assert (
         close_output_checking_issue(
-            "01AAA1AAAAAAA1AAAAA11A1AAA", user, "Closed for reasons", github_api
+            "01AAA1AAAAAAA1AAAAA11A1AAA",
+            user,
+            "Closed for reasons",
+            "ebmdatalab",
+            "opensafely-output-review",
+            github_api,
         )
         == "http://example.com/closed"
     )
@@ -99,8 +114,9 @@ def test_update_output_checking_request(github_api):
     assert (
         update_output_checking_issue(
             "01AAA1AAAAAAA1AAAAA11A1AAA",
-            user,
             ["file added (filegroup 'Group 1') by user test"],
+            "ebmdatalab",
+            "opensafely-output-review",
             github_api,
         )
         == "http://example.com/issues/comment"


### PR DESCRIPTION
Fixes https://github.com/opensafely-core/job-server/issues/4316
(along with Airlock PR https://github.com/opensafely-core/airlock/pull/306)

Also fixed a bug in the formatting for github that I found now that I was able to test real opening/updating/closing issues on the [test repo](https://github.com/ebmdatalab/output-checking-test/issues)