### PR TITLE
Expose datatable attributes in table-header component

### DIFF
--- a/templates/_components/table/table-header.html
+++ b/templates/_components/table/table-header.html
@@ -1,5 +1,5 @@
 <th
-  {% attrs data-type data-format scope %}
+  {% attrs data-type data-format data-searchable data-sortable data-hidden data-content data-order scope %}
   class="
     py-3.5 px-2 text-left text-sm font-semibold text-slate-900
     {% if nowrap %}whitespace-nowrap{% endif %}


### PR DESCRIPTION
As per docs:

https://fiduswriter.github.io/simple-datatables/documentation/Getting-Started
