### PR TITLE
Clarify `ProjectDeveloper` permissions

### DIFF
--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -132,9 +132,7 @@ class ProjectDeveloper:
     """
 
     display_name = "Project Developer"
-    description = (
-        "Run and cancel Jobs, publish released outputs, and manage workspaces."
-    )
+    description = "Run and cancel Jobs, and manage workspaces."
     models = [
         "jobserver.models.project_membership.ProjectMembership",
         "jobserver.models.user.User",


### PR DESCRIPTION
`ProjectDeveloper.description` stated that a project developer can publish released outputs. The ability to publish released outputs is governed by the `snapshot_publish` permission. However, `ProjectDeveloper.permissions` didn't include that permission.

We will assume that `ProjectDeveloper.permissions` is correct and `ProjectDeveloper.description` is incorrect, and remove the statement that a project developer can publish released outputs from `ProjectDeveloper.description`.

Closes #4331