### PR TITLE
Only add job-server deploy markers to job-server dataset

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,7 +198,7 @@ jobs:
           gh release download v0.2.10 -R honeycombio/honeymarker -p '*-linux-amd64*' -O honeymarker
           chmod 755 ./honeymarker
           # --dataset __all__ will ad an marker to *all* production datasets (this writekey is for production)
-          ./honeymarker --writekey ${{ secrets.HC_MARKER_APIKEY }} --dataset __all__ add --type deploy --msg "job-server deploy $GITHUB_SHA"
+          ./honeymarker --writekey ${{ secrets.HC_MARKER_APIKEY }} --dataset job-server add --type deploy --msg "job-server deploy $GITHUB_SHA"
 
       - name: Create Sentry release
         uses: getsentry/action-release@e769183448303de84c5a06aaaddf9da7be26d6c7 # v1.7.0


### PR DESCRIPTION
It was too noisy across all datasets
