### PR TITLE
Allow configuration of org/repo for airlock issues by organisation

### DIFF
--- a/airlock/config.py
+++ b/airlock/config.py
@@ -1,0 +1,7 @@
+ORG_OUTPUT_CHECKING_REPOS = {
+    "university-of-bristol": {
+        "org": "ebmdatalab",
+        "repo": "opensafely-output-review-bristol",
+    },
+    "default": {"org": "ebmdatalab", "repo": "opensafely-output-review"},
+}

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -154,6 +154,45 @@ def test_api_post_release_request_custom_org_and_repo(mock_create_issue, api_rf)
     ]
 
 
+@patch("airlock.views._get_github_api", FakeGitHubAPI)
+@patch("airlock.views.create_output_checking_issue")
+def test_api_post_release_request_default_org_and_repo(mock_create_issue, api_rf):
+    mock_create_issue.return_value = "http://example.com"
+    author = UserFactory(username="author")
+    workspace = WorkspaceFactory(name="test-workspace")
+    backend = BackendFactory(auth_token="test", name="test-backend")
+    BackendMembershipFactory(backend=backend, user=author)
+
+    data = {
+        "event_type": "request_submitted",
+        "updates": None,
+        "workspace": "test-workspace",
+        "request": "01AAA1AAAAAAA1AAAAA11A1AAA",
+        "request_author": author.username,
+        "user": author.username,
+    }
+    request = api_rf.post(
+        "/",
+        data=data,
+        format="json",
+        headers={
+            "authorization": "test",
+            "os-user": author.username,
+        },
+    )
+    response = airlock_event_view(request)
+    assert response.status_code == 201
+    assert response.data == {"status": "ok"}
+
+    assert list(mock_create_issue.call_args.args[:-1]) == [
+        workspace,
+        "01AAA1AAAAAAA1AAAAA11A1AAA",
+        author,
+        "ebmdatalab",
+        "opensafely-output-review",
+    ]
+
+
 @pytest.mark.parametrize(
     "event_type,updates,error",
     [


### PR DESCRIPTION
This allows  output-checking issues to be opened in custom repos, depending on organisation. Airlock can also send configuration to use, which allows an entire backend to use a different repo (e.g. the test backend, which we don't want to use a real output checking repo).

Note: the opensafely-readonly user will need to be added as a collaborator on Bristol's output checking repo so it has permissions to open/edit issues.