### PR TITLE
Update output-checking issues for Airlock returned and resubmitted events

### DIFF
--- a/airlock/emails.py
+++ b/airlock/emails.py
@@ -59,3 +59,20 @@ def send_request_updated_email(airlock_event):
         html_template_name="airlock/emails/request_updated.html",
         context=context,
     )
+
+
+def send_request_returned_email(airlock_event):
+    context = {
+        "release_request_id": airlock_event.release_request_id,
+        "request_author": airlock_event.request_author.name,
+        "workspace": airlock_event.workspace.name,
+    }
+
+    send(
+        to=airlock_event.request_author.email,
+        sender="notifications@jobs.opensafely.org",
+        subject=f"Release request returned: {airlock_event.workspace.name} ({airlock_event.release_request_id})",
+        template_name="airlock/emails/request_returned.txt",
+        html_template_name="airlock/emails/request_returned.html",
+        context=context,
+    )

--- a/templates/airlock/emails/request_returned.html
+++ b/templates/airlock/emails/request_returned.html
@@ -1,0 +1,6 @@
+{% extends "emails/base.html" %}
+
+{% block content %}
+<p>Dear {{ request_author }},</p>
+<p>Release request {{ release_request_id }} for {{ workspace }} has been returned.</p>
+{% endblock content %}

--- a/templates/airlock/emails/request_returned.txt
+++ b/templates/airlock/emails/request_returned.txt
@@ -1,0 +1,9 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
+
+Dear {{ request_author }},
+
+Release request {{ release_request_id }} for {{ workspace }} has been returned.
+
+{% endblock content %}

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -30,16 +30,20 @@ class FakeGithubApiWithError:
     [
         # No action for request_approved
         ("request_approved", True, None, False),
-        # author and user are different; emails are sent for rejected/released
+        # author and user are different; emails are sent for rejected/released/returned
+        ("request_submitted", False, None, False),
+        ("request_rejected", False, None, True),
+        ("request_withdrawn", False, None, False),
+        ("request_released", False, None, True),
+        ("request_returned", False, None, True),
+        ("request_resubmitted", False, None, False),
+        # author and user are the same; emails are still sent for rejected/released/returned
         ("request_submitted", True, None, False),
         ("request_rejected", True, None, True),
         ("request_withdrawn", True, None, False),
         ("request_released", True, None, True),
-        # author and user are the same; emails are still sent for rejected/released
-        ("request_submitted", True, None, False),
-        ("request_rejected", True, None, True),
-        ("request_withdrawn", True, None, False),
-        ("request_released", True, None, True),
+        ("request_returned", True, None, True),
+        ("request_resubmitted", True, None, False),
         # updated; emails are sent if at least one update is not by the author
         (
             "request_updated",
@@ -201,6 +205,16 @@ def test_api_post_release_request_default_org_and_repo(mock_create_issue, api_rf
         (
             "request_updated",
             [{"update_type": "file_added", "group": "Group 1", "user": "user"}],
+            "Error creating GitHub issue comment",
+        ),
+        (
+            "request_returned",
+            None,
+            "Error creating GitHub issue comment",
+        ),
+        (
+            "request_resubmitted",
+            None,
             "Error creating GitHub issue comment",
         ),
         ("bad_event_type", None, "Unknown event type 'BAD_EVENT_TYPE'"),


### PR DESCRIPTION
Airlock requests can now be returned and re-submitted. Notifications are sent accordingly:
- returned request: email author, update issue (add a comment to existing issue)
- resubmitted request:  update issue (add a comment to existing issue)

Note that we'll probably get rid of the UPDATED event type soon, and only send these notifications from Airlock on status changes (not on context/control editing or file adding/withdrawing), and the signature of the update_issue function might change, but leaving it as is for now.