### PR TITLE
Speed up file compression and decompression in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,13 +136,14 @@ jobs:
 
       - name: Save docker image
         run: |
-          docker save job-server | gzip > /tmp/job-server.tar.gz
+          docker save job-server | zstd --fast -o /tmp/job-server.tar.zst
 
       - name: Upload docker image
         uses: actions/upload-artifact@v4
         with:
             name: job-server-image
-            path: /tmp/job-server.tar.gz
+            path: /tmp/job-server.tar.zst
+            compression-level: 0
 
   deploy:
     needs: [check, test, docker-test, lint-dockerfile]
@@ -170,7 +171,7 @@ jobs:
             path: /tmp/image
 
       - name: Import docker image
-        run: gunzip -c /tmp/image/job-server.tar.gz | docker load
+        run: docker image load --input /tmp/image/job-server.tar.zst
 
       - name: Test image we imported from previous job works
         run: |


### PR DESCRIPTION
Replace gzip with ZStandard in fast mode.

Pass compressed file directly to `docker image load` removing a redundant separate decompression and pipe.

Fixes #4354 