### PR TITLE
Increase "Simple description" character limit

### DIFF
--- a/applications/form_specs.py
+++ b/applications/form_specs.py
@@ -132,7 +132,7 @@ form_specs = [
                         label="Provide a short lay description of your study purpose for the general public",
                         help_text=snippet("description-help_text"),
                         template_name="form_textarea",
-                        attributes=Attributes(maxlength=1500),
+                        attributes=Attributes(maxlength=2500),
                     ),
                 ],
             ),

--- a/snippets/description-help_text.md
+++ b/snippets/description-help_text.md
@@ -1,1 +1,1 @@
-Ideally 100-300 words, briefly covering background, populations/cohort, main comparator groups, what intervention or issue you are measuring and why it is important.
+Ideally 300-500 words, briefly covering background, populations/cohort, main comparator groups, what intervention or issue you are measuring and why it is important.


### PR DESCRIPTION
Increase the character limit for the "Study purpose" > "Simple description" field. We use characters as a proxy for words, as it's far easier to set a character limit than a word limit.

Changed elements highlighted in red, below.

![Study purpose](https://github.com/opensafely-core/job-server/assets/477263/e3572585-4081-4e65-b1df-4e54f7de0c11)

Co-authored-by: JulietUnderdown1 <162142133+JulietUnderdown1@users.noreply.github.com>

Closes #4374