### PR TITLE
Fix project redirect regression

### DIFF
--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -230,7 +230,7 @@ class ProjectEdit(UpdateView):
 
     @transaction.atomic()
     def form_valid(self, form):
-        new = projects.edit(old=self.object, form=form, by=self.request.user)
+        new = projects.edit(old=self.get_object(), form=form, by=self.request.user)
 
         return redirect(new.get_staff_url())
 


### PR DESCRIPTION
7ba76cf refactored project editing into a command
and in the process the `old` Project instance in
this edit method was changed from `form.get_object()`
to `form.object`.

The latter is the same as the `new` Project instance
and so redirects were being created with the same URL
for both old and new.

fixes #4158