### PR TITLE
Slack notifications for Airlock events

### DIFF
--- a/airlock/config.py
+++ b/airlock/config.py
@@ -16,3 +16,10 @@ ORG_OUTPUT_CHECKING_REPOS = {
         ),
     },
 }
+
+
+ORG_SLACK_CHANNELS = {
+    "default": env.str(
+        "DEFAULT_OUTPUT_CHECKING_SLACK_CHANNEL", default="opensafely-outputs"
+    ),
+}

--- a/airlock/config.py
+++ b/airlock/config.py
@@ -1,7 +1,18 @@
+from environs import Env
+
+
+env = Env()
+
+
 ORG_OUTPUT_CHECKING_REPOS = {
     "university-of-bristol": {
         "org": "ebmdatalab",
         "repo": "opensafely-output-review-bristol",
     },
-    "default": {"org": "ebmdatalab", "repo": "opensafely-output-review"},
+    "default": {
+        "org": "ebmdatalab",
+        "repo": env.str(
+            "DEFAULT_OUTPUT_CHECKING_REPO", default="opensafely-output-review"
+        ),
+    },
 }

--- a/airlock/issues.py
+++ b/airlock/issues.py
@@ -3,6 +3,8 @@ from furl import furl
 
 from jobserver.utils import strip_whitespace
 
+from .slack import post_slack_update
+
 
 def get_issue_title(workspace_name, release_request_id):
     return f"{workspace_name} {release_request_id}"
@@ -52,7 +54,9 @@ def close_output_checking_issue(
     return data["html_url"]
 
 
-def update_output_checking_issue(release_request_id, updates, org, repo, github_api):
+def update_output_checking_issue(
+    release_request_id, workspace_name, updates, org, repo, github_api, notify_slack
+):
     updates_string = "\n".join([f"- {update}" for update in updates])
     body = f"Release request updated:\n{updates_string}"
 
@@ -63,4 +67,13 @@ def update_output_checking_issue(release_request_id, updates, org, repo, github_
         body=body,
     )
 
-    return data["html_url"]
+    comment_url = data["html_url"]
+    if notify_slack:
+        post_slack_update(
+            org,
+            comment_url,
+            get_issue_title(workspace_name, release_request_id),
+            updates_string,
+        )
+
+    return comment_url

--- a/airlock/slack.py
+++ b/airlock/slack.py
@@ -1,0 +1,11 @@
+from services import slack
+
+from .config import ORG_SLACK_CHANNELS
+
+
+def post_slack_update(org, update_url, issue_title, update_text):
+    channel = ORG_SLACK_CHANNELS.get(org, ORG_SLACK_CHANNELS["default"])
+
+    title_link = slack.link(update_url, f"{issue_title} has been updated")
+    message_text = f"{title_link}\n{update_text}"
+    slack.post(message_text, channel)

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -123,8 +123,8 @@ def create_issue(airlock_event: AirlockEvent, github_api=None):
             airlock_event.repo,
             github_api,
         )
-    except HTTPError:
-        raise NotificationError("Error creating GitHub issue")
+    except HTTPError as e:
+        raise NotificationError(f"Error creating GitHub issue: {e}")
 
 
 def close_issue(airlock_event: AirlockEvent, github_api=None):
@@ -139,8 +139,8 @@ def close_issue(airlock_event: AirlockEvent, github_api=None):
             airlock_event.repo,
             github_api,
         )
-    except HTTPError:
-        raise NotificationError("Error closing GitHub issue")
+    except HTTPError as e:
+        raise NotificationError(f"Error closing GitHub issue: {e}")
 
 
 def update_issue(airlock_event: AirlockEvent, github_api=None):
@@ -154,8 +154,8 @@ def update_issue(airlock_event: AirlockEvent, github_api=None):
             airlock_event.repo,
             github_api,
         )
-    except HTTPError:
-        raise NotificationError("Error creating GitHub issue comment")
+    except HTTPError as e:
+        raise NotificationError(f"Error creating GitHub issue comment: {e}")
 
 
 def email_author(airlock_event: AirlockEvent):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ env = [
   "SECRET_KEY=12345",
   "SOCIAL_AUTH_GITHUB_KEY=test",
   "SOCIAL_AUTH_GITHUB_SECRET=test",
+  "DEFAULT_OUTPUT_CHECKING_REPO=test-repo",
 ]
 filterwarnings = [
     "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ env = [
   "SOCIAL_AUTH_GITHUB_KEY=test",
   "SOCIAL_AUTH_GITHUB_SECRET=test",
   "DEFAULT_OUTPUT_CHECKING_REPO=test-repo",
+  "DEFAULT_OUTPUT_CHECKING_SLACK_CHANNEL=test-channel",
 ]
 filterwarnings = [
     "error",

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -26,34 +26,37 @@ class FakeGithubApiWithError:
 
 
 @pytest.mark.parametrize(
-    "event_type,author_is_user,updates,email_sent",
+    "event_type,author_is_user,updates,email_sent,slack_notified",
     [
         # No action for request_approved
-        ("request_approved", True, None, False),
+        ("request_approved", True, None, False, False),
         # author and user are different; emails are sent for rejected/released/returned
-        ("request_submitted", False, None, False),
-        ("request_rejected", False, None, True),
-        ("request_withdrawn", False, None, False),
-        ("request_released", False, None, True),
-        ("request_returned", False, None, True),
-        ("request_resubmitted", False, None, False),
-        ("request_partially_reviewed", False, None, False),
-        ("request_reviewed", False, None, False),
+        # slack notifications are sent for resubmitted/partially_reviewed/reviewed
+        ("request_submitted", False, None, False, False),
+        ("request_rejected", False, None, True, False),
+        ("request_withdrawn", False, None, False, False),
+        ("request_released", False, None, True, False),
+        ("request_returned", False, None, True, False),
+        ("request_resubmitted", False, None, False, True),
+        ("request_partially_reviewed", False, None, False, True),
+        ("request_reviewed", False, None, False, True),
         # author and user are the same; emails are still sent for rejected/released/returned
-        ("request_submitted", True, None, False),
-        ("request_rejected", True, None, True),
-        ("request_withdrawn", True, None, False),
-        ("request_released", True, None, True),
-        ("request_returned", True, None, True),
-        ("request_resubmitted", True, None, False),
-        ("request_partially_reviewed", True, None, False),
-        ("request_reviewed", True, None, False),
+        # slack notifications are still sent for resubmitted/partially_reviewed/reviewed
+        ("request_submitted", True, None, False, False),
+        ("request_rejected", True, None, True, False),
+        ("request_withdrawn", True, None, False, False),
+        ("request_released", True, None, True, False),
+        ("request_returned", True, None, True, False),
+        ("request_resubmitted", True, None, False, True),
+        ("request_partially_reviewed", True, None, False, True),
+        ("request_reviewed", True, None, False, True),
         # updated; emails are sent if at least one update is not by the author
         (
             "request_updated",
             True,
             [{"update_type": "file_added", "group": "Group 1", "user": "test_user"}],
             True,
+            False,
         ),
         (
             "request_updated",
@@ -61,6 +64,7 @@ class FakeGithubApiWithError:
             [
                 {"update_type": "context_edited", "group": "Group 2", "user": "author"},
             ],
+            False,
             False,
         ),
         (
@@ -75,12 +79,20 @@ class FakeGithubApiWithError:
                 {"update_type": "comment_added", "group": "Group 1", "user": "author"},
             ],
             True,
+            False,
         ),
     ],
 )
 @patch("airlock.views._get_github_api", FakeGitHubAPI)
 def test_api_post_release_request_post_by_non_author(
-    api_rf, mailoutbox, event_type, author_is_user, updates, email_sent
+    api_rf,
+    mailoutbox,
+    slack_messages,
+    event_type,
+    author_is_user,
+    updates,
+    email_sent,
+    slack_notified,
 ):
     author = UserFactory(username="author")
     if author_is_user:
@@ -119,6 +131,11 @@ def test_api_post_release_request_post_by_non_author(
         assert len(mailoutbox) == 1
     else:
         assert len(mailoutbox) == 0
+
+    if slack_notified:
+        assert len(slack_messages) == 1
+    else:
+        assert len(slack_messages) == 0
 
 
 @patch("airlock.views._get_github_api", FakeGitHubAPI)

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -16,13 +16,13 @@ from tests.fakes import FakeGitHubAPI
 
 class FakeGithubApiWithError:
     def create_issue(*args, **kwargs):
-        raise HTTPError()
+        raise HTTPError("An error occurred")
 
     def create_issue_comment(*args, **kwargs):
-        raise HTTPError()
+        raise HTTPError("An error occurred")
 
     def close_issue(*args, **kwargs):
-        raise HTTPError()
+        raise HTTPError("An error occurred")
 
 
 @pytest.mark.parametrize(
@@ -204,22 +204,22 @@ def test_api_post_release_request_default_org_and_repo(mock_create_issue, api_rf
 @pytest.mark.parametrize(
     "event_type,updates,error",
     [
-        ("request_submitted", None, "Error creating GitHub issue"),
-        ("request_rejected", None, "Error closing GitHub issue"),
+        ("request_submitted", None, "Error creating GitHub issue: An error occurred"),
+        ("request_rejected", None, "Error closing GitHub issue: An error occurred"),
         (
             "request_updated",
             [{"update_type": "file_added", "group": "Group 1", "user": "user"}],
-            "Error creating GitHub issue comment",
+            "Error creating GitHub issue comment: An error occurred",
         ),
         (
             "request_returned",
             None,
-            "Error creating GitHub issue comment",
+            "Error creating GitHub issue comment: An error occurred",
         ),
         (
             "request_resubmitted",
             None,
-            "Error creating GitHub issue comment",
+            "Error creating GitHub issue comment: An error occurred",
         ),
         ("bad_event_type", None, "Unknown event type 'BAD_EVENT_TYPE'"),
     ],

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -197,7 +197,7 @@ def test_api_post_release_request_default_org_and_repo(mock_create_issue, api_rf
         "01AAA1AAAAAAA1AAAAA11A1AAA",
         author,
         "ebmdatalab",
-        "opensafely-output-review",
+        "test-repo",
     ]
 
 


### PR DESCRIPTION
Fixes https://github.com/opensafely-core/airlock/issues/402

The following release request changes need to notify output checkers, and don't automatically post in slack (they update an existing github issue by adding a comment, which doesn't get posted into slack by the github integration):
- partially reviewed (i.e. reviewed by the first output-checker) in a round
- fully reviewed (i.e. reviewed by the second output-checker) in a round
- resubmitted (after a request was previously reviewed and returned)