### PR TITLE
Update Permissions-Policy to disable Topics

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -362,6 +362,9 @@ INTERNAL_IPS = [
 # Permissions Policy
 PERMISSIONS_POLICY = {
     "interest-cohort": [],
+    # The following disables Google's Topics. For more information, see:
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/browsing-topics
+    "browsing-topics": [],
 }
 
 # Python/Django Social Auth


### PR DESCRIPTION
django-permissions-policy was added by #495 to disable Google's [Federated Learning of Cohorts](https://privacysandbox.com/proposals/floc/) (FLoC). FLoC was replaced by [Topics](https://privacysandbox.com/proposals/topics/) in May 2023, so we update the Permissions-Policy header to disable Topics.

Closes #4390