### PR TITLE
Move hard-coded slack channels and github repos to settings

### DIFF
--- a/airlock/config.py
+++ b/airlock/config.py
@@ -1,7 +1,4 @@
-from environs import Env
-
-
-env = Env()
+from django.conf import settings
 
 
 ORG_OUTPUT_CHECKING_REPOS = {
@@ -10,16 +7,10 @@ ORG_OUTPUT_CHECKING_REPOS = {
         "repo": "opensafely-output-review-bristol",
     },
     "default": {
-        "org": "ebmdatalab",
-        "repo": env.str(
-            "DEFAULT_OUTPUT_CHECKING_REPO", default="opensafely-output-review"
-        ),
+        "org": settings.DEFAULT_OUTPUT_CHECKING_GITHUB_ORG,
+        "repo": settings.DEFAULT_OUTPUT_CHECKING_REPO,
     },
 }
 
 
-ORG_SLACK_CHANNELS = {
-    "default": env.str(
-        "DEFAULT_OUTPUT_CHECKING_SLACK_CHANNEL", default="opensafely-outputs"
-    ),
-}
+ORG_SLACK_CHANNELS = {"default": settings.DEFAULT_OUTPUT_CHECKING_SLACK_CHANNEL}

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -32,3 +32,17 @@ VITE_SENTRY_DSN=
 
 # To send to honecomb in dev, create a token for the development and set it here.
 # OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=TOKEN34"
+
+
+# For issues and slack notifications in dev
+# If DEBUG is on, job-server will print messages to the console and won't
+# attempt to create issues or post to slack. These variables are only required
+# for testing real slack notifications and GitHub issues with DEBUG off.
+# Note these all have prod defaults in settings.py
+# RELEASES_SLACK_CHANNEL=
+# REGISTRATIONS_SLACK_CHANNEL=
+# APPLICATIONS_SLACK_CHANNEL=
+# COPILOT_SUPPORT_SLACK_CHANNEL=
+# DEFAULT_OUTPUT_CHECKING_SLACK_CHANNEL=
+# DEFAULT_OUTPUT_CHECKING_GITHUB_ORG
+# DEFAULT_OUTPUT_CHECKING_REPO=

--- a/interactive/issues.py
+++ b/interactive/issues.py
@@ -43,8 +43,8 @@ def create_output_checking_request(job_request, github_api):
     body = strip_whitespace(body)
 
     return github_api.create_issue(
-        org="ebmdatalab",
-        repo="opensafely-output-review",
+        org=settings.DEFAULT_OUTPUT_CHECKING_GITHUB_ORG,
+        repo=settings.DEFAULT_OUTPUT_CHECKING_REPO,
         title=f"Review request: {job_request.workspace.project.name} [{job_request.analysis_request.pk}]",
         body=body,
         labels=["interactive"],

--- a/jobserver/issues.py
+++ b/jobserver/issues.py
@@ -119,8 +119,8 @@ def create_output_checking_request(release, github_api):
     body = strip_whitespace(body)
 
     data = github_api.create_issue(
-        org="ebmdatalab",
-        repo="opensafely-output-review",
+        org=settings.DEFAULT_OUTPUT_CHECKING_GITHUB_ORG,
+        repo=settings.DEFAULT_OUTPUT_CHECKING_REPO,
         title=release.workspace.name,
         body=body,
         labels=["internal" if is_internal else "external"],

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -407,6 +407,33 @@ BACKEND_IP_MAP = {
     # "127.0.0.1": "tpp",
 }
 
+
+# SLACK CHANNELS
+RELEASES_SLACK_CHANNEL = env.str(
+    "RELEASES_SLACK_CHANNEL", default="opensafely-releases"
+)
+REGISTRATIONS_SLACK_CHANNEL = env.str(
+    "REGISTRATIONS_SLACK_CHANNEL", default="job-server-registrations"
+)
+APPLICATIONS_SLACK_CHANNEL = env.str(
+    "RELEASES_SLACK_CHANNEL", default="job-server-applications"
+)
+COPILOT_SUPPORT_SLACK_CHANNEL = env.str(
+    "COPILOT_SUPPORT_SLACK_CHANNEL", default="co-pilot-support"
+)
+# for Airlock
+DEFAULT_OUTPUT_CHECKING_SLACK_CHANNEL = env.str(
+    "DEFAULT_OUTPUT_CHECKING_SLACK_CHANNEL", "opensafely-outputs"
+)
+
+# OUTPUT_CHECKING_REPOS
+DEFAULT_OUTPUT_CHECKING_GITHUB_ORG = env.str(
+    "DEFAULT_OUTPUT_CHECKING_GITHUB_ORG", "ebmdatalab"
+)
+DEFAULT_OUTPUT_CHECKING_REPO = env.str(
+    "DEFAULT_OUTPUT_CHECKING_REPO", "opensafely-output-review"
+)
+
 # These orgs are not copiloted
 BENNETT_ORG_PK = 3
 GRAPHNET_ORG_PK = 12

--- a/jobserver/slacks.py
+++ b/jobserver/slacks.py
@@ -15,7 +15,7 @@ from .utils import strip_whitespace
 
 
 def notify_github_release(
-    path, created_by, files, backend, channel="opensafely-releases"
+    path, created_by, files, backend, channel=settings.RELEASES_SLACK_CHANNEL
 ):
     """
     path: path on level 4 server
@@ -34,7 +34,7 @@ def notify_github_release(
     slack.post(text="\n".join(message), channel=channel)
 
 
-def notify_release_created(release, channel="opensafely-releases"):
+def notify_release_created(release, channel=settings.RELEASES_SLACK_CHANNEL):
     workspace_url = slack.link(
         release.workspace.get_absolute_url(), release.workspace.name
     )
@@ -46,7 +46,7 @@ def notify_release_created(release, channel="opensafely-releases"):
     slack.post(message, channel)
 
 
-def notify_release_file_uploaded(rfile, channel="opensafely-releases"):
+def notify_release_file_uploaded(rfile, channel=settings.RELEASES_SLACK_CHANNEL):
     release = rfile.release
     user = rfile.created_by
 
@@ -65,14 +65,16 @@ def notify_release_file_uploaded(rfile, channel="opensafely-releases"):
     slack.post(message, channel)
 
 
-def notify_new_user(user, channel="job-server-registrations"):
+def notify_new_user(user, channel=settings.REGISTRATIONS_SLACK_CHANNEL):
     slack.post(
         text=f"New user ({user.username}) registered: {slack.link(user.get_staff_url())}",
         channel=channel,
     )
 
 
-def notify_application(application, user, msg, channel="job-server-applications"):
+def notify_application(
+    application, user, msg, channel=settings.APPLICATIONS_SLACK_CHANNEL
+):
     """
     Send a message to slack about an Application instance
 
@@ -85,7 +87,9 @@ def notify_application(application, user, msg, channel="job-server-applications"
     )
 
 
-def notify_copilot_windows_closing(projects, channel="co-pilot-support"):
+def notify_copilot_windows_closing(
+    projects, channel=settings.COPILOT_SUPPORT_SLACK_CHANNEL
+):
     def build_line(p):
         end_date = naturalday(p.copilot_support_ends_at)
         return f"\n * {slack.link(p.get_staff_url(), p.name)} ({end_date})"
@@ -96,7 +100,9 @@ def notify_copilot_windows_closing(projects, channel="co-pilot-support"):
     slack.post(text=message, channel=channel)
 
 
-def notify_copilots_of_repo_sign_off(repo, channel="co-pilot-support"):
+def notify_copilots_of_repo_sign_off(
+    repo, channel=settings.COPILOT_SUPPORT_SLACK_CHANNEL
+):
     repo_link = slack.link(repo.get_staff_url(), repo.name)
 
     user_link = slack.link(
@@ -130,7 +136,7 @@ def notify_copilots_of_repo_sign_off(repo, channel="co-pilot-support"):
 
 
 def notify_copilots_of_publish_request(
-    publish_request, report, issue_url, channel="co-pilot-support"
+    publish_request, report, issue_url, channel=settings.COPILOT_SUPPORT_SLACK_CHANNEL
 ):
     report_url = furl(settings.BASE_URL) / report.get_absolute_url()
 


### PR DESCRIPTION
Instead of hard-coding slack channels and github org/repos in multiple places, move them to settings and allow them to be overridden by environment variables. This makes it much easier to  set up local testing that includes testing slack/github integrations without posting to production channels/repos.