### PR TITLE
Return info about workspace archived status in releases auth endpoint

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -580,8 +580,11 @@ def build_level4_user(user):
     # this is 1 or 2 queries per project, not ideal, but we permissions are not stored in the db
     for project in user.projects.all():
         if has_permission(user, permissions.unreleased_outputs_view, project=project):
-            for workspace in project.workspaces.all().values("name"):
-                workspaces[workspace["name"]] = {"project": project.name}
+            for workspace in project.workspaces.all().values("name", "is_archived"):
+                workspaces[workspace["name"]] = {
+                    "project": project.name,
+                    "archived": workspace["is_archived"],
+                }
 
     # using a DRF serializer for now, so we've *some* schema definition
     level4_user = Level4AuthenticatedUser(

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1618,7 +1618,7 @@ def test_level4tokenauthenticationapi_success(
 ):
     # give user correct permissions on this project
     project1 = ProjectFactory()
-    workspace1 = WorkspaceFactory(project=project1)
+    workspace1 = WorkspaceFactory(project=project1, is_archived=True)
     workspace2 = WorkspaceFactory(project=project1)
     project_membership(
         user=token_login_user,
@@ -1647,8 +1647,8 @@ def test_level4tokenauthenticationapi_success(
         "username": token_login_user.username,
         "fullname": token_login_user.fullname,
         "workspaces": {
-            workspace1.name: {"project": project1.name},
-            workspace2.name: {"project": project1.name},
+            workspace1.name: {"project": project1.name, "archived": True},
+            workspace2.name: {"project": project1.name, "archived": False},
         },  # should not include workspace3
         "output_checker": False,
         "staff": False,
@@ -1689,8 +1689,8 @@ def test_level4tokenauthenticationapi_success_privileged(
         "username": token_login_user.username,
         "fullname": token_login_user.fullname,
         "workspaces": {
-            workspace1.name: {"project": project.name},
-            workspace2.name: {"project": project.name},
+            workspace1.name: {"project": project.name, "archived": False},
+            workspace2.name: {"project": project.name, "archived": False},
         },  # should not include workspace3
         "output_checker": True,
         "staff": True,
@@ -1826,8 +1826,8 @@ def test_level4authorisationapi_success(
         "username": token_login_user.username,
         "fullname": token_login_user.fullname,
         "workspaces": {
-            workspace1.name: {"project": project1.name},
-            workspace2.name: {"project": project1.name},
+            workspace1.name: {"project": project1.name, "archived": False},
+            workspace2.name: {"project": project1.name, "archived": False},
         },  # should not include workspace3
         "output_checker": False,
         "staff": False,


### PR DESCRIPTION
Airlock needs information about whether a user's workspaces are archived, so it can allow browsing of those workspaces, but restrict release requests for them. 