### PR TITLE
Improve testing of redirects following project edit

### DIFF
--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -421,6 +421,7 @@ def test_projectedit_post_success_when_not_changing_slug(rf, core_developer):
     assert project.slug == "test"
     assert project.number == 456
     assert project.copilot == new_copilot
+    assert project.redirects.count() == 0
 
 
 def test_projectedit_post_unauthorized(rf):

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -360,6 +360,7 @@ def test_projectedit_get_unauthorized(rf):
 
 def test_projectedit_post_success(rf, core_developer):
     project = ProjectFactory(name="test", number=123, orgs=[OrgFactory()])
+    old_project_url = project.get_absolute_url()
 
     new_copilot = UserFactory()
     new_org = OrgFactory()
@@ -390,6 +391,7 @@ def test_projectedit_post_success(rf, core_developer):
     assert set_from_qs(project.orgs.all()) == {new_org.pk}
     assert project.updated_by == core_developer
     assert project.redirects.count() == 1
+    assert project.redirects.first().old_url == old_project_url
 
 
 def test_projectedit_post_success_when_not_changing_slug(rf, core_developer):


### PR DESCRIPTION
#4407  was missing a suitable test for the reported bug condition that a editing a project's slug resulted in creation of a redirect where the old and new URLs were the same.

This PR adds such a test in, and also checks that redirects are not created where projects are edited without changing the slug.