### PR TITLE
Remove staff_nav function

### DIFF
--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -28,30 +28,6 @@ def disable_creating_jobs(request):
     return {"disable_creating_jobs": settings.DISABLE_CREATING_JOBS}
 
 
-@queries_dangerously_enabled()
-def staff_nav(request):
-    if not has_role(request.user, CoreDeveloper):
-        return {"staff_nav": []}
-
-    is_active = functools.partial(_is_active, request)
-
-    items = [
-        NavItem(name="Analysis Requests", url_name="staff:analysis-request-list"),
-        NavItem(name="Applications", url_name="staff:application-list"),
-        NavItem(name="Backends", url_name="staff:backend-list"),
-        NavItem(name="Dashboards", url_name="staff:dashboard:index"),
-        NavItem(name="Orgs", url_name="staff:org-list"),
-        NavItem(name="Redirects", url_name="staff:redirect-list"),
-        NavItem(name="Projects", url_name="staff:project-list"),
-        NavItem(name="Reports", url_name="staff:report-list"),
-        NavItem(name="Repos", url_name="staff:repo-list"),
-        NavItem(name="Users", url_name="staff:user-list"),
-        NavItem(name="Workspaces", url_name="staff:workspace-list"),
-    ]
-
-    return {"staff_nav": list(iter_nav(items, request, is_active))}
-
-
 def nav(request):
     is_active = functools.partial(_is_active, request)
 

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -113,7 +113,6 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "django.template.context_processors.media",
                 "jobserver.context_processors.can_view_staff_area",
-                "jobserver.context_processors.staff_nav",
                 "jobserver.context_processors.nav",
                 "jobserver.context_processors.disable_creating_jobs",
                 "jobserver.context_processors.login_url",

--- a/tests/unit/jobserver/test_context_processors.py
+++ b/tests/unit/jobserver/test_context_processors.py
@@ -1,8 +1,6 @@
-import pytest
 from django.urls import reverse
-from first import first
 
-from jobserver.context_processors import can_view_staff_area, nav, staff_nav
+from jobserver.context_processors import can_view_staff_area, nav
 
 from ...factories import UserFactory
 
@@ -19,25 +17,6 @@ def test_can_view_staff_area_without_core_developer(rf):
     request.user = UserFactory()
 
     assert not can_view_staff_area(request)["user_can_view_staff_area"]
-
-
-@pytest.mark.parametrize(
-    ("url_name",),
-    [("backend-list",), ("project-list",), ("user-list",)],
-)
-def test_staff_nav_selected_urls(rf, core_developer, url_name):
-    url = reverse(f"staff:{url_name}")
-
-    request = rf.get(url)
-    request.user = core_developer
-
-    nav_items = staff_nav(request)["staff_nav"]
-
-    selected_url = first(nav_items, key=lambda u: u["url"] == url)
-    assert selected_url["is_active"]
-
-    unselected_urls = filter(lambda u: u["url"] != url, nav_items)
-    assert all(u["is_active"] is False for u in unselected_urls)
 
 
 def test_nav_jobs(rf):


### PR DESCRIPTION
As part of [#4391](https://github.com/opensafely-core/job-server/issues/4391) to remove the use of zen-queries, I noticed that the only use of this function was removed in 4dd6c3 and so it's no longer needed.

