### PR TITLE
Remove zen-queries from context processors

### DIFF
--- a/docs/adr/0020-replace-zen-queries.md
+++ b/docs/adr/0020-replace-zen-queries.md
@@ -1,0 +1,55 @@
+# 20. Replace Zen Queries
+
+Date: 2024-07-10
+
+## Status
+
+Accepted
+
+## Context
+
+Zen Queries is a third-party library that throws an exception if a database query is made unexpectedly in a template. We've been using it in Job Server for a [year](https://github.com/opensafely-core/job-server/commit/baee5890f2652aab9d1a95faf0651cd8ec8dd304), as we encountered some [performance issues](https://github.com/opensafely-core/job-server/pull/3591/commits/0ebf4e7bd8d2a3621d27e5ee1091e0d1f114d5af) when accidentally making additional database calls in some of our templates and we need some way of being alerted when this happens.
+
+However, Zen Queries throws an exception in both production and development mode. As a result, users have encountered this error before developers. The exception message is also not very informative and it's not always clear what action to take (see [here](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1708035538382269) and [here](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1708946787197529)).
+
+Options:
+1. Keep Zen Queries and add tests to check the template is rendered without exceptions being thrown.
+1. Remove Zen Queries and add tests to check the number of database queries in the rendered template is what we expect.
+1. Remove Zen Queries and do nothing, as before.
+
+## Decision
+
+We will remove Zen Queries and add tests to check the number of database queries in the rendered template is what we expect.
+
+We will use `django_assert_num_queries` to check the view and rendered template. For example this test will fail if the number of database queries in the view changes from the expected eight or 10 when including the rendered template:
+
+```python
+def test_jobrequestdetail_count_db_queries(
+    client, rf, django_assert_num_queries
+):
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, updated_at=minutes_ago(timezone.now(), 31))
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    with django_assert_num_queries(8):
+        response = JobRequestDetail.as_view()(
+            request,
+            project_slug=job_request.workspace.project.slug,
+            workspace_slug=job_request.workspace.name,
+            pk=job_request.pk,
+        )
+
+    with django_assert_num_queries(10):
+        response = client.get(job_request.get_absolute_url())
+        assert response.status_code == 200
+        assert job_request.identifier in response.rendered_content
+```
+
+## Consequences
+
+We now have one less dependency. We've already using `django_assert_num_queries` as it comes with pytest-django, which we use as standard with our Django projects.
+
+This approach is more transparent. It's easy to see from the above code the number of database queries being made and where they're being made. If something changes, then the developer receives a clear error message, with an option to see the generated queries, and the affected code doesn't make it into production.
+
+This removes extraneous (and somewhat mysterious) code from our views and templates. e.g the decorator `@queries_dangerously_enabled()` and `{% queries_dangerously_enabled %}` codeblocks.

--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -4,7 +4,6 @@ import structlog
 from django.conf import settings
 from django.urls import reverse
 from furl import furl
-from zen_queries import queries_dangerously_enabled
 
 from .authorization import CoreDeveloper, has_role
 from .nav import NavItem, iter_nav
@@ -17,7 +16,6 @@ def _is_active(request, prefix):
     return request.path.startswith(prefix)
 
 
-@queries_dangerously_enabled()
 def can_view_staff_area(request):
     can_view_staff_area = has_role(request.user, CoreDeveloper)
 

--- a/tests/unit/jobserver/test_context_processors.py
+++ b/tests/unit/jobserver/test_context_processors.py
@@ -19,6 +19,16 @@ def test_can_view_staff_area_without_core_developer(rf):
     assert not can_view_staff_area(request)["user_can_view_staff_area"]
 
 
+def test_can_view_staff_area_makes_no_db_queries(
+    rf, core_developer, django_assert_num_queries
+):
+    request = rf.get("/")
+    request.user = core_developer
+
+    with django_assert_num_queries(0):
+        assert can_view_staff_area(request)["user_can_view_staff_area"]
+
+
 def test_nav_jobs(rf):
     request = rf.get(reverse("job-list"))
     request.user = UserFactory()
@@ -37,3 +47,11 @@ def test_nav_status(rf):
 
     assert jobs["is_active"] is False
     assert status["is_active"] is True
+
+
+def test_nav_makes_no_db_queries(rf, django_assert_num_queries):
+    request = rf.get(reverse("status"))
+    request.user = UserFactory()
+
+    with django_assert_num_queries(0):
+        assert nav(request)


### PR DESCRIPTION
The call to zen-queries has been replaced with some unit tests instead. I'm in two minds about keeping these unit tests and would appreciate feedback. They were useful for convincing myself that no db calls were being made and the intent is certainly clear, but if it's already obvious that no DB calls are being made then we should remove them.

I've added an ADR because this change is the first step to removing zen-queries and that seemed like the sort of thing we should document.

Refs: #4391