### PR TITLE
Make `update-interactive-templates` select one tag

### DIFF
--- a/justfile
+++ b/justfile
@@ -117,7 +117,7 @@ update-interactive-templates tag="": && prodenv
 
     # pick the tag to work with, defaulting to what's passed in
     tag="{{ tag }}"
-    test "$tag" == "" && tag=$(git ls-remote --tags https://github.com/opensafely-core/interactive-templates | awk '{print $2}' | sed s#refs/tags/##)
+    test "$tag" == "" && tag=$(git ls-remote --tags --sort=version:refname https://github.com/opensafely-core/interactive-templates | awk 'END {print $2}' | sed s#refs/tags/##)
 
     # update the spec in requirements.prod.in
     prefix="interactive_templates@https://github.com/opensafely-core/interactive-templates/archive/refs/tags"


### PR DESCRIPTION
Without this commit, what happens when you have multiple tags in the
`interactive-templates` repository is that:

1. The `tag` value contains each of those tags, separated by newlines.
2. The subsequent `sed` (not the one in the changed line) that edits the
   requirements fails.

We only want to replace the text with the single version tag that we
want to upgrade to.

Other notes:
* This change also explicitly uses `--sort` for `ls-remote` so that we
  can be assured of the position of the latest version. It's not clear
  from the `ls-remote` documentation that results are sorted or not
  otherwise. We take the latest version.
* We use `END` with `awk` to use the last line of the `ls-remote`
  output. We could use `tail` but that means adding an extra pipeline
  command, whereas we can use `awk` directly.