### PR TITLE
Remove Zen Queries in staff area "applications" section

### DIFF
--- a/staff/views/applications.py
+++ b/staff/views/applications.py
@@ -153,7 +153,7 @@ class ApplicationEdit(UpdateView):
         "status_comment",
     ]
     model = Application
-    response_class = zTemplateResponse
+    response_class = TemplateResponse
     template_name = "staff/application/edit.html"
 
     def dispatch(self, request, *args, **kwargs):

--- a/staff/views/applications.py
+++ b/staff/views/applications.py
@@ -8,8 +8,6 @@ from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.generic import FormView, ListView, UpdateView, View
-from zen_queries import TemplateResponse as zTemplateResponse
-from zen_queries import fetch
 
 from applications.form_specs import form_specs
 from applications.models import Application
@@ -180,7 +178,7 @@ class ApplicationEdit(UpdateView):
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
 class ApplicationList(ListView):
-    response_class = zTemplateResponse
+    response_class = TemplateResponse
     ordering = "-created_at"
     paginate_by = 25
     template_name = "staff/application/list.html"
@@ -231,7 +229,7 @@ class ApplicationList(ListView):
         if user := self.request.GET.get("user"):
             qs = qs.filter(created_by__username=user)
 
-        return fetch(qs.distinct())
+        return list(qs.distinct())
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")

--- a/staff/views/applications.py
+++ b/staff/views/applications.py
@@ -7,7 +7,8 @@ from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.generic import FormView, ListView, UpdateView, View
-from zen_queries import TemplateResponse, fetch
+from zen_queries import TemplateResponse as zTemplateResponse
+from zen_queries import fetch
 
 from applications.form_specs import form_specs
 from applications.models import Application
@@ -25,7 +26,7 @@ from ..forms import ApplicationApproveForm
 class ApplicationApprove(FormView):
     form_class = ApplicationApproveForm
     model = Application
-    response_class = TemplateResponse
+    response_class = zTemplateResponse
     template_name = "staff/application/approve.html"
 
     def dispatch(self, request, *args, **kwargs):
@@ -126,7 +127,7 @@ class ApplicationDetail(View):
             "pages": pages,
         }
 
-        return TemplateResponse(request, "staff/application/detail.html", ctx)
+        return zTemplateResponse(request, "staff/application/detail.html", ctx)
 
     def post(self, request, *args, **kwargs):
         wizard = Wizard(self.application, form_specs)
@@ -151,7 +152,7 @@ class ApplicationEdit(UpdateView):
         "status_comment",
     ]
     model = Application
-    response_class = TemplateResponse
+    response_class = zTemplateResponse
     template_name = "staff/application/edit.html"
 
     def dispatch(self, request, *args, **kwargs):
@@ -178,7 +179,7 @@ class ApplicationEdit(UpdateView):
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")
 class ApplicationList(ListView):
-    response_class = TemplateResponse
+    response_class = zTemplateResponse
     ordering = "-created_at"
     paginate_by = 25
     template_name = "staff/application/list.html"

--- a/staff/views/applications.py
+++ b/staff/views/applications.py
@@ -4,6 +4,7 @@ from django.contrib import messages
 from django.db import transaction
 from django.db.models import Max, Q, Value
 from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.generic import FormView, ListView, UpdateView, View
@@ -26,7 +27,7 @@ from ..forms import ApplicationApproveForm
 class ApplicationApprove(FormView):
     form_class = ApplicationApproveForm
     model = Application
-    response_class = zTemplateResponse
+    response_class = TemplateResponse
     template_name = "staff/application/approve.html"
 
     def dispatch(self, request, *args, **kwargs):
@@ -73,7 +74,7 @@ class ApplicationApprove(FormView):
 
     def get_form_kwargs(self):
         return super().get_form_kwargs() | {
-            "orgs": fetch(Org.objects.order_by("name")),
+            "orgs": Org.objects.order_by("name"),
         }
 
     def get_initial(self):

--- a/staff/views/applications.py
+++ b/staff/views/applications.py
@@ -122,13 +122,13 @@ class ApplicationDetail(View):
 
         ctx = {
             "application": self.application,
-            "researchers": fetch(
-                self.application.researcher_registrations.order_by("created_at")
+            "researchers": self.application.researcher_registrations.order_by(
+                "created_at"
             ),
             "pages": pages,
         }
 
-        return zTemplateResponse(request, "staff/application/detail.html", ctx)
+        return TemplateResponse(request, "staff/application/detail.html", ctx)
 
     def post(self, request, *args, **kwargs):
         wizard = Wizard(self.application, form_specs)

--- a/templates/staff/application/detail.html
+++ b/templates/staff/application/detail.html
@@ -1,7 +1,5 @@
 {% extends "staff/base.html" %}
 
-{% load zen_queries %}
-
 {% block metatitle %}Application {{ application.pk_hash }}: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
 
 {% block breadcrumbs %}
@@ -224,12 +222,10 @@
                   &mdash;
                 {% endif %}
               </li>
-              {% queries_dangerously_enabled %}
               <li>
                 <strong>Last reviewed by:</strong>
                 {{ page.wizard_page.page_instance.reviewed_by|default_if_none:"Not yet reviewed"}}</li>
               </li>
-              {% end_queries_dangerously_enabled %}
             </ul>
           {% /card_footer %}
 

--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -190,7 +190,7 @@ def test_applicationapprove_without_study_information_page(rf, core_developer):
 
 
 def test_applicationdetail_success_with_complete_application(
-    rf, django_assert_max_num_queries, core_developer, complete_application
+    rf, core_developer, complete_application
 ):
     application = complete_application
     page = application.contactdetailspage
@@ -200,14 +200,29 @@ def test_applicationdetail_success_with_complete_application(
     request = rf.get("/")
     request.user = core_developer
 
-    with django_assert_max_num_queries(19):
-        response = ApplicationDetail.as_view()(request, pk_hash=application.pk_hash)
+    response = ApplicationDetail.as_view()(request, pk_hash=application.pk_hash)
 
     assert response.status_code == 200
     assert response.context_data["pages"][0]["title"] == "Contact details"
     assert response.context_data["pages"][0]["started"] is True
     assert "Mickey Mouse" in response.rendered_content
     assert "User has not started this page" not in response.rendered_content
+
+
+def test_applicationdetail_num_queries(
+    rf, django_assert_max_num_queries, core_developer, complete_application
+):
+    request = rf.get("/")
+    request.user = core_developer
+
+    with django_assert_max_num_queries(19):
+        response = ApplicationDetail.as_view()(
+            request, pk_hash=complete_application.pk_hash
+        )
+        assert response.status_code == 200
+
+    with django_assert_max_num_queries(36):
+        response.render()
 
 
 def test_applicationdetail_success_with_incomplete_application(

--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -513,18 +513,29 @@ def test_applicationlist_search(rf, core_developer):
     assert set_from_list(response.context_data["object_list"]) == {app1.pk, app2.pk}
 
 
-def test_applicationlist_success(rf, django_assert_num_queries, core_developer):
+def test_applicationlist_success(rf, core_developer):
     ApplicationFactory.create_batch(5)
 
     request = rf.get("/")
     request.user = core_developer
 
-    with django_assert_num_queries(2):
-        response = ApplicationList.as_view()(request)
+    response = ApplicationList.as_view()(request)
 
     assert response.status_code == 200
-
     assert len(response.context_data["object_list"]) == 5
+
+
+def test_applicationlist_num_queries(rf, django_assert_num_queries, core_developer):
+    ApplicationFactory.create_batch(5)
+    request = rf.get("/")
+    request.user = core_developer
+
+    with django_assert_num_queries(2):
+        response = ApplicationList.as_view()(request)
+        assert response.status_code == 200
+
+    with django_assert_num_queries(1):
+        response.render()
 
 
 def test_applicationremove_already_approved(rf, core_developer):

--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -382,16 +382,31 @@ def test_applicationdetail_post_with_incomplete_application(
         application.researcherdetailspage
 
 
-def test_applicationedit_get_success(rf, django_assert_num_queries, core_developer):
+def test_applicationedit_get_success(rf, core_developer):
     application = ApplicationFactory()
 
     request = rf.get("/")
     request.user = core_developer
 
-    with django_assert_num_queries(1):
-        response = ApplicationEdit.as_view()(request, pk_hash=application.pk_hash)
+    response = ApplicationEdit.as_view()(request, pk_hash=application.pk_hash)
 
     assert response.status_code == 200
+
+
+def test_applicationedit_num_queries(
+    rf, django_assert_num_queries, core_developer, complete_application
+):
+    request = rf.get("/")
+    request.user = core_developer
+
+    with django_assert_num_queries(1):
+        response = ApplicationEdit.as_view()(
+            request, pk_hash=complete_application.pk_hash
+        )
+        assert response.status_code == 200
+
+    with django_assert_num_queries(1):
+        response.render()
 
 
 def test_applicationedit_post_success(rf, django_assert_num_queries, core_developer):

--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -35,11 +35,25 @@ def test_applicationapprove_already_approved(rf, core_developer, complete_applic
     assert response.url == complete_application.get_staff_url()
 
 
-def test_applicationapprove_get_success(
-    rf, django_assert_num_queries, core_developer, complete_application
-):
+def test_applicationapprove_get_success(rf, core_developer, complete_application):
     ProjectFactory(number=7)  # check default is set via Form.initial
 
+    request = rf.get("/")
+    request.user = core_developer
+
+    response = ApplicationApprove.as_view()(
+        request, pk_hash=complete_application.pk_hash
+    )
+
+    assert response.status_code == 200
+    assert response.context_data["application"] == complete_application
+    assert response.context_data["form"]["org"].initial is None
+    assert response.context_data["form"]["project_number"].initial == 8
+
+
+def test_applicationapprove_num_queries(
+    rf, django_assert_num_queries, core_developer, complete_application
+):
     request = rf.get("/")
     request.user = core_developer
 
@@ -47,11 +61,10 @@ def test_applicationapprove_get_success(
         response = ApplicationApprove.as_view()(
             request, pk_hash=complete_application.pk_hash
         )
+        assert response.status_code == 200
 
-    assert response.status_code == 200
-    assert response.context_data["application"] == complete_application
-    assert response.context_data["form"]["org"].initial is None
-    assert response.context_data["form"]["project_number"].initial == 8
+    with django_assert_num_queries(1):
+        response.render()
 
 
 def test_applicationapprove_get_with_org_slug(rf, core_developer, complete_application):


### PR DESCRIPTION
This follows on from PR #4436. It removes zen queries from applications in the staff area and replaces it with some tests that explicitly count the number of DB queries that are made.

I expect to use the same approach here for the remaining parts of the codebase that use zen queries. So I would particularly appreciate any feedback that gives some thought to the same kind of code being used in multiple other places (now is a good time to be pernickety about test names, etc).

Refs: https://github.com/opensafely-core/job-server/issues/4391