### PR TITLE
Update interactive-templates to v2024.07.09.130747

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -19,7 +19,7 @@ furl
 opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/v2024.03.19.153938.zip
 gunicorn
 incuna-mail
-interactive_templates@https://github.com/opensafely-core/interactive-templates/archive/refs/tags/v2023.09.12.100407.zip
+interactive_templates@https://github.com/opensafely-core/interactive-templates/archive/refs/tags/v2024.07.09.130747.zip
 itsdangerous
 markdown
 nh3

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -460,8 +460,8 @@ incuna-mail==4.1.1 \
     --hash=sha256:4071949a7cc70f88c1acea5f06ac8ba439029f655ff5d8c98277bbc8cc8d4bd5 \
     --hash=sha256:d8ef4979264fba729fa1478819d71f66af17a795e82d9607d8e7ccd7edaafe10
     # via -r requirements.prod.in
-interactive-templates @ https://github.com/opensafely-core/interactive-templates/archive/refs/tags/v2023.09.12.100407.zip \
-    --hash=sha256:a6bfaa4f6a7a44633dc1cd161b886819808505d513116fc9ab7d5b28149f10cf
+interactive-templates @ https://github.com/opensafely-core/interactive-templates/archive/refs/tags/v2024.07.09.130747.zip \
+    --hash=sha256:55a5f8c23c3c32fbd36222e928b051c512b0f9a77f0e8a9dccac6a53e1393563
     # via -r requirements.prod.in
 itsdangerous==2.2.0 \
     --hash=sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef \


### PR DESCRIPTION
This is a manual update, because the machinery for generating an automatic PR for that update is fragile.

See opensafely-core/interactive-templates#377.