### PR TITLE
Add interactive-templates update workflow

### DIFF
--- a/.github/workflows/update-interactive-templates.yml
+++ b/.github/workflows/update-interactive-templates.yml
@@ -1,25 +1,17 @@
 ---
-name: "Create PR to update job-server"
+name: "Create PR to update interactive-templates"
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - CI
-    branches:
-      - main
-    types:
-      - completed
+  schedule:
+    - cron: "25 13 * * *"
 
 jobs:
   create_job_server_pr:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') || (github.event_name == 'workflow_dispatch') }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: opensafely-core/job-server
 
       - uses: opensafely-core/setup-action@v1
         with:
@@ -27,21 +19,36 @@ jobs:
           python-version: "3.12"
 
       - name: Update requirement to latest
-        run: just update-interactive-templates "$GITHUB_SHA"
+        run: |
+          just update-interactive-templates
+          updated_version="$(sed -n 's|^interactive_templates@https://github.com/opensafely-core/interactive-templates/archive/refs/tags/\(v[0-9.].*\).zip$|\1|p' requirements.prod.in)"
+          echo "UPDATED_VERSION=$updated_version" >> "$GITHUB_ENV"
 
       - name: Create a Pull Request if there are any changes
         id: create_pr
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: "${{ secrets.JOB_SERVER_PR_TOKEN }}"
+          add-paths: requirements.*
+          base: main
           branch: bot/update-interactive-templates
-          commit-message: "feat: Update interactive templates to latest version"
-          title: "Update interactive templates to latest version"
-          body: "Update interative-templates to ${{ github.sha }}"
+          author: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
+          committer: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
+          commit-message: "feat: Update interactive templates to ${{ env.UPDATED_VERSION }}"
+          title: "Update interactive templates to ${{ env.UPDATED_VERSION }}"
+          body: |
+            To get tests to run on this PR there's an odd workflow:
+             - Approve it
+             - Close it
+             - Re-open it
+             - Re-enable automerge
 
-      # untested
-      #- name: Enable automerge
-      #  if: steps.create_pr.outputs.pull-request-operation == 'created'
-      #  env:
-      #    GH_TOKEN: "${{ secrets.JOB_SERVER_PR_TOKEN }} "
-      #  run: gh pr merge --merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
+            You can read more on why this is needed in the `create-pull-request` [docs][1].
+
+            [1]: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+
+      - name: Enable automerge
+        if: steps.create_pr.outputs.pull-request-operation == 'created'
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }} "
+        run: gh pr merge --merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}

--- a/.github/workflows/update-interactive-templates.yml
+++ b/.github/workflows/update-interactive-templates.yml
@@ -34,7 +34,7 @@ jobs:
           branch: bot/update-interactive-templates
           author: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
           committer: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
-          commit-message: "feat: Update interactive templates to ${{ env.UPDATED_VERSION }}"
+          commit-message: "Bump interactive-templates to ${{ env.UPDATED_VERSION }}"
           title: "Update interactive templates to ${{ env.UPDATED_VERSION }}"
           body: |
             To get tests to run on this PR there's an odd workflow:

--- a/.github/workflows/update-interactive-templates.yml
+++ b/.github/workflows/update-interactive-templates.yml
@@ -1,0 +1,47 @@
+---
+name: "Create PR to update job-server"
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - CI
+    branches:
+      - main
+    types:
+      - completed
+
+jobs:
+  create_job_server_pr:
+    if: ${{ (github.event.workflow_run.conclusion == 'success') || (github.event_name == 'workflow_dispatch') }}
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: opensafely-core/job-server
+
+      - uses: opensafely-core/setup-action@v1
+        with:
+          install-just: true
+          python-version: "3.12"
+
+      - name: Update requirement to latest
+        run: just update-interactive-templates "$GITHUB_SHA"
+
+      - name: Create a Pull Request if there are any changes
+        id: create_pr
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+        with:
+          token: "${{ secrets.JOB_SERVER_PR_TOKEN }}"
+          branch: bot/update-interactive-templates
+          commit-message: "feat: Update interactive templates to latest version"
+          title: "Update interactive templates to latest version"
+          body: "Update interative-templates to ${{ github.sha }}"
+
+      # untested
+      #- name: Enable automerge
+      #  if: steps.create_pr.outputs.pull-request-operation == 'created'
+      #  env:
+      #    GH_TOKEN: "${{ secrets.JOB_SERVER_PR_TOKEN }} "
+      #  run: gh pr merge --merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}


### PR DESCRIPTION
This is a proposal to move the [interactive-templates update workflow](https://github.com/opensafely-core/interactive-templates/blob/b8f742c2ecea2de223aa74ec8c8773f953e5a2d9/.github/workflows/create-job-server-pr.yml) from the interactive-templates repository to here.

The workflow was added in the interactive-templates repository to run on a new release of interactive-templates, and then open a pull request to job-server. The workflow is run daily and can be run manually on request.

This is based on the version of the workflow from opensafely-core/interactive-templates#377 which has fixes necessary for the workflow to work. The workflow operates like the "check resource for update and create a PR if so" [workflows in ehrQL](https://github.com/opensafely-core/ehrql/blob/5f36cc0c99397ab07e1bc0844c6ebeb3f2ab0871/.github/workflows/update-external-studies.yml).

See opensafely-core/interactive-templates#118 which proposed this.

The main motivation for moving it here is to remove the need for the personal access token, which appears to have expired. With the low frequency of updates, it also seems reasonable to simplify this.