### PR TITLE
Airlock notification updates

### DIFF
--- a/airlock/emails.py
+++ b/airlock/emails.py
@@ -43,24 +43,6 @@ def send_request_rejected_email(airlock_event):
     )
 
 
-def send_request_updated_email(airlock_event):
-    context = {
-        "release_request_id": airlock_event.release_request_id,
-        "request_author": airlock_event.request_author.name,
-        "workspace": airlock_event.workspace.name,
-        "updates": airlock_event.describe_updates(),
-    }
-
-    send(
-        to=airlock_event.request_author.email,
-        sender="notifications@jobs.opensafely.org",
-        subject=f"Release request updated: {airlock_event.workspace.name} ({airlock_event.release_request_id})",
-        template_name="airlock/emails/request_updated.txt",
-        html_template_name="airlock/emails/request_updated.html",
-        context=context,
-    )
-
-
 def send_request_returned_email(airlock_event):
     context = {
         "release_request_id": airlock_event.release_request_id,

--- a/airlock/emails.py
+++ b/airlock/emails.py
@@ -5,16 +5,24 @@ from incuna_mail import send
 from jobserver.models import Release
 
 
+def get_email_context(airlock_event):
+    # The first update is the event itself, don't include this in emails
+    updates = airlock_event.describe_updates()[1:]
+    return {
+        "release_request_id": airlock_event.release_request_id,
+        "request_author": airlock_event.request_author.name,
+        "workspace": airlock_event.workspace.name,
+        "updates": updates,
+    }
+
+
 def send_request_released_email(airlock_event):
     release = Release.objects.get(id=airlock_event.release_request_id)
     f = furl(settings.BASE_URL)
     f.path = release.get_absolute_url()
 
-    context = {
-        "url": f.url,
-        "request_author": airlock_event.request_author.name,
-        "workspace": airlock_event.workspace.name,
-    }
+    context = get_email_context(airlock_event)
+    context["url"] = f.url
 
     send(
         to=airlock_event.request_author.email,
@@ -27,12 +35,7 @@ def send_request_released_email(airlock_event):
 
 
 def send_request_rejected_email(airlock_event):
-    context = {
-        "release_request_id": airlock_event.release_request_id,
-        "request_author": airlock_event.request_author.name,
-        "workspace": airlock_event.workspace.name,
-    }
-
+    context = get_email_context(airlock_event)
     send(
         to=airlock_event.request_author.email,
         sender="notifications@jobs.opensafely.org",
@@ -44,12 +47,7 @@ def send_request_rejected_email(airlock_event):
 
 
 def send_request_returned_email(airlock_event):
-    context = {
-        "release_request_id": airlock_event.release_request_id,
-        "request_author": airlock_event.request_author.name,
-        "workspace": airlock_event.workspace.name,
-    }
-
+    context = get_email_context(airlock_event)
     send(
         to=airlock_event.request_author.email,
         sender="notifications@jobs.opensafely.org",

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -92,19 +92,23 @@ class AirlockEvent:
     def describe_event(self):
         return self.event_type.value
 
-    def describe_updates(self):
-        if self.event_type in [
-            EventType.REQUEST_RESUBMITTED,
-            EventType.REQUEST_RETURNED,
-            EventType.REQUEST_PARTIALLY_REVIEWED,
-            EventType.REQUEST_REVIEWED,
-        ]:
-            return [f"{self.describe_event()} by user {self.user.username}"]
+    def _update_dict_to_string(self, update_dict):
+        user = update_dict.get("user")
+        group = update_dict.get("group")
+        update = update_dict.get("update_type") or update_dict.get("update")
 
-        return [
-            f"{update['update_type']} (filegroup {update['group']}) by user {update['user']}"
-            for update in self.updates
-        ]
+        update_string = update
+        if group:
+            update_string = f"{update_string} (filegroup {group})"
+        if user:
+            update_string = f"{update_string} by user {user}"
+        return update_string
+
+    def describe_updates(self):
+        updates = [f"{self.describe_event()} by user {self.user.username}"]
+        for update_dict in self.updates:
+            updates.append(self._update_dict_to_string(update_dict))
+        return updates
 
 
 def create_issue(airlock_event: AirlockEvent, github_api=None):

--- a/templates/airlock/emails/includes/updates.html
+++ b/templates/airlock/emails/includes/updates.html
@@ -1,0 +1,7 @@
+{% if updates %}
+    <ul>
+        {% for update in updates %}
+            <li>{{ update }}</li>
+        {% endfor %}
+    </ul>
+{% endif %}

--- a/templates/airlock/emails/includes/updates.txt
+++ b/templates/airlock/emails/includes/updates.txt
@@ -1,0 +1,5 @@
+{% if updates %}
+{% for update in updates %}
+    - {{ update }}
+{% endfor %}
+{% endif %}

--- a/templates/airlock/emails/request_rejected.html
+++ b/templates/airlock/emails/request_rejected.html
@@ -3,4 +3,5 @@
 {% block content %}
 <p>Dear {{ request_author }},</p>
 <p>Release request {{ release_request_id }} for {{ workspace }} has been rejected.</p>
+{% include "airlock/emails/includes/updates.html" %}
 {% endblock content %}

--- a/templates/airlock/emails/request_rejected.txt
+++ b/templates/airlock/emails/request_rejected.txt
@@ -5,5 +5,6 @@
 Dear {{ request_author }},
 
 Release request {{ release_request_id }} for {{ workspace }} has been rejected.
+{% include "airlock/emails/includes/updates.txt" %}
 
 {% endblock content %}

--- a/templates/airlock/emails/request_released.html
+++ b/templates/airlock/emails/request_released.html
@@ -3,5 +3,7 @@
 {% block content %}
 <p>Dear {{ request_author }},</p>
 <p>Your files for workspace {{ workspace }} have been released.</p>
+{% include "airlock/emails/includes/updates.html" %}
+
 <p>You can now view your <a href="{{ url }}">released files here</a>.</p>
 {% endblock content %}

--- a/templates/airlock/emails/request_released.txt
+++ b/templates/airlock/emails/request_released.txt
@@ -5,6 +5,7 @@
 Dear {{ request_author }},
 
 Your files for workspace {{ workspace }} have been released.
+{% include "airlock/emails/includes/updates.txt" %}
 
 You can now view your <a href="{{ url }}">released files here.
 

--- a/templates/airlock/emails/request_returned.html
+++ b/templates/airlock/emails/request_returned.html
@@ -3,4 +3,5 @@
 {% block content %}
 <p>Dear {{ request_author }},</p>
 <p>Release request {{ release_request_id }} for {{ workspace }} has been returned.</p>
+{% include "airlock/emails/includes/updates.html" %}
 {% endblock content %}

--- a/templates/airlock/emails/request_returned.txt
+++ b/templates/airlock/emails/request_returned.txt
@@ -5,5 +5,6 @@
 Dear {{ request_author }},
 
 Release request {{ release_request_id }} for {{ workspace }} has been returned.
+{% include "airlock/emails/includes/updates.txt" %}
 
 {% endblock content %}

--- a/templates/airlock/emails/request_updated.html
+++ b/templates/airlock/emails/request_updated.html
@@ -3,9 +3,5 @@
 {% block content %}
 <p>Dear {{ request_author }},</p>
 <p>Release request {{ release_request_id }} for {{ workspace }} has been updated. The following updates have been made:</p>
-<ul>
-    {% for update in updates %}
-        <li>{{ update }}</li>
-    {% endfor%}
-</ul>
+{% include "airlock/emails/includes/updates.html" %}
 {% endblock content %}

--- a/templates/airlock/emails/request_updated.txt
+++ b/templates/airlock/emails/request_updated.txt
@@ -5,8 +5,6 @@
 Dear {{ request_author }},
 
 Release request {{ release_request_id }} for {{ workspace }} has been updated. The following updates have been made:
-{% for update in updates %}
-    - {{ update }}
-{% endfor %}
+{% include "airlock/emails/includes/updates.txt" %}
 
 {% endblock content %}

--- a/tests/unit/airlock/test_emails.py
+++ b/tests/unit/airlock/test_emails.py
@@ -1,0 +1,98 @@
+import pytest
+from django.core import mail
+
+from airlock.emails import (
+    send_request_rejected_email,
+    send_request_released_email,
+    send_request_returned_email,
+)
+from airlock.views import AirlockEvent, EventType
+from tests.factories import (
+    BackendFactory,
+    BackendMembershipFactory,
+    ReleaseFactory,
+    UserFactory,
+    WorkspaceFactory,
+)
+
+
+@pytest.fixture
+def airlock_event():
+    def _airlock_event(event_type, updates):
+        author = UserFactory(username="author", email="author@example.com")
+
+        workspace = WorkspaceFactory(name="test-workspace")
+        backend = BackendFactory(auth_token="test", name="test-backend")
+        BackendMembershipFactory(backend=backend, user=author)
+
+        return AirlockEvent(
+            event_type=event_type,
+            workspace=workspace,
+            updates=updates,
+            release_request_id="request-id",
+            request_author=author,
+            user=author,
+            org="org",
+            repo="repo",
+        )
+
+    yield _airlock_event
+
+
+@pytest.mark.parametrize(
+    "updates,expected_email_updates",
+    [
+        ([], []),
+        (
+            [
+                {"update": "change requested"},
+                {"update": "file rejected", "user": "test"},
+            ],
+            ["change requested", "file rejected by user test"],
+        ),
+    ],
+)
+def test_returned_email(airlock_event, updates, expected_email_updates):
+    event = airlock_event(EventType.REQUEST_RETURNED, updates=updates)
+    send_request_returned_email(event)
+    assert_email(event, "Release request returned", expected_email_updates)
+
+
+@pytest.mark.parametrize(
+    "updates,expected_email_updates",
+    [
+        ([], []),
+        ([{"update": "comment added", "user": "test"}], ["comment added by user test"]),
+    ],
+)
+def test_rejected_email(airlock_event, updates, expected_email_updates):
+    event = airlock_event(EventType.REQUEST_REJECTED, updates=updates)
+    send_request_rejected_email(event)
+    assert_email(event, "Release request rejected", expected_email_updates)
+
+
+@pytest.mark.parametrize(
+    "updates,expected_email_updates",
+    [
+        ([], []),
+        ([{"update": "comment added", "user": "test"}], ["comment added by user test"]),
+    ],
+)
+def test_released_email(airlock_event, updates, expected_email_updates):
+    ReleaseFactory(id="request-id")
+    event = airlock_event(EventType.REQUEST_RELEASED, updates=updates)
+    send_request_released_email(event)
+    assert_email(event, "Files released", expected_email_updates)
+
+
+def assert_email(airlock_event, subject, expected_email_updates):
+    assert len(mail.outbox) == 1
+    email = mail.outbox[0]
+    assert email.to == ["author@example.com"]
+    assert subject in email.subject
+
+    update_strings = airlock_event.describe_updates()
+    assert update_strings[0] not in email.body
+    assert update_strings[1:] == expected_email_updates
+    for update in expected_email_updates:
+        assert update in email.body

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -50,37 +50,6 @@ class FakeGithubApiWithError:
         ("request_resubmitted", True, None, False, True),
         ("request_partially_reviewed", True, None, False, True),
         ("request_reviewed", True, None, False, True),
-        # updated; emails are sent if at least one update is not by the author
-        (
-            "request_updated",
-            True,
-            [{"update_type": "file_added", "group": "Group 1", "user": "test_user"}],
-            True,
-            False,
-        ),
-        (
-            "request_updated",
-            False,
-            [
-                {"update_type": "context_edited", "group": "Group 2", "user": "author"},
-            ],
-            False,
-            False,
-        ),
-        (
-            "request_updated",
-            False,
-            [
-                {
-                    "update_type": "comment_added",
-                    "group": "Group 1",
-                    "user": "test_user",
-                },
-                {"update_type": "comment_added", "group": "Group 1", "user": "author"},
-            ],
-            True,
-            False,
-        ),
     ],
 )
 @patch("airlock.views._get_github_api", FakeGitHubAPI)
@@ -224,11 +193,6 @@ def test_api_post_release_request_default_org_and_repo(mock_create_issue, api_rf
         ("request_submitted", None, "Error creating GitHub issue: An error occurred"),
         ("request_rejected", None, "Error closing GitHub issue: An error occurred"),
         (
-            "request_updated",
-            [{"update_type": "file_added", "group": "Group 1", "user": "user"}],
-            "Error creating GitHub issue comment: An error occurred",
-        ),
-        (
             "request_returned",
             None,
             "Error creating GitHub issue comment: An error occurred",
@@ -297,18 +261,6 @@ def test_api_airlock_event_error(api_rf, event_type, updates, error):
             ["request reviewed by user user1"],
         ),
         (EventType.REQUEST_REVIEWED, "user2", [], ["request reviewed by user user2"]),
-        (
-            EventType.REQUEST_UPDATED,
-            "author",
-            [
-                {"update_type": "file_added", "group": "Group 1", "user": "author"},
-                {"update_type": "context_edited", "group": "Group 2", "user": "author"},
-            ],
-            [
-                "file_added (filegroup Group 1) by user author",
-                "context_edited (filegroup Group 2) by user author",
-            ],
-        ),
     ],
 )
 def test_airlock_event_describe_updates(event_type, user, updates, descriptions):

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -242,11 +242,21 @@ def test_api_airlock_event_error(api_rf, event_type, updates, error):
 @pytest.mark.parametrize(
     "event_type,user,updates,descriptions",
     [
-        (EventType.REQUEST_SUBMITTED, "author", [], []),
-        (EventType.REQUEST_WITHDRAWN, "author", [], []),
-        (EventType.REQUEST_APPROVED, "user1", [], []),
-        (EventType.REQUEST_RELEASED, "user1", [], []),
-        (EventType.REQUEST_REJECTED, "user1", [], []),
+        (
+            EventType.REQUEST_SUBMITTED,
+            "author",
+            [],
+            ["request submitted by user author"],
+        ),
+        (
+            EventType.REQUEST_WITHDRAWN,
+            "author",
+            [],
+            ["request withdrawn by user author"],
+        ),
+        (EventType.REQUEST_APPROVED, "user1", [], ["request approved by user user1"]),
+        (EventType.REQUEST_RELEASED, "user1", [], ["request released by user user1"]),
+        (EventType.REQUEST_REJECTED, "user1", [], ["request rejected by user user1"]),
         (EventType.REQUEST_RETURNED, "user1", [], ["request returned by user user1"]),
         (
             EventType.REQUEST_RESUBMITTED,
@@ -261,6 +271,23 @@ def test_api_airlock_event_error(api_rf, event_type, updates, error):
             ["request reviewed by user user1"],
         ),
         (EventType.REQUEST_REVIEWED, "user2", [], ["request reviewed by user user2"]),
+        (
+            EventType.REQUEST_RETURNED,
+            "user1",
+            [
+                {"update_type": "comment added", "user": "user_a", "group": "group"},
+                {"update": "a thing was updated"},
+                {"update": "another thing updated", "user": "user_b"},
+                {"update": "thing X updated", "user": "user_b", "group": "group"},
+            ],
+            [
+                "request returned by user user1",
+                "comment added (filegroup group) by user user_a",
+                "a thing was updated",
+                "another thing updated by user user_b",
+                "thing X updated (filegroup group) by user user_b",
+            ],
+        ),
     ],
 )
 def test_airlock_event_describe_updates(event_type, user, updates, descriptions):


### PR DESCRIPTION
Airlock now sends notifications for status changes only, with potential optional update messages that are now included in emails.