### PR TITLE
Fix `ApplicationList` view

### DIFF
--- a/staff/views/applications.py
+++ b/staff/views/applications.py
@@ -182,6 +182,7 @@ class ApplicationList(ListView):
     ordering = "-created_at"
     paginate_by = 25
     template_name = "staff/application/list.html"
+    context_object_name = "application_list"
 
     def get_context_data(self, **kwargs):
         # sort in Python because `User.name` is a property to pick either


### PR DESCRIPTION
4371e7e modified `ApplicationList.get_queryset` to return a list, rather than an evaluated query set (the result of passing an unevaluated query set to django-zen-queries' `fetch` function). Doing so meant that `ApplicationList.context_object_name` was not set, which meant that the corresponding template no longer had `application_list` in its context, which meant that the list of applications was empty.

Thanks, @LiamHart-hub for reporting this issue.