### PR TITLE
Test `ApplicationList` view's context

### DIFF
--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -476,6 +476,17 @@ def test_applicationedit_without_core_dev_role(rf):
         ApplicationEdit.as_view()(request, pk_hash=application.pk_hash)
 
 
+def test_applicationlist_context_object_name(rf, core_developer):
+    ApplicationFactory()
+
+    request = rf.get("/")
+    request.user = core_developer
+
+    response = ApplicationList.as_view()(request)
+    assert "object_list" in response.context_data
+    assert "application_list" in response.context_data
+
+
 def test_applicationlist_filter_by_status(rf, core_developer):
     ApplicationFactory(status=Application.Statuses.APPROVED_FULLY)
 


### PR DESCRIPTION
This test corresponds to the fix introduced by #4459. Here, we test that `ApplicationList` view's context contains `object_list`, which is provided by `BaseListView`. More importantly, we test that it contains `application_list`, which is used by `staff/application/list.html`.