### PR TITLE
Replace zen queries in the staff area

### DIFF
--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -15,8 +15,6 @@ from django.views.generic import (
 from django_htmx.http import HttpResponseClientRedirect
 from furl import furl
 from markdown import markdown
-from zen_queries import TemplateResponse as zTemplateResponse
-from zen_queries import fetch
 
 from applications.models import Application
 from interactive.commands import create_repo, create_workspace
@@ -95,7 +93,6 @@ class ProjectAddMember(FormView):
 class ProjectAuditLog(ListView):
     paginate_by = 25
     template_name = "staff/project/audit_log.html"
-    response_class = zTemplateResponse
 
     def dispatch(self, request, *args, **kwargs):
         self.project = get_object_or_404(Project, slug=self.kwargs["slug"])
@@ -126,7 +123,7 @@ class ProjectAuditLog(ListView):
         if types := self.request.GET.getlist("types"):
             qs = qs.filter(type__in=types)
 
-        return fetch(qs.distinct())
+        return qs.distinct()
 
 
 @method_decorator(require_role(CoreDeveloper), name="dispatch")

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -10,8 +10,6 @@ from django.utils.decorators import method_decorator
 from django.views.generic import FormView, ListView, UpdateView, View
 from django.views.generic.detail import SingleObjectMixin
 from social_django.models import UserSocialAuth
-from zen_queries import TemplateResponse as zTemplateResponse
-from zen_queries import fetch
 
 from interactive.commands import create_user
 from interactive.emails import send_welcome_email
@@ -43,7 +41,6 @@ logger = structlog.get_logger(__name__)
 class UserAuditLog(ListView):
     paginate_by = 25
     template_name = "staff/user/audit_log.html"
-    response_class = zTemplateResponse
 
     def dispatch(self, request, *args, **kwargs):
         self.user = get_object_or_404(User, username=self.kwargs["username"])
@@ -84,7 +81,7 @@ class UserAuditLog(ListView):
         if types := self.request.GET.getlist("types"):
             qs = qs.filter(type__in=types)
 
-        return fetch(qs.distinct())
+        return qs.distinct()
 
 
 @method_decorator(require_permission(permissions.user_manage), name="dispatch")


### PR DESCRIPTION
This removes zen queries from the remaining places that it's used in the staff area.

Refs #4391.