### PR TITLE
Custom per-page datatables

### DIFF
--- a/assets/src/scripts/_datatable.js
+++ b/assets/src/scripts/_datatable.js
@@ -64,9 +64,10 @@ function setPaginationButtons(currentPage, table) {
   pageButtonState(previousPageBtn, pagination.previousPage, table);
 }
 
-const initCustomTable = async () => {
+const initCustomTable = async (perPage) => {
   /** @type {HTMLTableElement | null} */
   const tableEl = document.querySelector("table#customTable");
+  const paginationPerPage = perPage || 25;
 
   if (tableEl) {
     const { DataTable } = await import("simple-datatables");
@@ -75,7 +76,7 @@ const initCustomTable = async () => {
 
     const dataTable = new DataTable(tableEl, {
       paging: true,
-      perPage: 25,
+      perPage: paginationPerPage,
       searchable: true,
       sortable: true,
       tableRender: (_data, table) => {

--- a/assets/src/scripts/_datatable.js
+++ b/assets/src/scripts/_datatable.js
@@ -75,7 +75,7 @@ const initCustomTable = async () => {
 
     const dataTable = new DataTable(tableEl, {
       paging: true,
-      perPage: tableEl.dataset.perpage ? tableEl.dataset.perpage : 25,
+      perPage: 25,
       searchable: true,
       sortable: true,
       tableRender: (_data, table) => {

--- a/templates/_components/index.html
+++ b/templates/_components/index.html
@@ -691,7 +691,7 @@
       <h2>Modal</h2>
       <ul>
         <li><code>button_text</code>: [string] - the text to display on the button to open the dialog</li>
-        <li><code>button_variant</code>: [string] - the butten variant (default: primary)</li>
+        <li><code>button_variant</code>: [string] - the button variant (default: primary)</li>
         <li><code>children</code>: [html] - display the children components. You could include one button with <code>type="cancel"</code>, which will close the modal window.</li>
         <li><code>custom_button</code>: [string] - add a fragment for a custom button. This button should have the attribute <code>data-modal=id`</code> in order to trigger opening the dialog modal.</li>
         <li><code>id</code>: [string] - HTML element ID for dialog element</li>

--- a/templates/_components/index.html
+++ b/templates/_components/index.html
@@ -691,7 +691,7 @@
       <h2>Modal</h2>
       <ul>
         <li><code>button_text</code>: [string] - the text to display on the button to open the dialog</li>
-        <li><code>button_variant</code>: [string] - the button variant (default: primary)</li>
+        <li><code>button_variant</code>: [string] - the butten variant (default: primary)</li>
         <li><code>children</code>: [html] - display the children components. You could include one button with <code>type="cancel"</code>, which will close the modal window.</li>
         <li><code>custom_button</code>: [string] - add a fragment for a custom button. This button should have the attribute <code>data-modal=id`</code> in order to trigger opening the dialog modal.</li>
         <li><code>id</code>: [string] - HTML element ID for dialog element</li>
@@ -951,7 +951,6 @@
       <ul>
         <li><code>children</code>: [html] - display the children components</li>
         <li><code>id</code>: [string] - add HTML ID to element</li>
-        <li><code>data-perpage</code>: [number] - Number of items per page (default: 25)</li>
       </ul>
 
       <h3>Table Body</h3>

--- a/templates/_components/table/table.html
+++ b/templates/_components/table/table.html
@@ -1,3 +1,3 @@
-<table class="min-w-full divide-y divide-slate-300" {% attrs id data-perpage %}>
+<table class="min-w-full divide-y divide-slate-300" {% attrs id %}>
   {{ children }}
 </table>


### PR DESCRIPTION
Reverting the previous commit and adding custom per-page pagination in the right way.

window.initCustomTable is exposed, so we can just pass a custom
per-page value into it, rather than depending on a data attribute.
This way it will also work with htmx.