### PR TITLE
Update study purpose help text

### DIFF
--- a/snippets/study_purpose-help_text.md
+++ b/snippets/study_purpose-help_text.md
@@ -1,3 +1,5 @@
 Briefly describe the aims, potential methods and the expected outputs (for example, peer-reviewed paper, policy white paper, blog, etc).
 
 If your study has a research and service evaluation/audit component, please describe each part separately under a research heading and a service/evaluation heading in this box.
+
+**If you are planning to conduct analyses to produce a risk prediction model to implement in clinical practice, you MUST also detail this in your Study Information section (explaining the methods to be used, the intended benefits, risks of methods and how you intend to mitigate these risks) so that NHS England and others can consider any regulatory or liability issues.**


### PR DESCRIPTION
This updates the study purpose help text, which is part of the "Study information" page, following a request from @LiamHart-hub.[^1]

The "Study information" page before the change is as follows:

![Study information before](https://github.com/user-attachments/assets/ece14f19-7285-4871-865d-296c6d535072)

The same page after the change is as follows:

![Study information after](https://github.com/user-attachments/assets/93328979-e5df-4c3e-8709-e82232772280)

The same page after the change, but with the change highlighted in red, is as follows:

![Study information after with highlight](https://github.com/user-attachments/assets/4b121f44-45ef-4be8-90b3-30f84906805d)

[^1]: https://bennettoxford.slack.com/archives/C068NDYALSF/p1721295082531219