### PR TITLE
Allow more customisation of modal button

### DIFF
--- a/templates/_components/index.html
+++ b/templates/_components/index.html
@@ -692,6 +692,9 @@
       <ul>
         <li><code>button_text</code>: [string] - the text to display on the button to open the dialog</li>
         <li><code>button_variant</code>: [string] - the button variant (default: primary)</li>
+        <li><code>button_small</code>: [boolean] - if True, will reduce the font size, weight, and padding</li>
+        <li><code>button_class</code>: [string] - extra classes to add to the button (default: flex-shrink-0)</li>
+        : [boolean] - if true, will reduce the font size, weight, and padding
         <li><code>children</code>: [html] - display the children components. You could include one button with <code>type="cancel"</code>, which will close the modal window.</li>
         <li><code>custom_button</code>: [string] - add a fragment for a custom button. This button should have the attribute <code>data-modal=id`</code> in order to trigger opening the dialog modal.</li>
         <li><code>id</code>: [string] - HTML element ID for dialog element</li>

--- a/templates/_components/modal/modal.html
+++ b/templates/_components/modal/modal.html
@@ -2,8 +2,8 @@
   {% if custom_button %}
     {{ custom_button }}
   {% else %}
-    {% #button class="flex-shrink-0" variant=button_variant|default:"primary" data-modal=id %}
-      {{ button_text }}
+    {% #button class=button_class|default:"flex-shrink-0" small=button_small|default:False variant=button_variant|default:"primary" data-modal=id %}
+    {{ button_text }}
     {% /button %}
   {% endif %}
 


### PR DESCRIPTION
Lets us pass on `small` and `class` attributes to the modal's button component, without having to override the entire button with `custom_button`