### PR TITLE
Make django-debug-toolbar a development dependency

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -45,6 +45,8 @@ if OLD_SECRET_KEY is not None:
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DEBUG", default=False)
 
+DEBUG_TOOLBAR = env.bool("DJANGO_DEBUG_TOOLBAR", default=False)
+
 BASE_URL = env.str("BASE_URL", default="http://localhost:8000")
 
 ALLOWED_HOSTS = ["*"]
@@ -59,7 +61,6 @@ INSTALLED_APPS = [
     "redirects",
     "staff",
     "anymail",
-    "debug_toolbar",
     "django_extensions",
     "django_htmx",
     "django_vite",
@@ -80,7 +81,6 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django_permissions_policy.PermissionsPolicyMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -95,6 +95,10 @@ MIDDLEWARE = [
     "jobserver.middleware.ClientAddressIdentification",
     "jobserver.middleware.TemplateNameMiddleware",
 ]
+
+if DEBUG_TOOLBAR:
+    INSTALLED_APPS.append("debug_toolbar")
+    MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
 
 ROOT_URLCONF = "jobserver.urls"
 

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -1,4 +1,3 @@
-import debug_toolbar
 import social_django.views as social_django_views
 from django.conf import settings
 from django.conf.urls.static import static
@@ -294,6 +293,11 @@ user_urls = [
     path("<str:username>/logs/", UserEventLog.as_view(), name="user-event-log"),
 ]
 
+if settings.DEBUG_TOOLBAR:  # pragma: no cover
+    debug_toolbar_urls = [path("__debug__/", include("debug_toolbar.urls"))]
+else:
+    debug_toolbar_urls = []
+
 urlpatterns = [
     path("", Index.as_view(), name="home"),
     path(
@@ -337,7 +341,7 @@ urlpatterns = [
     path("ui-components/", components),
     path("users/", include(user_urls)),
     path("workspaces/", yours.WorkspaceList.as_view(), name="your-workspaces"),
-    path("__debug__/", include(debug_toolbar.urls)),
+    *debug_toolbar_urls,
     path("<str:project_slug>/", include(project_urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 

--- a/justfile
+++ b/justfile
@@ -175,7 +175,7 @@ load-dev-data: devenv
 # Run the dev project
 run bind="localhost:8000": devenv
     $BIN/python manage.py migrate
-    $BIN/python manage.py runserver {{ bind }}
+    DJANGO_DEBUG_TOOLBAR=1 $BIN/python manage.py runserver {{ bind }}
 
 
 run-prod: prodenv

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -7,6 +7,7 @@
 black
 coverage[toml]
 coverage-enable-subprocess
+django-debug-toolbar
 django-upgrade
 factory_boy
 pip-tools

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,6 +4,12 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements.dev.txt --strip-extras requirements.dev.in
 #
+asgiref==3.7.2 \
+    --hash=sha256:89b2ef2247e3b562a16eef663bc0e2e703ec6468e2fa8a5cd61cd449786d4f6e \
+    --hash=sha256:9e0ce3aa93a819ba5b45120216b23878cf6e8525eb3848653452b4192b92afed
+    # via
+    #   -c requirements.prod.txt
+    #   django
 attrs==23.2.0 \
     --hash=sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30 \
     --hash=sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1
@@ -212,6 +218,16 @@ distlib==0.3.8 \
     --hash=sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784 \
     --hash=sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64
     # via virtualenv
+django==5.0.7 \
+    --hash=sha256:bd4505cae0b9bd642313e8fb71810893df5dc2ffcacaa67a33af2d5cd61888f2 \
+    --hash=sha256:f216510ace3de5de01329463a315a629f33480e893a9024fc93d8c32c22913da
+    # via
+    #   -c requirements.prod.txt
+    #   django-debug-toolbar
+django-debug-toolbar==4.4.6 \
+    --hash=sha256:36e421cb908c2f0675e07f9f41e3d1d8618dc386392ec82d23bcfcd5d29c7044 \
+    --hash=sha256:3beb671c9ec44ffb817fad2780667f172bd1c067dbcabad6268ce39a81335f45
+    # via -r requirements.dev.in
 django-upgrade==1.20.0 \
     --hash=sha256:47aa2133972b600a8d935bab8d58d69b2e426bfc985d4c4f4c2fefecd754dd88 \
     --hash=sha256:938afa1a531399a12904eb71ffacad0c997ddbe0c45ec38bc0883a1cdcfd99ef
@@ -441,6 +457,13 @@ six==1.16.0 \
     # via
     #   -c requirements.prod.txt
     #   python-dateutil
+sqlparse==0.5.0 \
+    --hash=sha256:714d0a4932c059d16189f58ef5411ec2287a4360f17cdd0edd2d09d4c5087c93 \
+    --hash=sha256:c204494cd97479d0e39f28c93d46c0b2d5959c7b9ab904762ea6c7af211c8663
+    # via
+    #   -c requirements.prod.txt
+    #   django
+    #   django-debug-toolbar
 stamina==24.2.0 \
     --hash=sha256:4dbd8076d2cb4e228046833e4507af3406cc31b9b6046e8a6729ffde934b2526 \
     --hash=sha256:8db72126f2342e428b153cbcf837f8a90f89b783aa55e19d4a17193116ee35ee

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -4,7 +4,6 @@ bs4
 django
 django-anymail[mailgun]
 django-csp
-django-debug-toolbar
 django-extensions
 django-htmx
 django-permissions-policy

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -364,7 +364,6 @@ django==5.0.7 \
     #   dj-database-url
     #   django-anymail
     #   django-csp
-    #   django-debug-toolbar
     #   django-extensions
     #   django-htmx
     #   django-permissions-policy
@@ -385,10 +384,6 @@ django-cache-url==3.4.5 \
 django-csp==3.8 \
     --hash=sha256:19b2978b03fcd73517d7d67acbc04fbbcaec0facc3e83baa502965892d1e0719 \
     --hash=sha256:ef0f1a9f7d8da68ae6e169c02e9ac661c0ecf04db70e0d1d85640512a68471c0
-    # via -r requirements.prod.in
-django-debug-toolbar==4.4.6 \
-    --hash=sha256:36e421cb908c2f0675e07f9f41e3d1d8618dc386392ec82d23bcfcd5d29c7044 \
-    --hash=sha256:3beb671c9ec44ffb817fad2780667f172bd1c067dbcabad6268ce39a81335f45
     # via -r requirements.prod.in
 django-extensions==3.2.3 \
     --hash=sha256:44d27919d04e23b3f40231c4ab7af4e61ce832ef46d610cc650d53e68328410a \
@@ -906,9 +901,7 @@ soupsieve==2.5 \
 sqlparse==0.5.0 \
     --hash=sha256:714d0a4932c059d16189f58ef5411ec2287a4360f17cdd0edd2d09d4c5087c93 \
     --hash=sha256:c204494cd97479d0e39f28c93d46c0b2d5959c7b9ab904762ea6c7af211c8663
-    # via
-    #   django
-    #   django-debug-toolbar
+    # via django
 structlog==24.4.0 \
     --hash=sha256:597f61e80a91cc0749a9fd2a098ed76715a1c8a01f73e336b746504d1aad7610 \
     --hash=sha256:b27bfecede327a6d2da5fbc96bd859f114ecc398a6389d664f62085ee7ae6fc4


### PR DESCRIPTION
Although making django-debug-toolbar (DDT) a development dependency introduces branches in `settings.py` and `urls.py`, which we have tried to avoid in the past (e.g. bfdc66f), it nevertheless makes our production deployment more secure. Depending on DDT only in development is also clearer than depending on it in production and in development, but indirectly disabling it in production via `settings.INTERNAL_IPS`.

This commit takes inspiration from opensafely-core/airlock#131 and isolates specific DDT-related settings from general debug-related settings. It does this with the `DJANGO_DEBUG_TOOLBAR` environment variable and the `DEBUG_TOOLBAR` setting (the `DJANGO_` prefix is dropped from the setting, as it's unnecessary). For safety, the setting is `False` by default. Because seeing DDT is a good reminder that the browser tab you're looking at is pointing to development and not production, DDT is enabled in development by hard-coding the environment variable in `just run`.

Closes #4441