### PR TITLE
Add Vite plugin for automatic browser reloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "prettier": "^3.3.2",
         "prettier-eslint": "^16.3.0",
         "vite": "^5.3.3",
+        "vite-plugin-live-reload": "^3.0.3",
         "vite-plugin-static-copy": "^1.0.6",
         "vitest": "^1.6.0",
         "vitest-fetch-mock": "^0.2.2",
@@ -10352,6 +10353,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-live-reload": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-live-reload/-/vite-plugin-live-reload-3.0.3.tgz",
+      "integrity": "sha512-ce1ygNPmfVdiO6SyjpephroZiK+X5+BFetkceD/FFOYZEPoVSydJRfKT2JPaL4/D3C3NwqJvtPjnla1GSa264A==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.0",
+        "picocolors": "^1.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/vite-plugin-static-copy": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prettier": "^3.3.2",
     "prettier-eslint": "^16.3.0",
     "vite": "^5.3.3",
+    "vite-plugin-live-reload": "^3.0.3",
     "vite-plugin-static-copy": "^1.0.6",
     "vitest": "^1.6.0",
     "vitest-fetch-mock": "^0.2.2",

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import react from "@vitejs/plugin-react-swc";
+import liveReload from "vite-plugin-live-reload";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 
 /**
@@ -33,6 +34,7 @@ const config = {
   },
   clearScreen: false,
   plugins: [
+    liveReload("templates/**/*.html"),
     react(),
     viteStaticCopy({
       targets: [


### PR DESCRIPTION
Add [vite-plugin-live-reload](https://github.com/arnoson/vite-plugin-live-reload/) to Vite config. This allows the page to reload when the template HTML files are changed, for example when HTML classes are changed for Tailwind styling.

This is required as [django-browser-reload has been removed](https://github.com/opensafely-core/job-server/pull/4472).