### PR TITLE
Remove zen queries in the Job Request View

### DIFF
--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -7,11 +7,11 @@ from django.db import transaction
 from django.db.models import Max, Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.views.generic import CreateView, ListView, RedirectView, View
 from pipeline import load_pipeline
-from zen_queries import TemplateResponse, fetch
 
 from .. import honeycomb
 from ..authorization import CoreDeveloper, has_permission, has_role, permissions
@@ -210,7 +210,7 @@ class JobRequestDetail(View):
         except (JobRequest.DoesNotExist, MultipleObjectsReturned):
             raise Http404
 
-        jobs = fetch(job_request.jobs.order_by("started_at"))
+        jobs = job_request.jobs.order_by("started_at")
 
         # we encode errors raised by job-runner when processing a JobRequest by
         # misusing a Job, since that's our only method of returning messages

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -1124,26 +1124,6 @@ def test_jobrequestdetail_without_permission(rf):
     assert "Cancel" not in response.rendered_content
 
 
-def test_jobrequestdetail_num_queries(rf, django_assert_num_queries):
-    user = UserFactory()
-    job_request = JobRequestFactory(created_by=user)
-
-    request = rf.get("/")
-    request.user = user
-
-    with django_assert_num_queries(8):
-        response = JobRequestDetail.as_view()(
-            request,
-            project_slug=job_request.workspace.project.slug,
-            workspace_slug=job_request.workspace.name,
-            pk=job_request.pk,
-        )
-        assert response.status_code == 200
-
-    with django_assert_num_queries(4):
-        response.render()
-
-
 def test_jobrequestdetail_with_permission_num_queries(
     rf, django_assert_num_queries, project_membership, role_factory
 ):

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -1131,7 +1131,7 @@ def test_jobrequestdetail_num_queries(rf, django_assert_num_queries):
     request = rf.get("/")
     request.user = user
 
-    with django_assert_num_queries(9):
+    with django_assert_num_queries(8):
         response = JobRequestDetail.as_view()(
             request,
             project_slug=job_request.workspace.project.slug,
@@ -1140,7 +1140,7 @@ def test_jobrequestdetail_num_queries(rf, django_assert_num_queries):
         )
         assert response.status_code == 200
 
-    with django_assert_num_queries(3):
+    with django_assert_num_queries(4):
         response.render()
 
 
@@ -1161,7 +1161,7 @@ def test_jobrequestdetail_with_permission_num_queries(
     request = rf.get("/")
     request.user = user
 
-    with django_assert_num_queries(10):
+    with django_assert_num_queries(9):
         response = JobRequestDetail.as_view()(
             request,
             project_slug=job_request.workspace.project.slug,
@@ -1170,7 +1170,7 @@ def test_jobrequestdetail_with_permission_num_queries(
         )
         assert response.status_code == 200
 
-    with django_assert_num_queries(3):
+    with django_assert_num_queries(4):
         response.render()
 
 

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -981,9 +981,7 @@ def test_jobrequestdetail_with_invalid_job_request(rf, django_assert_num_queries
     assert response.context_data["is_invalid"]
 
 
-def test_jobrequestdetail_with_permission(
-    rf, django_assert_num_queries, project_membership, role_factory
-):
+def test_jobrequestdetail_with_permission(rf, project_membership, role_factory):
     job_request = JobRequestFactory()
     JobFactory(job_request=job_request, updated_at=minutes_ago(timezone.now(), 31))
 
@@ -998,13 +996,12 @@ def test_jobrequestdetail_with_permission(
     request = rf.get("/")
     request.user = user
 
-    with django_assert_num_queries(10):
-        response = JobRequestDetail.as_view()(
-            request,
-            project_slug=job_request.workspace.project.slug,
-            workspace_slug=job_request.workspace.name,
-            pk=job_request.pk,
-        )
+    response = JobRequestDetail.as_view()(
+        request,
+        project_slug=job_request.workspace.project.slug,
+        workspace_slug=job_request.workspace.name,
+        pk=job_request.pk,
+    )
 
     assert response.status_code == 200
     assert not response.context_data["is_invalid"]
@@ -1125,6 +1122,56 @@ def test_jobrequestdetail_without_permission(rf):
 
     assert response.status_code == 200
     assert "Cancel" not in response.rendered_content
+
+
+def test_jobrequestdetail_num_queries(rf, django_assert_num_queries):
+    user = UserFactory()
+    job_request = JobRequestFactory(created_by=user)
+
+    request = rf.get("/")
+    request.user = user
+
+    with django_assert_num_queries(9):
+        response = JobRequestDetail.as_view()(
+            request,
+            project_slug=job_request.workspace.project.slug,
+            workspace_slug=job_request.workspace.name,
+            pk=job_request.pk,
+        )
+        assert response.status_code == 200
+
+    with django_assert_num_queries(3):
+        response.render()
+
+
+def test_jobrequestdetail_with_permission_num_queries(
+    rf, django_assert_num_queries, project_membership, role_factory
+):
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, updated_at=minutes_ago(timezone.now(), 31))
+
+    user = UserFactory()
+
+    project_membership(
+        project=job_request.workspace.project,
+        user=user,
+        roles=[role_factory(permission=permissions.job_cancel)],
+    )
+
+    request = rf.get("/")
+    request.user = user
+
+    with django_assert_num_queries(10):
+        response = JobRequestDetail.as_view()(
+            request,
+            project_slug=job_request.workspace.project.slug,
+            workspace_slug=job_request.workspace.name,
+            pk=job_request.pk,
+        )
+        assert response.status_code == 200
+
+    with django_assert_num_queries(3):
+        response.render()
 
 
 def test_jobrequestdetailredirect_success(rf):


### PR DESCRIPTION
Here I've removed Zen Queries from JobRequests.

I couldn't find a sensible way to avoid the extra query in the template, but I'd be open to ideas if anyone can see anything obvious. I could add the line: `jobs = list(jobs)` and that does work, but it seems messy for very little gain. There's no performance impact that I can see to having the extra query in the template at the moment.