### PR TITLE
Exclude floats from sensitive token checking

### DIFF
--- a/services/sentry.py
+++ b/services/sentry.py
@@ -57,7 +57,7 @@ def parse(data):
     if data is None:
         return
 
-    if isinstance(data, bool | int):
+    if isinstance(data, bool | int | float):
         return data
 
     if isinstance(data, dict):

--- a/tests/unit/services/sentry_event_cron_error.json
+++ b/tests/unit/services/sentry_event_cron_error.json
@@ -1,0 +1,58 @@
+{
+    "type": "check_in",
+    "monitor_slug": "test",
+    "check_in_id": "b0d6ba4d6c434e3cbb13180c010aae4d",
+    "status": "error",
+    "duration": 9.877637122001033,
+    "environment": "localhost",
+    "release": "7be872829421abebd71efd523162dbd65585eadf",
+    "monitor_config": {
+        "schedule": {
+            "type": "crontab",
+            "value": "@daily"
+        },
+        "timezone": "Etc/UTC",
+        "checkin_margin": 30,
+        "max_runtime": 10,
+        "failure_issue_threshold": 1,
+        "recovery_threshold": 1
+    },
+    "event_id": "2d6a2c3cb1c243eb827cac3277196df6",
+    "timestamp": "2024-07-25T14:05:16.788099Z",
+    "contexts": {
+        "trace": {
+            "trace_id": "89a57a1acce2426fb1cda60ef6962587",
+            "span_id": "9afd1a11ffcd62cd",
+            "parent_span_id": null,
+            "dynamic_sampling_context": {
+                "trace_id": "89a57a1acce2426fb1cda60ef6962587",
+                "environment": "localhost",
+                "release": "7be872829421abebd71efd523162dbd65585eadf",
+                "public_key": "f11c01639e084ed3aead0bae7981ebd2"
+            }
+        }
+    },
+    "server_name": "test",
+    "sdk": {
+        "name": "sentry.python.django",
+        "version": "2.10.0",
+        "packages": [
+            {
+                "name": "pypi:sentry-sdk",
+                "version": "2.10.0"
+            }
+        ],
+        "integrations": [
+            "argv",
+            "atexit",
+            "dedupe",
+            "django",
+            "excepthook",
+            "logging",
+            "modules",
+            "stdlib",
+            "threading"
+        ]
+    },
+    "platform": "python"
+}

--- a/tests/unit/services/sentry_event_cron_in_progress.json
+++ b/tests/unit/services/sentry_event_cron_in_progress.json
@@ -1,0 +1,20 @@
+{
+    "type": "check_in",
+    "monitor_slug": "test",
+    "check_in_id": "d5f18c7d46bc42068d109f81ed149ee6",
+    "status": "in_progress",
+    "duration": null,
+    "environment": "localhost",
+    "release": "7be872829421abebd71efd523162dbd65585eadf",
+    "monitor_config": {
+        "schedule": {
+            "type": "crontab",
+            "value": "@daily"
+        },
+        "timezone": "Etc/UTC",
+        "checkin_margin": 30,
+        "max_runtime": 10,
+        "failure_issue_threshold": 1,
+        "recovery_threshold": 1
+    }
+}

--- a/tests/unit/services/test_sentry.py
+++ b/tests/unit/services/test_sentry.py
@@ -48,6 +48,10 @@ def test_parse_without_envvar(event):
 
     data1 = event("sentry_event.json")
     data2 = event("sentry_event2.json")
+    data3 = event("sentry_event_cron_in_progress.json")
+    data4 = event("sentry_event_cron_error.json")
 
     assert parse(data1) == data1
     assert parse(data2) == data2
+    assert parse(data3) == data3
+    assert parse(data4) == data4


### PR DESCRIPTION
Sentry cron check-in events (#4421) contain float-typed fields which the `parse()` method would try to iterate whilst searching for sensitive tokens, causing an error.

The tokens listed in this method are all strings so safe to exclude floats for now.