### PR TITLE
Move health check to `app.json`

### DIFF
--- a/CHECKS
+++ b/CHECKS
@@ -1,5 +1,0 @@
-WAIT=30
-TIMEOUT=60
-ATTEMPTS=5
-
-/health-check/

--- a/app.json
+++ b/app.json
@@ -21,6 +21,7 @@
     "web": [
       {
         "name": "Web health check",
+        "type": "startup",
         "description": "Check if the app responds to the /health-check endpoint",
         "path": "/health-check",
         "port": 8000,

--- a/app.json
+++ b/app.json
@@ -16,5 +16,18 @@
       "command": "python manage.py runjobs monthly",
       "schedule": "@monthly"
     }
-  ]
+  ],
+  "healthchecks": {
+    "web": [
+      {
+        "name": "Web health check",
+        "description": "Check if the app responds to the /health-check endpoint",
+        "path": "/health-check",
+        "port": 8000,
+        "attempts": 5,
+        "initialDelay": 30,
+        "timeout": 60
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Fixes #4489.

`WAIT` was originally the time to wait before running the first check as explained, for example, in this old Dokku documentation page:

https://dokku.com/docs~v0.3.26/checks-examples/

This now corresponds to `initialDelay` in the `app.json` health check:

> Number of seconds to wait after a container has started before triggering the healthcheck.

(`wait` in `app.json` corresponds to the time between check attempts, which doesn't, from my reading, seem to have been configurable in the old `CHECKS` configuration. That is, a subsequent check would occur immediately after a failed check.)