### PR TITLE
Remove zen queries projects

### DIFF
--- a/jobserver/models/project.py
+++ b/jobserver/models/project.py
@@ -5,7 +5,6 @@ from django.urls import reverse
 from django.utils import functional, timezone
 from django.utils.text import slugify
 from furl import furl
-from zen_queries import queries_dangerously_enabled
 
 
 logger = structlog.get_logger(__name__)
@@ -201,11 +200,4 @@ class Project(models.Model):
 
     @functional.cached_property
     def org(self):
-        # zen-queries wants to stop Django's ORM executing queries "dangerously"; that
-        # is, executing one query for a set of elements, and then one extra query for
-        # each element. However, it's hard to hook properties into prefetch_related and,
-        # hence, to avoid making queries dangerously. We feel the costs of executing
-        # queries dangerously for this property are less than those of hooking this
-        # property into prefetch_related, so we ignore zen-queries for this property.
-        with queries_dangerously_enabled():
-            return self.orgs.filter(collaborations__is_lead=True).first()
+        return self.orgs.filter(collaborations__is_lead=True).first()

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -12,8 +12,6 @@ from django.views.generic import ListView, UpdateView, View
 from markdown import markdown
 from opentelemetry import context as otel_context
 from opentelemetry import trace
-from zen_queries import TemplateResponse as zTemplateResponse
-from zen_queries import fetch
 
 from jobserver import html_utils
 from jobserver.utils import set_from_qs
@@ -226,7 +224,6 @@ class ProjectEdit(UpdateView):
 
 class ProjectEventLog(ListView):
     paginate_by = 25
-    response_class = zTemplateResponse
     template_name = "project/event_log.html"
 
     def dispatch(self, request, *args, **kwargs):
@@ -240,7 +237,7 @@ class ProjectEventLog(ListView):
         }
 
     def get_queryset(self):
-        return fetch(
+        return (
             JobRequest.objects.with_started_at()
             .filter(workspace__project=self.project)
             .select_related("backend", "created_by", "workspace")

--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -381,11 +381,11 @@ def test_projecteventlog_num_queries(rf, django_assert_num_queries):
     request = rf.get("/")
     request.user = UserFactory()
 
-    with django_assert_num_queries(5):
+    with django_assert_num_queries(2):
         response = ProjectEventLog.as_view()(request, project_slug=project.slug)
         assert response.status_code == 200
 
-    with django_assert_num_queries(2):
+    with django_assert_num_queries(6):
         response.render()
 
 

--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -357,7 +357,7 @@ def test_projectedit_member_does_not_have_project_manage(rf, project_membership)
         ProjectEdit.as_view()(request, project_slug=project.slug)
 
 
-def test_projecteventlog_success(rf, django_assert_num_queries):
+def test_projecteventlog_success(rf):
     project = ProjectFactory()
     workspace = WorkspaceFactory(project=project)
 
@@ -366,13 +366,27 @@ def test_projecteventlog_success(rf, django_assert_num_queries):
     request = rf.get("/")
     request.user = UserFactory()
 
-    with django_assert_num_queries(5):
-        response = ProjectEventLog.as_view()(request, project_slug=project.slug)
+    response = ProjectEventLog.as_view()(request, project_slug=project.slug)
 
     assert response.status_code == 200
 
     expected = set_from_list(job_requests)
     assert set_from_list(response.context_data["object_list"]) == expected
+
+
+def test_projecteventlog_num_queries(rf, django_assert_num_queries):
+    project = ProjectFactory()
+    JobRequestFactory.create_batch(5, workspace=WorkspaceFactory(project=project))
+
+    request = rf.get("/")
+    request.user = UserFactory()
+
+    with django_assert_num_queries(5):
+        response = ProjectEventLog.as_view()(request, project_slug=project.slug)
+        assert response.status_code == 200
+
+    with django_assert_num_queries(2):
+        response.render()
 
 
 def test_projecteventlog_unknown_project(rf):


### PR DESCRIPTION
I've removed zen-queries from anything related to Projects. Only Users are left now!

Refs [#4391](https://github.com/opensafely-core/job-server/issues/4391)
