### PR TITLE
Warn if templates are missing variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ env = [
   "DEFAULT_OUTPUT_CHECKING_SLACK_CHANNEL=test-channel",
 ]
 filterwarnings = [
-    "error",
     "ignore::pytest.PytestUnraisableExceptionWarning:",
     "ignore:Call to deprecated method __init__:DeprecationWarning:",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ env = [
   "DEFAULT_OUTPUT_CHECKING_SLACK_CHANNEL=test-channel",
 ]
 filterwarnings = [
+    "error",
     "ignore::pytest.PytestUnraisableExceptionWarning:",
     "ignore:Call to deprecated method __init__:DeprecationWarning:",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:",

--- a/services/logging.py
+++ b/services/logging.py
@@ -80,6 +80,12 @@ class MissingVariableErrorFilter(logging.Filter):
         # are missing when pages are requested by a `RequestFactory` instance.
         "csp_nonce",  # csp.middleware.CSPMiddleware
         "template_name",  # jobserver.middleware.TemplateNameMiddleware
+        # And some template variables are just a pain, because of how we use them.
+        "name",  # jobserver.context_processors.nav
+        "q",
+        # The following is a property on User but not AnonymousUser. It's non-trivial to
+        # extend the latter to provide it, so we ignore it.
+        "all_roles",
     }
 
     def filter(self, record):  # pragma: no cover

--- a/services/logging.py
+++ b/services/logging.py
@@ -1,3 +1,6 @@
+import logging
+import warnings
+
 import structlog
 from environs import Env
 
@@ -50,6 +53,52 @@ structlog.configure(
     wrapper_class=structlog.stdlib.BoundLogger,
 )
 
+
+class MissingVariableErrorFilter(logging.Filter):
+    """
+    Convert "missing template variable" log messages into warnings.
+
+    Heavily inspired by Adam Johnson's work here:
+    https://adamj.eu/tech/2022/03/30/how-to-make-django-error-for-undefined-template-variables/
+    """
+
+    ignored_prefixes = (
+        # Some of Django's internal templates rely on the silent missing template
+        # variable behaviour
+        "admin/",
+        "auth/",
+        "django/",
+        # As does our internal component library
+        "_components",
+        "_partials",
+        # As do two of our internal applications
+        "applications/",
+        "interactive/",
+    )
+    ignored_variable_names = {
+        # Some template variables are added by middleware, and so
+        # are missing when pages are requested by a `RequestFactory` instance.
+        "csp_nonce",  # csp.middleware.CSPMiddleware
+        "template_name",  # jobserver.middleware.TemplateNameMiddleware
+    }
+
+    def filter(self, record):  # pragma: no cover
+        if record.msg.startswith("Exception while resolving variable "):
+            variable_name, template_name = record.args
+            if (
+                not template_name.startswith(self.ignored_prefixes)
+                # This shows up when rendering Django's internal error pages
+                and template_name != "unknown"
+                and variable_name not in self.ignored_variable_names
+            ):
+                # We use `warn_explicit` to raise the warning at whatever location the
+                # original log message was raised
+                warnings.warn_explicit(
+                    record.getMessage(), UserWarning, record.pathname, record.lineno
+                )
+        return False
+
+
 logging_config_dict = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -68,11 +117,20 @@ logging_config_dict = {
         }
     },
     "root": {"handlers": ["console"], "level": "WARNING"},
+    "filters": {
+        "missing_variable_error": {
+            "()": f"{MissingVariableErrorFilter.__module__}.{MissingVariableErrorFilter.__name__}"
+        }
+    },
     "loggers": {
         "django": {
             "handlers": ["console"],
             "level": env.str("DJANGO_LOG_LEVEL", default="INFO"),
             "propagate": False,
+        },
+        "django.template": {
+            "level": "DEBUG",
+            "filters": ["missing_variable_error"],
         },
         "gunicorn.access": {
             "handlers": ["console"],

--- a/templates/project/detail.html
+++ b/templates/project/detail.html
@@ -33,23 +33,21 @@
       lg:col-span-2
     ">
       <div class="flex-shrink-0 flex flex-col items-center">
-        {% with org=project.orgs.first %}
-        {% if org.logo_file %}
+        {% if project.org.logo_file %}
           <img
-            alt="{{ org.name }} logo"
+            alt="{{ project.org.name }} logo"
             class="w-24 h-24 bg-white aspect-square rounded-2xl border border-slate-200 shadow-sm overflow-hidden flex-shrink-0 mt-1 mb-2"
             height="144"
-            src="{{ org.logo_file.url }}"
+            src="{{ project.org.logo_file.url }}"
             width="144"
           />
         {% else %}
           <span class="grid place-content-center text-center w-24 h-24 bg-white border border-slate-300 rounded-md overflow-hidden flex-shrink-0 mt-1 mb-2">
             <span class="text-xs text-slate-600 tracking-tighter leading-4 p-1">
-              {{ org.name }}
+              {{ project.org.name }}
             </span>
           </span>
         {% endif %}
-        {% endwith %}
 
         {% pill sr_only="Status:" variant=status.variant text=status.title %}
         {% if status.sub_title %}

--- a/templates/project/event_log.html
+++ b/templates/project/event_log.html
@@ -98,9 +98,13 @@
 
       {% if page_obj.has_previous %}
         {% url_with_querystring page=page_obj.previous_page_number as prev_url %}
+      {% else %}
+        {% var prev_url="" %}
       {% endif %}
       {% if page_obj.has_next %}
         {% url_with_querystring page=page_obj.next_page_number as next_url %}
+      {% else %}
+        {% var next_url="" %}
       {% endif %}
       {% table_pagination paginator=page_obj next_url=next_url prev_url=prev_url %}
     {% /card %}

--- a/templates/staff/application/approve.html
+++ b/templates/staff/application/approve.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-{% block metatitle %}Approve application: {{ project.title }} | OpenSAFELY Jobs{% endblock metatitle %}
+{% block metatitle %}Approve application: {{ application.pk_hash }} | OpenSAFELY Jobs{% endblock metatitle %}
 
 {% block breadcrumbs %}
 {% #breadcrumbs %}

--- a/templates/staff/application/list.html
+++ b/templates/staff/application/list.html
@@ -85,6 +85,8 @@
       <form method="GET" class="flex flex-row gap-x-2 items-center">
         {% if request.GET.q %}
           {% var value=request.GET.q|stringformat:"s" %}
+        {% else %}
+          {% var value="" %}
         {% endif %}
         {% form_input custom_field=True type="search" id="applicationSearch" name="q" value=value label="Search for an application" label_class="sr-only" class="w-full" input_class="!m-0" %}
         {% #button type="submit" variant="primary" class="flex-shrink-0" %}Search{% /button %}

--- a/templates/staff/project/membership_create.html
+++ b/templates/staff/project/membership_create.html
@@ -60,7 +60,7 @@
                 <span class="font-bold block text-base">{{ label }}</span>
                 <span class="text-sm">{{ value|role_description|linebreaksbr }}</span>
               {% endfragment %}
-              {% form_checkbox custom_field=True name="roles" id="id_roles_"|add:id|slugify label=form_label value=value checked=checked %}
+              {% form_checkbox custom_field=True name="roles" id="id_roles_"|add:id|slugify label=form_label value=value checked=False %}
             {% endwith %}
           {% endfor %}
         {% /form_fieldset %}

--- a/templates/user/event_log.html
+++ b/templates/user/event_log.html
@@ -109,9 +109,13 @@
 
       {% if page_obj.has_previous %}
         {% url_with_querystring page=page_obj.previous_page_number as prev_url %}
+      {% else %}
+        {% var prev_url="" %}
       {% endif %}
       {% if page_obj.has_next %}
         {% url_with_querystring page=page_obj.next_page_number as next_url %}
+      {% else %}
+        {% var next_url="" %}
       {% endif %}
       {% table_pagination paginator=page_obj next_url=next_url prev_url=prev_url %}
     {% /card %}

--- a/tests/factories/project.py
+++ b/tests/factories/project.py
@@ -3,6 +3,18 @@ import factory
 from jobserver.models import Project
 
 
+def _project_collaboration_factory(obj, create, extracted, **kwargs):
+    from . import ProjectCollaborationFactory
+
+    if not create or not extracted:
+        # Simple build, or nothing to add, do nothing.
+        return
+
+    # Add the iterable of groups using bulk addition
+    for org in extracted:
+        ProjectCollaborationFactory(org=org, project=obj, is_lead=True)
+
+
 class ProjectFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Project
@@ -14,14 +26,4 @@ class ProjectFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f"Project {n}")
     slug = factory.Sequence(lambda n: f"project-{n}")
 
-    @factory.post_generation
-    def orgs(self, create, extracted, **kwargs):
-        from . import ProjectCollaborationFactory
-
-        if not create or not extracted:
-            # Simple build, or nothing to add, do nothing.
-            return
-
-        # Add the iterable of groups using bulk addition
-        for org in extracted:
-            ProjectCollaborationFactory(org=org, project=self, is_lead=True)
+    orgs = factory.PostGeneration(_project_collaboration_factory)

--- a/tests/factories/project.py
+++ b/tests/factories/project.py
@@ -1,3 +1,5 @@
+from collections import abc
+
 import factory
 
 from jobserver.models import Project
@@ -9,6 +11,8 @@ def _project_collaboration_factory(obj, create, extracted, **kwargs):
     if not create or not extracted:
         # Simple build, or nothing to add, do nothing.
         return
+
+    extracted = extracted if isinstance(extracted, abc.Iterable) else [extracted]
 
     # Add the iterable of groups using bulk addition
     for org in extracted:
@@ -26,4 +30,5 @@ class ProjectFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f"Project {n}")
     slug = factory.Sequence(lambda n: f"project-{n}")
 
+    org = factory.PostGeneration(_project_collaboration_factory)
     orgs = factory.PostGeneration(_project_collaboration_factory)

--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -103,7 +103,7 @@ def test_projectdetail_for_interactive_button(
 
 
 def test_projectdetail_with_multiple_releases(rf, freezer):
-    project = ProjectFactory()
+    project = ProjectFactory(org=OrgFactory())
 
     now = timezone.now()
 

--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -18,6 +18,7 @@ from jobserver.views.projects import (
 from ....factories import (
     JobFactory,
     JobRequestFactory,
+    OrgFactory,
     ProjectFactory,
     PublishRequestFactory,
     RepoFactory,
@@ -67,7 +68,7 @@ def test_projectdetail_success(rf, user):
 def test_projectdetail_for_interactive_button(
     rf, user, project_membership, role_factory
 ):
-    project = ProjectFactory()
+    project = ProjectFactory(org=OrgFactory())
     user = UserFactory(
         roles=[role_factory(permission=permissions.analysis_request_create)]
     )
@@ -173,7 +174,7 @@ def test_projectdetail_with_multiple_releases(rf, freezer):
 
 
 def test_projectdetail_with_no_github(rf):
-    project = ProjectFactory()
+    project = ProjectFactory(org=OrgFactory())
     WorkspaceFactory(
         project=project, repo=RepoFactory(url="https://github.com/owner/repo")
     )
@@ -215,7 +216,7 @@ def test_projectdetail_with_no_jobs(rf):
 
 
 def test_projectdetail_with_no_releases(rf):
-    project = ProjectFactory()
+    project = ProjectFactory(org=OrgFactory())
 
     request = rf.get("/")
     request.user = UserFactory()

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -33,6 +33,7 @@ from ....factories import (
     BackendMembershipFactory,
     JobFactory,
     JobRequestFactory,
+    OrgFactory,
     ProjectFactory,
     PublishRequestFactory,
     ReleaseFactory,
@@ -1319,7 +1320,7 @@ def test_workspaceoutputlist_success(
 
 
 def test_workspaceoutputlist_without_permission(rf, freezer, build_release_with_files):
-    workspace = WorkspaceFactory()
+    workspace = WorkspaceFactory(project__org=OrgFactory())
 
     now = timezone.now()
 
@@ -1358,7 +1359,7 @@ def test_workspaceoutputlist_without_permission(rf, freezer, build_release_with_
 
 
 def test_workspaceoutputlist_without_snapshots(rf, freezer, role_factory):
-    workspace = WorkspaceFactory()
+    workspace = WorkspaceFactory(project__org=OrgFactory())
 
     request = rf.get("/")
     request.user = UserFactory(

--- a/tests/unit/services/test_logging.py
+++ b/tests/unit/services/test_logging.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 
+import pytest
+from django.template import Context, Template
+
 from services.logging import timestamper
 
 
@@ -17,3 +20,25 @@ def test_timestamper_without_debug(monkeypatch):
     monkeypatch.setattr("services.logging.DEBUG", False)
 
     assert timestamper(None, None, {"event": "derp"}) == {"event": "derp"}
+
+
+def test_missing_variable_error_filter():
+    template = Template("*{{ my_missing_variable }}*", name="index.html")
+    context = Context({"my_variable": "my_value"})
+
+    with pytest.warns(UserWarning):
+        template.render(context)
+
+
+def test_missing_variable_error_filter_with_ignored_prefix():
+    template = Template("*{{ my_missing_variable }}*", name="admin/index.html")
+    context = Context({"my_variable": "my_value"})
+
+    template.render(context) == "**"
+
+
+def test_missing_variable_error_filter_with_ignored_variable_name():
+    template = Template("*{{ csp_nonce }}*", name="index.html")
+    context = Context({"csp_nonce": "csp_nonce_value"})
+
+    template.render(context) == "*csp_nonce_value*"

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -362,7 +362,7 @@ def test_projectdetail_success(rf, core_developer):
 
 
 def test_projectedit_get_success(rf, core_developer):
-    project = ProjectFactory()
+    project = ProjectFactory(orgs=[OrgFactory()])
 
     UserFactory(username="beng", fullname="Ben Goldacre")
 


### PR DESCRIPTION
Previously, messages about missing context variables were ignored. This was because the `django.template` logger logged them as `DEBUG` messages ([1][]), but the `django` logger (the parent of the `django.template` logger) sent only `INFO` messages (or higher) to the console.

Now, the `django.template` logger sends `DEBUG` messages (or higher) to the `missing_variable_error` filter. This filter always returns `False`, meaning that messages are (still) not sent to the console. However, it also converts messages about missing context variables to warnings.

pytest catches warnings during, and displays them at the end of, test sessions ([2][]). So, if a template is missing a context variable, and the template response associated with the template is tested, then pytest should tell us, shouldn't it? Sadly, it's not that simple. Messages about missing context variables are only generated when a template response is rendered. If a test constructs, but doesn't render, a template response, then pytest won't tell us about missing context variables because it won't know about them either. In these cases, because warning messages are written to `sys.stderr`, we would most likely find out about missing context variables by inspecting the output of Django's development server.

Notice that the `missing_variable_error` filter only converts *some* messages about missing context variables to warnings. Whilst some are beyond our control, others are not cost- effective to fix.

[1]: https://docs.djangoproject.com/en/5.1/ref/logging/#django-template
[2]: https://docs.pytest.org/en/latest/how-to/capture-warnings.html#warnings

Closes #4462 