### PR TITLE
Remove unused OrgCoordinator role

### DIFF
--- a/jobserver/authorization/__init__.py
+++ b/jobserver/authorization/__init__.py
@@ -1,7 +1,6 @@
 from .roles import (
     CoreDeveloper,
     InteractiveReporter,
-    OrgCoordinator,
     OutputChecker,
     OutputPublisher,
     ProjectCollaborator,
@@ -13,7 +12,6 @@ from .utils import has_permission, has_role, roles_for, strings_to_roles
 __all__ = [
     "CoreDeveloper",
     "InteractiveReporter",
-    "OrgCoordinator",
     "OutputChecker",
     "OutputPublisher",
     "ProjectCollaborator",

--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -62,19 +62,6 @@ class InteractiveReporter:
     ]
 
 
-class OrgCoordinator:
-    """
-    A responsible party for an Org
-    """
-
-    display_name = "Organisation Coordinator"
-    description = ""
-    models = [
-        "jobserver.models.org_membership.OrgMembership",
-    ]
-    permissions = []
-
-
 class OutputChecker:
     """
     Review output folders that have been proposed for release.

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -334,15 +334,11 @@ class UserRoleList(FormView):
         return redirect(self.user.get_staff_roles_url())
 
     def get_context_data(self, **kwargs):
-        org_memberships_with_roles = self.user.org_memberships.exclude(
-            roles=[]
-        ).order_by(Lower("org__name"))
         project_memberships_with_roles = self.user.project_memberships.exclude(
             roles=[]
         ).order_by("project__number", Lower("project__name"))
 
         return super().get_context_data(**kwargs) | {
-            "orgs": org_memberships_with_roles,
             "projects": project_memberships_with_roles,
             "user": self.user,
         }

--- a/templates/staff/user/role_list.html
+++ b/templates/staff/user/role_list.html
@@ -95,7 +95,7 @@
 
   {% #card title="Orgs" %}
     {% #list_group %}
-      {% for membership in org %}
+      {% for membership in orgs %}
         {% #list_group_item href=membership.get_staff_edit_url|add:"?next="|add:request.path %}
           {{ membership.org.name }}
           {% for role in membership.roles %}

--- a/templates/staff/user/role_list.html
+++ b/templates/staff/user/role_list.html
@@ -92,22 +92,5 @@
       {% endfor %}
     {% /list_group %}
   {% /card %}
-
-  {% #card title="Orgs" %}
-    {% #list_group %}
-      {% for membership in orgs %}
-        {% #list_group_item href=membership.get_staff_edit_url|add:"?next="|add:request.path %}
-          {{ membership.org.name }}
-          {% for role in membership.roles %}
-            <span class="block text-sm text-slate-700">
-              {{ role.display_name }}
-            </span>
-          {% endfor %}
-        {% /list_group_item %}
-      {% empty %}
-        {% list_group_empty icon=True title="No orgs" description="No organisation memberships with roles" %}
-      {% endfor %}
-    {% /list_group %}
-  {% /card %}
 </div>
 {% endblock content %}

--- a/tests/unit/jobserver/api/test_jobs.py
+++ b/tests/unit/jobserver/api/test_jobs.py
@@ -13,7 +13,7 @@ from jobserver.api.jobs import (
     get_backend_from_token,
     update_stats,
 )
-from jobserver.authorization import CoreDeveloper, OrgCoordinator, ProjectDeveloper
+from jobserver.authorization import CoreDeveloper, ProjectDeveloper
 from jobserver.models import Job, JobRequest, Stats
 from tests.factories import (
     AnalysisRequestFactory,
@@ -884,7 +884,7 @@ def test_userapidetail_success(api_rf, project_membership):
     project = ProjectFactory(orgs=[org])
     user = UserFactory(roles=[CoreDeveloper])
 
-    OrgMembershipFactory(org=org, user=user, roles=[OrgCoordinator])
+    OrgMembershipFactory(org=org, user=user, roles=[])
     project_membership(project=project, user=user, roles=[ProjectDeveloper])
 
     request = api_rf.get("/", headers={"authorization": backend.auth_token})
@@ -901,7 +901,6 @@ def test_userapidetail_success(api_rf, project_membership):
         "user_manage",
     ]
     assert permissions["orgs"] == [
-        # we have no permissions for OrgCoordinator yet
         {
             "slug": org.slug,
             "permissions": [],
@@ -926,7 +925,7 @@ def test_userapidetail_success(api_rf, project_membership):
     # roles
     roles = response.data["roles"]
     assert roles["global"] == ["CoreDeveloper"]
-    assert roles["orgs"] == [{"slug": org.slug, "roles": ["OrgCoordinator"]}]
+    assert roles["orgs"] == [{"slug": org.slug, "roles": []}]
     assert roles["projects"] == [{"slug": project.slug, "roles": ["ProjectDeveloper"]}]
 
 

--- a/tests/unit/jobserver/authorization/test_mappers.py
+++ b/tests/unit/jobserver/authorization/test_mappers.py
@@ -1,4 +1,4 @@
-from jobserver.authorization import CoreDeveloper, OrgCoordinator, ProjectCollaborator
+from jobserver.authorization import CoreDeveloper, ProjectCollaborator
 from jobserver.authorization.mappers import (
     get_org_roles_for_user,
     get_project_roles_for_user,
@@ -16,11 +16,11 @@ def test_get_org_roles_for_user_with_roles():
     org = OrgFactory()
     user = UserFactory(roles=[CoreDeveloper])
 
-    OrgMembershipFactory(org=org, user=user, roles=[OrgCoordinator])
+    OrgMembershipFactory(org=org, user=user, roles=[ProjectCollaborator])
 
     roles = get_org_roles_for_user(org, user)
 
-    assert roles == [OrgCoordinator]
+    assert roles == [ProjectCollaborator]
 
 
 def test_get_org_roles_for_user_unknown_membership():

--- a/tests/unit/staff/views/test_users.py
+++ b/tests/unit/staff/views/test_users.py
@@ -782,7 +782,7 @@ def test_userlist_success(rf, core_developer):
 
 
 def test_userrolelist_get_success(rf, core_developer):
-    user = UserFactory()
+    user = UserFactory(roles=[ProjectDeveloper])
 
     request = rf.get("/")
     request.user = core_developer
@@ -790,6 +790,8 @@ def test_userrolelist_get_success(rf, core_developer):
     response = UserRoleList.as_view()(request, username=user.username)
 
     assert response.status_code == 200
+
+    response.render()
 
 
 def test_userrolelist_post_success(rf, core_developer):


### PR DESCRIPTION
This removes the unused OrgCoordinator role and the one remaining reference of org roles in the UI.

This does not remove the role field from the OrgMembership class, which is a bigger change involving a migration and will be done separately.

Refs #4198