### PR TITLE
Don't store user GitHub access-tokens in db

### DIFF
--- a/jobserver/auth_pipeline.py
+++ b/jobserver/auth_pipeline.py
@@ -63,7 +63,6 @@ def pipeline(response, strategy, *args, **kwargs):
             "id": uid,
             "expires": response.get("expires", None),
             "login": response["login"],
-            "access_token": response["access_token"],
             "token_type": response["token_type"],
         }
 

--- a/tests/unit/jobserver/test_auth_pipeline.py
+++ b/tests/unit/jobserver/test_auth_pipeline.py
@@ -84,7 +84,7 @@ def test_pipeline_with_new_user(slack_messages, strategy):
 
     social = output["social"]
     assert social.user == user
-    assert social.extra_data["access_token"] == "sekret"
+    assert "sekret" not in social.extra_data.values()
 
     url = f"http://localhost:8000{user.get_staff_url()}"
 


### PR DESCRIPTION
We don't subsequently use these tokens and their unnecessary storage in the database represents a potential security risk.

Fixes #4222