### PR TITLE
Remove ProjectDeveloper global role

### DIFF
--- a/docs/adr/0023-deployment-administrator-role.md
+++ b/docs/adr/0023-deployment-administrator-role.md
@@ -1,0 +1,42 @@
+# 23. Replace Global Project Developer with Deployment Administrator Role
+
+Date: 2024-08-19
+
+## Status
+
+Accepted
+
+## Context
+
+The `ProjectDeveloper` role has historically been assignable both to a `ProjectMembership` (i.e. "this user is a developer on this project") and to a `User`, which effectively grants said user the `ProjectDeveloper` permissions globally across all projects.
+
+There is a lack of semantic consistency in a role name containing the word "project" with the fact the role it identifies can be used to grant global (rather than project-scoped) permissions.
+The permissions associated with the `ProjectDeveloper` role are wide ranging and are liable to raise questions as to the appropriateness of global assignment of these.
+
+Investigation revealed only members of Bennett Institute staff had been assigned this role, and after discussion amongst the Tech Group it was deemed that this was likely to facilitate Technical Support activities (primarily job management on behalf of researcher users).
+In instances of system unavailability, it may be preferable to re-run jobs on behalf of users rather than asking the user to perform this themselves for reasons of expediency and user ease.
+Whilst individual jobs can be re-run via `job-runner` this presents the following issues:
+
+- deletion of logs from the previous attempted run
+- re-use of job identifiers
+- we can only rerun individual jobs from job-runner. If a job fails, its dependencies are then cancelled. This can be quite inconvenient in the case of large job requests.
+
+The OpenSAFELY Developer Permissions Log states that a Platform Developer can only run jobs in any project if they have the Deployment Administrator role.
+If the user providing technical support has this role, then they may perform these tasks themselves; if they do not then they should delegate to a user who does.
+
+## Decision
+
+We will create a new role for users performing tech support tasks that require the Deployment Administrator role and is explicitly named as such, and has only the permissions allowed in the Developer Permissions Log for this role.
+At the time of writing this will solely be the ability to run and cancel jobs.
+
+We will reassign users with the "global" `ProjectDeveloper` role this new Deployment Administrator role.
+
+We will remove the ability to assign the `ProjectDeveloper` role to `User` model objects.
+
+## Consequences
+
+There will be greater clarity as to the purpose of roles within the system and the reasons for their assignment.
+
+Certain tech support activities that were previously possible with the `ProjectDeveloper` role may not be possible with the new Deployment Administrator role.
+Some these may have been better served by the user performing the activity themselves under guidance, others may be indicative of a need to modify the permissions associated with this role.
+We will monitor this internally through the Tech Group.

--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -121,7 +121,6 @@ class ProjectDeveloper:
     description = "Run and cancel Jobs, and manage workspaces."
     models = [
         "jobserver.models.project_membership.ProjectMembership",
-        "jobserver.models.user.User",
     ]
     permissions = [
         job_cancel,

--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -146,3 +146,24 @@ class SignOffRepoWithOutputs:
     permissions = [
         repo_sign_off_with_outputs,
     ]
+
+
+class DeploymentAdministrator:
+    """
+    Run and cancel Jobs on any project, for development and maintenance purposes
+    including technical support for Approved Projects.
+    See Developer Permissions Log for the list of individuals who are approved for this role.
+    """
+
+    display_name = "Deployment Administrator"
+    description = """
+    Run and cancel Jobs on any project, for development and maintenance purposes including technical support for Approved Projects.
+    See Developer Permissions Log for the list of individuals who are approved for this role.
+    """
+    models = [
+        "jobserver.models.user.User",
+    ]
+    permissions = [
+        job_cancel,
+        job_run,
+    ]

--- a/jobserver/migrations/0003_remove_global_projectdeveloper.py
+++ b/jobserver/migrations/0003_remove_global_projectdeveloper.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+from jobserver.authorization.roles import DeploymentAdministrator, ProjectDeveloper
+
+
+def replace_user_projectdeveloper_with_deploymentadministrator(apps, schema_editor):
+    User = apps.get_model("jobserver", "User")
+    for user in User.objects.filter(roles__contains=ProjectDeveloper):
+        user.roles.remove(ProjectDeveloper)
+        user.roles.append(DeploymentAdministrator)
+        user.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("jobserver", "0002_remove_user_github_access_tokens"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            replace_user_projectdeveloper_with_deploymentadministrator
+        ),
+    ]

--- a/jobserver/migrations/0003_remove_global_projectdeveloper.py
+++ b/jobserver/migrations/0003_remove_global_projectdeveloper.py
@@ -3,12 +3,20 @@ from django.db import migrations
 from jobserver.authorization.roles import DeploymentAdministrator, ProjectDeveloper
 
 
-def replace_user_projectdeveloper_with_deploymentadministrator(apps, schema_editor):
+def change_user_role(apps, from_role, to_role):
     User = apps.get_model("jobserver", "User")
-    for user in User.objects.filter(roles__contains=ProjectDeveloper):
-        user.roles.remove(ProjectDeveloper)
-        user.roles.append(DeploymentAdministrator)
+    for user in User.objects.filter(roles__contains=from_role):
+        user.roles.remove(from_role)
+        user.roles.append(to_role)
         user.save()
+
+
+def replace_user_projectdeveloper_with_deploymentadministrator(apps, schema_editor):
+    change_user_role(apps, ProjectDeveloper, DeploymentAdministrator)
+
+
+def replace_user_deploymentadministrator_with_projectdeveloper(apps, schema_editor):
+    change_user_role(apps, DeploymentAdministrator, ProjectDeveloper)
 
 
 class Migration(migrations.Migration):
@@ -18,6 +26,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(
-            replace_user_projectdeveloper_with_deploymentadministrator
+            replace_user_projectdeveloper_with_deploymentadministrator,
+            reverse_code=replace_user_deploymentadministrator_with_projectdeveloper,
         ),
     ]

--- a/tests/unit/staff/views/test_users.py
+++ b/tests/unit/staff/views/test_users.py
@@ -380,7 +380,7 @@ def test_userdetailwithoauth_get_success(rf, core_developer, project_membership)
     org = OrgFactory()
     project1 = ProjectFactory()
     project2 = ProjectFactory()
-    user = UserFactory(roles=[OutputPublisher, ProjectDeveloper])
+    user = UserFactory(roles=[OutputPublisher, ProjectCollaborator])
     UserSocialAuthFactory(user=user)
 
     # link the user to some Backends
@@ -408,7 +408,7 @@ def test_userdetailwithoauth_post_success(rf, core_developer, project_membership
 
     project1 = ProjectFactory()
     project2 = ProjectFactory()
-    user = UserFactory(roles=[OutputPublisher, ProjectDeveloper])
+    user = UserFactory(roles=[OutputPublisher, ProjectCollaborator])
     UserSocialAuthFactory(user=user)
 
     # link the user to some Backends
@@ -436,7 +436,7 @@ def test_userdetailwithoauth_post_with_unknown_backend(
 ):
     project1 = ProjectFactory()
     project2 = ProjectFactory()
-    user = UserFactory(roles=[OutputPublisher, ProjectDeveloper])
+    user = UserFactory(roles=[OutputPublisher, ProjectCollaborator])
     UserSocialAuthFactory(user=user)
 
     # link the user to some Backends
@@ -581,7 +581,7 @@ def test_userlist_filter_by_invalid_org(rf, core_developer):
 
 def test_userlist_filter_by_role(rf, core_developer):
     UserFactory(roles=[OutputPublisher])
-    UserFactory(roles=[ProjectDeveloper])
+    UserFactory(roles=[ProjectCollaborator])
 
     request = rf.get("/?role=OutputPublisher")
     request.user = core_developer
@@ -658,7 +658,7 @@ def test_userlist_filter_by_any_roles_yes_includes_org(
 
 def test_userlist_filter_by_any_roles_no_excludes_global_roles(rf, core_developer):
     UserFactory(roles=[OutputPublisher])
-    UserFactory(roles=[ProjectDeveloper])
+    UserFactory(roles=[ProjectCollaborator])
     user = UserFactory()
 
     request = rf.get("/?any_roles=no")
@@ -674,7 +674,7 @@ def test_userlist_filter_by_any_roles_no_excludes_project_roles(
 ):
     user = UserFactory()
 
-    actor = UserFactory(roles=[ProjectDeveloper])
+    actor = core_developer
 
     # set up projects so the creator can have roles
     project1 = ProjectFactory(created_by=actor, updated_by=actor)
@@ -715,7 +715,7 @@ def test_userlist_filter_by_any_roles_no_excludes_project_roles(
 
 def test_userlist_filter_by_any_roles_no_excludes_org_roles(rf, core_developer):
     UserFactory(roles=[OutputPublisher])
-    UserFactory(roles=[ProjectDeveloper])
+    UserFactory(roles=[ProjectCollaborator])
     user = UserFactory()
 
     user_with_project = UserFactory()
@@ -782,7 +782,7 @@ def test_userlist_success(rf, core_developer):
 
 
 def test_userrolelist_get_success(rf, core_developer):
-    user = UserFactory(roles=[ProjectDeveloper])
+    user = UserFactory(roles=[ProjectCollaborator])
 
     request = rf.get("/")
     request.user = core_developer
@@ -795,12 +795,12 @@ def test_userrolelist_get_success(rf, core_developer):
 
 
 def test_userrolelist_post_success(rf, core_developer):
-    user = UserFactory(roles=[ProjectDeveloper])
+    user = UserFactory(roles=[ProjectCollaborator])
 
     data = {
         "roles": [
             "jobserver.authorization.roles.OutputPublisher",
-            "jobserver.authorization.roles.ProjectDeveloper",
+            "jobserver.authorization.roles.ProjectCollaborator",
         ]
     }
     request = rf.post("/", data=data)
@@ -811,7 +811,7 @@ def test_userrolelist_post_success(rf, core_developer):
     assert response.status_code == 302, response.context_data["form"].errors
 
     user.refresh_from_db()
-    assert set(user.roles) == {OutputPublisher, ProjectDeveloper}
+    assert set(user.roles) == {OutputPublisher, ProjectCollaborator}
 
 
 def test_userrolelist_post_with_unknown_role(rf, core_developer):


### PR DESCRIPTION
Remove global assignment of the `ProjectDeveloper` role and replace with a dedicated Deployment Administrator role.