### PR TITLE
Only show repo sign off button to permissioned users

### DIFF
--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -305,9 +305,7 @@ class WorkspaceDetail(View):
         has_backends = request.user.is_authenticated and request.user.backends.exists()
 
         # should we show the admin section in the UI?
-        show_admin = (
-            can_archive_workspace or repo_is_private or can_toggle_notifications
-        )
+        show_admin = can_archive_workspace or can_toggle_notifications
 
         honeycomb_can_view_links = has_role(self.request.user, CoreDeveloper)
 

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -488,6 +488,42 @@ def test_workspacedetail_authorized_private_repo_show_change_visibility_banner(
     assert response.context_data["show_publish_repo_warning"]
 
 
+def test_workspacedetail_authorized_private_repo_show_workspace_admin_panel(
+    rf, project_membership, role_factory
+):
+    project = ProjectFactory()
+
+    # a workspace with a "private" repo
+    workspace = WorkspaceFactory(
+        project=project, repo=RepoFactory(url="http://example.com/repo/private1")
+    )
+
+    user = UserFactory()
+    BackendMembershipFactory(user=user)
+    project_membership(
+        project=project,
+        user=user,
+        roles=[role_factory(permission=permissions.workspace_archive)],
+    )
+
+    # this is what defines "private"
+    class AnotherFakeGitHubAPI:
+        def get_repo_is_private(self, owner, name):
+            return name.startswith("private")
+
+    request = rf.get("/")
+    request.user = user
+
+    response = WorkspaceDetail.as_view(get_github_api=AnotherFakeGitHubAPI)(
+        request,
+        project_slug=project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+    assert response.context_data["show_admin"]
+
+
 def test_workspacedetail_authorized_toggle_notifications(rf, role_factory):
     user = UserFactory(
         roles=[role_factory(permission=permissions.workspace_toggle_notifications)]
@@ -683,6 +719,42 @@ def test_workspacedetail_unauthorized(rf):
     # this is false because only a user with ProjectDeveloper should be able
     # to do this
     assert not response.context_data["user_can_toggle_notifications"]
+
+
+def test_workspacedetail_unauthorized_private_repo_show_workspace_admin_panel(
+    rf, project_membership, role_factory
+):
+    project = ProjectFactory()
+
+    # a workspace with a "private" repo
+    workspace = WorkspaceFactory(
+        project=project, repo=RepoFactory(url="http://example.com/repo/private1")
+    )
+
+    user = UserFactory()
+    BackendMembershipFactory(user=user)
+    project_membership(
+        project=project,
+        user=user,
+        roles=[],
+    )
+
+    # this is what defines "private"
+    class AnotherFakeGitHubAPI:
+        def get_repo_is_private(self, owner, name):
+            return name.startswith("private")
+
+    request = rf.get("/")
+    request.user = user
+
+    response = WorkspaceDetail.as_view(get_github_api=AnotherFakeGitHubAPI)(
+        request,
+        project_slug=project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+    assert not response.context_data["show_admin"]
 
 
 def test_workspacedetail_unknown_workspace(rf):

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -48,6 +48,12 @@ from ....fakes import FakeGitHubAPI
 from ....utils import minutes_ago
 
 
+# this is what defines "private"
+class AnotherFakeGitHubAPI:
+    def get_repo_is_private(self, owner, name):
+        return name.startswith("private")
+
+
 def test_workspacearchivetoggle_success(rf, project_membership, role_factory):
     user = UserFactory()
     workspace = WorkspaceFactory(is_archived=False)
@@ -427,11 +433,6 @@ def test_workspacedetail_authorized_public_repo_hide_change_visibility_banner(
         roles=[role_factory(permission=permissions.workspace_archive)],
     )
 
-    # this is what defines "private"
-    class AnotherFakeGitHubAPI:
-        def get_repo_is_private(self, owner, name):
-            return name.startswith("private")
-
     request = rf.get("/")
     request.user = user
 
@@ -470,11 +471,6 @@ def test_workspacedetail_authorized_private_repo_show_change_visibility_banner(
         roles=[role_factory(permission=permissions.workspace_archive)],
     )
 
-    # this is what defines "private"
-    class AnotherFakeGitHubAPI:
-        def get_repo_is_private(self, owner, name):
-            return name.startswith("private")
-
     request = rf.get("/")
     request.user = user
 
@@ -505,11 +501,6 @@ def test_workspacedetail_authorized_private_repo_show_workspace_admin_panel(
         user=user,
         roles=[role_factory(permission=permissions.workspace_archive)],
     )
-
-    # this is what defines "private"
-    class AnotherFakeGitHubAPI:
-        def get_repo_is_private(self, owner, name):
-            return name.startswith("private")
 
     request = rf.get("/")
     request.user = user
@@ -738,11 +729,6 @@ def test_workspacedetail_unauthorized_private_repo_show_workspace_admin_panel(
         user=user,
         roles=[],
     )
-
-    # this is what defines "private"
-    class AnotherFakeGitHubAPI:
-        def get_repo_is_private(self, owner, name):
-            return name.startswith("private")
 
     request = rf.get("/")
     request.user = user


### PR DESCRIPTION
bug: workspaces with private repos will show the "admin section" to all users regardless of their permissions.

cause: the display logic is to check that the repo is private OR the user has one of two relevant permissions.

fix: this changes the display logic to check that the repo is private AND the user has one of two relevant permissions.