### PR TITLE
Reduce use of `attrs`

### DIFF
--- a/jobserver/auditing/presenters/base.py
+++ b/jobserver/auditing/presenters/base.py
@@ -1,7 +1,7 @@
-from attrs import define
+from dataclasses import dataclass
 
 
-@define
+@dataclass
 class LinkableObject:
     display_value: str
     link: str
@@ -39,7 +39,7 @@ class LinkableObject:
         return cls(display_value=display_value, link=link)
 
 
-@define
+@dataclass
 class PresentableAuditableEvent:
     context: dict[str, str]
     template_name: str

--- a/jobserver/management/commands/list_missing_repos.py
+++ b/jobserver/management/commands/list_missing_repos.py
@@ -1,7 +1,7 @@
 import csv
 import re
+from dataclasses import dataclass
 
-from attrs import define
 from django.core.management.base import BaseCommand
 
 from jobserver.models import Repo
@@ -10,7 +10,7 @@ from jobserver.models import Repo
 url_pat = re.compile(r".*(?P<url>https://github.com/opensafely/.*)[/]?")
 
 
-@define
+@dataclass
 class Data:
     number: int
     url: str

--- a/jobserver/nav.py
+++ b/jobserver/nav.py
@@ -1,11 +1,11 @@
 from collections.abc import Callable
+from dataclasses import dataclass
 
-from attrs import define
 from django.http import HttpRequest
 from django.urls import reverse
 
 
-@define
+@dataclass
 class NavItem:
     name: str
     url_name: str

--- a/staff/views/repos.py
+++ b/staff/views/repos.py
@@ -1,8 +1,8 @@
+from dataclasses import dataclass
 from datetime import timedelta
 from urllib.parse import unquote
 
 import structlog
-from attrs import define
 from django.contrib import messages
 from django.db import transaction
 from django.db.models import Min
@@ -27,7 +27,7 @@ from .qwargs_tools import qwargs
 logger = structlog.get_logger(__name__)
 
 
-@define
+@dataclass
 class Disabled:
     already_signed_off: bool
     no_permission: bool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,11 @@ import hashlib
 import os
 import random
 import string
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 import structlog
-from attrs import define
 from django.conf import settings
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.backends.db import SessionStore
@@ -277,7 +277,7 @@ def github_api():
         comments = []
 
         def create_issue(self, **kwargs):
-            @define
+            @dataclass
             class Issue:
                 org: str
                 repo: str
@@ -293,7 +293,7 @@ def github_api():
             }
 
         def close_issue(self, **kwargs):
-            @define
+            @dataclass
             class Issue:
                 org: str
                 repo: str
@@ -309,7 +309,7 @@ def github_api():
             }
 
         def create_issue_comment(self, **kwargs):
-            @define
+            @dataclass
             class IssueComment:
                 org: str
                 repo: str


### PR DESCRIPTION
See #4532.

This goes a little bit towards removing `attrs` as a direct dependency. Apart from the two cases mentioned in the commit message, we're not using it in any exotic way.

It also makes the code clearer as using the standard Python dataclasses. It means there's less question on a code reader's part as to why `attrs` is being used.