### PR TITLE
Switch from `black` to `ruff format`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,9 @@ default_language_version:
 repos:
   - repo: local
     hooks:
-    - id: black
-      name: black
-      entry: just black
+    - id: format
+      name: format
+      entry: just format
       language: system
       types: [python]
       require_serial: true
@@ -16,9 +16,9 @@ repos:
       language: system
       types: [python]
       require_serial: true
-    - id: ruff
-      name: ruff
-      entry: just ruff
+    - id: lint
+      name: lint
+      entry: just lint
       language: system
       types: [python]
       require_serial: true

--- a/applications/migrations/0002_add_short_data_report.py
+++ b/applications/migrations/0002_add_short_data_report.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("applications", "0001_initial"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/applications/migrations/0003_add_read_analytic_methods_policy.py
+++ b/applications/migrations/0003_add_read_analytic_methods_policy.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("applications", "0002_add_short_data_report"),
     ]

--- a/jobserver/management/commands/create_workspace.py
+++ b/jobserver/management/commands/create_workspace.py
@@ -32,7 +32,6 @@ class Command(BaseCommand):
 
     @transaction.atomic()
     def handle(self, *args, **options):
-
         try:
             user = User.objects.get(username=options["username"])
         except User.DoesNotExist:

--- a/jobserver/migrations/0001_squashed_2024_06.py
+++ b/jobserver/migrations/0001_squashed_2024_06.py
@@ -24,7 +24,6 @@ import jobserver.models.user
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -389,7 +389,8 @@ LOCAL_GIT_REPOS = BASE_DIR / "repos"
 
 # Released files per-file size limit
 RELEASE_FILE_SIZE_LIMIT = env.int(
-    "RELEASE_FILE_SIZE_LIMIT", default=16 * 1024 * 1024  # 16Mb
+    "RELEASE_FILE_SIZE_LIMIT",
+    default=16 * 1024 * 1024,  # 16Mb
 )
 
 # Released files storage location

--- a/jobserver/views/components.py
+++ b/jobserver/views/components.py
@@ -5,7 +5,6 @@ from django.template.response import TemplateResponse
 
 
 class ExampleForm(forms.Form):
-
     example_select = forms.ChoiceField(
         choices=[
             ["", "Please select a language"],

--- a/justfile
+++ b/justfile
@@ -151,20 +151,20 @@ test *args: assets
     $BIN/pytest -n auto -m "not verification and not slow_test" {{ args }}
 
 
-black *args=".": devenv
-    $BIN/black --check {{ args }}
+format *args=".": devenv
+    $BIN/ruff format --check {{ args }}
 
 
 django-upgrade *args="$(find applications interactive jobserver redirects services staff tests -name '*.py' -type f)": devenv
     $BIN/django-upgrade --target-version=5.0 {{ args }}
 
 
-ruff *args=".": devenv
+lint *args=".": devenv
     $BIN/ruff check --output-format=full {{ args }}
 
 
 # run the various dev checks but does not change any files
-check: black django-upgrade ruff
+check: format django-upgrade lint
 
 
 check-migrations: devenv
@@ -174,8 +174,8 @@ check-migrations: devenv
 
 # fix formatting and import sort ordering
 fix: devenv
-    $BIN/black .
     $BIN/ruff check --fix .
+    $BIN/ruff format .
 
 
 load-dev-data: devenv

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,8 @@ extend-select = [
 extend-ignore = [
   "E501",
   "E731",
+  # Remove ISC001 when https://github.com/astral-sh/ruff/issues/8272 is resolved.
+  "ISC001",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,18 +17,6 @@ dynamic = ["version"]
 [tool.setuptools.packages.find]
 exclude = ["tests*"]  # exclude packages matching these glob patterns (empty by default)
 
-[tool.black]
-extend-exclude = '''
-(
-  /(
-      assets
-    | outputs
-    | snippets
-    | static
-  )/
-)
-'''
-
 [tool.coverage.run]
 branch = true
 relative_files = true
@@ -121,6 +109,7 @@ exclude = [
   "docs",
   "htmlcov",
   "node_modules",
+  "outputs",
   "release-hatch",
   "releases",
   "snippets",

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -4,7 +4,6 @@
 # To generate a requirements file that includes both prod and dev requirements, run:
 # pip-compile --generate-hashes --output-file=requirements.dev.txt requirements.dev.in
 
-black
 coverage[toml]
 coverage-enable-subprocess
 django-debug-toolbar

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -16,30 +16,6 @@ attrs==24.2.0 \
     # via
     #   -c requirements.prod.txt
     #   pytest-subtests
-black==24.8.0 \
-    --hash=sha256:09cdeb74d494ec023ded657f7092ba518e8cf78fa8386155e4a03fdcc44679e6 \
-    --hash=sha256:1f13f7f386f86f8121d76599114bb8c17b69d962137fc70efe56137727c7047e \
-    --hash=sha256:2500945420b6784c38b9ee885af039f5e7471ef284ab03fa35ecdde4688cd83f \
-    --hash=sha256:2b59b250fdba5f9a9cd9d0ece6e6d993d91ce877d121d161e4698af3eb9c1018 \
-    --hash=sha256:3c4285573d4897a7610054af5a890bde7c65cb466040c5f0c8b732812d7f0e5e \
-    --hash=sha256:505289f17ceda596658ae81b61ebbe2d9b25aa78067035184ed0a9d855d18afd \
-    --hash=sha256:62e8730977f0b77998029da7971fa896ceefa2c4c4933fcd593fa599ecbf97a4 \
-    --hash=sha256:649f6d84ccbae73ab767e206772cc2d7a393a001070a4c814a546afd0d423aed \
-    --hash=sha256:6e55d30d44bed36593c3163b9bc63bf58b3b30e4611e4d88a0c3c239930ed5b2 \
-    --hash=sha256:707a1ca89221bc8a1a64fb5e15ef39cd755633daa672a9db7498d1c19de66a42 \
-    --hash=sha256:72901b4913cbac8972ad911dc4098d5753704d1f3c56e44ae8dce99eecb0e3af \
-    --hash=sha256:73bbf84ed136e45d451a260c6b73ed674652f90a2b3211d6a35e78054563a9bb \
-    --hash=sha256:7c046c1d1eeb7aea9335da62472481d3bbf3fd986e093cffd35f4385c94ae368 \
-    --hash=sha256:81c6742da39f33b08e791da38410f32e27d632260e599df7245cccee2064afeb \
-    --hash=sha256:837fd281f1908d0076844bc2b801ad2d369c78c45cf800cad7b61686051041af \
-    --hash=sha256:972085c618ee94f402da1af548a4f218c754ea7e5dc70acb168bfaca4c2542ed \
-    --hash=sha256:9e84e33b37be070ba135176c123ae52a51f82306def9f7d063ee302ecab2cf47 \
-    --hash=sha256:b19c9ad992c7883ad84c9b22aaa73562a16b819c1d8db7a1a1a49fb7ec13c7d2 \
-    --hash=sha256:d6417535d99c37cee4091a2f24eb2b6d5ec42b144d50f1f2e436d9fe1916fe1a \
-    --hash=sha256:eab4dd44ce80dea27dc69db40dab62d4ca96112f87996bca68cd75639aeb2e4c \
-    --hash=sha256:f490dbd59680d809ca31efdae20e634f3fae27fba3ce0ba3208333b713bc3920 \
-    --hash=sha256:fb6e2c0b86bbd43dee042e48059c9ad7830abd5c94b0bc518c0eeec57c3eddc1
-    # via -r requirements.dev.in
 build==1.0.3 \
     --hash=sha256:538aab1b64f9828977f84bc63ae570b060a8ed1be419e7870b8b4fc5e6ea553b \
     --hash=sha256:589bf99a67df7c9cf07ec0ac0e5e2ea5d4b37ac63301c4986d1acb126aa83f8f
@@ -151,9 +127,7 @@ charset-normalizer==3.3.2 \
 click==8.1.7 \
     --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
-    # via
-    #   black
-    #   pip-tools
+    # via pip-tools
 coverage==7.3.2 \
     --hash=sha256:0cbf38419fb1a347aaf63481c00f0bdc86889d9fbf3f25109cf96c26b403fda1 \
     --hash=sha256:12d15ab5833a997716d76f2ac1e4b4d536814fc213c85ca72756c19e5a6b3d63 \
@@ -270,10 +244,6 @@ iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
     # via pytest
-mypy-extensions==1.0.0 \
-    --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d \
-    --hash=sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782
-    # via black
 nodeenv==1.8.0 \
     --hash=sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2 \
     --hash=sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec
@@ -283,13 +253,8 @@ packaging==23.2 \
     --hash=sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
     # via
     #   -c requirements.prod.txt
-    #   black
     #   build
     #   pytest
-pathspec==0.12.1 \
-    --hash=sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08 \
-    --hash=sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712
-    # via black
 pip-tools==7.4.1 \
     --hash=sha256:4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9 \
     --hash=sha256:864826f5073864450e24dbeeb85ce3920cdfb09848a3d69ebf537b521f14bcc9
@@ -297,9 +262,7 @@ pip-tools==7.4.1 \
 platformdirs==4.2.0 \
     --hash=sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068 \
     --hash=sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768
-    # via
-    #   black
-    #   virtualenv
+    # via virtualenv
 pluggy==1.4.0 \
     --hash=sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981 \
     --hash=sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be

--- a/tests/unit/airlock/test_issues.py
+++ b/tests/unit/airlock/test_issues.py
@@ -15,7 +15,6 @@ from tests.factories import (
 
 
 def test_create_output_checking_request_external(github_api):
-
     user = UserFactory()
     workspace = WorkspaceFactory(name="test-workspace")
 

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -207,7 +207,6 @@ def test_api_post_release_request_default_org_and_repo(mock_create_issue, api_rf
 )
 @patch("airlock.views._get_github_api", FakeGithubApiWithError)
 def test_api_airlock_event_error(api_rf, event_type, updates, error):
-
     author = UserFactory()
     user = UserFactory()
     WorkspaceFactory(name="test-workspace")


### PR DESCRIPTION
Fixes #4542.

`ruff format` is considerably faster than `black`, while maintaining almost entirely the same formatting output. After deleting the cache for both and running against job-server commit 241415f7c70a1b6b8b1327ab047b5f5fd646f3b6:

```
$ time ruff format .
warning: The following rules may cause conflicts when used with the formatter: `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
9 files reformatted, 402 files left unchanged

real	0m0.073s
…
$ time black .
All done! ✨ 🍰 ✨
411 files left unchanged.

real	0m1.345s
…
```

(Note: the Ruff warning is fixed in this PR; it's because the configuration's not updated on the `main` branch where I ran the above.)

As a bonus, this also removes several additional development dependencies.