### PR TITLE
Fix migrations command advice in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -169,7 +169,7 @@ check: black django-upgrade ruff
 
 check-migrations: devenv
     $BIN/python manage.py makemigrations --dry-run --check \
-    || echo "There is model state unaccounted for in the migrations, run python manage.py migrations to fix."
+    || echo "There is model state unaccounted for in the migrations, run python manage.py migrate to fix."
 
 
 # fix formatting and import sort ordering


### PR DESCRIPTION
The advised command `python manage.py migrations` doesn't exist.

It should be `python manage.py migrate`