### PR TITLE
Change repo-project from one-one to one-many

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 
 from .authorization.forms import RolesForm
-from .models import JobRequest, Project, Workspace
+from .models import JobRequest, Workspace
 
 
 class JobRequestCreateForm(forms.ModelForm):
@@ -135,7 +135,7 @@ class WorkspaceCreateForm(forms.Form):
         repo_url = cleaned_data.get("repo")
         branch = cleaned_data.get("branch")
 
-        if not (repo_url and branch):
+        if not (repo_url and branch):  # pragma: no cover
             return
 
         repo = next(
@@ -160,21 +160,6 @@ class WorkspaceCreateForm(forms.Form):
             )
 
         return name
-
-    def clean_repo(self):
-        repo = self.cleaned_data["repo"]
-
-        projects = Project.objects.filter(workspaces__repo__url=repo)
-        if not projects.exists():
-            # if the repo isn't used by any projects then we're good to go
-            return repo
-
-        if self.project not in projects:
-            raise forms.ValidationError(
-                "This repo has already been used in another project, please pick a different one"
-            )
-
-        return repo
 
 
 class WorkspaceEditForm(forms.Form):

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -5,7 +5,7 @@ from jobserver.backends import backends_to_choices
 from jobserver.forms import JobRequestCreateForm, WorkspaceCreateForm
 from jobserver.models import Backend
 
-from ...factories import BackendFactory, ProjectFactory, RepoFactory, WorkspaceFactory
+from ...factories import BackendFactory, ProjectFactory, WorkspaceFactory
 
 
 def test_jobrequestcreateform_with_single_backend():
@@ -200,91 +200,3 @@ def test_workspacecreateform_with_duplicate_name():
             'A workspace with the name "test" already exists, please choose a unique one.'
         ]
     }
-
-
-def test_workspacecreateform_repo_used_in_another_project():
-    project1 = ProjectFactory()
-    project2 = ProjectFactory()
-    repo = RepoFactory(url="test")
-    WorkspaceFactory(project=project1, repo=repo)
-
-    repos_with_branches = [
-        {
-            "name": "test",
-            "url": "test",
-            "branches": ["test-branch"],
-        }
-    ]
-    data = {
-        "name": "test",
-        "repo": "test",
-        "branch": "test-branch",
-        "purpose": "test",
-    }
-    form = WorkspaceCreateForm(project2, repos_with_branches, data)
-    form.is_valid()
-
-    assert form.errors == {
-        "repo": [
-            "This repo has already been used in another project, please pick a different one"
-        ]
-    }
-
-
-def test_workspacecreateform_repo_used_with_no_projects():
-    project = ProjectFactory()
-    repos_with_branches = [
-        {
-            "name": "test",
-            "url": "test",
-            "branches": ["test-branch"],
-        }
-    ]
-
-    form = WorkspaceCreateForm(project, repos_with_branches, {"repo": "test"})
-    form.cleaned_data = {"repo": "test"}
-
-    assert form.clean_repo()
-
-
-def test_workspacecreateform_repo_used_with_only_this_project():
-    project = ProjectFactory()
-    repo = RepoFactory(url="test")
-    WorkspaceFactory(project=project, repo=repo)
-    repos_with_branches = [
-        {
-            "name": "test",
-            "url": "test",
-            "branches": ["test-branch"],
-        }
-    ]
-
-    form = WorkspaceCreateForm(project, repos_with_branches, {"repo": "test"})
-    form.cleaned_data = {"repo": "test"}
-
-    assert form.clean_repo()
-
-
-def test_workspacecreateform_repo_used_with_this_and_other_projects():
-    repo = RepoFactory(url="test")
-
-    # an existing, different project
-    project1 = ProjectFactory()
-    WorkspaceFactory(project=project1, repo=repo)
-
-    # the project we're working on
-    project2 = ProjectFactory()
-    WorkspaceFactory(project=project2, repo=repo)
-
-    repos_with_branches = [
-        {
-            "name": "test",
-            "url": "test",
-            "branches": ["test-branch"],
-        }
-    ]
-
-    form = WorkspaceCreateForm(project2, repos_with_branches, {"repo": "test"})
-    form.cleaned_data = {"repo": "test"}
-
-    assert form.clean_repo()


### PR DESCRIPTION
For much, but not all, of job-server's life, one repo could be associated with one project. However, there are now a small number of repos that should be associated with two projects: these repos have "legacy" and "transitional" projects. To accommodate these repos, we change the repo-project relationship from one-to-one to one-to-many.

Are you expecting to see changes to a model? And not expecting to see changes to a form? The repo-project relationship was actually one-to-many early in job-server's life, so the database already contains several repos that are associated with two projects. For this reason, the one-to-one repo-project relationship was enforced within a form and not within a model.

Are you concerned that we may no longer be supporting an important use-case? The original use-case for changing from repo-project relationship from one-to-many to one-one was (we think) to help a member of the public navigate from GitHub's website to job-server's website ("When was this code run?"). In practice, however, supporting this use-case isn't easy. We feel an alternative design is required.