### PR TITLE
Fix deprecation warning

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -427,7 +427,7 @@ Your CheckConstraint which covers both states looks like this:
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         frobbed_at__isnull=True,
                         frobbed_by__isnull=True,
@@ -476,7 +476,7 @@ This is very similar to the pattern above, except we use `auto_now=True` and don
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=Q(updated_at__isnull=False, updated_by__isnull=False),
+                condition=Q(updated_at__isnull=False, updated_by__isnull=False),
                 name="%(app_label)s_%(class)s_both_updated_at_and_updated_by_set",
             ),
         ]

--- a/applications/migrations/0001_initial.py
+++ b/applications/migrations/0001_initial.py
@@ -901,7 +901,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="application",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("approved_at__isnull", True), ("approved_by__isnull", True)
                     ),
@@ -916,7 +916,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="application",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("deleted_at__isnull", True), ("deleted_by__isnull", True)
                     ),
@@ -931,7 +931,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="application",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("submitted_at__isnull", True), ("submitted_by__isnull", True)
                     ),

--- a/applications/models.py
+++ b/applications/models.py
@@ -67,7 +67,7 @@ class Application(models.Model):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         approved_at__isnull=True,
                         approved_by__isnull=True,
@@ -82,7 +82,7 @@ class Application(models.Model):
                 name="%(app_label)s_%(class)s_both_approved_at_and_approved_by_set",
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         deleted_at__isnull=True,
                         deleted_by__isnull=True,
@@ -97,7 +97,7 @@ class Application(models.Model):
                 name="%(app_label)s_%(class)s_both_deleted_at_and_deleted_by_set",
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         submitted_at__isnull=True,
                         submitted_by__isnull=True,

--- a/interactive/migrations/0001_initial.py
+++ b/interactive/migrations/0001_initial.py
@@ -83,7 +83,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="analysisrequest",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("created_at__isnull", True), ("created_by__isnull", True)
                     ),
@@ -98,7 +98,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="analysisrequest",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     ("updated_at__isnull", False), ("updated_by__isnull", False)
                 ),
                 name="interactive_analysisrequest_both_updated_at_and_updated_by_set",

--- a/interactive/models.py
+++ b/interactive/models.py
@@ -61,7 +61,7 @@ class AnalysisRequest(models.Model):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         created_at__isnull=True,
                         created_by__isnull=True,
@@ -76,7 +76,7 @@ class AnalysisRequest(models.Model):
                 name="%(app_label)s_%(class)s_both_created_at_and_created_by_set",
             ),
             models.CheckConstraint(
-                check=Q(updated_at__isnull=False, updated_by__isnull=False),
+                condition=Q(updated_at__isnull=False, updated_by__isnull=False),
                 name="%(app_label)s_%(class)s_both_updated_at_and_updated_by_set",
             ),
         ]

--- a/jobserver/migrations/0001_squashed_2024_06.py
+++ b/jobserver/migrations/0001_squashed_2024_06.py
@@ -977,7 +977,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="workspace",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("created_at__isnull", True), ("created_by__isnull", True)
                     ),
@@ -992,7 +992,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="workspace",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("signed_off_at__isnull", True), ("signed_off_by__isnull", True)
                     ),
@@ -1008,7 +1008,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="workspace",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     ("updated_at__isnull", False), ("updated_by__isnull", False)
                 ),
                 name="jobserver_workspace_both_updated_at_and_updated_by_set",
@@ -1021,7 +1021,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="snapshot",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("created_at__isnull", True), ("created_by__isnull", True)
                     ),
@@ -1036,7 +1036,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="report",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("created_at__isnull", True), ("created_by__isnull", True)
                     ),
@@ -1051,7 +1051,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="report",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("updated_at__isnull", True), ("updated_by__isnull", True)
                     ),
@@ -1066,7 +1066,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="repo",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("internal_signed_off_at__isnull", True),
                         ("internal_signed_off_by__isnull", True),
@@ -1083,7 +1083,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="repo",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("researcher_signed_off_at__isnull", True),
                         ("researcher_signed_off_by__isnull", True),
@@ -1100,7 +1100,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="releasefilereview",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("created_at__isnull", True), ("created_by__isnull", True)
                     ),
@@ -1115,7 +1115,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="releasefile",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("created_at__isnull", True), ("created_by__isnull", True)
                     ),
@@ -1130,7 +1130,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="releasefile",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("deleted_at__isnull", True), ("deleted_by__isnull", True)
                     ),
@@ -1145,7 +1145,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="release",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("created_at__isnull", True), ("created_by__isnull", True)
                     ),
@@ -1160,7 +1160,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="publishrequest",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("created_at__isnull", True), ("created_by__isnull", True)
                     ),
@@ -1175,7 +1175,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="publishrequest",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("decision__isnull", True),
                         ("decision_at__isnull", True),
@@ -1194,7 +1194,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="publishrequest",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("updated_at__isnull", True), ("updated_by__isnull", True)
                     ),
@@ -1225,7 +1225,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="jobrequest",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("created_at__isnull", True), ("created_by__isnull", True)
                     ),
@@ -1244,7 +1244,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="user",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("pat_expires_at__isnull", True), ("pat_token__isnull", True)
                     ),
@@ -1259,7 +1259,8 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="project",
             constraint=models.CheckConstraint(
-                check=models.Q(("slug", ""), _negated=True), name="slug_is_not_empty"
+                condition=models.Q(("slug", ""), _negated=True),
+                name="slug_is_not_empty",
             ),
         ),
         migrations.AlterField(
@@ -1270,7 +1271,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="workspace",
             constraint=models.CheckConstraint(
-                check=models.Q(("name__regex", "^[-a-zA-Z0-9_]+\\Z")),
+                condition=models.Q(("name__regex", "^[-a-zA-Z0-9_]+\\Z")),
                 name="name_is_valid",
             ),
         ),
@@ -1370,7 +1371,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="project",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     ("created_at__isnull", False), ("created_by__isnull", False)
                 ),
                 name="jobserver_project_both_created_at_and_created_by_set",
@@ -1388,7 +1389,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="project",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     ("updated_at__isnull", False), ("updated_by__isnull", False)
                 ),
                 name="jobserver_project_both_updated_at_and_updated_by_set",

--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -97,7 +97,7 @@ class JobRequest(models.Model):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         created_at__isnull=True,
                         created_by__isnull=True,

--- a/jobserver/models/project.py
+++ b/jobserver/models/project.py
@@ -80,7 +80,7 @@ class Project(models.Model):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         created_at__isnull=False,
                         created_by__isnull=False,
@@ -89,7 +89,7 @@ class Project(models.Model):
                 name="%(app_label)s_%(class)s_both_created_at_and_created_by_set",
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         updated_at__isnull=False,
                         updated_by__isnull=False,
@@ -104,7 +104,7 @@ class Project(models.Model):
                 condition=Q(number__isnull=False),
             ),
             models.CheckConstraint(
-                check=~Q(slug=""),
+                condition=~Q(slug=""),
                 name="slug_is_not_empty",
             ),
         ]

--- a/jobserver/models/publish_request.py
+++ b/jobserver/models/publish_request.py
@@ -59,7 +59,7 @@ class PublishRequest(models.Model):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         created_at__isnull=True,
                         created_by__isnull=True,
@@ -74,7 +74,7 @@ class PublishRequest(models.Model):
                 name="%(app_label)s_%(class)s_both_created_at_and_created_by_set",
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         decision_at__isnull=True,
                         decision_by__isnull=True,
@@ -91,7 +91,7 @@ class PublishRequest(models.Model):
                 name="%(app_label)s_%(class)s_both_decision_at_decision_by_and_decision_set",
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         updated_at__isnull=True,
                         updated_by__isnull=True,

--- a/jobserver/models/release.py
+++ b/jobserver/models/release.py
@@ -56,7 +56,7 @@ class Release(models.Model):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         created_at__isnull=True,
                         created_by__isnull=True,

--- a/jobserver/models/release_file.py
+++ b/jobserver/models/release_file.py
@@ -75,7 +75,7 @@ class ReleaseFile(models.Model):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         created_at__isnull=True,
                         created_by__isnull=True,
@@ -90,7 +90,7 @@ class ReleaseFile(models.Model):
                 name="%(app_label)s_%(class)s_both_created_at_and_created_by_set",
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         deleted_at__isnull=True,
                         deleted_by__isnull=True,

--- a/jobserver/models/release_file_review.py
+++ b/jobserver/models/release_file_review.py
@@ -32,7 +32,7 @@ class ReleaseFileReview(models.Model):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         created_at__isnull=True,
                         created_by__isnull=True,

--- a/jobserver/models/repo.py
+++ b/jobserver/models/repo.py
@@ -33,7 +33,7 @@ class Repo(models.Model):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         internal_signed_off_at__isnull=True,
                         internal_signed_off_by__isnull=True,
@@ -48,7 +48,7 @@ class Repo(models.Model):
                 name="%(app_label)s_%(class)s_both_internal_signed_off_at_and_internal_signed_off_by_set",
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         researcher_signed_off_at__isnull=True,
                         researcher_signed_off_by__isnull=True,

--- a/jobserver/models/report.py
+++ b/jobserver/models/report.py
@@ -44,7 +44,7 @@ class Report(models.Model):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         created_at__isnull=True,
                         created_by__isnull=True,
@@ -59,7 +59,7 @@ class Report(models.Model):
                 name="%(app_label)s_%(class)s_both_created_at_and_created_by_set",
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         updated_at__isnull=True,
                         updated_by__isnull=True,

--- a/jobserver/models/snapshot.py
+++ b/jobserver/models/snapshot.py
@@ -37,7 +37,7 @@ class Snapshot(models.Model):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         created_at__isnull=True,
                         created_by__isnull=True,

--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -156,7 +156,7 @@ class User(AbstractBaseUser):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         pat_expires_at__isnull=True,
                         pat_token__isnull=True,

--- a/jobserver/models/workspace.py
+++ b/jobserver/models/workspace.py
@@ -78,11 +78,11 @@ class Workspace(models.Model):
         constraints = [
             # mirror Django's validate_slug validator into the database
             models.CheckConstraint(
-                check=Q(name__regex=r"^[-a-zA-Z0-9_]+\Z"),
+                condition=Q(name__regex=r"^[-a-zA-Z0-9_]+\Z"),
                 name="name_is_valid",
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         created_at__isnull=True,
                         created_by__isnull=True,
@@ -97,7 +97,7 @@ class Workspace(models.Model):
                 name="%(app_label)s_%(class)s_both_created_at_and_created_by_set",
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         signed_off_at__isnull=True,
                         signed_off_by__isnull=True,
@@ -112,7 +112,7 @@ class Workspace(models.Model):
                 name="%(app_label)s_%(class)s_both_signed_off_at_and_signed_off_by_set",
             ),
             models.CheckConstraint(
-                check=Q(updated_at__isnull=False, updated_by__isnull=False),
+                condition=Q(updated_at__isnull=False, updated_by__isnull=False),
                 name="%(app_label)s_%(class)s_both_updated_at_and_updated_by_set",
             ),
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ filterwarnings = [
     "ignore:Call to deprecated method __init__:DeprecationWarning:",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:",
     "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning:",
-    "ignore:CheckConstraint.check is deprecated in favor of `.condition`.:django.utils.deprecation.RemovedInDjango60Warning:",
     "ignore:The FORMS_URLFIELD_ASSUME_HTTPS transitional setting is deprecated.:django.utils.deprecation.RemovedInDjango60Warning:",
 
     # this is actually in protobuf, via the opentelemetry stack vendored into

--- a/redirects/migrations/0001_initial.py
+++ b/redirects/migrations/0001_initial.py
@@ -101,7 +101,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="redirect",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("deleted_at__isnull", True), ("deleted_by__isnull", True)
                     ),
@@ -116,7 +116,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="redirect",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         ("analysis_request__isnull", False),
                         ("org__isnull", True),

--- a/redirects/migrations/0002_ensure_old_url_has_leading_and_trailing_slashes.py
+++ b/redirects/migrations/0002_ensure_old_url_has_leading_and_trailing_slashes.py
@@ -17,14 +17,14 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="redirect",
             constraint=models.CheckConstraint(
-                check=models.Q(("old_url", ""), _negated=True),
+                condition=models.Q(("old_url", ""), _negated=True),
                 name="old_url_is_not_empty",
             ),
         ),
         migrations.AddConstraint(
             model_name="redirect",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     ("old_url__endswith", "/"), ("old_url__startswith", "/")
                 ),
                 name="old_url_endswith_and_startswith_slash",

--- a/redirects/models.py
+++ b/redirects/models.py
@@ -66,15 +66,15 @@ class Redirect(models.Model):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=~Q(old_url=""),
+                condition=~Q(old_url=""),
                 name="old_url_is_not_empty",
             ),
             models.CheckConstraint(
-                check=Q(old_url__endswith="/") & Q(old_url__startswith="/"),
+                condition=Q(old_url__endswith="/") & Q(old_url__startswith="/"),
                 name="old_url_endswith_and_startswith_slash",
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         deleted_at__isnull=True,
                         deleted_by__isnull=True,
@@ -89,7 +89,7 @@ class Redirect(models.Model):
                 name="%(app_label)s_%(class)s_both_deleted_at_and_deleted_by_set",
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(
                         analysis_request__isnull=False,
                         org__isnull=True,


### PR DESCRIPTION
`CheckConstraint.check` was deprecated in favour of `CheckConstraint.condition` in 5.1. It will be removed in 6.0. 9c6329b temporarily ignored the deprecation warning, as it prevented us from bumping Django. We fix it here.