### PR TITLE
Update description of deployment administrator

### DIFF
--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -149,14 +149,13 @@ class SignOffRepoWithOutputs:
 
 class DeploymentAdministrator:
     """
-    Run and cancel Jobs on any project, for development and maintenance purposes
-    including technical support for Approved Projects.
+    Run and cancel Jobs on any project, for debugging and performance observation.
     See Developer Permissions Log for the list of individuals who are approved for this role.
     """
 
     display_name = "Deployment Administrator"
     description = """
-    Run and cancel Jobs on any project, for development and maintenance purposes including technical support for Approved Projects.
+    Run and cancel Jobs on any project, for debugging and performance observation.
     See Developer Permissions Log for the list of individuals who are approved for this role.
     """
     models = [


### PR DESCRIPTION
The deployment administrator role is intended for general technical support, rather than for specific tech support (with a hyphen). To reduce confusion, we mirror the description in the Developer Permissions Log.

Thanks for clarifying, @lucyb and @CLStables.