### PR TITLE
Point to Airlock for viewing log outputs

### DIFF
--- a/templates/job/detail.html
+++ b/templates/job/detail.html
@@ -142,13 +142,10 @@
 
             {% if log_path %}
               <p class="text-slate-600">
-                You can check the log output in the {% link text="outputs viewer" href=log_path_url %}
-                {% pill text="VPN Required" variant="primary" %}
+                If you have VPN access you can view the log output in {% link text="Airlock" href="https://docs.opensafely.org/using-opensafely/releasing-research-outputs/releasing-with-airlock/" append_after="," %} in the workspace file:
+                <pre class="text-slate-500 break-all whitespace-pre-wrap">{{ log_path }}</pre>
               </p>
-              <p class="text-slate-600">
-                Alternatively, view the file on the {{ job.job_request.backend.name }} server at: <pre class="text-slate-500 break-all whitespace-pre-wrap">{{ log_path }}</pre>
-              </p>
-              {% endif %}
+            {% endif %}
           </div>
         {% /description_item %}
 

--- a/templates/workspace/detail.html
+++ b/templates/workspace/detail.html
@@ -256,11 +256,6 @@
 
       {% #card title="Releases" %}
         {% #list_group small=True %}
-          {% #list_group_item href=workspace.get_files_url disabled=outputs.level_4.disabled %}
-            <span class="mr-2">Level 4 Outputs</span>
-            {% pill text="VPN Required" variant="primary" %}
-          {% /list_group_item%}
-
           {% #list_group_item href=workspace.get_releases_url disabled=outputs.released.disabled %}
             Released Outputs
           {% /list_group_item%}

--- a/tests/unit/jobserver/views/test_jobs.py
+++ b/tests/unit/jobserver/views/test_jobs.py
@@ -297,14 +297,7 @@ def test_jobdetail_with_nonzero_exit_code(rf):
     )
 
     assert response.status_code == 200
-    assert (
-        response.context_data["log_path"]
-        == f"/var/test/{job_request.workspace.name}/metadata/my_action.log"
-    )
-    assert (
-        response.context_data["log_path_url"]
-        == f"{job.job_request.workspace.get_files_url()}metadata/my_action.log"
-    )
+    assert response.context_data["log_path"] == "metadata/my_action.log"
 
 
 def test_jobdetail_with_partial_identifier_failure(rf):


### PR DESCRIPTION
There's no point linking directly to the relevant Airlock URL because we don't expect users to be accessing Job Server from within Level 4 going forward, and even you have Airlock open in a VM you can't copy/paste URLs across.

Instead we link to the Airlock docs and describe the location of the file. This replaces both the link the output viewer and the reference to the old "Level 4 file sync" directory.

Example:
![image](https://github.com/user-attachments/assets/5bf0474b-bc9d-4850-9999-6aef958ef042)

Previously we restricted these links to only show for the TPP backend, but on the assumption that we will be running an instance of Airlock for every backend I have removed this restriction.

There's now a significant chunk of redundant code in Job Server relating to the "Level 4 files viewer". I'll make a separate ticket to track what needs removing here, and will tackle this in future PRs.

Closes #4583