### PR TITLE
Remove requirement for blank placeholder

### DIFF
--- a/templates/_components/form/input.html
+++ b/templates/_components/form/input.html
@@ -39,8 +39,7 @@
     <input
       {% attrs autocapitalize autocomplete autocorrect inputmode name=input_name placeholder required value=input_value %}
       class="
-        mt-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm
-        {% if show_placeholder %}placeholder:text-slate-400{% else %}placeholder:text-white{% endif %}
+        mt-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm placeholder:text-slate-400
         focus:border-oxford-500 focus:ring-oxford-500
         sm:text-sm
         [&:user-invalid]:border-bn-ribbon-600 [&:user-invalid]:ring-bn-ribbon-600 [&:user-invalid]:ring-1

--- a/templates/_components/form/input.html
+++ b/templates/_components/form/input.html
@@ -43,7 +43,7 @@
         {% if show_placeholder %}placeholder:text-slate-400{% else %}placeholder:text-white{% endif %}
         focus:border-oxford-500 focus:ring-oxford-500
         sm:text-sm
-        [&:not(:placeholder-shown):not(:focus)]:invalid:border-bn-ribbon-600 [&:not(:placeholder-shown):not(:focus)]:invalid:ring-bn-ribbon-600 [&:not(:placeholder-shown):not(:focus)]:invalid:ring-1
+        [&:user-invalid]:border-bn-ribbon-600 [&:user-invalid]:ring-bn-ribbon-600 [&:user-invalid]:ring-1
         {{ input_class }}
       "
       id="{{ input_id }}"

--- a/templates/_components/form/select.html
+++ b/templates/_components/form/select.html
@@ -32,7 +32,7 @@
 
     <select
       {% attrs id=select_id name=select_name required %}
-      class="mt-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm focus:border-oxford-500 focus:ring-oxford-500 sm:text-sm invalid:border-bn-ribbon-600 invalid:ring-bn-ribbon-600 invalid:ring-1"
+      class="mt-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm focus:border-oxford-500 focus:ring-oxford-500 sm:text-sm [&:user-invalid]:border-bn-ribbon-600 [&:user-invalid]:ring-bn-ribbon-600 [&:user-invalid]:ring-1"
     >
       {% for value, label in choices %}
         <option

--- a/templates/_components/form/textarea.html
+++ b/templates/_components/form/textarea.html
@@ -39,10 +39,9 @@
     <textarea
       {% attrs autocapitalize autocomplete autocorrect inputmode maxlength name=textarea_name placeholder readonly required rows=rows|default:"4" %}
       class="
-        mt-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm
+        mt-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm placeholder:text-slate-400
         {% if readonly %}bg-slate-100 cursor-not-allowed focus:!outline-none focus:!border-slate-300 focus:!ring-0{% endif %}
         {% if not resize %}resize-none{% endif %}
-        {% if show_placeholder %}placeholder:text-slate-400{% else %}placeholder:text-white{% endif %}
         sm:text-sm
         focus:border-oxford-500 focus:ring-oxford-500
         [&:user-invalid]:border-bn-ribbon-600 [&:user-invalid]:ring-bn-ribbon-600 [&:user-invalid]:ring-1

--- a/templates/_components/form/textarea.html
+++ b/templates/_components/form/textarea.html
@@ -45,7 +45,7 @@
         {% if show_placeholder %}placeholder:text-slate-400{% else %}placeholder:text-white{% endif %}
         sm:text-sm
         focus:border-oxford-500 focus:ring-oxford-500
-        [&:not(:placeholder-shown):not(:focus)]:invalid:border-bn-ribbon-600 [&:not(:placeholder-shown):not(:focus)]:invalid:ring-bn-ribbon-600 [&:not(:placeholder-shown):not(:focus)]:invalid:ring-1
+        [&:user-invalid]:border-bn-ribbon-600 [&:user-invalid]:ring-bn-ribbon-600 [&:user-invalid]:ring-1
       "
       id="{{ textarea_id }}"
     >{% if textarea_value %}{{ textarea_value }}{% endif %}</textarea>

--- a/templates/_components/index.html
+++ b/templates/_components/index.html
@@ -398,7 +398,6 @@
         <li><code>name</code>: [string] - set the HTML name for the input element</li>
         <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#placeholder"><code>placeholder</code></a></li>
         <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required"><code>required</code></a></li>
-        <li><code>show_placeholder</code>: [boolean] - if true, display the placeholder text</li>
         <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types"><code>type</code></a></li>
         <li><code>value</code>: [string] - set the HTML value for the input element</li>
       </ul>
@@ -534,11 +533,10 @@
         <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly"><code>readonly</code></a></li>
         <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required"><code>required</code></a></li>
         <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-rows"><code>rows</code></a></li>
-        <li><code>show_placeholder</code>: [boolean] - if true, display the placeholder text</li>
         <li><code>value</code>: [string] - set the HTML value for the input element</li>
       </ul>
       <div class="not-prose flex flex-col gap-y-8 relative w-screen max-w-5xl left-1/2 -translate-x-1/2 p-8 bg-slate-200 border border-slate-500 rounded">
-        {% form_textarea class="max-w-lg w-full mx-auto" field=example_form.example_textarea label="Enter a short description of the project" resize=True rows=8 %}
+        {% form_textarea class="max-w-lg w-full mx-auto" field=example_form.example_textarea label="Enter a short description of the project" resize=True rows=8 required=True %}
         <pre><code class="language-django">{% verbatim %}{% form_textarea class="max-w-lg w-full mx-auto" field=example_form.example_textarea label="Enter a short description of the project" resize=True rows=8 %}{% endverbatim %}</code></pre>
       </div>
     </section>

--- a/templates/applications/page.html
+++ b/templates/applications/page.html
@@ -78,9 +78,9 @@
 
             {% for field in fieldset.fields %}
               {% if field.template_name == "form_input" %}
-                {% form_input custom_field=True required=field.required placeholder=field.name id="id_"|add:field.name label=field.label name=field.name value=field.field.value errors=field.errors hint_below=True hint_text=field.field.help_text type=field.attributes.type inputmode=field.attributes.inputmode autocomplete=field.attributes.autocomplete autocapitalize=field.attributes.autocapitalize spellcheck=field.attributes.spellcheck autocorrect=field.attributes.autocorrect maxlength=field.attributes.maxlength %}
+                {% form_input custom_field=True required=field.required id="id_"|add:field.name label=field.label name=field.name value=field.field.value errors=field.errors hint_below=True hint_text=field.field.help_text type=field.attributes.type inputmode=field.attributes.inputmode autocomplete=field.attributes.autocomplete autocapitalize=field.attributes.autocapitalize spellcheck=field.attributes.spellcheck autocorrect=field.attributes.autocorrect maxlength=field.attributes.maxlength %}
               {% elif field.template_name == "form_textarea" %}
-                {% form_textarea custom_field=True required=field.required placeholder=field.name id="id_"|add:field.name label=field.label name=field.name value=field.field.value errors=field.errors hint_below=True hint_text=field.field.help_text type=field.attributes.type inputmode=field.attributes.inputmode autocomplete=field.attributes.autocomplete autocapitalize=field.attributes.autocapitalize spellcheck=field.attributes.spellcheck autocorrect=field.attributes.autocorrect maxlength=field.attributes.maxlength rows=8 %}
+                {% form_textarea custom_field=True required=field.required id="id_"|add:field.name label=field.label name=field.name value=field.field.value errors=field.errors hint_below=True hint_text=field.field.help_text type=field.attributes.type inputmode=field.attributes.inputmode autocomplete=field.attributes.autocomplete autocapitalize=field.attributes.autocapitalize spellcheck=field.attributes.spellcheck autocorrect=field.attributes.autocorrect maxlength=field.attributes.maxlength rows=8 %}
               {% elif field.template_name == "form_radio" %}
                 {% #form_fieldset %}
                   {% form_legend text=field.label %}
@@ -106,7 +106,7 @@
                 {% /form_fieldset %}
               {% elif field.template_name == "form_checkbox" %}
                 <div class="flex flex-col -mb-3">
-                  {% form_checkbox custom_field=True required=field.required placeholder=field.name id="id_"|add:field.name label=field.label name=field.name value=field.value errors=field.errors hint_below=True hint_text=field.field.help_text checked=field.field.value %}
+                  {% form_checkbox custom_field=True required=field.required id="id_"|add:field.name label=field.label name=field.name value=field.value errors=field.errors hint_below=True hint_text=field.field.help_text checked=field.field.value %}
                 </div>
               {% endif %}
             {% endfor %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -64,7 +64,7 @@
         <input type="hidden" name="next" value="{{ next_url }}" />
 
         {% form_input type="text" field=token_form.user label="GitHub username or Email address" required=True class="mb-3" placeholder="opensafely" input_class="max-w-md" %}
-        {% form_input type="text" field=token_form.token label="Single Use Token" required=True placeholder="three random words" show_placeholder=True class="mb-3" input_class="max-w-md" %}
+        {% form_input type="text" field=token_form.token label="Single Use Token" required=True placeholder="three random words" class="mb-3" input_class="max-w-md" %}
 
         {% #button type="submit" variant="primary-outline" %}
             Log in with token

--- a/templates/staff/application/list.html
+++ b/templates/staff/application/list.html
@@ -55,7 +55,7 @@
     {% if users %}
       {% #card title="Filter by application author" %}
         <filter-input aria-owns="usersFilter">
-          {% form_input custom_field=True class="px-4 -mt-2 mb-4 sm:px-6" id="filterUsers" name="filter-users" label="Search for an author" label_class="sr-only" placeholder="Search for an author" show_placeholder=True %}
+          {% form_input custom_field=True class="px-4 -mt-2 mb-4 sm:px-6" id="filterUsers" name="filter-users" label="Search for an author" label_class="sr-only" placeholder="Search for an author" %}
         </filter-input>
         {% #list_group small=True class="max-h-96 overflow-y-auto" data_filter_list=True id="usersFilter" %}
           {% for user in users %}

--- a/templates/staff/org/detail.html
+++ b/templates/staff/org/detail.html
@@ -47,7 +47,7 @@
                 {% endif %}
 
                 <div class="flex flex-col items-stretch gap-y-6 w-full max-w-3xl mb-6">
-                {% form_input custom_field=True id="id_name" label="Organisation name" name="name" placeholder="GitHub Organisation name" show_placeholder=True %}
+                {% form_input custom_field=True id="id_name" label="Organisation name" name="name" placeholder="GitHub Organisation name" %}
                 </div>
 
                 <div class="flex flex-row flex-wrap gap-2">

--- a/templates/staff/project/list.html
+++ b/templates/staff/project/list.html
@@ -55,7 +55,7 @@
         {% if request.GET.q %}
           {% var value=request.GET.q|stringformat:"s" %}
         {% endif %}
-        {% form_input custom_field=True type="search" id="projectSearch" name="q" value=value label="Search for a project" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by project name" show_placeholder=True %}
+        {% form_input custom_field=True type="search" id="projectSearch" name="q" value=value label="Search for a project" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by project name" %}
         {% #button type="submit" variant="primary" class="flex-shrink-0" %}Search{% /button %}
       </form>
       {% if request.GET.q %}

--- a/templates/staff/redirect/list.html
+++ b/templates/staff/redirect/list.html
@@ -56,7 +56,7 @@
           {% if request.GET.q %}
             {% var value=request.GET.q|stringformat:"s" %}
           {% endif %}
-          {% form_input custom_field=True type="search" id="redirectSearch" name="q" value=value label="Search for a redirect" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by old url, analysis, creator, org, project, or workspace" show_placeholder=True %}
+          {% form_input custom_field=True type="search" id="redirectSearch" name="q" value=value label="Search for a redirect" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by old url, analysis, creator, org, project, or workspace" %}
           {% #button type="submit" variant="primary" class="flex-shrink-0" %}Search{% /button %}
         </form>
         {% if request.GET.q %}

--- a/templates/staff/repo/list.html
+++ b/templates/staff/repo/list.html
@@ -77,7 +77,7 @@
           {% if request.GET.q %}
             {% var value=request.GET.q|stringformat:"s" %}
           {% endif %}
-          {% form_input custom_field=True type="search" id="repoSearch" name="q" value=value label="Search for a repo" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by repo name" show_placeholder=True %}
+          {% form_input custom_field=True type="search" id="repoSearch" name="q" value=value label="Search for a repo" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by repo name" %}
           {% #button type="submit" variant="primary" class="flex-shrink-0" %}Search{% /button %}
         </form>
         {% if request.GET.q %}

--- a/templates/staff/report/list.html
+++ b/templates/staff/report/list.html
@@ -68,7 +68,7 @@
           {% if request.GET.q %}
             {% var value=request.GET.q|stringformat:"s" %}
           {% endif %}
-          {% form_input custom_field=True type="search" id="reportSearch" name="q" value=value label="Search for a report" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by report name or author name" show_placeholder=True %}
+          {% form_input custom_field=True type="search" id="reportSearch" name="q" value=value label="Search for a report" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by report name or author name" %}
           {% #button type="submit" variant="primary" class="flex-shrink-0" %}Search{% /button %}
         </form>
         {% if request.GET.q %}

--- a/templates/staff/user/list.html
+++ b/templates/staff/user/list.html
@@ -109,7 +109,7 @@
         {% if request.GET.q %}
           {% var value=request.GET.q|stringformat:"s" %}
         {% endif %}
-        {% form_input custom_field=True type="search" id="userSearch" name="q" value=value label="Search for a user" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by user name" show_placeholder=True %}
+        {% form_input custom_field=True type="search" id="userSearch" name="q" value=value label="Search for a user" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by user name" %}
         {% #button type="submit" variant="primary" class="flex-shrink-0" %}Search{% /button %}
       </form>
       {% if request.GET.q %}

--- a/templates/staff/workspace/list.html
+++ b/templates/staff/workspace/list.html
@@ -58,7 +58,7 @@
           {% if request.GET.q %}
             {% var value=request.GET.q|stringformat:"s" %}
           {% endif %}
-          {% form_input custom_field=True type="search" id="workspaceSearch" name="q" value=value label="Search for a workspace" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by workspace name" show_placeholder=True %}
+          {% form_input custom_field=True type="search" id="workspaceSearch" name="q" value=value label="Search for a workspace" label_class="sr-only" class="w-full" input_class="!m-0" placeholder="Search by workspace name" %}
           {% #button type="submit" variant="primary" class="flex-shrink-0" %}Search{% /button %}
         </form>
         {% if request.GET.q %}

--- a/templates/workspace/create.html
+++ b/templates/workspace/create.html
@@ -32,9 +32,9 @@
       {% endif %}
 
       <div class="max-w-prose grid gap-y-6">
-        {% form_input field=form.name label="Workspace name" required=True placeholder="Workspace name" %}
+        {% form_input field=form.name label="Workspace name" required=True %}
 
-        {% form_textarea field=form.purpose label="Workspace purpose" required=True placeholder="Workspace purpose" %}
+        {% form_textarea field=form.purpose label="Workspace purpose" required=True %}
 
         {% form_select field=form.repo label="GitHub repo" choices=form.repo.field.choices hint_text="If your repo doesn’t show up here, reach out to the OpenSAFELY team on Slack." required=True %}
 


### PR DESCRIPTION
Closes #4290

Previously we were using a combination of properties to show the invalid states to users when the information they entered into a textarea or input was not valid. This included using a hidden placeholder to find if the user had entered content.

The [new `:user-invalid` pseudo-class solves this very issue](https://www.bram.us/2021/01/28/form-validation-you-want-notfocusinvalid-not-invalid/#v5) and means that hack is no longer required.

Whilst browser support for this pseudo-class is recent, this is an additive feature, so users will still be alerted if they have not filled in a required field, but the browser will highlight this for them on form submit.