### PR TITLE
Project page doesnt load when GitHub api is unreachable

### DIFF
--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 import requests
 from django.contrib.auth.models import AnonymousUser
@@ -214,13 +212,7 @@ def test_projectdetail_with_timed_out_github(rf):
 
     class BrokenGitHubAPI:
         def get_repo_is_private(self, *args):
-            response = requests.Response()
-            response.status_code = 504
-            time.sleep(31)
-            raise requests.HTTPError(
-                "504 Server Error: Gateway Timeout for url: https://api.github.com/user",
-                response=response,
-            )
+            raise TimeoutError
 
     response = ProjectDetail.as_view(get_github_api=BrokenGitHubAPI)(
         request, project_slug=project.slug

--- a/tests/unit/jobserver/views/test_projects.py
+++ b/tests/unit/jobserver/views/test_projects.py
@@ -207,6 +207,7 @@ def test_projectdetail_with_timed_out_github(rf):
     WorkspaceFactory(
         project=project, repo=RepoFactory(url="https://github.com/owner/repo")
     )
+    WorkspaceFactory(project=project, repo=RepoFactory(url="/path/on/disk/to/repo"))
 
     request = rf.get("/")
     request.user = UserFactory()
@@ -230,7 +231,11 @@ def test_projectdetail_with_timed_out_github(rf):
     # check there is no public/private badge when GitHub returns an
     # unsuccessful response
     assert not response.context_data["public_repos"]
-    assert response.context_data["private_repos"][0]["is_private"] is None
+    assert response.context_data["private_repos"][0] == {
+        "name": "GitHub API Unavailable",
+        "is_private": None,
+        "url": "",
+    }
     assert "Public" not in response.rendered_content
 
 


### PR DESCRIPTION
Fixes #4534 

I don't believe retrying in case of a `TimeoutError` here is necessary for this feature, but am happy to be convinced otherwise. For now, this just handles it and provides a "Github API unavailable" placeholder `Repo` for the relevant bit of the template