### PR TITLE
Remove most uses of `pragma: no branch`

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -113,13 +113,18 @@ class WorkspaceCreateForm(forms.Form):
 
         # has there been a repo selected already?
         if "data" in kwargs and "repo" in kwargs["data"]:
-            repo = next(  # pragma: no branch
-                (
-                    r
-                    for r in self.repos_with_branches
-                    if r["url"] == kwargs["data"]["repo"]
-                ),
-            )
+            try:
+                repo = next(
+                    (
+                        r
+                        for r in self.repos_with_branches
+                        if r["url"] == kwargs["data"]["repo"]
+                    ),
+                )
+            except StopIteration:
+                raise forms.ValidationError(
+                    "No matching repos found, please reload the page and try again"
+                )
         else:
             repo = self.repos_with_branches[0]
 

--- a/jobserver/middleware.py
+++ b/jobserver/middleware.py
@@ -38,9 +38,7 @@ class TemplateNameMiddleware:
 
         # flatten template_name to a string
         if isinstance(template_name, list):
-            template_name = next(  # pragma: no branch
-                (t for t in template_name if t), None
-            )
+            template_name = template_name[0]
 
         response.context_data["template_name"] = template_name
         return response

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -200,3 +200,18 @@ def test_workspacecreateform_with_duplicate_name():
             'A workspace with the name "test" already exists, please choose a unique one.'
         ]
     }
+
+
+def test_workspacecreateform_with_no_repo_match():
+    project = ProjectFactory()
+    WorkspaceFactory(name="test")
+
+    data = {
+        "name": "test",
+        "repo": "different",
+        "branch": "test",
+        "purpose": "test",
+    }
+    repos_with_branches = [{"name": "test", "url": "test", "branches": ["test"]}]
+    with pytest.raises(ValidationError):
+        WorkspaceCreateForm(project, repos_with_branches, data=data)


### PR DESCRIPTION
Fixes #4562.

This removes most uses of `pragma: no branch` from production code.

We decided to leave one exemption in the code, as it makes sense in context: we never expect that alternate execution branch to happen. See [the discussion](https://github.com/opensafely-core/job-server/pull/4603#discussion_r1757340223).