### PR TITLE
Set `concurrency` on entire deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,11 +14,11 @@ on:
 concurrency: deploy-production
 
 jobs:
-  run-main:
+  test-and-build-docker-image:
     uses: ./.github/workflows/main.yml
 
   deploy:
-    needs: [run-main]
+    needs: [test-and-build-docker-image]
 
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,83 @@
+---
+name: Deploy
+
+env:
+  IMAGE_NAME: job-server
+  PUBLIC_IMAGE_NAME: ghcr.io/opensafely-core/job-server
+  REGISTRY: ghcr.io
+  SSH_AUTH_SOCK: /tmp/agent.sock
+
+on:
+  push:
+    branches: [main]
+
+concurrency: deploy-production
+
+jobs:
+  run-main:
+    uses: ./.github/workflows/main.yml
+
+  deploy:
+    needs: [run-main]
+
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: "opensafely-core/setup-action@v1"
+        with:
+          install-just: true
+
+      - name: Download docker image
+        uses: actions/download-artifact@v4
+        with:
+            name: job-server-image
+            path: /tmp/image
+
+      - name: Import docker image
+        # Note that this filename is also set in the build workflow.
+        # Changing it will require updating it elsewhere.
+        run: docker image load --input /tmp/image/job-server.tar.zst
+
+      - name: Test image we imported from previous job works
+        run: |
+            SKIP_BUILD=1 just docker-serve prod -d
+            sleep 5
+            just docker-smoke-test || { docker logs job-server_prod_1; exit 1; }
+
+      - name: Publish image
+        run: |
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login "$REGISTRY" -u "${{ github.actor }}" --password-stdin
+            docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:latest"
+            docker push "$PUBLIC_IMAGE_NAME:latest"
+
+      - name: Deploy image
+        run: |
+            ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
+            ssh-add - <<< "${{ secrets.DOKKU4_DEPLOY_SSH_KEY }}"
+            SHA=$(docker inspect --format='{{index .RepoDigests 0}}' "$PUBLIC_IMAGE_NAME:latest")
+            ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" dokku@dokku4.ebmdatalab.net git:from-image job-server "$SHA"
+
+      - name: Create Honeycomb Marker
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download v0.2.10 -R honeycombio/honeymarker -p '*-linux-amd64*' -O honeymarker
+          chmod 755 ./honeymarker
+          # --dataset __all__ will ad an marker to *all* production datasets (this writekey is for production)
+          ./honeymarker --writekey ${{ secrets.HC_MARKER_APIKEY }} --dataset job-server add --type deploy --msg "job-server deploy $GITHUB_SHA"
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@e769183448303de84c5a06aaaddf9da7be26d6c7 # v1.7.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_RELEASE_INTEGRATION_TOKEN }}
+          SENTRY_ORG: ebm-datalab
+          SENTRY_PROJECT: job-server
+        with:
+          environment: production

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,11 @@
 ---
-name: CI
-
-env:
-  IMAGE_NAME: job-server
-  PUBLIC_IMAGE_NAME: ghcr.io/opensafely-core/job-server
-  REGISTRY: ghcr.io
-  SSH_AUTH_SOCK: /tmp/agent.sock
+name: Test and build Docker image
 
 on:
   merge_group:
   pull_request:
-  push:
-    branches: [main]
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   check:
@@ -144,68 +138,3 @@ jobs:
             name: job-server-image
             path: /tmp/job-server.tar.zst
             compression-level: 0
-
-  deploy:
-    needs: [check, test, docker-test, lint-dockerfile]
-
-    runs-on: ubuntu-22.04
-
-    permissions:
-      contents: read
-      packages: write
-
-    if: github.ref == 'refs/heads/main'
-
-    concurrency: deploy-production
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: "opensafely-core/setup-action@v1"
-        with:
-          install-just: true
-
-      - name: Download docker image
-        uses: actions/download-artifact@v4
-        with:
-            name: job-server-image
-            path: /tmp/image
-
-      - name: Import docker image
-        run: docker image load --input /tmp/image/job-server.tar.zst
-
-      - name: Test image we imported from previous job works
-        run: |
-            SKIP_BUILD=1 just docker-serve prod -d
-            sleep 5
-            just docker-smoke-test || { docker logs job-server_prod_1; exit 1; }
-
-      - name: Publish image
-        run: |
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login "$REGISTRY" -u "${{ github.actor }}" --password-stdin
-            docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:latest"
-            docker push "$PUBLIC_IMAGE_NAME:latest"
-
-      - name: Deploy image
-        run: |
-            ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
-            ssh-add - <<< "${{ secrets.DOKKU4_DEPLOY_SSH_KEY }}"
-            SHA=$(docker inspect --format='{{index .RepoDigests 0}}' "$PUBLIC_IMAGE_NAME:latest")
-            ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" dokku@dokku4.ebmdatalab.net git:from-image job-server "$SHA"
-
-      - name: Create Honeycomb Marker
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download v0.2.10 -R honeycombio/honeymarker -p '*-linux-amd64*' -O honeymarker
-          chmod 755 ./honeymarker
-          # --dataset __all__ will ad an marker to *all* production datasets (this writekey is for production)
-          ./honeymarker --writekey ${{ secrets.HC_MARKER_APIKEY }} --dataset job-server add --type deploy --msg "job-server deploy $GITHUB_SHA"
-
-      - name: Create Sentry release
-        uses: getsentry/action-release@e769183448303de84c5a06aaaddf9da7be26d6c7 # v1.7.0
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_RELEASE_INTEGRATION_TOKEN }}
-          SENTRY_ORG: ebm-datalab
-          SENTRY_PROJECT: job-server
-        with:
-          environment: production

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,16 +181,16 @@ jobs:
 
       - name: Publish image
         run: |
-            echo ${{ secrets.GITHUB_TOKEN }} | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
-            docker tag $IMAGE_NAME $PUBLIC_IMAGE_NAME:latest
-            docker push $PUBLIC_IMAGE_NAME:latest
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login "$REGISTRY" -u "${{ github.actor }}" --password-stdin
+            docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:latest"
+            docker push "$PUBLIC_IMAGE_NAME:latest"
 
       - name: Deploy image
         run: |
-            ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+            ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
             ssh-add - <<< "${{ secrets.DOKKU4_DEPLOY_SSH_KEY }}"
-            SHA=$(docker inspect --format='{{index .RepoDigests 0}}' $PUBLIC_IMAGE_NAME:latest)
-            ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" dokku@dokku4.ebmdatalab.net git:from-image job-server $SHA
+            SHA=$(docker inspect --format='{{index .RepoDigests 0}}' "$PUBLIC_IMAGE_NAME:latest")
+            ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" dokku@dokku4.ebmdatalab.net git:from-image job-server "$SHA"
 
       - name: Create Honeycomb Marker
         env:


### PR DESCRIPTION
This fixes a problem identified in #4607.

It was possible to have multiple `main` workflow runs simultaneously. GitHub's `concurrency` option was set on the actual `deploy` job in that workflow. However, it's possible that for runs started close in time, that a later run actually gets to the `deploy` job before the earlier one.

Instead, we lock the entire deploy workflow, separating out the tests into a reusable workflow to avoid duplication.