### PR TITLE
Extra instructions for changing the User model

### DIFF
--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -95,9 +95,13 @@ def get_or_create_user(username, email, fullname, update_fields=None):
 
 class User(AbstractBaseUser):
     """
-    A custom User model used throughout the codebase
+    A custom User model used throughout the codebase.
 
     Using a custom Model allows us to add extra fields trivially, eg Roles.
+
+    Changing any fields in the User model may require the corresponding
+    view, used by Grafana, to be regenerated after deployment. More
+    information can be found in https://github.com/ebmdatalab/metrics/blob/main/grafana/README.md
     """
 
     backends = models.ManyToManyField(


### PR DESCRIPTION
We have a custom view that's used by Grafana to access a subset of the User table. If fields on the User model are changed, this updates the underlying database table linked to that view, and means the view needs to be regenerated. I've added a pointer to the instructions that tells someone how to do that.