### PR TITLE
Fix `default_language_version`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3.12
 
 repos:
   - repo: local


### PR DESCRIPTION
pre-commit's `default_language_version` should have been bumped from 3.11 to 3.12 almost exactly a year ago (c1759e89), but it was missed. Those with a python3.11 binary won't have noticed, but those without, like @KatieB5, would. Thank you for spotting this, Katie!