### PR TITLE
Parametrize `test_workspacecreateform_success`

### DIFF
--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -116,7 +116,7 @@ def test_workspacecreateform_success():
     assert form.is_valid()
 
 
-def test_workspacecreateform_success_with_upper_case_names():
+def test_workspacecreateform_success_with_mixed_case_name():
     project = ProjectFactory()
     data = {
         "name": "TeSt",

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -96,10 +96,17 @@ def test_jobrequestcreateform_with_bad_codelists(
         )
 
 
-def test_workspacecreateform_success():
+@pytest.mark.parametrize(
+    "name,cleaned_name",
+    [
+        pytest.param("test", "test", id="lower_case_name"),
+        pytest.param("TeSt", "test", id="mixed_case_name"),
+    ],
+)
+def test_workspacecreateform_success(name, cleaned_name):
     project = ProjectFactory()
     data = {
-        "name": "test",
+        "name": name,
         "repo": "http://example.com/derp/test-repo",
         "branch": "test-branch",
         "purpose": "test",
@@ -114,28 +121,7 @@ def test_workspacecreateform_success():
     form = WorkspaceCreateForm(project, repos_with_branches, data)
 
     assert form.is_valid()
-    assert form.cleaned_data["name"] == "test"
-
-
-def test_workspacecreateform_success_with_mixed_case_name():
-    project = ProjectFactory()
-    data = {
-        "name": "TeSt",
-        "repo": "http://example.com/derp/test-repo",
-        "branch": "test-branch",
-        "purpose": "test",
-    }
-    repos_with_branches = [
-        {
-            "name": "test-repo",
-            "url": "http://example.com/derp/test-repo",
-            "branches": ["test-branch"],
-        }
-    ]
-    form = WorkspaceCreateForm(project, repos_with_branches, data)
-
-    assert form.is_valid()
-    assert form.cleaned_data["name"] == "test"
+    assert form.cleaned_data["name"] == cleaned_name
 
 
 def test_workspacecreateform_unknown_branch():

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -114,6 +114,7 @@ def test_workspacecreateform_success():
     form = WorkspaceCreateForm(project, repos_with_branches, data)
 
     assert form.is_valid()
+    assert form.cleaned_data["name"] == "test"
 
 
 def test_workspacecreateform_success_with_mixed_case_name():
@@ -134,7 +135,7 @@ def test_workspacecreateform_success_with_mixed_case_name():
     form = WorkspaceCreateForm(project, repos_with_branches, data)
 
     assert form.is_valid()
-    assert form.cleaned_data["name"] == "test", form.cleaned_data["name"]
+    assert form.cleaned_data["name"] == "test"
 
 
 def test_workspacecreateform_unknown_branch():


### PR DESCRIPTION
In this PR, we make a couple of small changes to two tests. These small changes help us see that the two tests are basically the same, save for two parameters. We then parameterise one test and remove the other, meaning we have the same tests for 14 fewer lines of code.

We use the [`pytest.mark.parametrize`](https://docs.pytest.org/en/latest/how-to/parametrize.html#pytest-mark-parametrize) decorator to parameterise the test, also using [`pytest.param`](https://docs.pytest.org/en/latest/reference/reference.html#pytest.param) to assign a more descriptive ID to each parameter set. Doing so also makes it easier to run the test with either parameter set:

```sh
pytest tests/unit/jobserver/test_forms.py::test_workspacecreateform_success[lower_case_name]

pytest tests/unit/jobserver/test_forms.py::test_workspacecreateform_success[mixed_case_name]
```

Or with both parameter sets:

```sh
pytest tests/unit/jobserver/test_forms.py::test_workspacecreateform_success
```

Although out of scope, I think it's worth noting that `test_workspacecreateform_success` would be a great candidate for [property-based testing](https://hypothesis.readthedocs.io/en/latest/). It's unlikely that every `name` will be either lower-case or mixed-case ASCII in real life, so verifying that `WorkspaceCreateForm.clean_name` works correctly with a wide range of `name`s is important.

I created this PR whilst working on #4593. It doesn't address that issue, but it does make that issue easier to address.