### PR TITLE
Unpin `urllib3`

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -35,8 +35,6 @@ slippers
 social-auth-app-django
 social-auth-core
 structlog
-# 2.1.0 appears to be causing some problems with exporting
-# https://github.com/opensafely-core/job-server/issues/3955
-urllib3<=2.2.3
+urllib3
 whitenoise[brotli]
 xkcdpass


### PR DESCRIPTION
v2.2.3 is the latest `urllib3` and we've had Dependabot pull requests update this version.

Example: https://github.com/opensafely-core/job-server/pull/4609

Therefore, this comment is no longer correct, and it implies the pinning is no longer required.