### PR TITLE
Remove unneeded dependencies from L4 file viewer

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -16,11 +16,9 @@ opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tag
 gunicorn
 incuna-mail
 interactive_templates@https://github.com/opensafely-core/interactive-templates/archive/refs/tags/v2024.07.09.130747.zip
-itsdangerous
 markdown
 nh3
 psycopg[binary]
-pydantic
 pygments
 python-ulid
 opentelemetry-exporter-otlp-proto-http==1.22.0

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -12,7 +12,7 @@ django-vite
 djangorestframework
 environs[django]
 furl
-opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/v2024.03.19.153938.zip
+opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/v2024.10.08.124104.zip
 gunicorn
 incuna-mail
 interactive_templates@https://github.com/opensafely-core/interactive-templates/archive/refs/tags/v2024.07.09.130747.zip

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -438,10 +438,6 @@ incuna-mail==4.1.1 \
 interactive-templates @ https://github.com/opensafely-core/interactive-templates/archive/refs/tags/v2024.07.09.130747.zip \
     --hash=sha256:55a5f8c23c3c32fbd36222e928b051c512b0f9a77f0e8a9dccac6a53e1393563
     # via -r requirements.prod.in
-itsdangerous==2.2.0 \
-    --hash=sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef \
-    --hash=sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173
-    # via -r requirements.prod.in
 jinja2==3.1.4 \
     --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369 \
     --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
@@ -720,51 +716,6 @@ pycparser==2.21 \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \
     --hash=sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206
     # via cffi
-pydantic==1.10.18 \
-    --hash=sha256:069b9c9fc645474d5ea3653788b544a9e0ccd3dca3ad8c900c4c6eac844b4620 \
-    --hash=sha256:06a189b81ffc52746ec9c8c007f16e5167c8b0a696e1a726369327e3db7b2a82 \
-    --hash=sha256:11d9d9b87b50338b1b7de4ebf34fd29fdb0d219dc07ade29effc74d3d2609c62 \
-    --hash=sha256:15fdbe568beaca9aacfccd5ceadfb5f1a235087a127e8af5e48df9d8a45ae85c \
-    --hash=sha256:19a3bd00b9dafc2cd7250d94d5b578edf7a0bd7daf102617153ff9a8fa37871c \
-    --hash=sha256:23e8ec1ce4e57b4f441fc91e3c12adba023fedd06868445a5b5f1d48f0ab3682 \
-    --hash=sha256:24a4a159d0f7a8e26bf6463b0d3d60871d6a52eac5bb6a07a7df85c806f4c048 \
-    --hash=sha256:2ce3fcf75b2bae99aa31bd4968de0474ebe8c8258a0110903478bd83dfee4e3b \
-    --hash=sha256:335a32d72c51a313b33fa3a9b0fe283503272ef6467910338e123f90925f0f03 \
-    --hash=sha256:3445426da503c7e40baccefb2b2989a0c5ce6b163679dd75f55493b460f05a8f \
-    --hash=sha256:34a3613c7edb8c6fa578e58e9abe3c0f5e7430e0fc34a65a415a1683b9c32d9a \
-    --hash=sha256:3d5492dbf953d7d849751917e3b2433fb26010d977aa7a0765c37425a4026ff1 \
-    --hash=sha256:44ae8a3e35a54d2e8fa88ed65e1b08967a9ef8c320819a969bfa09ce5528fafe \
-    --hash=sha256:467a14ee2183bc9c902579bb2f04c3d3dac00eff52e252850509a562255b2a33 \
-    --hash=sha256:46f379b8cb8a3585e3f61bf9ae7d606c70d133943f339d38b76e041ec234953f \
-    --hash=sha256:49e26c51ca854286bffc22b69787a8d4063a62bf7d83dc21d44d2ff426108518 \
-    --hash=sha256:65f7361a09b07915a98efd17fdec23103307a54db2000bb92095457ca758d485 \
-    --hash=sha256:6951f3f47cb5ca4da536ab161ac0163cab31417d20c54c6de5ddcab8bc813c3f \
-    --hash=sha256:72fa46abace0a7743cc697dbb830a41ee84c9db8456e8d77a46d79b537efd7ec \
-    --hash=sha256:74fe19dda960b193b0eb82c1f4d2c8e5e26918d9cda858cbf3f41dd28549cb70 \
-    --hash=sha256:7a4c5eec138a9b52c67f664c7d51d4c7234c5ad65dd8aacd919fb47445a62c86 \
-    --hash=sha256:80b982d42515632eb51f60fa1d217dfe0729f008e81a82d1544cc392e0a50ddf \
-    --hash=sha256:941a2eb0a1509bd7f31e355912eb33b698eb0051730b2eaf9e70e2e1589cae1d \
-    --hash=sha256:9f463abafdc92635da4b38807f5b9972276be7c8c5121989768549fceb8d2588 \
-    --hash=sha256:a00e63104346145389b8e8f500bc6a241e729feaf0559b88b8aa513dd2065481 \
-    --hash=sha256:aad8771ec8dbf9139b01b56f66386537c6fe4e76c8f7a47c10261b69ad25c2c9 \
-    --hash=sha256:ae6fa2008e1443c46b7b3a5eb03800121868d5ab6bc7cda20b5df3e133cde8b3 \
-    --hash=sha256:b661ce52c7b5e5f600c0c3c5839e71918346af2ef20062705ae76b5c16914cab \
-    --hash=sha256:b74be007703547dc52e3c37344d130a7bfacca7df112a9e5ceeb840a9ce195c7 \
-    --hash=sha256:baebdff1907d1d96a139c25136a9bb7d17e118f133a76a2ef3b845e831e3403a \
-    --hash=sha256:c20f682defc9ef81cd7eaa485879ab29a86a0ba58acf669a78ed868e72bb89e0 \
-    --hash=sha256:c3e742f62198c9eb9201781fbebe64533a3bbf6a76a91b8d438d62b813079dbc \
-    --hash=sha256:c5ae6b7c8483b1e0bf59e5f1843e4fd8fd405e11df7de217ee65b98eb5462861 \
-    --hash=sha256:c6d0a9f9eccaf7f438671a64acf654ef0d045466e63f9f68a579e2383b63f357 \
-    --hash=sha256:cbfbca662ed3729204090c4d09ee4beeecc1a7ecba5a159a94b5a4eb24e3759a \
-    --hash=sha256:d5389eb3b48a72da28c6e061a247ab224381435256eb541e175798483368fdd3 \
-    --hash=sha256:e306e280ebebc65040034bff1a0a81fd86b2f4f05daac0131f29541cafd80b80 \
-    --hash=sha256:e405ffcc1254d76bb0e760db101ee8916b620893e6edfbfee563b3c6f7a67c02 \
-    --hash=sha256:e9ee4e6ca1d9616797fa2e9c0bfb8815912c7d67aca96f77428e316741082a1b \
-    --hash=sha256:ef0fe7ad7cbdb5f372463d42e6ed4ca9c443a52ce544472d8842a0576d830da5 \
-    --hash=sha256:efbc8a7f9cb5fe26122acba1852d8dcd1e125e723727c59dcd244da7bdaa54f2 \
-    --hash=sha256:fcb20d4cb355195c75000a49bb4a31d75e4295200df620f454bbc6bdf60ca890 \
-    --hash=sha256:fe734914977eed33033b70bfc097e1baaffb589517863955430bf2e0846ac30f
-    # via -r requirements.prod.in
 pygments==2.18.0 \
     --hash=sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199 \
     --hash=sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a
@@ -903,7 +854,6 @@ typing-extensions==4.9.0 \
     #   dj-database-url
     #   opentelemetry-sdk
     #   psycopg
-    #   pydantic
     #   slippers
 urllib3==2.2.3 \
     --hash=sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac \

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -540,8 +540,8 @@ oauthlib==3.2.2 \
     # via
     #   requests-oauthlib
     #   social-auth-core
-opensafely-pipeline @ https://github.com/opensafely-core/pipeline/archive/refs/tags/v2024.03.19.153938.zip \
-    --hash=sha256:f1fb0829c832f4c52a495d7fe167e0656c2a77fde4e58426268c60754a5f6e89
+opensafely-pipeline @ https://github.com/opensafely-core/pipeline/archive/refs/tags/v2024.10.08.124104.zip \
+    --hash=sha256:190637a7fb67b3bdfd67e4b14b1b79a5eba3346b2b5ddc4dbb487aa4b130d122
     # via -r requirements.prod.in
 opentelemetry-api==1.22.0 \
     --hash=sha256:15ae4ca925ecf9cfdfb7a709250846fbb08072260fca08ade78056c502b86bed \
@@ -764,9 +764,7 @@ pydantic==1.10.18 \
     --hash=sha256:efbc8a7f9cb5fe26122acba1852d8dcd1e125e723727c59dcd244da7bdaa54f2 \
     --hash=sha256:fcb20d4cb355195c75000a49bb4a31d75e4295200df620f454bbc6bdf60ca890 \
     --hash=sha256:fe734914977eed33033b70bfc097e1baaffb589517863955430bf2e0846ac30f
-    # via
-    #   -r requirements.prod.in
-    #   opensafely-pipeline
+    # via -r requirements.prod.in
 pygments==2.18.0 \
     --hash=sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199 \
     --hash=sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a


### PR DESCRIPTION
This PR updates `opensafely-pipeline` which facilitates removing `pydantic` and `itsdangerous`.

Fixes #4661.