### PR TITLE
Don't render large YAML in JobRequestDetail view.

### DIFF
--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -281,14 +281,20 @@ class JobRequestDetail(View):
     def get_project_yaml(self, job_request):
         is_empty = job_request.project_definition == ""
 
-        # We know files that are 2.43MB take too long to render with pygments
-        # in production and crash browser tabs locally, so we're limiting the
-        # size.  The current 1MB is arbitrary until we can get some telemetry
-        # from production.
-        is_too_large = len(job_request.project_definition) > 10_000  # ~1MB
+        # Is this file too large to render? Files around 2.43MB crash tabs and
+        # render slowly. The 10K character limit (~10-40KB) is arbitrary. It
+        # could be refined, perhaps with telemetry. Length is an imperfect
+        # proxy for render cost, but better than size, which ignores encoding.
+        is_too_large = len(job_request.project_definition) > 10_000  # ~10-40KB
 
         if is_empty:
+            # Nothing to render, may as well not call render_definition.
             project_definition = ""
+        elif is_too_large:
+            # Skip rendering as the template shouldn't display the result.
+            # Return a human-readable string in case the template behavior
+            # changes and shows project_definition despite is_too_large.
+            project_definition = "This file is too large to render."
         else:
             project_definition = mark_safe(
                 render_definition(


### PR DESCRIPTION
Fixes #3704.

The `job-request-detail` template doesn't display the rendered project YAML if the context flags `project_yaml` sub-key `is_too_large` (from #3870, which was also towards #3704). Therefore the view code doesn't need to render the definition in that case. Doing so was slowing down page rendering by 5 or more seconds in some cases.

The extant code arbitrarily defined "large" as longer than 10,000 characters, but the comments mentioned ~1MB , which doesn't match. I've updated the comment. I've not considered updating the arbitrary value used.

As well as a unit test for the "too large" case, I added one for the rendering actually taking effect, as it was missing. And added checks that the `project_yaml` `is_too_large` or `is_empty` are as they should be in the other "happy path" tests.