### PR TITLE
Tidy CoreDeveloper vestigial indirect references.

### DIFF
--- a/jobserver/management/commands/create_user.py
+++ b/jobserver/management/commands/create_user.py
@@ -21,12 +21,14 @@ class Command(BaseCommand):
         parser.add_argument("--email", help="Defaults to username@example.com")
         parser.add_argument("--name", help="Defaults to username")
         parser.add_argument(
+            "-o",
             "--output-checker",
             action="store_true",
             help="Make user global OutputChecker",
         )
         parser.add_argument(
-            "--core-developer",
+            "-s",
+            "--staff-area-administrator",
             action="store_true",
             help="Make user global StaffAreaAdministrator",
         )
@@ -52,7 +54,7 @@ class Command(BaseCommand):
         roles = []
         if options["output_checker"]:
             roles.append(OutputChecker)
-        if options["core_developer"]:
+        if options["staff_area_administrator"]:
             roles.append(StaffAreaAdministrator)
 
         updated = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def api_rf():
 
 
 @pytest.fixture
-def core_developer():
+def staff_area_administrator():
     return UserFactory(roles=[StaffAreaAdministrator])
 
 

--- a/tests/unit/applications/test_views.py
+++ b/tests/unit/applications/test_views.py
@@ -561,13 +561,13 @@ def test_page_with_approved_application_and_non_staff_user(rf):
     assert str(messages[0]) == msg
 
 
-def test_page_with_approved_application_and_staff_user(rf, core_developer):
+def test_page_with_approved_application_and_staff_user(rf, staff_area_administrator):
     application = ApplicationFactory(
-        approved_at=timezone.now(), approved_by=core_developer
+        approved_at=timezone.now(), approved_by=staff_area_administrator
     )
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = page(request, pk_hash=application.pk_hash, key="study-purpose")
 

--- a/tests/unit/interactive/test_models.py
+++ b/tests/unit/interactive/test_models.py
@@ -167,10 +167,10 @@ def test_analysisrequest_visible_to_creator():
     assert analysis_request.visible_to(analysis_request.created_by)
 
 
-def test_analysisrequest_visible_to_staff(core_developer):
+def test_analysisrequest_visible_to_staff(staff_area_administrator):
     analysis_request = AnalysisRequestFactory()
 
-    assert analysis_request.visible_to(core_developer)
+    assert analysis_request.visible_to(staff_area_administrator)
 
 
 def test_analysisrequest_visible_to_other_user():

--- a/tests/unit/jobserver/authorization/test_decorators.py
+++ b/tests/unit/jobserver/authorization/test_decorators.py
@@ -7,9 +7,9 @@ from jobserver.authorization.decorators import require_manage_backends, require_
 from ....factories import UserFactory
 
 
-def test_require_manage_backends_with_core_dev_role(rf, core_developer):
+def test_require_manage_backends_with_core_dev_role(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     def dispatch(request):
         return request

--- a/tests/unit/jobserver/management/commands/test_create_user.py
+++ b/tests/unit/jobserver/management/commands/test_create_user.py
@@ -26,8 +26,8 @@ def test_create_user_args(capsys):
         "username",
         "--email=foo@bar.com",
         "--name=fullname",
+        "--staff-area-administrator",
         "--output-checker",
-        "--core-developer",
     )
 
     user = User.objects.get(username="username")
@@ -43,5 +43,5 @@ def test_create_user_args(capsys):
         "--email=foo@bar.com",
         "--name=fullname",
         "--output-checker",
-        "--core-developer",
+        "--staff-area-administrator",
     )

--- a/tests/unit/jobserver/test_context_processors.py
+++ b/tests/unit/jobserver/test_context_processors.py
@@ -5,14 +5,16 @@ from jobserver.context_processors import can_view_staff_area, nav
 from ...factories import UserFactory
 
 
-def test_can_view_staff_area_with_core_developer(rf, core_developer):
+def test_can_view_staff_area_with_staff_area_administrator(
+    rf, staff_area_administrator
+):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     assert can_view_staff_area(request)["user_can_view_staff_area"]
 
 
-def test_can_view_staff_area_without_core_developer(rf):
+def test_can_view_staff_area_without_staff_area_administrator(rf):
     request = rf.get("/")
     request.user = UserFactory()
 
@@ -20,10 +22,10 @@ def test_can_view_staff_area_without_core_developer(rf):
 
 
 def test_can_view_staff_area_makes_no_db_queries(
-    rf, core_developer, django_assert_num_queries
+    rf, staff_area_administrator, django_assert_num_queries
 ):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with django_assert_num_queries(0):
         assert can_view_staff_area(request)["user_can_view_staff_area"]

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -1009,7 +1009,7 @@ def test_jobrequestdetail_with_permission(rf, project_membership, role_factory):
     assert "Cancel" in response.rendered_content
 
 
-def test_jobrequestdetail_with_permission_core_developer(rf, freezer):
+def test_jobrequestdetail_with_permission_staff_area_administrator(rf, freezer):
     freezer.move_to("2022-06-16 12:00")
     job_request = JobRequestFactory()
     job = JobFactory(  # noqa: F841

--- a/tests/unit/jobserver/views/test_jobs.py
+++ b/tests/unit/jobserver/views/test_jobs.py
@@ -180,7 +180,7 @@ def test_jobdetail_with_permission(rf, project_membership, role_factory):
     assert "Honeycomb" not in response.rendered_content
 
 
-def test_jobdetail_with_core_developer(rf, freezer):
+def test_jobdetail_with_staff_area_administrator(rf, freezer):
     freezer.move_to("2022-06-16 12:00")
 
     job_request = JobRequestFactory()
@@ -221,7 +221,7 @@ def test_jobdetail_with_core_developer(rf, freezer):
     assert job_request.identifier in response.rendered_content
 
 
-def test_jobdetail_with_core_developer_with_completed_at(rf, freezer):
+def test_jobdetail_with_staff_area_administrator_with_completed_at(rf, freezer):
     freezer.move_to("2022-06-15 13:00")
 
     job_request = JobRequestFactory()

--- a/tests/unit/staff/views/dashboards/test_copiloting.py
+++ b/tests/unit/staff/views/dashboards/test_copiloting.py
@@ -50,7 +50,7 @@ def test_build_repos_by_project_with_broken_github_api():
     assert build_repos_by_project(projects, get_github_api=BrokenGitHubAPI) == {}
 
 
-def test_copiloting_success(rf, core_developer):
+def test_copiloting_success(rf, staff_area_administrator):
     project = ProjectFactory()
     repo = RepoFactory(url="https://github.com/opensafely/research-repo-1")
     workspace = WorkspaceFactory(project=project, repo=repo)
@@ -63,7 +63,7 @@ def test_copiloting_success(rf, core_developer):
     JobFactory(job_request=job_request2, started_at=datetime(2021, 9, 3, tzinfo=UTC))
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = Copiloting.as_view(get_github_api=FakeGitHubAPI)(request)
 
@@ -86,7 +86,7 @@ def test_copiloting_unauthorized(rf):
         Copiloting.as_view(get_github_api=FakeGitHubAPI)(request)
 
 
-def test_copiloting_with_broken_github_api(rf, core_developer):
+def test_copiloting_with_broken_github_api(rf, staff_area_administrator):
     project = ProjectFactory()
     repo = RepoFactory(url="https://github.com/opensafely/research-repo-1")
     workspace = WorkspaceFactory(project=project, repo=repo)
@@ -99,7 +99,7 @@ def test_copiloting_with_broken_github_api(rf, core_developer):
     JobFactory(job_request=job_request2, started_at=datetime(2021, 9, 3, tzinfo=UTC))
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     class BrokenGitHubAPI:
         def get_repos_with_status_and_url(self, orgs):

--- a/tests/unit/staff/views/dashboards/test_index.py
+++ b/tests/unit/staff/views/dashboards/test_index.py
@@ -6,9 +6,9 @@ from staff.views.dashboards.index import DashboardIndex
 from .....factories import UserFactory
 
 
-def test_dashboardindex_success(rf, core_developer):
+def test_dashboardindex_success(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = DashboardIndex.as_view()(request)
 

--- a/tests/unit/staff/views/dashboards/test_projects.py
+++ b/tests/unit/staff/views/dashboards/test_projects.py
@@ -16,7 +16,7 @@ from .....factories import (
 )
 
 
-def test_projects_success(rf, core_developer):
+def test_projects_success(rf, staff_area_administrator):
     project = ProjectFactory()
     workspace = WorkspaceFactory(project=project)
     release = ReleaseFactory(workspace=workspace)
@@ -28,7 +28,7 @@ def test_projects_success(rf, core_developer):
     JobFactory(job_request=job_request2, started_at=datetime(2021, 9, 3, tzinfo=UTC))
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ProjectsDashboard.as_view()(request)
 

--- a/tests/unit/staff/views/dashboards/test_repos.py
+++ b/tests/unit/staff/views/dashboards/test_repos.py
@@ -21,7 +21,9 @@ from .....fakes import FakeGitHubAPI
 from .....utils import minutes_ago
 
 
-def test_privatereposdashboard_success(rf, django_assert_num_queries, core_developer):
+def test_privatereposdashboard_success(
+    rf, django_assert_num_queries, staff_area_administrator
+):
     eleven_months_ago = timezone.now() - timedelta(days=30 * 11)
 
     # 3 private repos
@@ -74,7 +76,7 @@ def test_privatereposdashboard_success(rf, django_assert_num_queries, core_devel
     JobFactory(job_request=rr5_jr_1, started_at=None)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with django_assert_num_queries(2):
         response = PrivateReposDashboard.as_view(get_github_api=FakeGitHubAPI)(request)
@@ -99,7 +101,7 @@ def test_privatereposdashboard_unauthorized(rf):
 
 
 def test_reposwithmultipleprojects_success(
-    rf, django_assert_num_queries, core_developer
+    rf, django_assert_num_queries, staff_area_administrator
 ):
     # research-repo-1
     repo1 = RepoFactory(url="https://github.com/opensafely/repo-1")
@@ -114,7 +116,7 @@ def test_reposwithmultipleprojects_success(
     WorkspaceFactory.create_batch(5, repo=repo3, project=ProjectFactory())
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with django_assert_num_queries(2):
         response = ReposWithMultipleProjects.as_view()(request)

--- a/tests/unit/staff/views/test_analysis_requests.py
+++ b/tests/unit/staff/views/test_analysis_requests.py
@@ -22,7 +22,9 @@ from ....factories import (
 )
 
 
-def test_analysisrequestdetail_success_with_publish_requests(rf, core_developer):
+def test_analysisrequestdetail_success_with_publish_requests(
+    rf, staff_area_administrator
+):
     rfile = ReleaseFileFactory()
     snapshot = SnapshotFactory()
     snapshot.files.add(rfile)
@@ -33,7 +35,7 @@ def test_analysisrequestdetail_success_with_publish_requests(rf, core_developer)
     analysis_request = AnalysisRequestFactory(report=report)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = AnalysisRequestDetail.as_view()(request, slug=analysis_request.slug)
 
@@ -41,11 +43,13 @@ def test_analysisrequestdetail_success_with_publish_requests(rf, core_developer)
     assert len(response.context_data["publish_requests"]) == 2
 
 
-def test_analysisrequestdetail_success_without_publish_requests(rf, core_developer):
+def test_analysisrequestdetail_success_without_publish_requests(
+    rf, staff_area_administrator
+):
     analysis_request = AnalysisRequestFactory()
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = AnalysisRequestDetail.as_view()(request, slug=analysis_request.slug)
 
@@ -63,35 +67,35 @@ def test_analysisrequestdetail_unauthorized(rf):
         AnalysisRequestDetail.as_view()(request, slug=analysis_request.slug)
 
 
-def test_analysisrequestdetail_unknown_analysis_request(rf, core_developer):
+def test_analysisrequestdetail_unknown_analysis_request(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         AnalysisRequestDetail.as_view()(request, slug="")
 
 
-def test_analysisrequestresubmit_success(rf, core_developer):
+def test_analysisrequestresubmit_success(rf, staff_area_administrator):
     project = ProjectFactory()
     analysis_request = AnalysisRequestFactory(project=project)
     WorkspaceFactory(name=project.interactive_slug, project=project)
 
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     AnalysisRequestResubmit.as_view(get_github_api=FakeGitHubAPI)(
         request, slug=analysis_request.id
     )
 
 
-def test_analysisrequestlist_filter_by_project(rf, core_developer):
+def test_analysisrequestlist_filter_by_project(rf, staff_area_administrator):
     project = ProjectFactory()
     ar1 = AnalysisRequestFactory(project=project)
     AnalysisRequestFactory()
     ar3 = AnalysisRequestFactory(project=project)
 
     request = rf.get(f"/?project={project.slug}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = AnalysisRequestList.as_view()(request)
 
@@ -99,13 +103,13 @@ def test_analysisrequestlist_filter_by_project(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {ar1.pk, ar3.pk}
 
 
-def test_analysisrequestlist_filter_by_report_no(rf, core_developer):
+def test_analysisrequestlist_filter_by_report_no(rf, staff_area_administrator):
     ar1 = AnalysisRequestFactory()
     AnalysisRequestFactory(report=ReportFactory())
     ar3 = AnalysisRequestFactory()
 
     request = rf.get("/?has_report=no")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = AnalysisRequestList.as_view()(request)
 
@@ -113,12 +117,12 @@ def test_analysisrequestlist_filter_by_report_no(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {ar1.pk, ar3.pk}
 
 
-def test_analysisrequestlist_filter_by_report_yes(rf, core_developer):
+def test_analysisrequestlist_filter_by_report_yes(rf, staff_area_administrator):
     ar1 = AnalysisRequestFactory(report=ReportFactory())
     AnalysisRequestFactory.create_batch(2)
 
     request = rf.get("/?has_report=yes")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = AnalysisRequestList.as_view()(request)
 
@@ -126,13 +130,13 @@ def test_analysisrequestlist_filter_by_report_yes(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {ar1.pk}
 
 
-def test_analysisrequestlist_filter_by_user(rf, core_developer):
+def test_analysisrequestlist_filter_by_user(rf, staff_area_administrator):
     user = UserFactory()
     ar1 = AnalysisRequestFactory(created_by=user)
     AnalysisRequestFactory.create_batch(2)
 
     request = rf.get(f"/?user={user.username}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = AnalysisRequestList.as_view()(request)
 
@@ -140,12 +144,12 @@ def test_analysisrequestlist_filter_by_user(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {ar1.pk}
 
 
-def test_analysisrequestlist_search(rf, core_developer):
+def test_analysisrequestlist_search(rf, staff_area_administrator):
     ar1 = AnalysisRequestFactory(created_by=UserFactory(username="beng"))
     AnalysisRequestFactory()
 
     request = rf.get("/?q=ben")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = AnalysisRequestList.as_view()(request)
 
@@ -153,11 +157,11 @@ def test_analysisrequestlist_search(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {ar1.pk}
 
 
-def test_analysisrequestlist_success(rf, core_developer):
+def test_analysisrequestlist_success(rf, staff_area_administrator):
     AnalysisRequestFactory.create_batch(5)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = AnalysisRequestList.as_view()(request)
 

--- a/tests/unit/staff/views/test_backends.py
+++ b/tests/unit/staff/views/test_backends.py
@@ -12,22 +12,22 @@ from staff.views.backends import (
 from ....factories import BackendFactory
 
 
-def test_backendcreate_get_success(rf, core_developer):
+def test_backendcreate_get_success(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = BackendCreate.as_view()(request)
 
     assert response.status_code == 200
 
 
-def test_backendcreate_post_success(rf, core_developer):
+def test_backendcreate_post_success(rf, staff_area_administrator):
     data = {
         "name": "New Backend",
         "slug": "new-backend",
     }
     request = rf.post("/", data)
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = BackendCreate.as_view()(request)
 
@@ -43,11 +43,11 @@ def test_backendcreate_post_success(rf, core_developer):
     assert response.url == backend.get_staff_url()
 
 
-def test_backendedit_success(rf, core_developer):
+def test_backendedit_success(rf, staff_area_administrator):
     backend = BackendFactory()
 
     request = rf.post("/", {"level_4_url": "http://testing"})
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = BackendEdit.as_view()(request, pk=backend.pk)
 
@@ -58,22 +58,22 @@ def test_backendedit_success(rf, core_developer):
     assert backend.level_4_url == "http://testing"
 
 
-def test_backenddetail_success(rf, core_developer):
+def test_backenddetail_success(rf, staff_area_administrator):
     backend = BackendFactory()
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
     response = BackendDetail.as_view()(request, pk=backend.pk)
 
     assert response.status_code == 200
     assert response.context_data["backend"] == backend
 
 
-def test_backendlist_success(rf, core_developer):
+def test_backendlist_success(rf, staff_area_administrator):
     BackendFactory.create_batch(3)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = BackendList.as_view()(request)
 
@@ -81,11 +81,11 @@ def test_backendlist_success(rf, core_developer):
     assert len(response.context_data["object_list"]) == 3
 
 
-def test_backendrotatetoken_success(rf, core_developer):
+def test_backendrotatetoken_success(rf, staff_area_administrator):
     backend = BackendFactory()
 
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
     response = BackendRotateToken.as_view()(request, pk=backend.pk)
 
     assert response.status_code == 302

--- a/tests/unit/staff/views/test_index.py
+++ b/tests/unit/staff/views/test_index.py
@@ -8,9 +8,9 @@ from ....factories import (
 )
 
 
-def test_index_without_search(rf, core_developer):
+def test_index_without_search(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = Index.as_view()(request)
 
@@ -18,7 +18,7 @@ def test_index_without_search(rf, core_developer):
     assert response.context_data["results"] == []
 
 
-def test_index_search(rf, core_developer, project_membership):
+def test_index_search(rf, staff_area_administrator, project_membership):
     backend = BackendFactory(name="GHickman's Research Thing")
     BackendFactory.create_batch(2)
 
@@ -35,7 +35,7 @@ def test_index_search(rf, core_developer, project_membership):
     project_membership(project=project2, user=user)
 
     request = rf.get("/?q=ghickman")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = Index.as_view()(request)
 

--- a/tests/unit/staff/views/test_job_requests.py
+++ b/tests/unit/staff/views/test_job_requests.py
@@ -18,7 +18,7 @@ from ....factories import (
 )
 
 
-def test_jobrequestcancel_success(rf, core_developer):
+def test_jobrequestcancel_success(rf, staff_area_administrator):
     job_request = JobRequestFactory(cancelled_actions=[])
     JobFactory(job_request=job_request, action="test1", status="failed")
     JobFactory(job_request=job_request, action="test2", status="succeeded")
@@ -26,7 +26,7 @@ def test_jobrequestcancel_success(rf, core_developer):
     JobFactory(job_request=job_request, action="test4", status="pending")
 
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     request.session = "session"
     messages = FallbackStorage(request)
@@ -56,21 +56,21 @@ def test_jobrequestcancel_unauthorized(rf):
         JobRequestCancel.as_view()(request, pk=job_request.pk)
 
 
-def test_jobrequestcancel_unknown_job_request(rf, core_developer):
+def test_jobrequestcancel_unknown_job_request(rf, staff_area_administrator):
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         JobRequestCancel.as_view()(request, pk=0)
 
 
-def test_jobrequestcancel_with_completed_job_request(rf, core_developer):
+def test_jobrequestcancel_with_completed_job_request(rf, staff_area_administrator):
     job_request = JobRequestFactory(cancelled_actions=[])
     JobFactory(job_request=job_request, status="failed")
     JobFactory(job_request=job_request, status="succeeded")
 
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestCancel.as_view()(request, pk=job_request.pk)
 
@@ -81,11 +81,11 @@ def test_jobrequestcancel_with_completed_job_request(rf, core_developer):
     assert not job_request.cancelled_actions
 
 
-def test_jobrequestdetail_success(rf, core_developer):
+def test_jobrequestdetail_success(rf, staff_area_administrator):
     job_request = JobRequestFactory()
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestDetail.as_view()(request, pk=job_request.pk)
 
@@ -102,15 +102,15 @@ def test_jobrequestdetail_unauthorized(rf):
         JobRequestDetail.as_view()(request, pk=job_request.pk)
 
 
-def test_jobrequestdetail_unknown_job_request(rf, core_developer):
+def test_jobrequestdetail_unknown_job_request(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         JobRequestDetail.as_view()(request, pk=0)
 
 
-def test_jobrequestlist_filter_by_backends(rf, core_developer):
+def test_jobrequestlist_filter_by_backends(rf, staff_area_administrator):
     JobRequestFactory.create_batch(5)
 
     backend1 = BackendFactory()
@@ -120,7 +120,7 @@ def test_jobrequestlist_filter_by_backends(rf, core_developer):
     job_request2 = JobRequestFactory(backend=backend2)
 
     request = rf.get(f"/?backends={backend1.slug}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -130,7 +130,7 @@ def test_jobrequestlist_filter_by_backends(rf, core_developer):
     # now check with 2 backends
 
     request = rf.get(f"/?backends={backend1.slug}&backends={backend2.slug}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -141,7 +141,7 @@ def test_jobrequestlist_filter_by_backends(rf, core_developer):
     }
 
 
-def test_jobrequestlist_filter_by_orgs(rf, core_developer):
+def test_jobrequestlist_filter_by_orgs(rf, staff_area_administrator):
     JobRequestFactory.create_batch(5)
 
     org1 = OrgFactory(slug="test-a")
@@ -155,7 +155,7 @@ def test_jobrequestlist_filter_by_orgs(rf, core_developer):
     job_request2 = JobRequestFactory(workspace=workspace2)
 
     request = rf.get(f"/?orgs={org1.slug}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -165,7 +165,7 @@ def test_jobrequestlist_filter_by_orgs(rf, core_developer):
     # now check with 2 orgs
 
     request = rf.get(f"/?orgs={org1.slug}&orgs={org2.slug}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -176,7 +176,7 @@ def test_jobrequestlist_filter_by_orgs(rf, core_developer):
     }
 
 
-def test_jobrequestlist_filter_by_project(rf, core_developer):
+def test_jobrequestlist_filter_by_project(rf, staff_area_administrator):
     JobRequestFactory.create_batch(5)
 
     project = ProjectFactory()
@@ -184,7 +184,7 @@ def test_jobrequestlist_filter_by_project(rf, core_developer):
     job_request = JobRequestFactory(workspace=workspace)
 
     request = rf.get(f"/?project={project.slug}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -192,14 +192,14 @@ def test_jobrequestlist_filter_by_project(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
 
 
-def test_jobrequestlist_filter_by_user(rf, core_developer):
+def test_jobrequestlist_filter_by_user(rf, staff_area_administrator):
     JobRequestFactory.create_batch(5)
 
     user = UserFactory()
     job_request = JobRequestFactory(created_by=user)
 
     request = rf.get(f"/?user={user.username}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -207,14 +207,14 @@ def test_jobrequestlist_filter_by_user(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
 
 
-def test_jobrequestlist_filter_by_workspace(rf, core_developer):
+def test_jobrequestlist_filter_by_workspace(rf, staff_area_administrator):
     JobRequestFactory.create_batch(5)
 
     workspace = WorkspaceFactory(name="workspace-testing-research")
     job_request = JobRequestFactory(workspace=workspace)
 
     request = rf.get(f"/?workspace={workspace.name}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -222,14 +222,14 @@ def test_jobrequestlist_filter_by_workspace(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
 
 
-def test_jobrequestlist_search_using_fullname(rf, core_developer):
+def test_jobrequestlist_search_using_fullname(rf, staff_area_administrator):
     JobRequestFactory.create_batch(5)
 
     user = UserFactory(fullname="Ben Goldacre")
     job_request = JobRequestFactory(created_by=user)
 
     request = rf.get("/?q=ben+goldacre")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -237,14 +237,14 @@ def test_jobrequestlist_search_using_fullname(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
 
 
-def test_jobrequestlist_search_using_identifier(rf, core_developer):
+def test_jobrequestlist_search_using_identifier(rf, staff_area_administrator):
     for i in range(5):
         JobRequestFactory.create(identifier=f"{i:016}")
 
     job_request = JobRequestFactory(identifier="1234abcd")
 
     request = rf.get("/?q=1234abcd")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -252,7 +252,7 @@ def test_jobrequestlist_search_using_identifier(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
 
     request = rf.get("/?q=34ab")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -260,7 +260,7 @@ def test_jobrequestlist_search_using_identifier(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
 
 
-def test_jobrequestlist_search_using_job_identifier(rf, core_developer):
+def test_jobrequestlist_search_using_job_identifier(rf, staff_area_administrator):
     for i in range(5):
         JobRequestFactory.create(identifier=f"{i:016}")
 
@@ -270,7 +270,7 @@ def test_jobrequestlist_search_using_job_identifier(rf, core_developer):
     assert JobRequest.objects.count() == 6
 
     request = rf.get("/?q=34ab")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -278,7 +278,7 @@ def test_jobrequestlist_search_using_job_identifier(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
 
 
-def test_jobrequestlist_search_using_org(rf, core_developer):
+def test_jobrequestlist_search_using_org(rf, staff_area_administrator):
     JobRequestFactory.create_batch(5)
 
     org = OrgFactory(name="University of Testing")
@@ -287,7 +287,7 @@ def test_jobrequestlist_search_using_org(rf, core_developer):
     job_request = JobRequestFactory(workspace=workspace)
 
     request = rf.get("/?q=university")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -295,13 +295,13 @@ def test_jobrequestlist_search_using_org(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
 
 
-def test_jobrequestlist_search_using_pk(rf, core_developer):
+def test_jobrequestlist_search_using_pk(rf, staff_area_administrator):
     JobRequestFactory.create_batch(5)
 
     job_request = JobRequestFactory()
 
     request = rf.get(f"/?q={job_request.pk}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -310,7 +310,7 @@ def test_jobrequestlist_search_using_pk(rf, core_developer):
     assert job_request.pk in set_from_qs(response.context_data["object_list"])
 
 
-def test_jobrequestlist_search_using_project(rf, core_developer):
+def test_jobrequestlist_search_using_project(rf, staff_area_administrator):
     JobRequestFactory.create_batch(5)
 
     project = ProjectFactory(name="A Very Important Project")
@@ -318,7 +318,7 @@ def test_jobrequestlist_search_using_project(rf, core_developer):
     job_request = JobRequestFactory(workspace=workspace)
 
     request = rf.get("/?q=important")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -326,7 +326,7 @@ def test_jobrequestlist_search_using_project(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
 
 
-def test_jobrequestlist_search_using_username(rf, core_developer):
+def test_jobrequestlist_search_using_username(rf, staff_area_administrator):
     for i in range(5):
         JobRequestFactory.create(identifier=f"{i:016}")
 
@@ -334,7 +334,7 @@ def test_jobrequestlist_search_using_username(rf, core_developer):
     job_request = JobRequestFactory(created_by=user)
 
     request = rf.get("/?q=ben")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -342,14 +342,14 @@ def test_jobrequestlist_search_using_username(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
 
 
-def test_jobrequestlist_search_using_workspace(rf, core_developer):
+def test_jobrequestlist_search_using_workspace(rf, staff_area_administrator):
     JobRequestFactory.create_batch(5)
 
     workspace = WorkspaceFactory(name="workspace-testing-research")
     job_request = JobRequestFactory(workspace=workspace)
 
     request = rf.get("/?q=research")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 
@@ -357,11 +357,11 @@ def test_jobrequestlist_search_using_workspace(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {job_request.pk}
 
 
-def test_jobrequestlist_success(rf, core_developer):
+def test_jobrequestlist_success(rf, staff_area_administrator):
     JobRequestFactory.create_batch(5)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = JobRequestList.as_view()(request)
 

--- a/tests/unit/staff/views/test_orgs.py
+++ b/tests/unit/staff/views/test_orgs.py
@@ -18,12 +18,12 @@ from staff.views.orgs import (
 from ....factories import OrgFactory, OrgMembershipFactory, UserFactory
 
 
-def test_orgaddgithuborg_get_success(rf, core_developer):
+def test_orgaddgithuborg_get_success(rf, staff_area_administrator):
     org = OrgFactory(github_orgs=["one", "two"])
 
     request = rf.get("/")
     request.htmx = True
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = org_add_github_org(request, slug=org.slug)
 
@@ -31,12 +31,12 @@ def test_orgaddgithuborg_get_success(rf, core_developer):
     assert response.context_data["form"]
 
 
-def test_orgaddgithuborg_post_invalid_form(rf, core_developer):
+def test_orgaddgithuborg_post_invalid_form(rf, staff_area_administrator):
     org = OrgFactory(github_orgs=["one", "two"])
 
     request = rf.post("/", {"foo": "three"})
     request.htmx = True
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = org_add_github_org(request, slug=org.slug)
 
@@ -47,12 +47,12 @@ def test_orgaddgithuborg_post_invalid_form(rf, core_developer):
     assert org.github_orgs == ["one", "two"]
 
 
-def test_orgaddgithuborg_post_success(rf, core_developer):
+def test_orgaddgithuborg_post_success(rf, staff_area_administrator):
     org = OrgFactory(github_orgs=["one", "two"])
 
     request = rf.post("/", {"name": "three"})
     request.htmx = True
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = org_add_github_org(request, slug=org.slug)
 
@@ -63,7 +63,7 @@ def test_orgaddgithuborg_post_success(rf, core_developer):
     assert org.github_orgs == ["one", "two", "three"]
 
 
-def test_orgaddgithuborg_unauthorized(rf, core_developer):
+def test_orgaddgithuborg_unauthorized(rf, staff_area_administrator):
     request = rf.post("/")
     request.user = UserFactory()
 
@@ -71,18 +71,18 @@ def test_orgaddgithuborg_unauthorized(rf, core_developer):
         org_add_github_org(request)
 
 
-def test_orgaddgithuborg_unknown_org(rf, core_developer):
+def test_orgaddgithuborg_unknown_org(rf, staff_area_administrator):
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         org_add_github_org(request, slug="test")
 
 
-def test_orgcreate_get_success(rf, core_developer):
+def test_orgcreate_get_success(rf, staff_area_administrator):
     request = rf.get("/")
     request.htmx = False
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgCreate.as_view()(request)
 
@@ -90,10 +90,10 @@ def test_orgcreate_get_success(rf, core_developer):
     assert response.template_name == ["staff/org/create.html"]
 
 
-def test_orgcreate_get_htmx_success(rf, core_developer):
+def test_orgcreate_get_htmx_success(rf, staff_area_administrator):
     request = rf.get("/")
     request.htmx = True
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgCreate.as_view()(request)
 
@@ -101,10 +101,10 @@ def test_orgcreate_get_htmx_success(rf, core_developer):
     assert response.template_name == ["staff/org/create.htmx.html"]
 
 
-def test_orgcreate_post_success(rf, core_developer):
+def test_orgcreate_post_success(rf, staff_area_administrator):
     request = rf.post("/", {"name": "A New Org"})
     request.htmx = False
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgCreate.as_view()(request)
 
@@ -115,14 +115,14 @@ def test_orgcreate_post_success(rf, core_developer):
 
     org = orgs.first()
     assert org.name == "A New Org"
-    assert org.created_by == core_developer
+    assert org.created_by == staff_area_administrator
     assert response.url == org.get_staff_url()
 
 
-def test_orgcreate_post_htmx_success_with_next(rf, core_developer):
+def test_orgcreate_post_htmx_success_with_next(rf, staff_area_administrator):
     request = rf.post("/?next=/next/page/", {"name": "A New Org"})
     request.htmx = True
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgCreate.as_view()(request)
 
@@ -130,10 +130,10 @@ def test_orgcreate_post_htmx_success_with_next(rf, core_developer):
     assert response.headers["HX-Redirect"] == "/next/page/?org-slug=a-new-org"
 
 
-def test_orgcreate_post_htmx_success_without_next(rf, core_developer):
+def test_orgcreate_post_htmx_success_without_next(rf, staff_area_administrator):
     request = rf.post("/", {"name": "A New Org"})
     request.htmx = True
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgCreate.as_view()(request)
 
@@ -144,12 +144,12 @@ def test_orgcreate_post_htmx_success_without_next(rf, core_developer):
     assert response.headers["HX-Redirect"] == expected
 
 
-def test_orgdetail_get_success(rf, core_developer):
+def test_orgdetail_get_success(rf, staff_area_administrator):
     org = OrgFactory()
     UserFactory(username="beng", fullname="Ben Goldacre")
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgDetail.as_view()(request, slug=org.slug)
 
@@ -165,14 +165,14 @@ def test_orgdetail_get_success(rf, core_developer):
     assert output == expected
 
 
-def test_orgdetail_post_success(rf, core_developer):
+def test_orgdetail_post_success(rf, staff_area_administrator):
     org = OrgFactory()
 
     user1 = UserFactory()
     user2 = UserFactory()
 
     request = rf.post("/", {"users": [str(user1.pk), str(user2.pk)]})
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgDetail.as_view()(request, slug=org.slug)
 
@@ -182,11 +182,11 @@ def test_orgdetail_post_success(rf, core_developer):
     assert set_from_qs(org.members.all()) == {user1.pk, user2.pk}
 
 
-def test_orgdetail_post_with_bad_data(rf, core_developer):
+def test_orgdetail_post_with_bad_data(rf, staff_area_administrator):
     org = OrgFactory()
 
     request = rf.post("/", {"test": "test"})
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgDetail.as_view()(request, slug=org.slug)
 
@@ -204,11 +204,11 @@ def test_orgdetail_unauthorized(rf):
         OrgDetail.as_view()(request, slug=org.slug)
 
 
-def test_orgedit_get_success(rf, core_developer):
+def test_orgedit_get_success(rf, staff_area_administrator):
     org = OrgFactory()
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgEdit.as_view()(request, slug=org.slug)
 
@@ -225,7 +225,7 @@ def test_orgedit_get_unauthorized(rf):
         OrgEdit.as_view()(request, slug=org.slug)
 
 
-def test_orgedit_post_success(rf, core_developer, tmp_path):
+def test_orgedit_post_success(rf, staff_area_administrator, tmp_path):
     logo = tmp_path / "new_logo.png"
     logo.write_text("test")
 
@@ -233,7 +233,7 @@ def test_orgedit_post_success(rf, core_developer, tmp_path):
 
     data = {"name": "New Name", "slug": "new-name", "logo_file": logo.open()}
     request = rf.post("/", data)
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgEdit.as_view()(request, slug=org.slug)
 
@@ -246,7 +246,9 @@ def test_orgedit_post_success(rf, core_developer, tmp_path):
     assert org.logo_file
 
 
-def test_orgedit_post_success_when_not_changing_slug(rf, core_developer, tmp_path):
+def test_orgedit_post_success_when_not_changing_slug(
+    rf, staff_area_administrator, tmp_path
+):
     logo = tmp_path / "new_logo.png"
     logo.write_text("test")
 
@@ -254,7 +256,7 @@ def test_orgedit_post_success_when_not_changing_slug(rf, core_developer, tmp_pat
 
     data = {"name": "New Name", "slug": "slug", "logo_file": logo.open()}
     request = rf.post("/", data)
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgEdit.as_view()(request, slug=org.slug)
 
@@ -276,13 +278,13 @@ def test_orgedit_post_unauthorized(rf):
         OrgEdit.as_view()(request, slug=org.slug)
 
 
-def test_orglist_find_by_name(rf, core_developer):
+def test_orglist_find_by_name(rf, staff_area_administrator):
     OrgFactory(name="ben")
     OrgFactory(name="benjamin")
     OrgFactory(name="seb")
 
     request = rf.get("/?q=ben")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgList.as_view()(request)
 
@@ -291,11 +293,11 @@ def test_orglist_find_by_name(rf, core_developer):
     assert len(response.context_data["org_list"]) == 2
 
 
-def test_orglist_success(rf, core_developer):
+def test_orglist_success(rf, staff_area_administrator):
     OrgFactory.create_batch(5)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = OrgList.as_view()(request)
 
@@ -312,11 +314,11 @@ def test_orglist_unauthorized(rf):
         OrgList.as_view()(request)
 
 
-def test_orgremovegithuborg_success(rf, core_developer):
+def test_orgremovegithuborg_success(rf, staff_area_administrator):
     org = OrgFactory(github_orgs=["one", "two"])
 
     request = rf.post("/", {"name": "two"})
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     # set up messages framework
     request.session = "session"
@@ -345,21 +347,21 @@ def test_orgremovegithuborg_unauthorized(rf):
         OrgRemoveGitHubOrg.as_view()(request)
 
 
-def test_orgremovegithuborg_unknown_org(rf, core_developer):
+def test_orgremovegithuborg_unknown_org(rf, staff_area_administrator):
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         OrgRemoveGitHubOrg.as_view()(request, slug="test")
 
 
-def test_orgremovegithuborg_unknown_github_org(rf, core_developer):
+def test_orgremovegithuborg_unknown_github_org(rf, staff_area_administrator):
     org = OrgFactory()
 
     assert "test" not in org.github_orgs
 
     request = rf.post("/", {"name": "test"})
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     # set up messages framework
     request.session = "session"
@@ -380,14 +382,14 @@ def test_orgremovegithuborg_unknown_github_org(rf, core_developer):
     assert str(messages[0]) == f"test is not assigned to {org.name}"
 
 
-def test_orgremovemember_success(rf, core_developer):
+def test_orgremovemember_success(rf, staff_area_administrator):
     org = OrgFactory()
     user = UserFactory()
 
     OrgMembershipFactory(org=org, user=user)
 
     request = rf.post("/", {"username": user.username})
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     # set up messages framework
     request.session = "session"
@@ -416,21 +418,21 @@ def test_orgremovemember_unauthorized(rf):
         OrgRemoveMember.as_view()(request)
 
 
-def test_orgremovemember_unknown_org(rf, core_developer):
+def test_orgremovemember_unknown_org(rf, staff_area_administrator):
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         OrgRemoveMember.as_view()(request, slug="test")
 
 
-def test_orgremovemember_unknown_member(rf, core_developer):
+def test_orgremovemember_unknown_member(rf, staff_area_administrator):
     org = OrgFactory()
 
     assert org.memberships.count() == 0
 
     request = rf.post("/", {"username": "test"})
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     # set up messages framework
     request.session = "session"

--- a/tests/unit/staff/views/test_redirects.py
+++ b/tests/unit/staff/views/test_redirects.py
@@ -18,12 +18,12 @@ from ....factories import (
 )
 
 
-def test_redirectdelete_success(rf, core_developer):
+def test_redirectdelete_success(rf, staff_area_administrator):
     workspace = WorkspaceFactory()
     redirect = RedirectFactory(workspace=workspace)
 
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     # set up messages framework
     request.session = "session"
@@ -43,9 +43,9 @@ def test_redirectdelete_success(rf, core_developer):
     assert str(messages[0]) == f"Deleted redirect for Workspace: {workspace.name}"
 
 
-def test_redirectdelete_with_unknown_redirect(rf, core_developer):
+def test_redirectdelete_with_unknown_redirect(rf, staff_area_administrator):
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         RedirectDelete.as_view()(request, pk="0")
@@ -61,11 +61,11 @@ def test_redirectdelete_without_core_dev_role(rf):
         RedirectDelete.as_view()(request, pk=redirect.pk)
 
 
-def test_redirectedetail_success(rf, core_developer):
+def test_redirectedetail_success(rf, staff_area_administrator):
     redirect = RedirectFactory(workspace=WorkspaceFactory())
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = RedirectDetail.as_view()(request, pk=redirect.pk)
 
@@ -73,9 +73,9 @@ def test_redirectedetail_success(rf, core_developer):
     assert response.context_data["object"] == redirect
 
 
-def test_redirectedetail_with_unknown_redirect(rf, core_developer):
+def test_redirectedetail_with_unknown_redirect(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         RedirectDetail.as_view()(request, pk="0")
@@ -91,12 +91,12 @@ def test_redirectedetail_without_core_dev_role(rf):
         RedirectDetail.as_view()(request, pk=redirect.pk)
 
 
-def test_redirectlist_filter_by_object_type(rf, core_developer):
+def test_redirectlist_filter_by_object_type(rf, staff_area_administrator):
     project_redirects = RedirectFactory.create_batch(3, project=ProjectFactory())
     workspace_redirects = RedirectFactory.create_batch(3, workspace=WorkspaceFactory())
 
     request = rf.get("/?type=project")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = RedirectList.as_view()(request)
 
@@ -104,7 +104,7 @@ def test_redirectlist_filter_by_object_type(rf, core_developer):
     assert set(response.context_data["object_list"]) == set(project_redirects)
 
     request = rf.get("/?type=workspace")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = RedirectList.as_view()(request)
 
@@ -112,7 +112,7 @@ def test_redirectlist_filter_by_object_type(rf, core_developer):
     assert set(response.context_data["object_list"]) == set(workspace_redirects)
 
 
-def test_redirectlist_search_by_analysis_request(rf, core_developer):
+def test_redirectlist_search_by_analysis_request(rf, staff_area_administrator):
     analysis_request = AnalysisRequestFactory()
     redirect = RedirectFactory(analysis_request=analysis_request)
 
@@ -121,7 +121,7 @@ def test_redirectlist_search_by_analysis_request(rf, core_developer):
     RedirectFactory(workspace=WorkspaceFactory())
 
     request = rf.get(f"/?q={analysis_request.title}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = RedirectList.as_view()(request)
 
@@ -129,7 +129,7 @@ def test_redirectlist_search_by_analysis_request(rf, core_developer):
     assert set(response.context_data["object_list"]) == {redirect}
 
 
-def test_jobrequestlist_search_by_fullname(rf, core_developer):
+def test_jobrequestlist_search_by_fullname(rf, staff_area_administrator):
     org = OrgFactory()
     user = UserFactory(fullname="Ben Goldacre")
     redirect = RedirectFactory(org=org, created_by=user)
@@ -137,7 +137,7 @@ def test_jobrequestlist_search_by_fullname(rf, core_developer):
     RedirectFactory.create_batch(5, org=org)
 
     request = rf.get("/?q=ben")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = RedirectList.as_view()(request)
 
@@ -145,14 +145,14 @@ def test_jobrequestlist_search_by_fullname(rf, core_developer):
     assert set(response.context_data["object_list"]) == {redirect}
 
 
-def test_redirectlist_search_by_old_url(rf, core_developer):
+def test_redirectlist_search_by_old_url(rf, staff_area_administrator):
     org = OrgFactory()
     redirect = RedirectFactory(org=org, old_url="/test/foo/bar/")
 
     RedirectFactory.create_batch(5, org=org)
 
     request = rf.get("/?q=foo")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = RedirectList.as_view()(request)
 
@@ -160,7 +160,7 @@ def test_redirectlist_search_by_old_url(rf, core_developer):
     assert set(response.context_data["object_list"]) == {redirect}
 
 
-def test_redirectlist_search_by_org(rf, core_developer):
+def test_redirectlist_search_by_org(rf, staff_area_administrator):
     org = OrgFactory()
     redirect = RedirectFactory(org=org)
 
@@ -169,7 +169,7 @@ def test_redirectlist_search_by_org(rf, core_developer):
     RedirectFactory(workspace=WorkspaceFactory())
 
     request = rf.get(f"/?q={org.name}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = RedirectList.as_view()(request)
 
@@ -177,7 +177,7 @@ def test_redirectlist_search_by_org(rf, core_developer):
     assert set(response.context_data["object_list"]) == {redirect}
 
 
-def test_redirectlist_search_by_project(rf, core_developer):
+def test_redirectlist_search_by_project(rf, staff_area_administrator):
     project = ProjectFactory()
     redirect = RedirectFactory(project=project)
 
@@ -187,7 +187,7 @@ def test_redirectlist_search_by_project(rf, core_developer):
     RedirectFactory(workspace=WorkspaceFactory())
 
     request = rf.get(f"/?q={project.name}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = RedirectList.as_view()(request)
 
@@ -195,7 +195,7 @@ def test_redirectlist_search_by_project(rf, core_developer):
     assert set(response.context_data["object_list"]) == {redirect}
 
 
-def test_redirectlist_search_by_username(rf, core_developer):
+def test_redirectlist_search_by_username(rf, staff_area_administrator):
     org = OrgFactory()
     user = UserFactory(username="beng")
     redirect = RedirectFactory(org=org, created_by=user)
@@ -203,7 +203,7 @@ def test_redirectlist_search_by_username(rf, core_developer):
     RedirectFactory.create_batch(5, org=org)
 
     request = rf.get("/?q=ben")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = RedirectList.as_view()(request)
 
@@ -211,7 +211,7 @@ def test_redirectlist_search_by_username(rf, core_developer):
     assert set(response.context_data["object_list"]) == {redirect}
 
 
-def test_redirectlist_search_by_workspace(rf, core_developer):
+def test_redirectlist_search_by_workspace(rf, staff_area_administrator):
     project = ProjectFactory()
     redirect = RedirectFactory(project=project)
 
@@ -220,7 +220,7 @@ def test_redirectlist_search_by_workspace(rf, core_developer):
     RedirectFactory(workspace=WorkspaceFactory())
 
     request = rf.get(f"/?q={project.name}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = RedirectList.as_view()(request)
 
@@ -228,11 +228,11 @@ def test_redirectlist_search_by_workspace(rf, core_developer):
     assert set(response.context_data["object_list"]) == {redirect}
 
 
-def test_redirectlist_success(rf, core_developer):
+def test_redirectlist_success(rf, staff_area_administrator):
     RedirectFactory.create_batch(5, project=ProjectFactory())
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = RedirectList.as_view()(request)
 

--- a/tests/unit/staff/views/test_reports.py
+++ b/tests/unit/staff/views/test_reports.py
@@ -25,11 +25,11 @@ from ....factories import (
 )
 
 
-def test_reportdetail_success(rf, core_developer):
+def test_reportdetail_success(rf, staff_area_administrator):
     report = ReportFactory()
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ReportDetail.as_view()(request, pk=report.pk)
 
@@ -46,11 +46,11 @@ def test_reportdetail_unauthorized(rf):
         ReportDetail.as_view()(request, pk=report.pk)
 
 
-def test_reportlist_success(rf, core_developer):
+def test_reportlist_success(rf, staff_area_administrator):
     ReportFactory.create_batch(5)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ReportList.as_view()(request)
 
@@ -58,7 +58,7 @@ def test_reportlist_success(rf, core_developer):
     assert len(response.context_data["object_list"]) == 5
 
 
-def test_reportlist_filter_by_state_approved(rf, core_developer):
+def test_reportlist_filter_by_state_approved(rf, staff_area_administrator):
     report = ReportFactory()
     snapshot = SnapshotFactory()
     snapshot.files.set([report.release_file])
@@ -73,7 +73,7 @@ def test_reportlist_filter_by_state_approved(rf, core_developer):
     PublishRequestFactory.create_batch(5)
 
     request = rf.get("?state=approved")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ReportList.as_view()(request)
 
@@ -81,7 +81,7 @@ def test_reportlist_filter_by_state_approved(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {report.pk}
 
 
-def test_reportlist_filter_by_state_pending(rf, core_developer):
+def test_reportlist_filter_by_state_pending(rf, staff_area_administrator):
     report = ReportFactory()
     snapshot = SnapshotFactory()
     snapshot.files.set([report.release_file])
@@ -101,7 +101,7 @@ def test_reportlist_filter_by_state_pending(rf, core_developer):
     )
 
     request = rf.get("?state=pending")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ReportList.as_view()(request)
 
@@ -109,7 +109,7 @@ def test_reportlist_filter_by_state_pending(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {report.pk}
 
 
-def test_reportlist_filter_by_state_rejected(rf, core_developer):
+def test_reportlist_filter_by_state_rejected(rf, staff_area_administrator):
     report = ReportFactory()
     snapshot = SnapshotFactory()
     snapshot.files.set([report.release_file])
@@ -124,7 +124,7 @@ def test_reportlist_filter_by_state_rejected(rf, core_developer):
     PublishRequestFactory.create_batch(5)
 
     request = rf.get("?state=rejected")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ReportList.as_view()(request)
 
@@ -132,7 +132,7 @@ def test_reportlist_filter_by_state_rejected(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {report.pk}
 
 
-def test_reportlist_filter_by_org(rf, core_developer):
+def test_reportlist_filter_by_org(rf, staff_area_administrator):
     org = OrgFactory()
     project = ProjectFactory(orgs=[org])
     workspace = WorkspaceFactory(project=project)
@@ -142,7 +142,7 @@ def test_reportlist_filter_by_org(rf, core_developer):
     ReportFactory.create_batch(2)
 
     request = rf.get(f"/?org={org.slug}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ReportList.as_view()(request)
 
@@ -150,7 +150,7 @@ def test_reportlist_filter_by_org(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {r1.pk}
 
 
-def test_reportlist_filter_by_project(rf, core_developer):
+def test_reportlist_filter_by_project(rf, staff_area_administrator):
     project = ProjectFactory()
     workspace = WorkspaceFactory(project=project)
     rfile = ReleaseFileFactory(workspace=workspace)
@@ -159,7 +159,7 @@ def test_reportlist_filter_by_project(rf, core_developer):
     ReportFactory.create_batch(2)
 
     request = rf.get(f"/?project={project.slug}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ReportList.as_view()(request)
 
@@ -167,14 +167,14 @@ def test_reportlist_filter_by_project(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {r1.pk}
 
 
-def test_reportlist_filter_by_user(rf, core_developer):
+def test_reportlist_filter_by_user(rf, staff_area_administrator):
     user = UserFactory()
 
     r1 = ReportFactory(created_by=user)
     ReportFactory.create_batch(2)
 
     request = rf.get(f"/?user={user.username}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ReportList.as_view()(request)
 
@@ -182,14 +182,14 @@ def test_reportlist_filter_by_user(rf, core_developer):
     assert set_from_qs(response.context_data["object_list"]) == {r1.pk}
 
 
-def test_reportlist_search(rf, core_developer):
+def test_reportlist_search(rf, staff_area_administrator):
     user = UserFactory(username="beng")
 
     r1 = ReportFactory(created_by=user)
     ReportFactory.create_batch(2)
 
     request = rf.get("/?q=ben")
-    request.user = core_developer
+    request.user = staff_area_administrator
     response = ReportList.as_view()(request)
 
     assert response.status_code == 200
@@ -205,12 +205,12 @@ def test_reportlist_unauthorized(rf):
 
 
 def test_reportpublishrequestapprove_success(
-    rf, core_developer, mailoutbox, publish_request_with_report
+    rf, staff_area_administrator, mailoutbox, publish_request_with_report
 ):
     report = publish_request_with_report.report
 
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ReportPublishRequestApprove.as_view()(
         request,
@@ -242,21 +242,23 @@ def test_reportpublishrequestapprove_unauthorized(rf):
         )
 
 
-def test_reportpublishrequestapprove_unknown_publish_request(rf, core_developer):
+def test_reportpublishrequestapprove_unknown_publish_request(
+    rf, staff_area_administrator
+):
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         ReportPublishRequestApprove.as_view()(request, pk="0", publish_request_pk="0")
 
 
 def test_reportpublishrequestreject_success(
-    rf, core_developer, publish_request_with_report
+    rf, staff_area_administrator, publish_request_with_report
 ):
     report = publish_request_with_report.report
 
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ReportPublishRequestReject.as_view()(
         request,
@@ -269,7 +271,7 @@ def test_reportpublishrequestreject_success(
 
     publish_request_with_report.refresh_from_db()
     assert publish_request_with_report.decision_at
-    assert publish_request_with_report.decision_by == core_developer
+    assert publish_request_with_report.decision_by == staff_area_administrator
     assert publish_request_with_report.decision == PublishRequest.Decisions.REJECTED
 
 
@@ -288,9 +290,11 @@ def test_reportpublishrequestreject_unauthorized(rf):
         )
 
 
-def test_reportpublishrequestreject_unknown_publish_request(rf, core_developer):
+def test_reportpublishrequestreject_unknown_publish_request(
+    rf, staff_area_administrator
+):
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         ReportPublishRequestReject.as_view()(request, pk="0", publish_request_pk="0")

--- a/tests/unit/staff/views/test_researchers.py
+++ b/tests/unit/staff/views/test_researchers.py
@@ -7,12 +7,12 @@ from staff.views.researchers import ResearcherEdit
 from ....factories import ApplicationFactory, ResearcherRegistrationFactory, UserFactory
 
 
-def test_researcheredit_get_success(rf, core_developer):
+def test_researcheredit_get_success(rf, staff_area_administrator):
     application = ApplicationFactory()
     researcher = ResearcherRegistrationFactory(application=application)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ResearcherEdit.as_view()(
         request,
@@ -23,7 +23,7 @@ def test_researcheredit_get_success(rf, core_developer):
     assert response.status_code == 200
 
 
-def test_researcheredit_post_success(rf, core_developer):
+def test_researcheredit_post_success(rf, staff_area_administrator):
     application = ApplicationFactory()
     researcher = ResearcherRegistrationFactory(application=application)
 
@@ -35,7 +35,7 @@ def test_researcheredit_post_success(rf, core_developer):
         "daa": "http://example.com",
     }
     request = rf.post("/", data)
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = ResearcherEdit.as_view()(
         request,
@@ -54,27 +54,27 @@ def test_researcheredit_post_success(rf, core_developer):
     assert researcher.daa == "http://example.com"
 
 
-def test_researcheredit_unknown_application(rf, core_developer):
+def test_researcheredit_unknown_application(rf, staff_area_administrator):
     researcher = ResearcherRegistrationFactory()
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         ResearcherEdit.as_view()(request, pk_hash="", pk=researcher.pk)
 
 
-def test_researcheredit_unknown_researcher(rf, core_developer):
+def test_researcheredit_unknown_researcher(rf, staff_area_administrator):
     application = ApplicationFactory()
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         ResearcherEdit.as_view()(request, pk_hash=application.pk_hash, pk=0)
 
 
-def test_researcheredit_without_core_dev_role(rf, core_developer):
+def test_researcheredit_without_core_dev_role(rf, staff_area_administrator):
     application = ApplicationFactory()
     researcher = ResearcherRegistrationFactory(application=application)
 

--- a/tests/unit/staff/views/test_sentry.py
+++ b/tests/unit/staff/views/test_sentry.py
@@ -6,9 +6,9 @@ from staff.views import sentry
 from staff.views.sentry import sentry_sdk
 
 
-def test_error_success(rf, core_developer):
+def test_error_success(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(ZeroDivisionError):
         sentry.error(request)
@@ -22,9 +22,9 @@ def test_error_unauthorized(rf):
         sentry.error(request)
 
 
-def test_index_success(rf, core_developer):
+def test_index_success(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = sentry.index(request)
 
@@ -39,9 +39,9 @@ def test_index_unauthorized(rf):
         sentry.index(request)
 
 
-def test_message_success(rf, core_developer, mocker):
+def test_message_success(rf, staff_area_administrator, mocker):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     spy = mocker.spy(sentry_sdk, "capture_message")
 

--- a/tests/unit/staff/views/test_users.py
+++ b/tests/unit/staff/views/test_users.py
@@ -35,7 +35,7 @@ from ....factories import (
 )
 
 
-def test_userauditlog_filter_by_type(rf, core_developer, project_membership):
+def test_userauditlog_filter_by_type(rf, staff_area_administrator, project_membership):
     actor = UserFactory()
     project = ProjectFactory()
     user = UserFactory()
@@ -53,7 +53,7 @@ def test_userauditlog_filter_by_type(rf, core_developer, project_membership):
     )
 
     request = rf.get("/?types=project_member_added")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserAuditLog.as_view()(request, username=user.username)
 
@@ -64,7 +64,7 @@ def test_userauditlog_filter_by_type(rf, core_developer, project_membership):
     )
 
 
-def test_userauditlog_success(rf, core_developer, project_membership):
+def test_userauditlog_success(rf, staff_area_administrator, project_membership):
     actor = UserFactory()
     project = ProjectFactory()
     user = UserFactory()
@@ -91,7 +91,7 @@ def test_userauditlog_success(rf, core_developer, project_membership):
     )
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserAuditLog.as_view()(request, username=user.username)
 
@@ -111,7 +111,7 @@ def test_userauditlog_unauthorized(rf):
 
 
 def test_userauditlog_num_queries(
-    rf, django_assert_num_queries, core_developer, project_membership
+    rf, django_assert_num_queries, staff_area_administrator, project_membership
 ):
     project = ProjectFactory()
     user = UserFactory()
@@ -128,7 +128,7 @@ def test_userauditlog_num_queries(
     )
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with django_assert_num_queries(13):
         response = UserAuditLog.as_view()(request, username=user.username)
@@ -138,21 +138,21 @@ def test_userauditlog_num_queries(
         response.render()
 
 
-def test_userauditlog_unknown_project(rf, core_developer):
+def test_userauditlog_unknown_project(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         UserAuditLog.as_view()(request, username="")
 
 
 @pytest.mark.parametrize("next_url", ["", "/some/other/url/"])
-def test_userclearroles_success(rf, core_developer, next_url):
+def test_userclearroles_success(rf, staff_area_administrator, next_url):
     user = UserFactory()
 
     suffix = f"?next={next_url}" if next_url else ""
     request = rf.post(f"/{suffix}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserClearRoles.as_view()(request, username=user.username)
 
@@ -162,9 +162,9 @@ def test_userclearroles_success(rf, core_developer, next_url):
     assert response.url == expected
 
 
-def test_userclearroles_with_unknown_user(rf, core_developer):
+def test_userclearroles_with_unknown_user(rf, staff_area_administrator):
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         UserClearRoles.as_view()(request, username="")
@@ -180,20 +180,20 @@ def test_userclearroles_unauthorized(rf):
         UserClearRoles.as_view()(request, username=user.username)
 
 
-def test_usercreate_get_success(rf, core_developer):
+def test_usercreate_get_success(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserCreate.as_view()(request)
 
     assert response.status_code == 200
 
 
-def test_usercreate_get_success_with_project_slug(rf, core_developer):
+def test_usercreate_get_success_with_project_slug(rf, staff_area_administrator):
     project = ProjectFactory()
 
     request = rf.get(f"/?project-slug={project.slug}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserCreate.as_view()(request)
 
@@ -201,9 +201,9 @@ def test_usercreate_get_success_with_project_slug(rf, core_developer):
     assert response.context_data["form"].initial["project"] == project
 
 
-def test_usercreate_get_success_with_unknown_args(rf, core_developer):
+def test_usercreate_get_success_with_unknown_args(rf, staff_area_administrator):
     request = rf.get("/?project-slug=test")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserCreate.as_view()(request)
 
@@ -212,7 +212,7 @@ def test_usercreate_get_success_with_unknown_args(rf, core_developer):
     assert "project" not in response.context_data["form"].initial
 
 
-def test_usercreate_post_success(rf, core_developer):
+def test_usercreate_post_success(rf, staff_area_administrator):
     project = ProjectFactory()
     WorkspaceFactory(project=project, name=project.interactive_slug)
 
@@ -222,7 +222,7 @@ def test_usercreate_post_success(rf, core_developer):
         "email": "test@example.com",
     }
     request = rf.post("/", data)
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserCreate.as_view()(request)
 
@@ -233,7 +233,7 @@ def test_usercreate_post_success(rf, core_developer):
 
     user = User.objects.get(email="test@example.com")
     assert response.url == user.get_staff_url()
-    assert user.created_by == core_developer
+    assert user.created_by == staff_area_administrator
     assert user.name == "New Name-Name"
     assert set_from_qs(user.orgs.all()) == set_from_qs(project.orgs.all())
     assert user.projects.first() == project
@@ -248,7 +248,7 @@ def test_usercreate_unauthorized(rf):
 
 
 def test_userdetail_with_email_user_invokes_userdetailwithemail(
-    rf, core_developer, project_membership
+    rf, staff_area_administrator, project_membership
 ):
     org = OrgFactory()
     project = ProjectFactory()
@@ -259,7 +259,7 @@ def test_userdetail_with_email_user_invokes_userdetailwithemail(
     project_membership(project=project, user=user, roles=[ProjectDeveloper])
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserDetail.as_view()(request, username=user.username)
 
@@ -267,7 +267,7 @@ def test_userdetail_with_email_user_invokes_userdetailwithemail(
 
 
 def test_userdetail_with_oauth_user_invokes_userdetailwithoauth(
-    rf, core_developer, project_membership
+    rf, staff_area_administrator, project_membership
 ):
     org = OrgFactory()
     project = ProjectFactory()
@@ -280,16 +280,16 @@ def test_userdetail_with_oauth_user_invokes_userdetailwithoauth(
     project_membership(project=project, user=user, roles=[ProjectDeveloper])
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserDetail.as_view()(request, username=user.username)
 
     assert response.status_code == 200
 
 
-def test_userdetail_with_unknown_user(rf, core_developer):
+def test_userdetail_with_unknown_user(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         UserDetail.as_view()(request, username="test")
@@ -303,7 +303,9 @@ def test_userdetail_without_core_dev_role(rf):
         UserDetail.as_view()(request, username="test")
 
 
-def test_userdetailwithemail_get_success(rf, core_developer, project_membership):
+def test_userdetailwithemail_get_success(
+    rf, staff_area_administrator, project_membership
+):
     user = UserFactory()
 
     # add a couple of memberships so the orgs and projects comprehensions in
@@ -312,14 +314,14 @@ def test_userdetailwithemail_get_success(rf, core_developer, project_membership)
     project_membership(user=user)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserDetailWithEmail.as_view()(request, username=user.username)
 
     assert response.status_code == 200
 
 
-def test_userdetailwithemail_post_success(rf, core_developer):
+def test_userdetailwithemail_post_success(rf, staff_area_administrator):
     user = UserFactory(fullname="testing", email="test@example.com")
 
     data = {
@@ -327,7 +329,7 @@ def test_userdetailwithemail_post_success(rf, core_developer):
         "email": "testing@example.com",
     }
     request = rf.post("/", data=data)
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserDetailWithEmail.as_view()(request, username=user.username)
 
@@ -340,7 +342,7 @@ def test_userdetailwithemail_post_success(rf, core_developer):
 
 
 def test_userdetailwithemail_with_oauth_user_invokes_userdetailwithoauth(
-    rf, core_developer, project_membership
+    rf, staff_area_administrator, project_membership
 ):
     org = OrgFactory()
     project = ProjectFactory()
@@ -353,22 +355,22 @@ def test_userdetailwithemail_with_oauth_user_invokes_userdetailwithoauth(
     project_membership(project=project, user=user, roles=[ProjectDeveloper])
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserDetailWithEmail.as_view()(request, username=user.username)
 
     assert response.status_code == 200
 
 
-def test_userdetailwithemail_with_unknown_user(rf, core_developer):
+def test_userdetailwithemail_with_unknown_user(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         UserDetailWithEmail.as_view()(request, username="test")
 
 
-def test_userdetailwithemail_without_core_dev_role(rf, core_developer):
+def test_userdetailwithemail_without_core_dev_role(rf, staff_area_administrator):
     request = rf.get("/")
     request.user = UserFactory()
 
@@ -376,7 +378,9 @@ def test_userdetailwithemail_without_core_dev_role(rf, core_developer):
         UserDetailWithEmail.as_view()(request, username="test")
 
 
-def test_userdetailwithoauth_get_success(rf, core_developer, project_membership):
+def test_userdetailwithoauth_get_success(
+    rf, staff_area_administrator, project_membership
+):
     org = OrgFactory()
     project1 = ProjectFactory()
     project2 = ProjectFactory()
@@ -395,7 +399,7 @@ def test_userdetailwithoauth_get_success(rf, core_developer, project_membership)
     project_membership(project=project2, user=user)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserDetailWithOAuth.as_view()(request, username=user.username)
 
@@ -403,7 +407,9 @@ def test_userdetailwithoauth_get_success(rf, core_developer, project_membership)
     assert response.context_data["user"] == user
 
 
-def test_userdetailwithoauth_post_success(rf, core_developer, project_membership):
+def test_userdetailwithoauth_post_success(
+    rf, staff_area_administrator, project_membership
+):
     backend = BackendFactory()
 
     project1 = ProjectFactory()
@@ -420,7 +426,7 @@ def test_userdetailwithoauth_post_success(rf, core_developer, project_membership
     project_membership(project=project2, user=user)
 
     request = rf.post("/", {"backends": [backend.slug]})
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserDetailWithOAuth.as_view()(request, username=user.username)
 
@@ -432,7 +438,7 @@ def test_userdetailwithoauth_post_success(rf, core_developer, project_membership
 
 
 def test_userdetailwithoauth_post_with_unknown_backend(
-    rf, core_developer, project_membership
+    rf, staff_area_administrator, project_membership
 ):
     project1 = ProjectFactory()
     project2 = ProjectFactory()
@@ -448,7 +454,7 @@ def test_userdetailwithoauth_post_with_unknown_backend(
     project_membership(project=project2, user=user)
 
     request = rf.post("/", {"backends": ["not-a-real-backend"]})
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserDetailWithOAuth.as_view()(request, username=user.username)
 
@@ -471,7 +477,7 @@ def test_userdetailwithoauth_post_with_unknown_backend(
 
 
 def test_userdetailwithoauth_with_email_only_user_invokes_userdetailwithemail(
-    rf, core_developer, project_membership
+    rf, staff_area_administrator, project_membership
 ):
     org = OrgFactory()
     project = ProjectFactory()
@@ -482,16 +488,16 @@ def test_userdetailwithoauth_with_email_only_user_invokes_userdetailwithemail(
     project_membership(project=project, user=user, roles=[InteractiveReporter])
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserDetailWithOAuth.as_view()(request, username=user.username)
 
     assert response.status_code == 200
 
 
-def test_userdetailwithoauth_with_unknown_user(rf, core_developer):
+def test_userdetailwithoauth_with_unknown_user(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         UserDetailWithOAuth.as_view()(request, username="test")
@@ -505,57 +511,60 @@ def test_userdetailwithoauth_without_core_dev_role(rf):
         UserDetailWithOAuth.as_view()(request, username="test")
 
 
-def test_userlist_filter_by_backend(rf, core_developer):
+def test_userlist_filter_by_backend(rf, staff_area_administrator):
     backend = BackendFactory()
 
     BackendMembershipFactory(user=UserFactory(), backend=backend)
     BackendMembershipFactory(user=UserFactory())
 
     request = rf.get(f"/?backend={backend.pk}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
     assert len(response.context_data["object_list"]) == 1
 
 
-def test_userlist_filter_by_invalid_backend(rf, core_developer):
+def test_userlist_filter_by_invalid_backend(rf, staff_area_administrator):
     request = rf.get("/?backend=test")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(BadRequest):
         UserList.as_view()(request)
 
 
-def test_userlist_filter_by_invalid_missing(rf, core_developer):
+def test_userlist_filter_by_invalid_missing(rf, staff_area_administrator):
     request = rf.get("/?missing=test")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
-    assert list(response.context_data["object_list"]) == [core_developer]
+    assert list(response.context_data["object_list"]) == [staff_area_administrator]
 
 
-def test_userlist_filter_by_missing(rf, core_developer):
+def test_userlist_filter_by_missing(rf, staff_area_administrator):
     backend = BackendFactory()
-    UserSocialAuthFactory(user=core_developer)
+    UserSocialAuthFactory(user=staff_area_administrator)
     social = UserSocialAuthFactory()
 
     BackendMembershipFactory(
         user=UserFactory(),
-        created_by=core_developer,
+        created_by=staff_area_administrator,
         backend=backend,
     )
 
     request = rf.get("/?missing=backend")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
-    assert list(response.context_data["object_list"]) == [core_developer, social.user]
+    assert list(response.context_data["object_list"]) == [
+        staff_area_administrator,
+        social.user,
+    ]
 
 
-def test_userlist_filter_by_org(rf, core_developer):
+def test_userlist_filter_by_org(rf, staff_area_administrator):
     org1 = OrgFactory()
     org2 = OrgFactory()
 
@@ -563,59 +572,61 @@ def test_userlist_filter_by_org(rf, core_developer):
     OrgMembershipFactory(user=UserFactory(), org=org2)
 
     request = rf.get(f"/?org={org1.slug}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
     assert len(response.context_data["object_list"]) == 1
 
 
-def test_userlist_filter_by_invalid_org(rf, core_developer):
+def test_userlist_filter_by_invalid_org(rf, staff_area_administrator):
     request = rf.get("/?org=test")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
     assert len(response.context_data["object_list"]) == 0
 
 
-def test_userlist_filter_by_role(rf, core_developer):
+def test_userlist_filter_by_role(rf, staff_area_administrator):
     UserFactory(roles=[OutputPublisher])
     UserFactory(roles=[ProjectCollaborator])
 
     request = rf.get("/?role=OutputPublisher")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
     assert len(response.context_data["object_list"]) == 1
 
 
-def test_userlist_filter_by_invalid_role(rf, core_developer):
+def test_userlist_filter_by_invalid_role(rf, staff_area_administrator):
     request = rf.get("/?role=unknown")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Exception, match="^Unknown Roles:"):
         UserList.as_view()(request)
 
 
-def test_userlist_filter_by_any_roles_yes_includes_global_roles(rf, core_developer):
+def test_userlist_filter_by_any_roles_yes_includes_global_roles(
+    rf, staff_area_administrator
+):
     user = UserFactory(roles=[OutputPublisher])
     UserFactory()
 
     request = rf.get("/?any_roles=yes")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
     assert set_from_qs(response.context_data["object_list"]) == {
-        core_developer.pk,
+        staff_area_administrator.pk,
         user.pk,
     }
 
 
 def test_userlist_filter_by_any_roles_yes_includes_project(
-    rf, core_developer, project_membership
+    rf, staff_area_administrator, project_membership
 ):
     UserFactory()
 
@@ -623,18 +634,18 @@ def test_userlist_filter_by_any_roles_yes_includes_project(
     project_membership(user=user_with_project, roles=[ProjectDeveloper])
 
     request = rf.get("/?any_roles=yes")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
     assert set_from_qs(response.context_data["object_list"]) == {
-        core_developer.pk,
+        staff_area_administrator.pk,
         user_with_project.pk,
     }
 
 
 def test_userlist_filter_by_any_roles_yes_includes_org(
-    rf, core_developer, project_membership
+    rf, staff_area_administrator, project_membership
 ):
     UserFactory()
 
@@ -642,23 +653,25 @@ def test_userlist_filter_by_any_roles_yes_includes_org(
     project_membership(user=user_with_project, roles=[ProjectDeveloper])
 
     request = rf.get("/?any_roles=yes")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
     assert set_from_qs(response.context_data["object_list"]) == {
-        core_developer.pk,
+        staff_area_administrator.pk,
         user_with_project.pk,
     }
 
 
-def test_userlist_filter_by_any_roles_no_excludes_global_roles(rf, core_developer):
+def test_userlist_filter_by_any_roles_no_excludes_global_roles(
+    rf, staff_area_administrator
+):
     UserFactory(roles=[OutputPublisher])
     UserFactory(roles=[ProjectCollaborator])
     user = UserFactory()
 
     request = rf.get("/?any_roles=no")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
@@ -666,11 +679,11 @@ def test_userlist_filter_by_any_roles_no_excludes_global_roles(rf, core_develope
 
 
 def test_userlist_filter_by_any_roles_no_excludes_project_roles(
-    rf, core_developer, project_membership
+    rf, staff_area_administrator, project_membership
 ):
     user = UserFactory()
 
-    actor = core_developer
+    actor = staff_area_administrator
 
     # set up projects so the creator can have roles
     project1 = ProjectFactory(created_by=actor, updated_by=actor)
@@ -699,7 +712,7 @@ def test_userlist_filter_by_any_roles_no_excludes_project_roles(
     )
 
     request = rf.get("/?any_roles=no")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
@@ -709,25 +722,27 @@ def test_userlist_filter_by_any_roles_no_excludes_project_roles(
     }
 
 
-def test_userlist_filter_by_any_roles_invalid_does_nothing(rf, core_developer):
+def test_userlist_filter_by_any_roles_invalid_does_nothing(
+    rf, staff_area_administrator
+):
     UserFactory(roles=[OutputPublisher])
     UserFactory(roles=[])
 
     request = rf.get("/?any_roles=asdf")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
     assert len(response.context_data["object_list"]) == 3
 
 
-def test_userlist_find_by_username(rf, core_developer):
+def test_userlist_find_by_username(rf, staff_area_administrator):
     UserFactory(username="ben")
     UserFactory(fullname="ben g")
     UserFactory(username="seb")
 
     request = rf.get("/?q=ben")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
@@ -736,26 +751,26 @@ def test_userlist_find_by_username(rf, core_developer):
     assert len(response.context_data["object_list"]) == 2
 
 
-def test_userlist_success(rf, core_developer):
+def test_userlist_success(rf, staff_area_administrator):
     UserFactory.create_batch(5)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserList.as_view()(request)
 
     assert response.status_code == 200
 
-    # the core_developer fixture creates a User object as well as the 5 we
+    # the staff_area_administrator fixture creates a User object as well as the 5 we
     # created in the batch call above
     assert len(response.context_data["object_list"]) == 6
 
 
-def test_userrolelist_get_success(rf, core_developer):
+def test_userrolelist_get_success(rf, staff_area_administrator):
     user = UserFactory(roles=[ProjectCollaborator])
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserRoleList.as_view()(request, username=user.username)
 
@@ -764,7 +779,7 @@ def test_userrolelist_get_success(rf, core_developer):
     response.render()
 
 
-def test_userrolelist_post_success(rf, core_developer):
+def test_userrolelist_post_success(rf, staff_area_administrator):
     user = UserFactory(roles=[ProjectCollaborator])
 
     data = {
@@ -774,7 +789,7 @@ def test_userrolelist_post_success(rf, core_developer):
         ]
     }
     request = rf.post("/", data=data)
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserRoleList.as_view()(request, username=user.username)
 
@@ -784,11 +799,11 @@ def test_userrolelist_post_success(rf, core_developer):
     assert set(user.roles) == {OutputPublisher, ProjectCollaborator}
 
 
-def test_userrolelist_post_with_unknown_role(rf, core_developer):
+def test_userrolelist_post_with_unknown_role(rf, staff_area_administrator):
     user = UserFactory()
 
     request = rf.post("/", {"roles": ["not-a-real-role"]})
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserRoleList.as_view()(request, username=user.username)
 
@@ -810,9 +825,9 @@ def test_userrolelist_post_with_unknown_role(rf, core_developer):
     )
 
 
-def test_userrolelist_with_unknown_user(rf, core_developer):
+def test_userrolelist_with_unknown_user(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         UserRoleList.as_view()(request, username="")
@@ -828,7 +843,7 @@ def test_userrolelist_without_core_dev_role(rf):
         UserRoleList.as_view()(request, username=user.username)
 
 
-def test_usersetorgs_get_success(rf, core_developer):
+def test_usersetorgs_get_success(rf, staff_area_administrator):
     org1 = OrgFactory()
     org2 = OrgFactory()
     user = UserFactory()
@@ -837,7 +852,7 @@ def test_usersetorgs_get_success(rf, core_developer):
     OrgMembershipFactory(org=org2, user=user)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserSetOrgs.as_view()(request, username=user.username)
 
@@ -845,7 +860,7 @@ def test_usersetorgs_get_success(rf, core_developer):
     assert response.context_data["user"] == user
 
 
-def test_usersetorgs_post_success(rf, core_developer):
+def test_usersetorgs_post_success(rf, staff_area_administrator):
     existing_org = OrgFactory()
     new_org1 = OrgFactory()
     new_org2 = OrgFactory()
@@ -855,7 +870,7 @@ def test_usersetorgs_post_success(rf, core_developer):
     OrgMembershipFactory(org=existing_org, user=user)
 
     request = rf.post("/", {"orgs": [new_org1.pk, new_org2.pk]})
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = UserSetOrgs.as_view()(request, username=user.username)
 
@@ -866,8 +881,8 @@ def test_usersetorgs_post_success(rf, core_developer):
     assert set_from_qs(user.orgs.all()) == {new_org1.pk, new_org2.pk}
 
 
-def test_usersetorgs_unknown_user(rf, core_developer):
+def test_usersetorgs_unknown_user(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
     with pytest.raises(Http404):
         UserSetOrgs.as_view()(request, username="")

--- a/tests/unit/staff/views/test_workspaces.py
+++ b/tests/unit/staff/views/test_workspaces.py
@@ -15,11 +15,11 @@ from ....factories import (
 )
 
 
-def test_workspacedetail_success(rf, core_developer):
+def test_workspacedetail_success(rf, staff_area_administrator):
     workspace = WorkspaceFactory()
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = WorkspaceDetail.as_view()(request, slug=workspace.name)
 
@@ -28,9 +28,9 @@ def test_workspacedetail_success(rf, core_developer):
     assert response.context_data["workspace"] == workspace
 
 
-def test_workspacedetail_with_unknown_user(rf, core_developer):
+def test_workspacedetail_with_unknown_user(rf, staff_area_administrator):
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         WorkspaceDetail.as_view()(request, slug="test")
@@ -46,11 +46,11 @@ def test_workspacedetail_without_core_dev_role(rf):
         WorkspaceDetail.as_view()(request, slug=workspace.name)
 
 
-def test_workspaceedit_get_success(rf, core_developer):
+def test_workspaceedit_get_success(rf, staff_area_administrator):
     workspace = WorkspaceFactory()
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = WorkspaceEdit.as_view()(request, slug=workspace.name)
 
@@ -58,7 +58,7 @@ def test_workspaceedit_get_success(rf, core_developer):
     assert workspace.name in response.rendered_content
 
 
-def test_workspaceedit_post_success(rf, core_developer):
+def test_workspaceedit_post_success(rf, staff_area_administrator):
     old_project = ProjectFactory()
     workspace = WorkspaceFactory(project=old_project, purpose="old value")
 
@@ -69,7 +69,7 @@ def test_workspaceedit_post_success(rf, core_developer):
         "project": str(new_project.pk),
     }
     request = rf.post("/", data)
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = WorkspaceEdit.as_view()(request, slug=workspace.name)
 
@@ -88,7 +88,9 @@ def test_workspaceedit_post_success(rf, core_developer):
     )
 
 
-def test_workspaceedit_post_success_when_not_changing_project(rf, core_developer):
+def test_workspaceedit_post_success_when_not_changing_project(
+    rf, staff_area_administrator
+):
     project = ProjectFactory()
     workspace = WorkspaceFactory(project=project)
 
@@ -97,7 +99,7 @@ def test_workspaceedit_post_success_when_not_changing_project(rf, core_developer
         "project": str(project.pk),
     }
     request = rf.post("/", data)
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = WorkspaceEdit.as_view()(request, slug=workspace.name)
 
@@ -119,22 +121,22 @@ def test_workspaceedit_unauthorized(rf):
         WorkspaceEdit.as_view()(request, slug=workspace.name)
 
 
-def test_workspaceedit_unknown_workspace(rf, core_developer):
+def test_workspaceedit_unknown_workspace(rf, staff_area_administrator):
     request = rf.post("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     with pytest.raises(Http404):
         WorkspaceEdit.as_view()(request, slug="")
 
 
-def test_workspacelist_filter_by_org(rf, core_developer):
+def test_workspacelist_filter_by_org(rf, staff_area_administrator):
     org = OrgFactory()
     project = ProjectFactory(orgs=[org])
     workspace = WorkspaceFactory(project=project)
     WorkspaceFactory.create_batch(2)
 
     request = rf.get(f"/?orgs={org.slug}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = WorkspaceList.as_view()(request)
 
@@ -142,13 +144,13 @@ def test_workspacelist_filter_by_org(rf, core_developer):
     assert set_from_qs(response.context_data["workspace_list"]) == {workspace.pk}
 
 
-def test_workspacelist_filter_by_project(rf, core_developer):
+def test_workspacelist_filter_by_project(rf, staff_area_administrator):
     project = ProjectFactory()
     workspace = WorkspaceFactory(project=project)
     WorkspaceFactory.create_batch(2)
 
     request = rf.get(f"/?projects={project.slug}")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = WorkspaceList.as_view()(request)
 
@@ -156,13 +158,13 @@ def test_workspacelist_filter_by_project(rf, core_developer):
     assert set_from_qs(response.context_data["workspace_list"]) == {workspace.pk}
 
 
-def test_workspacelist_search(rf, core_developer):
+def test_workspacelist_search(rf, staff_area_administrator):
     WorkspaceFactory(name="ben")
     WorkspaceFactory(repo=RepoFactory(url="ben"))
     WorkspaceFactory(name="seb")
 
     request = rf.get("/?q=ben")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = WorkspaceList.as_view()(request)
 
@@ -171,11 +173,11 @@ def test_workspacelist_search(rf, core_developer):
     assert len(response.context_data["object_list"]) == 2
 
 
-def test_workspacelist_success(rf, core_developer):
+def test_workspacelist_success(rf, staff_area_administrator):
     WorkspaceFactory.create_batch(5)
 
     request = rf.get("/")
-    request.user = core_developer
+    request.user = staff_area_administrator
 
     response = WorkspaceList.as_view()(request)
     assert response.status_code == 200


### PR DESCRIPTION
Resolves #4604.

#4639 re-named the CoreDeveloper role to StaffAreaAdministrator. Direct references were updated. There are a couple of places with vestigial indirect references. In the management command `create_user` `--core-developer` flag and the `pytest`  fixture `core_developer` and therefore throughout `tests/`. Let's tidy these up as the vestigial references are potentially confusing and unclear. Better to reference the new role name.