### PR TITLE
Use group for dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,14 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-    allow:
-      - dependency-type: "production"
+      interval: "daily"
+      time: "13:00"
+      timezone: "Europe/London"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
     reviewers:
       - "tomodwyer"
     open-pull-requests-limit: 20


### PR DESCRIPTION
- Group npm dependabot updates in to development and production PRs
- Set the update interval to daily to test this process
- Set the time to check for updates to 1pm for testing purposes