### PR TITLE
Switch to weekly dependabot checks for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "13:00"
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
       timezone: "Europe/London"
     groups:
       production-dependencies:


### PR DESCRIPTION
https://github.com/opensafely-core/job-server/pull/4694 and https://github.com/opensafely-core/job-server/pull/4695 proved to be a success, therefore we can now return to weekly dependency checks.