### PR TITLE
Remove unused `ResetPasswordForm`

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -83,10 +83,6 @@ class ProjectMembershipForm(RolesForm):
     pass
 
 
-class ResetPasswordForm(forms.Form):
-    email = forms.EmailField(widget=forms.EmailInput(attrs={"autocomplete": "email"}))
-
-
 class WorkspaceArchiveToggleForm(forms.Form):
     is_archived = forms.BooleanField(required=False)
 


### PR DESCRIPTION
`ResetPasswordForm` has not been referenced since #2750 / commit [5ff6e215527236fd3ac30ed664f15d8995808206](https://github.com/opensafely-core/job-server/pull/2750/commits/5ff6e215527236fd3ac30ed664f15d8995808206#diff-5ed5b91c7902cf27c8ac19b378638c4de79c0d87140fb789faaf073599590413L27) removed the `ResetPassword` view. It appears that not removing the form was an oversight.