### PR TITLE
Document and link to private repo policy

### DIFF
--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -197,7 +197,7 @@ class WorkspaceDetail(View):
             name=self.kwargs["workspace_slug"],
         )
 
-        # get the first job for this workspace's repo
+        # Get the first job for this workspace's repo.
         first_job = (
             Job.objects.filter(job_request__workspace__project=workspace.project)
             .annotate(run_at=Least("started_at", "created_at"))
@@ -205,19 +205,18 @@ class WorkspaceDetail(View):
             .first()
         )
 
-        # if the first job to run against this workspace's repo was more than
-        # 11 months ago then show a warning
+        # Warn if the first job run on this workspace's repo was over 11 months
+        # ago. Policy: Private research repos must be made public within
+        # twelve months of the first code execution. Documentation reference:
+        # https://docs.opensafely.org/repositories/#when-you-need-to-make-your-code-public
         eleven_months_ago = timezone.now() - timedelta(days=30 * 11)
-
         is_member = request.user in workspace.project.members.all()
-
         try:
             repo_is_private = self.get_github_api().get_repo_is_private(
                 workspace.repo.owner, workspace.repo.name
             )
         except (requests.ConnectionError, requests.HTTPError):
             repo_is_private = None
-
         show_publish_repo_warning = (
             is_member
             and first_job
@@ -238,7 +237,7 @@ class WorkspaceDetail(View):
         )
         has_backends = request.user.is_authenticated and request.user.backends.exists()
 
-        # should we show the admin section in the UI?
+        # Should we show the admin section in the UI?
         show_admin = can_archive_workspace or can_toggle_notifications
 
         honeycomb_can_view_links = has_role(self.request.user, StaffAreaAdministrator)

--- a/staff/views/dashboards/repos.py
+++ b/staff/views/dashboards/repos.py
@@ -29,9 +29,8 @@ class PrivateReposDashboard(View):
         List private repos due for conversion to public.
 
         Policy: Private research repos must be made public within twelve months
-        of the first code execution. The Information Governance team monitors
-        this dashboard to ensure compliance. Such repos nearing twelve months
-        are listed here. Documentation reference:
+        of the first code execution.  Such repos nearing twelve months are
+        listed here. Documentation reference:
 
         https://docs.opensafely.org/repositories/#when-you-need-to-make-your-code-public
 

--- a/staff/views/dashboards/repos.py
+++ b/staff/views/dashboards/repos.py
@@ -26,12 +26,19 @@ class PrivateReposDashboard(View):
     @csp_exempt
     def get(self, request, *args, **kwargs):
         """
-        List private repos which are in need of converting to public
+        List private repos due for conversion to public.
+
+        Policy: Private research repos must be made public within twelve months
+        of the first code execution. The Information Governance team monitors
+        this dashboard to ensure compliance. Such repos nearing twelve months
+        are listed here. Documentation reference:
+
+        https://docs.opensafely.org/repositories/#when-you-need-to-make-your-code-public
 
         Repos should be:
-         * Private
-         * not have `non-research` topic
-         * first job was run > 11 months ago
+         * Private.
+         * Not have the `non-research` topic.
+         * First associated job was run > 11 months ago.
         """
         all_repos = list(self.get_github_api().get_repos_with_dates("opensafely"))
 

--- a/templates/staff/dashboards/index.html
+++ b/templates/staff/dashboards/index.html
@@ -26,7 +26,7 @@
 
           {% url "staff:dashboards:repos" as staff_dashboards_repos_url %}
           {% #list_group_rich_item title="Private Repos" type="Dashboard" url=staff_dashboards_repos_url %}
-            <p>Private repos attached to one or more workspaces, where code was first run more than 11 months ago</p>
+            <p>Private research repositories linked to one or more workspaces, with initial code execution over 11 months ago, for IG monitoring</p>
           {% /list_group_rich_item %}
 
           {% url "staff:dashboards:projects" as staff_dashboards_projects_url %}

--- a/templates/staff/dashboards/index.html
+++ b/templates/staff/dashboards/index.html
@@ -26,7 +26,7 @@
 
           {% url "staff:dashboards:repos" as staff_dashboards_repos_url %}
           {% #list_group_rich_item title="Private Repos" type="Dashboard" url=staff_dashboards_repos_url %}
-            <p>Private research repositories linked to one or more workspaces, with initial code execution over 11 months ago, for IG monitoring</p>
+            <p>Private research repositories linked to one or more workspaces, with initial code execution over 11 months ago</p>
           {% /list_group_rich_item %}
 
           {% url "staff:dashboards:projects" as staff_dashboards_projects_url %}

--- a/templates/staff/dashboards/repos.html
+++ b/templates/staff/dashboards/repos.html
@@ -13,7 +13,7 @@
 {% endblock breadcrumbs %}
 
 {% block hero %}
-  {% staff_hero title="OpenSAFELY Private Repos" text="This table contains all private research repositories linked to one or more workspaces, with initial code execution over 11 months ago. Per policy, these must be made public within 12 months. This dashboard is monitored by the Information Governance team for compliance." %}
+  {% staff_hero title="OpenSAFELY Private Repos" text="This table contains all private research repositories linked to one or more workspaces, with initial code execution over 11 months ago. Per policy, these must be made public within 12 months." %}
 {% endblock hero %}
 
 {% block full_width_content %}

--- a/templates/staff/dashboards/repos.html
+++ b/templates/staff/dashboards/repos.html
@@ -13,7 +13,7 @@
 {% endblock breadcrumbs %}
 
 {% block hero %}
-  {% staff_hero title="OpenSAFELY Private Repos" text="This table contains all private repos attached to one or more workspaces, where code was first run more than 11 months ago." %}
+  {% staff_hero title="OpenSAFELY Private Repos" text="This table contains all private research repositories linked to one or more workspaces, with initial code execution over 11 months ago. Per policy, these must be made public within 12 months. This dashboard is monitored by the Information Governance team for compliance." %}
 {% endblock hero %}
 
 {% block full_width_content %}

--- a/templates/workspace/detail.html
+++ b/templates/workspace/detail.html
@@ -218,9 +218,10 @@
           <p class="text-sm mb-2">
             The
             {% link text="first job to run against the git repository" href=first_job.get_absolute_url %}
-            for this workspace ran over 11 months ago.  As per our platform
-            policy, we ask that repositories are made public 12 months after
-            they are first executed against patient data.
+            for this workspace ran over 11 months ago. Per our
+            {% link text="platform policy" href="https://docs.opensafely.org/repositories/#when-you-need-to-make-your-code-public" %}
+            we ask that repositories are made public 12 months after they
+            are first executed against patient data.
           </p>
           <p class="text-sm">
             {% link text="Change repository visibility &rarr;" href=workspace.repo.get_sign_off_url %}


### PR DESCRIPTION
We display warnings to the user when they are viewing a workspace attached to a private repo nearing their public release date. Provide a link to the policy documentation in these messages.

Explain the related policy and process on the private repo dashboard, and add explanations in the relevant code sections with links to the policy document. Existing information did not make this clear.

Here is [the policy](https://docs.opensafely.org/repositories/#when-you-need-to-make-your-code-public) and a (Bennett internal) [Slack thread](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1730106471692929) discussing this and other dashboards. 

The template changes can be tested locally by visiting the [dashboard](http://localhost:8000/staff/dashboards/) and by editing the `WorkspaceDetail` view to set `show_publish_repo_warning = True` then visiting the page for a `Workspace` to which you have access (`/project-slug/workspace-slug/`).