### PR TITLE
Handle GitHub api problems consistently

### DIFF
--- a/airlock/views.py
+++ b/airlock/views.py
@@ -1,13 +1,12 @@
 from dataclasses import dataclass
 from enum import Enum
 
-from requests.exceptions import HTTPError
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import api_view, authentication_classes
 from rest_framework.response import Response
 
 from jobserver.api.authentication import get_backend_from_token
-from jobserver.github import _get_github_api
+from jobserver.github import GitHubError, _get_github_api
 from jobserver.models import User, Workspace
 
 from .config import ORG_OUTPUT_CHECKING_REPOS
@@ -122,7 +121,7 @@ def create_issue(airlock_event: AirlockEvent, github_api=None):
             airlock_event.repo,
             github_api,
         )
-    except HTTPError as e:
+    except GitHubError as e:
         raise NotificationError(f"Error creating GitHub issue: {e}")
 
 
@@ -138,7 +137,7 @@ def close_issue(airlock_event: AirlockEvent, github_api=None):
             airlock_event.repo,
             github_api,
         )
-    except HTTPError as e:
+    except GitHubError as e:
         raise NotificationError(f"Error closing GitHub issue: {e}")
 
 
@@ -155,7 +154,7 @@ def update_issue(airlock_event: AirlockEvent, github_api=None, notify_slack=Fals
             github_api,
             notify_slack=notify_slack,
         )
-    except HTTPError as e:
+    except GitHubError as e:
         raise NotificationError(f"Error creating GitHub issue comment: {e}")
 
 

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -25,15 +25,13 @@ session.headers = {
 class GitHubError(Exception):
     """Base exception to target all other exceptions we define here"""
 
-    pass
-
 
 class RepoAlreadyExists(GitHubError):
-    pass
+    """An API call failed as the repo to be created already exists."""
 
 
 class RepoNotYetCreated(GitHubError):
-    pass
+    """An API call failed as the repo to be deleted already exists."""
 
 
 class GitHubAPI:

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -21,17 +21,42 @@ session.headers = {
     "User-Agent": "OpenSAFELY Jobs",
 }
 
+# Clients should catch GitHubError to handle common, often transient, connection
+# issues gracefully. Some HTTPError status codes indicate specific API errors
+# related to remote state (e.g., attempting to create an object that already
+# exists). These cases should raise specific HTTPError exceptions from this
+# module, allowing clients to handle such errors without relying on internal
+# implementation details.
+
 
 class GitHubError(Exception):
-    """Base exception to target all other exceptions we define here"""
+    """Base exception for this module. A problem contacting or using the GitHub
+    API."""
 
 
-class RepoAlreadyExists(GitHubError):
-    """An API call failed as the repo to be created already exists."""
+class Timeout(GitHubError):
+    """A request to the GitHub API timed out."""
 
 
-class RepoNotYetCreated(GitHubError):
-    """An API call failed as the repo to be deleted already exists."""
+class ConnectionException(GitHubError):
+    """A connection error occurred while contacting the GitHub API."""
+
+    # ConnectionError is a Python default exception class, so let's avoid using
+    # that name. Otherwise we might have mirrored the name of
+    # requests.exceptions.ConnectionError.
+
+
+class HTTPError(GitHubError):
+    """An HTTP request with an error status code was returned by the GitHub
+    API."""
+
+
+class RepoAlreadyExists(HTTPError):
+    """Tried to create a repo that already existed."""
+
+
+class RepoNotYetCreated(HTTPError):
+    """Tried to delete a repo that did not already exist."""
 
 
 class GitHubAPI:

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -380,10 +380,10 @@ class GitHubAPI:
         }
         r = self._post(url, headers=headers, json=payload)
 
-        try:
-            r.raise_for_status()
-        except requests.HTTPError as e:
-            raise RepoAlreadyExists from e
+        if r.status_code == 422:
+            raise RepoAlreadyExists()
+
+        r.raise_for_status()
 
         return r.json()
 

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -76,7 +76,7 @@ class GitHubAPI:
 
     def __init__(self, _session=session, token=None):
         """
-        Initialise the wrapper with a session and maybe token
+        Initialise the wrapper with a session and maybe token.
 
         We pass in the session here so that tests can pass in a fake object to
         test internals.
@@ -98,20 +98,15 @@ class GitHubAPI:
 
     def _request(self, method, *args, **kwargs):
         """
-        Thin wrapper of requests.Session._request()
+        Make a request to the remote GitHub API.
 
-        This wrapper exists solely to inject the Authorization header if a
-        token has been set on the current instance and that headers hasn't
-        already been set in a given requests headers.
+        A wrapper for `requests.Session.request` that injects an
+        `Authorization` header if a token is set on the API instance and not
+        already included in the request headers.
 
-        This solves a tension between using an application-level session object
-        and wanting GitHubAPI instance-level authentication.  We want to
-        support the use of different tokens for typical running (eg in prod),
-        verification tests (eg in CI), and the ability to query the API without
-        a token (less likely but can be useful) so we can't just set the header
-        on the session when it's defined at the module level.  However if we
-        set it on the session then it persists beyond the life time of a given
-        GitHubAPI instance.
+        This design allows for instance-level authentication with different
+        tokens (e.g., for production, CI verification tests, or unauthenticated
+        queries) without setting the header globally on the session.
         """
         headers = kwargs.pop("headers", {})
 
@@ -122,7 +117,7 @@ class GitHubAPI:
 
     def _get_query_page(self, *, query, session, cursor, **kwargs):
         """
-        Get a page of the given query
+        Get a page of the given query.
 
         This uses the GraphQL API to avoid making O(N) calls to GitHub's (v3) REST
         API.  The passed cursor is a GraphQL cursor [1] allowing us to call this
@@ -158,7 +153,7 @@ class GitHubAPI:
 
     def _iter_query_results(self, query, **kwargs):
         """
-        Get results from a GraphQL query
+        Get results from a GraphQL query.
 
         Given a GraphQL query, return all results across one or more pages as a
         single generator.  We currently assume all results live under
@@ -183,7 +178,7 @@ class GitHubAPI:
             if not data["pageInfo"]["hasNextPage"]:
                 break
 
-            # update the cursor we pass into the GraphQL query
+            # Update the cursor we pass into the GraphQL query.
             cursor = data["pageInfo"]["endCursor"]  # pragma: no cover
 
     def _url(self, path_segments, query_args=None):
@@ -440,10 +435,10 @@ class GitHubAPI:
             print(r.content)
 
         if r.status_code == 403:
-            # it's possible for us to create and then attempt to delete a repo
+            # It's possible for us to create and then attempt to delete a repo
             # faster than GitHub can create it on disk, so lets wait and retry
-            # if that's happened
-            # Note: 403 isn't just used for this state
+            # if that's happened.
+            # Note: 403 isn't just used for this state.
             msg = "Repository cannot be deleted until it is done being created on disk."
             if msg in r.json().get("message", ""):
                 raise RepoNotYetCreated()
@@ -612,7 +607,7 @@ class GitHubAPI:
                 topics = [n["topic"]["name"] for n in repo["repositoryTopics"]["nodes"]]
 
             if "non-research" in topics:
-                continue  # ignore non-research repos
+                continue  # Ignore non-research repos.
 
             yield {
                 "name": repo["name"],

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -2,7 +2,6 @@ import concurrent
 import itertools
 import operator
 
-import requests
 from django.core.exceptions import PermissionDenied
 from django.db.models import Min, OuterRef, Subquery
 from django.db.models.functions import Least, Lower
@@ -17,7 +16,7 @@ from jobserver import html_utils
 from jobserver.utils import set_from_qs
 
 from ..authorization import has_permission, permissions
-from ..github import _get_github_api
+from ..github import GitHubError, _get_github_api
 from ..models import Job, JobRequest, Project, PublishRequest, Repo, Snapshot
 
 
@@ -173,7 +172,7 @@ class ProjectDetail(View):
                     is_private = self.get_github_api().get_repo_is_private(
                         repo.owner, repo.name
                     )
-                except (requests.HTTPError, requests.Timeout, requests.ConnectionError):
+                except GitHubError:
                     is_private = None
                 span = trace.get_current_span()
                 span.set_attribute("repo_owner", repo.owner)

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-import requests
 from csp.decorators import csp_exempt
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
@@ -27,7 +26,7 @@ from ..forms import (
     WorkspaceEditForm,
     WorkspaceNotificationsToggleForm,
 )
-from ..github import _get_github_api
+from ..github import GitHubError, _get_github_api
 from ..models import (
     Backend,
     Job,
@@ -134,7 +133,7 @@ class WorkspaceCreate(CreateView):
             self.repos_with_branches = list(
                 self.get_github_api().get_repos_with_branches(gh_org)
             )
-        except requests.HTTPError:
+        except GitHubError:
             # gracefully handle not being able to access GitHub's API
             msg = (
                 "An error occurred while retrieving the list of repositories from GitHub, "
@@ -215,7 +214,7 @@ class WorkspaceDetail(View):
             repo_is_private = self.get_github_api().get_repo_is_private(
                 workspace.repo.owner, workspace.repo.name
             )
-        except (requests.ConnectionError, requests.HTTPError):
+        except GitHubError:
             repo_is_private = None
         show_publish_repo_warning = (
             is_member

--- a/staff/views/dashboards/copiloting.py
+++ b/staff/views/dashboards/copiloting.py
@@ -1,6 +1,5 @@
 import itertools
 
-import requests
 import structlog
 from csp.decorators import csp_exempt
 from django.conf import settings
@@ -12,7 +11,7 @@ from django.views.generic import TemplateView
 
 from jobserver.authorization import StaffAreaAdministrator
 from jobserver.authorization.decorators import require_role
-from jobserver.github import _get_github_api
+from jobserver.github import GitHubError, _get_github_api
 from jobserver.models import Project, ReleaseFile, Repo
 
 
@@ -45,10 +44,10 @@ def build_repos_by_project(projects, get_github_api=_get_github_api):
 
     try:
         github_repos = list(get_github_api().get_repos_with_status_and_url(repo_orgs))
-    except requests.HTTPError:
-        # if the GitHub API is down log some details but don't block the page
+    except GitHubError as exc:
         logger.exception(
-            "Failed to get repo status and URL from GitHub API", repo_orgs=repo_orgs
+            f"Failed to get repo status and URL from GitHub API due to: {exc}",
+            repo_orgs=repo_orgs,
         )
         return {}
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -3,8 +3,13 @@ from datetime import UTC, datetime
 
 from django.utils import timezone
 
+from jobserver.github import GitHubError
+
 
 class FakeGitHubAPI:
+    """Fake GitHubAPI that returns reasonable values for each corresponding
+    public function."""
+
     def add_repo_to_team(self, team, org, repo):
         return
 
@@ -158,6 +163,69 @@ class FakeGitHubAPI:
         return {
             "names": [],
         }
+
+
+class FakeGitHubAPIWithErrors:
+    """Fake GitHubAPI that returns an error for each corresponding public
+    function."""
+
+    def add_repo_to_team(self, team, org, repo):
+        raise GitHubError()
+
+    def create_issue(self, org, repo, title, body, labels):
+        # Some unit tests want to check the message.
+        raise GitHubError("An error occurred")
+
+    def get_issue_number_from_title(
+        self, org, repo, title_text, latest=True, state=None
+    ):
+        raise GitHubError()
+
+    def create_issue_comment(
+        self, org, repo, title_text, body, latest=True, issue_number=1
+    ):
+        # Some unit tests want to check the message.
+        raise GitHubError("An error occurred")
+
+    def close_issue(self, org, repo, title_text, comment=None, latest=True):
+        # Some unit tests want to check the message.
+        raise GitHubError("An error occurred")
+
+    def create_repo(self, org, repo):
+        raise GitHubError()
+
+    def get_branch(self, org, repo, branch):
+        raise GitHubError()
+
+    def get_branches(self, org, repo):
+        raise GitHubError()
+
+    def get_branch_sha(self, org, repo, branch):
+        raise GitHubError()
+
+    def get_tag_sha(self, org, repo, tag):
+        raise GitHubError()
+
+    def get_file(self, org, repo, branch, filepath="project.yaml"):
+        raise GitHubError()
+
+    def get_repo(self, org, repo):
+        raise GitHubError()
+
+    def get_repo_is_private(self, org, repo):
+        raise GitHubError()
+
+    def get_repos_with_branches(self, org):
+        raise GitHubError()
+
+    def get_repos_with_dates(self, org):
+        raise GitHubError()
+
+    def get_repos_with_status_and_url(self, orgs):
+        raise GitHubError()
+
+    def set_repo_topics(self, org, repo, topics):
+        raise GitHubError()
 
 
 class FakeOpenCodelistsAPI:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -56,7 +56,7 @@ class FakeGitHubAPI:
     def get_tag_sha(self, org, repo, tag):
         return "test_sha"
 
-    def get_file(self, org, repo, branch, filepath=None):
+    def get_file(self, org, repo, branch, filepath="project.yaml"):
         return textwrap.dedent(
             """
             actions:

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 import pytest
-from requests.exceptions import HTTPError
 
 from airlock.views import AirlockEvent, EventType, airlock_event_view
 from tests.factories import (
@@ -11,18 +10,7 @@ from tests.factories import (
     UserFactory,
     WorkspaceFactory,
 )
-from tests.fakes import FakeGitHubAPI
-
-
-class FakeGithubApiWithError:
-    def create_issue(*args, **kwargs):
-        raise HTTPError("An error occurred")
-
-    def create_issue_comment(*args, **kwargs):
-        raise HTTPError("An error occurred")
-
-    def close_issue(*args, **kwargs):
-        raise HTTPError("An error occurred")
+from tests.fakes import FakeGitHubAPI, FakeGitHubAPIWithErrors
 
 
 @pytest.mark.parametrize(
@@ -205,7 +193,7 @@ def test_api_post_release_request_default_org_and_repo(mock_create_issue, api_rf
         ("bad_event_type", None, "Unknown event type 'BAD_EVENT_TYPE'"),
     ],
 )
-@patch("airlock.views._get_github_api", FakeGithubApiWithError)
+@patch("airlock.views._get_github_api", FakeGitHubAPIWithErrors)
 def test_api_airlock_event_error(api_rf, event_type, updates, error):
     author = UserFactory()
     user = UserFactory()

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -21,6 +21,7 @@ from .utils import assert_deep_type_equality, assert_public_method_signature_equ
 pytestmark = [pytest.mark.verification, pytest.mark.disable_db]
 
 
+@pytest.mark.disable_db
 class TestGitHubAPIAgainstFakes:
     def test_fake_public_method_signatures(self):
         """Test that `FakeGitHubAPI` has the same public methods with the same
@@ -65,6 +66,7 @@ def github_api():
     return GitHubAPI(token=Env().str("GITHUB_TOKEN_TESTING"))
 
 
+@pytest.mark.disable_db
 @pytest.mark.usefixtures("enable_network")
 class TestGithubAPIPrivate:
     """Tests of the real GitHubAPI that require permissions on a private
@@ -227,6 +229,7 @@ class TestGithubAPIPrivate:
         assert repo["topics"] == ["testing"]
 
 
+@pytest.mark.disable_db
 @pytest.mark.usefixtures("enable_network")
 class TestGithubAPINonPrivate:
     """Tests of the real GitHubAPI that don't require permissions on a private

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -7,7 +7,7 @@ from jobserver.github import GitHubAPI, RepoAlreadyExists, RepoNotYetCreated
 from jobserver.models.common import new_ulid_str
 
 from ..fakes import FakeGitHubAPI
-from .utils import compare
+from .utils import assert_deep_type_equality
 
 
 pytestmark = [pytest.mark.verification, pytest.mark.disable_db]
@@ -60,7 +60,7 @@ def test_create_issue(enable_network, github_api):
     real = github_api.create_issue(*args)
     fake = FakeGitHubAPI().create_issue(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
     assert real is not None
 
@@ -72,7 +72,7 @@ def test_get_issue_number(enable_network, github_api):
 
     real = github_api.get_issue_number_from_title(*args)
     fake = FakeGitHubAPI().get_issue_number_from_title(*args)
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
     assert real is not None
 
@@ -110,7 +110,7 @@ def test_create_issue_comment(enable_network, github_api):
     real = github_api.create_issue_comment(*args)
     fake = FakeGitHubAPI().create_issue_comment(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
     assert real is not None
 
@@ -133,7 +133,7 @@ def test_close_issue(enable_network, github_api, comment):
     real = github_api.close_issue(*args)
     fake = FakeGitHubAPI().close_issue(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
     assert real is not None
 
@@ -161,8 +161,7 @@ def test_create_repo(enable_network, github_api):
         real = github_api.create_repo(*args)
         fake = FakeGitHubAPI().create_repo(*args)
 
-        # does the fake work as expected?
-        compare(fake, real)
+        assert_deep_type_equality(fake, real)
 
         assert real is not None
 
@@ -183,7 +182,7 @@ def test_get_branch(enable_network, github_api):
     real = github_api.get_branch(*args)
     fake = FakeGitHubAPI().get_branch(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
     assert real is not None
 
@@ -198,7 +197,7 @@ def test_get_branches(enable_network, github_api):
     real = github_api.get_branches(*args)
     fake = FakeGitHubAPI().get_branches(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
     assert real is not None
 
@@ -209,7 +208,7 @@ def test_get_branches_with_unknown_org(enable_network, github_api):
     real = github_api.get_branches(*args)
     fake = FakeGitHubAPI().get_branches(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
     assert real == []
 
@@ -220,7 +219,7 @@ def test_get_branches_with_unknown_repo(enable_network, github_api):
     real = github_api.get_branches(*args)
     fake = FakeGitHubAPI().get_branches(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
     assert real == []
 
@@ -234,7 +233,7 @@ def test_get_branch_sha(enable_network, github_api):
     assert real == "71650d527c9288f90aa01d089f5a9884b683f7ed"
 
     # get_branch_sha is a wrapper for get_branch to extract just the SHA as a
-    # string so no need to throw compare() at it
+    # string so no need to throw assert_deep_type_equality() at it
     assert isinstance(fake, str)
 
 
@@ -265,7 +264,7 @@ def test_get_default_file(enable_network, github_api):
     real = github_api.get_file(*args)
     fake = FakeGitHubAPI().get_file(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
 
 def test_get_file(enable_network, github_api):
@@ -274,7 +273,7 @@ def test_get_file(enable_network, github_api):
     real = github_api.get_file(*args)
     fake = FakeGitHubAPI().get_file(*args, filepath="README.md")
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
 
 def test_get_file_missing_project_yml(enable_network, github_api):
@@ -293,7 +292,7 @@ def test_get_repo(enable_network, github_api):
     real = github_api.get_repo(*args)
     fake = FakeGitHubAPI().get_repo(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
 
 def test_get_repo_is_private(enable_network, github_api):
@@ -317,7 +316,7 @@ def test_get_repos_with_branches(enable_network, github_api):
     real = list(github_api.get_repos_with_branches(*args))
     fake = FakeGitHubAPI().get_repos_with_branches(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
 
 def test_get_repos_with_dates(enable_network, github_api):
@@ -326,7 +325,7 @@ def test_get_repos_with_dates(enable_network, github_api):
     real = list(github_api.get_repos_with_dates(*args))
     fake = FakeGitHubAPI().get_repos_with_dates(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
 
 def test_get_repos_with_status_and_url(enable_network, github_api):
@@ -335,7 +334,7 @@ def test_get_repos_with_status_and_url(enable_network, github_api):
     real = list(github_api.get_repos_with_status_and_url(args))
     fake = FakeGitHubAPI().get_repos_with_status_and_url(args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
 
 def test_graphql_error_handling(enable_network, github_api):
@@ -367,8 +366,7 @@ def test_set_repo_topics(enable_network, github_api, clear_topics):
     real = github_api.set_repo_topics(*args)
     fake = FakeGitHubAPI().set_repo_topics(*args)
 
-    # does the fake work as expected?
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
     assert real is not None
 

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -21,26 +21,26 @@ from .utils import assert_deep_type_equality, assert_public_method_signature_equ
 pytestmark = [pytest.mark.verification, pytest.mark.disable_db]
 
 
-def test_fake_public_method_signatures():
-    """Test that `FakeGitHubAPI` has the same public methods with the same
-    signatures as the real one."""
-    assert_public_method_signature_equality(
-        GitHubAPI,
-        FakeGitHubAPI,
-        # delete_repo is only used in testing.
-        ignored_methods=["delete_repo"],
-    )
+class TestGitHubAPIAgainstFakes:
+    def test_fake_public_method_signatures(self):
+        """Test that `FakeGitHubAPI` has the same public methods with the same
+        signatures as the real one."""
+        assert_public_method_signature_equality(
+            GitHubAPI,
+            FakeGitHubAPI,
+            # delete_repo is only used in testing.
+            ignored_methods=["delete_repo"],
+        )
 
-
-def test_fake_with_errors_public_method_signatures():
-    """Test that the fake `WithErrors` API has the same public methods with the
-    same signatures as the real one."""
-    assert_public_method_signature_equality(
-        GitHubAPI,
-        FakeGitHubAPIWithErrors,
-        # delete_repo is only used in testing.
-        ignored_methods=["delete_repo"],
-    )
+    def test_fake_with_errors_public_method_signatures(self):
+        """Test that the fake `WithErrors` API has the same public methods with the
+        same signatures as the real one."""
+        assert_public_method_signature_equality(
+            GitHubAPI,
+            FakeGitHubAPIWithErrors,
+            # delete_repo is only used in testing.
+            ignored_methods=["delete_repo"],
+        )
 
 
 @pytest.fixture
@@ -65,398 +65,382 @@ def github_api():
     return GitHubAPI(token=Env().str("GITHUB_TOKEN_TESTING"))
 
 
-def test_add_repo_to_team(enable_network, github_api):
-    args = [
-        "testing",
-        "opensafely-testing",
-        "github-api-testing-topics",
-    ]
+@pytest.mark.usefixtures("enable_network")
+class TestGithubAPIPrivate:
+    """Tests of the real GitHubAPI that require permissions on a private
+    repo."""
 
-    assert github_api.add_repo_to_team(*args) is None
-    assert FakeGitHubAPI().add_repo_to_team(*args) is None
-
-
-def test_create_issue(enable_network, github_api):
-    # use a private repo to test here so we can mirror what the output checkers
-    # are doing
-    args = [
-        "opensafely-testing",
-        "github-api-testing-private",
-        "Test Issue",
-        "test content",
-        ["testing"],
-    ]
-
-    real = github_api.create_issue(*args)
-    fake = FakeGitHubAPI().create_issue(*args)
-
-    assert_deep_type_equality(fake, real)
-
-    assert real is not None
-
-
-def test_get_issue_number(enable_network, github_api):
-    # use a private repo to test here so we can mirror what the output checkers
-    # are doing
-    args = ["opensafely-testing", "github-api-testing-private", "Test Issue"]
-
-    real = github_api.get_issue_number_from_title(*args)
-    fake = FakeGitHubAPI().get_issue_number_from_title(*args)
-    assert_deep_type_equality(fake, real)
-
-    assert real is not None
-
-
-def test_get_issue_number_with_sort_order(enable_network, github_api):
-    # use a private repo to test here so we can mirror what the output checkers
-    # are doing
-    args = ["opensafely-testing", "github-api-testing-private", "Test Issue"]
-
-    default_order = github_api.get_issue_number_from_title(*args)
-    latest = github_api.get_issue_number_from_title(*args, latest=True)
-    oldest = github_api.get_issue_number_from_title(*args, latest=False)
-    assert default_order == latest
-    assert latest > oldest
-
-
-def test_get_issue_number_no_matches(enable_network, github_api):
-    args = ["opensafely-testing", "github-api-testing-private", new_ulid_str()]
-    real = github_api.get_issue_number_from_title(*args)
-    assert real is None
-
-
-def test_create_issue_comment(enable_network, github_api):
-    # use a private repo to test here so we can mirror what the output checkers
-    # are doing
-    # We assume there's at least one existing issue entitled "Test Issue"
-    # (generated in previous test runs)
-    args = [
-        "opensafely-testing",
-        "github-api-testing-private",
-        "Test Issue",
-        "A test comment",
-    ]
-
-    real = github_api.create_issue_comment(*args)
-    fake = FakeGitHubAPI().create_issue_comment(*args)
-
-    assert_deep_type_equality(fake, real)
-
-    assert real is not None
-
-
-@pytest.mark.parametrize("comment", [None, "Closed with reason"])
-def test_close_issue(enable_network, github_api, comment):
-    # use a private repo to test here so we can mirror what the output checkers
-    # are doing
-    # We assume there's at least one existing open issue entitled "Test Issue"
-    # (generated in previous test runs)
-    args = [
-        "opensafely-testing",
-        "github-api-testing-private",
-        "Test Issue",
-        comment,
-        # Sort ascending, so we close the oldest one
-        "asc",
-    ]
-
-    real = github_api.close_issue(*args)
-    fake = FakeGitHubAPI().close_issue(*args)
-
-    assert_deep_type_equality(fake, real)
-
-    assert real is not None
-
-    # reset the issue state
-    github_api._change_issue_state(
-        "opensafely-testing", "github-api-testing-private", real["number"], "open"
-    )
-
-
-def test_create_repo(enable_network, github_api):
-    try:
-        # create a unique ID for this test using our existing ULID function.
-        # we can have multiple CI runs executing concurrently which means this
-        # test can be running in different CI jobs at the same time.  Given the
-        # test talks to an external API we can't use the same repo name for every
-        # execution.  Instead we use our new_ulid_str since it's already available
-        # and should have more than enough uniqueness for our needs to create
-        # a unique repo name.
-        unique_id = new_ulid_str()
+    def test_add_repo_to_team(self, github_api):
         args = [
+            "testing",
             "opensafely-testing",
-            f"testing-create_repo-{unique_id}",
+            "github-api-testing-topics",
         ]
 
-        real = github_api.create_repo(*args)
-        fake = FakeGitHubAPI().create_repo(*args)
+        assert github_api.add_repo_to_team(*args) is None
+        assert FakeGitHubAPI().add_repo_to_team(*args) is None
+
+    def test_create_issue(self, github_api):
+        # use a private repo to test here so we can mirror what the output checkers
+        # are doing
+        args = [
+            "opensafely-testing",
+            "github-api-testing-private",
+            "Test Issue",
+            "test content",
+            ["testing"],
+        ]
+
+        real = github_api.create_issue(*args)
+        fake = FakeGitHubAPI().create_issue(*args)
 
         assert_deep_type_equality(fake, real)
 
         assert real is not None
 
-        # do we get the appropriate error when the repo already exists?
-        with pytest.raises(RepoAlreadyExists):
-            github_api.create_repo(*args)
-    finally:
-        # clean up after the test but accept that sometimes the repo hasn't
-        # been created and make a few attempts at removing it
-        for attempt in stamina.retry_context(on=RepoNotYetCreated):
-            with attempt:
-                github_api.delete_repo(*args)
+    def test_get_issue_number(self, github_api):
+        # use a private repo to test here so we can mirror what the output checkers
+        # are doing
+        args = ["opensafely-testing", "github-api-testing-private", "Test Issue"]
+
+        real = github_api.get_issue_number_from_title(*args)
+        fake = FakeGitHubAPI().get_issue_number_from_title(*args)
+        assert_deep_type_equality(fake, real)
+
+        assert real is not None
+
+    def test_get_issue_number_with_sort_order(self, github_api):
+        # use a private repo to test here so we can mirror what the output checkers
+        # are doing
+        args = ["opensafely-testing", "github-api-testing-private", "Test Issue"]
+
+        default_order = github_api.get_issue_number_from_title(*args)
+        latest = github_api.get_issue_number_from_title(*args, latest=True)
+        oldest = github_api.get_issue_number_from_title(*args, latest=False)
+        assert default_order == latest
+        assert latest > oldest
+
+    def test_get_issue_number_no_matches(self, github_api):
+        args = ["opensafely-testing", "github-api-testing-private", new_ulid_str()]
+        real = github_api.get_issue_number_from_title(*args)
+        assert real is None
+
+    def test_create_issue_comment(self, github_api):
+        # use a private repo to test here so we can mirror what the output checkers
+        # are doing
+        # We assume there's at least one existing issue entitled "Test Issue"
+        # (generated in previous test runs)
+        args = [
+            "opensafely-testing",
+            "github-api-testing-private",
+            "Test Issue",
+            "A test comment",
+        ]
+
+        real = github_api.create_issue_comment(*args)
+        fake = FakeGitHubAPI().create_issue_comment(*args)
+
+        assert_deep_type_equality(fake, real)
+
+        assert real is not None
+
+    @pytest.mark.parametrize("comment", [None, "Closed with reason"])
+    def test_close_issue(self, github_api, comment):
+        # use a private repo to test here so we can mirror what the output checkers
+        # are doing
+        # We assume there's at least one existing open issue entitled "Test Issue"
+        # (generated in previous test runs)
+        args = [
+            "opensafely-testing",
+            "github-api-testing-private",
+            "Test Issue",
+            comment,
+            # Sort ascending, so we close the oldest one
+            "asc",
+        ]
+
+        real = github_api.close_issue(*args)
+        fake = FakeGitHubAPI().close_issue(*args)
+
+        assert_deep_type_equality(fake, real)
+
+        assert real is not None
+
+        # reset the issue state
+        github_api._change_issue_state(
+            "opensafely-testing", "github-api-testing-private", real["number"], "open"
+        )
 
+    def test_create_repo(self, github_api):
+        try:
+            # create a unique ID for this test using our existing ULID function.
+            # we can have multiple CI runs executing concurrently which means this
+            # test can be running in different CI jobs at the same time.  Given the
+            # test talks to an external API we can't use the same repo name for every
+            # execution.  Instead we use our new_ulid_str since it's already available
+            # and should have more than enough uniqueness for our needs to create
+            # a unique repo name.
+            unique_id = new_ulid_str()
+            args = [
+                "opensafely-testing",
+                f"testing-create_repo-{unique_id}",
+            ]
 
-def test_get_branch(enable_network, github_api):
-    args = ["opensafely-testing", "github-api-testing", "main"]
+            real = github_api.create_repo(*args)
+            fake = FakeGitHubAPI().create_repo(*args)
 
-    real = github_api.get_branch(*args)
-    fake = FakeGitHubAPI().get_branch(*args)
+            assert_deep_type_equality(fake, real)
 
-    assert_deep_type_equality(fake, real)
+            assert real is not None
 
-    assert real is not None
+            # do we get the appropriate error when the repo already exists?
+            with pytest.raises(RepoAlreadyExists):
+                github_api.create_repo(*args)
+        finally:
+            # clean up after the test but accept that sometimes the repo hasn't
+            # been created and make a few attempts at removing it
+            for attempt in stamina.retry_context(on=RepoNotYetCreated):
+                with attempt:
+                    github_api.delete_repo(*args)
 
+    def test_get_repo_is_private(self, github_api):
+        args = ["opensafely-testing", "github-api-testing-private"]
 
-def test_get_branch_with_missing_branch(enable_network, github_api):
-    assert github_api.get_branch("opensafely-testing", "some_repo", "missing") is None
+        assert github_api.get_repo_is_private(*args)
+        assert FakeGitHubAPI().get_repo_is_private(*args)
 
+    def test_set_repo_topics(self, github_api, clear_topics):
+        args = [
+            "opensafely-testing",
+            "github-api-testing-topics",
+            ["testing"],
+        ]
 
-def test_get_branches(enable_network, github_api):
-    args = ["opensafely-testing", "github-api-testing"]
+        real = github_api.set_repo_topics(*args)
+        fake = FakeGitHubAPI().set_repo_topics(*args)
 
-    real = github_api.get_branches(*args)
-    fake = FakeGitHubAPI().get_branches(*args)
+        assert_deep_type_equality(fake, real)
 
-    assert_deep_type_equality(fake, real)
+        assert real is not None
 
-    assert real is not None
+        repo = github_api.get_repo("opensafely-testing", "github-api-testing-topics")
+        assert repo["topics"] == ["testing"]
 
 
-def test_get_branches_with_unknown_org(enable_network, github_api):
-    args = ["opensafely-not-real", "github-api-testing"]
+@pytest.mark.usefixtures("enable_network")
+class TestGithubAPINonPrivate:
+    """Tests of the real GitHubAPI that don't require permissions on a private
+    repo."""
 
-    real = github_api.get_branches(*args)
-    fake = FakeGitHubAPI().get_branches(*args)
+    def test_get_branch(self, github_api):
+        args = ["opensafely-testing", "github-api-testing", "main"]
 
-    assert_deep_type_equality(fake, real)
+        real = github_api.get_branch(*args)
+        fake = FakeGitHubAPI().get_branch(*args)
 
-    assert real == []
+        assert_deep_type_equality(fake, real)
 
+        assert real is not None
 
-def test_get_branches_with_unknown_repo(enable_network, github_api):
-    args = ["opensafely-testing", "github-api-not-real"]
+    def test_get_branch_with_missing_branch(self, github_api):
+        assert (
+            github_api.get_branch("opensafely-testing", "some_repo", "missing") is None
+        )
 
-    real = github_api.get_branches(*args)
-    fake = FakeGitHubAPI().get_branches(*args)
+    def test_get_branches(self, github_api):
+        args = ["opensafely-testing", "github-api-testing"]
 
-    assert_deep_type_equality(fake, real)
+        real = github_api.get_branches(*args)
+        fake = FakeGitHubAPI().get_branches(*args)
 
-    assert real == []
+        assert_deep_type_equality(fake, real)
 
+        assert real is not None
 
-def test_get_branch_sha(enable_network, github_api):
-    args = ["opensafely-testing", "github-api-testing", "test-get_branch_sha"]
+    def test_get_branches_with_unknown_org(self, github_api):
+        args = ["opensafely-not-real", "github-api-testing"]
 
-    real = github_api.get_branch_sha(*args)
-    fake = FakeGitHubAPI().get_branch_sha(*args)
+        real = github_api.get_branches(*args)
+        fake = FakeGitHubAPI().get_branches(*args)
 
-    assert real == "71650d527c9288f90aa01d089f5a9884b683f7ed"
+        assert_deep_type_equality(fake, real)
 
-    # get_branch_sha is a wrapper for get_branch to extract just the SHA as a
-    # string so no need to throw assert_deep_type_equality() at it
-    assert isinstance(fake, str)
+        assert real == []
 
+    def test_get_branches_with_unknown_repo(self, github_api):
+        args = ["opensafely-testing", "github-api-not-real"]
 
-def test_get_tag_sha(enable_network, github_api):
-    args = ["opensafely-testing", "github-api-testing", "test-tag"]
+        real = github_api.get_branches(*args)
+        fake = FakeGitHubAPI().get_branches(*args)
 
-    real = github_api.get_tag_sha(*args)
-    fake = FakeGitHubAPI().get_tag_sha(*args)
+        assert_deep_type_equality(fake, real)
 
-    assert real == "7c48e4e81db5fe932628cd92f51c7858759d6b98"
+        assert real == []
 
-    assert isinstance(fake, str)
+    def test_get_branch_sha(self, github_api):
+        args = ["opensafely-testing", "github-api-testing", "test-get_branch_sha"]
 
+        real = github_api.get_branch_sha(*args)
+        fake = FakeGitHubAPI().get_branch_sha(*args)
 
-def test_get_branch_sha_with_missing_branch(enable_network, github_api):
-    sha = github_api.get_branch_sha(
-        "opensafely-testing",
-        "some_repo",
-        "missing",
-    )
+        assert real == "71650d527c9288f90aa01d089f5a9884b683f7ed"
 
-    assert sha is None
+        # get_branch_sha is a wrapper for get_branch to extract just the SHA as a
+        # string so no need to throw assert_deep_type_equality() at it
+        assert isinstance(fake, str)
 
+    def test_get_tag_sha(self, github_api):
+        args = ["opensafely-testing", "github-api-testing", "test-tag"]
 
-def test_get_default_file(enable_network, github_api):
-    args = ["opensafely-testing", "github-api-testing", "main"]
+        real = github_api.get_tag_sha(*args)
+        fake = FakeGitHubAPI().get_tag_sha(*args)
 
-    real = github_api.get_file(*args)
-    fake = FakeGitHubAPI().get_file(*args)
+        assert real == "7c48e4e81db5fe932628cd92f51c7858759d6b98"
 
-    assert_deep_type_equality(fake, real)
+        assert isinstance(fake, str)
 
+    def test_get_branch_sha_with_missing_branch(self, github_api):
+        sha = github_api.get_branch_sha(
+            "opensafely-testing",
+            "some_repo",
+            "missing",
+        )
 
-def test_get_file(enable_network, github_api):
-    args = ["opensafely-testing", "github-api-testing", "main"]
+        assert sha is None
 
-    real = github_api.get_file(*args)
-    fake = FakeGitHubAPI().get_file(*args, filepath="README.md")
+    def test_get_default_file(self, github_api):
+        args = ["opensafely-testing", "github-api-testing", "main"]
 
-    assert_deep_type_equality(fake, real)
+        real = github_api.get_file(*args)
+        fake = FakeGitHubAPI().get_file(*args)
 
+        assert_deep_type_equality(fake, real)
 
-def test_get_file_missing_project_yml(enable_network, github_api):
-    output = github_api.get_file(
-        "opensafely-testing",
-        "github-api-testing",
-        "missing_project",
-    )
+    def test_get_file(self, github_api):
+        args = ["opensafely-testing", "github-api-testing", "main"]
 
-    assert output is None
+        real = github_api.get_file(*args)
+        fake = FakeGitHubAPI().get_file(*args, filepath="README.md")
 
+        assert_deep_type_equality(fake, real)
 
-def test_get_repo(enable_network, github_api):
-    args = ["opensafely-testing", "github-api-testing"]
+    def test_get_file_missing_project_yml(self, github_api):
+        output = github_api.get_file(
+            "opensafely-testing",
+            "github-api-testing",
+            "missing_project",
+        )
 
-    real = github_api.get_repo(*args)
-    fake = FakeGitHubAPI().get_repo(*args)
+        assert output is None
 
-    assert_deep_type_equality(fake, real)
+    def test_get_repo(self, github_api):
+        args = ["opensafely-testing", "github-api-testing"]
 
+        real = github_api.get_repo(*args)
+        fake = FakeGitHubAPI().get_repo(*args)
 
-def test_get_repo_is_private(enable_network, github_api):
-    args = ["opensafely-testing", "github-api-testing-private"]
+        assert_deep_type_equality(fake, real)
 
-    assert github_api.get_repo_is_private(*args)
-    assert FakeGitHubAPI().get_repo_is_private(*args)
+    def test_get_repo_is_private_with_unknown_repo(self, github_api):
+        assert github_api.get_repo_is_private("opensafely-testing", "unknown") is None
 
+    def test_get_repo_with_unknown_repo(self, github_api):
+        assert github_api.get_repo("opensafely-testing", "unknown") is None
 
-def test_get_repo_is_private_with_unknown_repo(enable_network, github_api):
-    assert github_api.get_repo_is_private("opensafely-testing", "unknown") is None
+    def test_get_repos_with_branches(self, github_api):
+        args = ["opensafely-testing"]
 
+        real = list(github_api.get_repos_with_branches(*args))
+        fake = FakeGitHubAPI().get_repos_with_branches(*args)
 
-def test_get_repo_with_unknown_repo(enable_network, github_api):
-    assert github_api.get_repo("opensafely-testing", "unknown") is None
+        assert_deep_type_equality(fake, real)
 
+    def test_get_repos_with_dates(self, github_api):
+        args = ["opensafely-testing"]
 
-def test_get_repos_with_branches(enable_network, github_api):
-    args = ["opensafely-testing"]
+        real = list(github_api.get_repos_with_dates(*args))
+        fake = FakeGitHubAPI().get_repos_with_dates(*args)
 
-    real = list(github_api.get_repos_with_branches(*args))
-    fake = FakeGitHubAPI().get_repos_with_branches(*args)
+        assert_deep_type_equality(fake, real)
 
-    assert_deep_type_equality(fake, real)
+    def test_get_repos_with_status_and_url(self, github_api):
+        args = ["opensafely-testing"]
 
+        real = list(github_api.get_repos_with_status_and_url(args))
+        fake = FakeGitHubAPI().get_repos_with_status_and_url(args)
 
-def test_get_repos_with_dates(enable_network, github_api):
-    args = ["opensafely-testing"]
+        assert_deep_type_equality(fake, real)
 
-    real = list(github_api.get_repos_with_dates(*args))
-    fake = FakeGitHubAPI().get_repos_with_dates(*args)
+    def test_graphql_error_handling(self, github_api):
+        """
+        Are we raising errors around unexpected GraphQL responses?
 
-    assert_deep_type_equality(fake, real)
+        Some GraphQL responses, typically to malformed queries, don't return a
+        `data` key in their response.
+        """
+        query = """
+        query {
+          viewer {
+            not_a_real_field
+          }
+        }
+        """
 
+        with pytest.raises(RuntimeError):
+            list(github_api._iter_query_results(query))
 
-def test_get_repos_with_status_and_url(enable_network, github_api):
-    args = ["opensafely-testing"]
+    def test_unauthenticated_request(self):
+        try:
+            assert GitHubAPI().get_repo("opensafely-testing", "github-api-testing")
+        except HTTPError as e:  # pragma: no cover
+            forbidden = e.response.status_code == 403
+            rate_limited = "rate limit exceeded for url" in str(e)
 
-    real = list(github_api.get_repos_with_status_and_url(args))
-    fake = FakeGitHubAPI().get_repos_with_status_and_url(args)
+            if forbidden and rate_limited:
+                # being rate limited is still a valid access of the API
+                assert True
+            else:
+                raise
 
-    assert_deep_type_equality(fake, real)
+    # The following tests patch the remote API accesses to simulate various
+    # request-related problems and assert that they are transformed into
+    # module-specific exceptions. We could test every public function for each
+    # type of error. But this is costly and verbose and we don't expect the
+    # implementation detail to vary substantially. Instead let's just test them
+    # on one of the simple query ones.
 
+    def test_timeout(self, github_api, monkeypatch):
+        """Test mocked Timeout exception is transformed."""
 
-def test_graphql_error_handling(enable_network, github_api):
-    """
-    Are we raising errors around unexpected GraphQL responses?
+        def mock_request(*args, **kwargs):
+            raise requests.exceptions.Timeout()
 
-    Some GraphQL responses, typically to malformed queries, don't return a
-    `data` key in their response.
-    """
-    query = """
-    query {
-      viewer {
-        not_a_real_field
-      }
-    }
-    """
+        monkeypatch.setattr(github_api.session, "request", mock_request)
 
-    with pytest.raises(RuntimeError):
-        list(github_api._iter_query_results(query))
+        with pytest.raises(Timeout):
+            github_api.get_repo("opensafely-testing", "github-api-testing")
 
+    def test_connection_error(self, github_api, monkeypatch):
+        """Test mocked connection exception is transformed."""
 
-def test_set_repo_topics(enable_network, github_api, clear_topics):
-    args = [
-        "opensafely-testing",
-        "github-api-testing-topics",
-        ["testing"],
-    ]
+        def mock_request(*args, **kwargs):
+            raise requests.exceptions.ConnectionError()
 
-    real = github_api.set_repo_topics(*args)
-    fake = FakeGitHubAPI().set_repo_topics(*args)
+        monkeypatch.setattr(github_api.session, "request", mock_request)
 
-    assert_deep_type_equality(fake, real)
+        with pytest.raises(ConnectionException):
+            github_api.get_repo("opensafely-testing", "github-api-testing")
 
-    assert real is not None
+    def test_http_error(self, github_api, monkeypatch):
+        """Test mocked response with error status_code raises Exception."""
 
-    repo = github_api.get_repo("opensafely-testing", "github-api-testing-topics")
-    assert repo["topics"] == ["testing"]
+        def mock_request(*args, **kwargs):
+            mock_response = Response()
+            mock_response.status_code = 403
+            mock_response._content = b"Not allowed"
+            return mock_response
 
+        monkeypatch.setattr(github_api.session, "request", mock_request)
 
-def test_unauthenticated_request(enable_network):
-    try:
-        assert GitHubAPI().get_repo("opensafely-testing", "github-api-testing")
-    except HTTPError as e:  # pragma: no cover
-        forbidden = e.response.status_code == 403
-        rate_limited = "rate limit exceeded for url" in str(e)
-
-        if forbidden and rate_limited:
-            # being rate limited is still a valid access of the API
-            assert True
-        else:
-            raise
-
-
-# We could test every public function for the `Exception` that are consistently
-# transformed into `GitHubError`. But this is costly as we hit the real API.
-# Instead let's just test them on one of the simple ones.
-
-
-def test_timeout(enable_network, github_api, monkeypatch):
-    """Test mocked Timeout exception is transformed."""
-
-    def mock_request(*args, **kwargs):
-        raise requests.exceptions.Timeout()
-
-    monkeypatch.setattr(github_api.session, "request", mock_request)
-
-    with pytest.raises(Timeout):
-        github_api.get_repo("opensafely-testing", "github-api-testing")
-
-
-def test_connection_error(enable_network, github_api, monkeypatch):
-    """Test mocked connection exception is transformed."""
-
-    def mock_request(*args, **kwargs):
-        raise requests.exceptions.ConnectionError()
-
-    monkeypatch.setattr(github_api.session, "request", mock_request)
-
-    with pytest.raises(ConnectionException):
-        github_api.get_repo("opensafely-testing", "github-api-testing")
-
-
-def test_http_error(enable_network, github_api, monkeypatch):
-    """Test mocked response with error status_code raises Exception."""
-
-    def mock_request(*args, **kwargs):
-        mock_response = Response()
-        mock_response.status_code = 403
-        mock_response._content = b"Not allowed"
-        return mock_response
-
-    monkeypatch.setattr(github_api.session, "request", mock_request)
-
-    with pytest.raises(HTTPError):
-        github_api.get_repo("opensafely-testing", "github-api-testing")
+        with pytest.raises(HTTPError):
+            github_api.get_repo("opensafely-testing", "github-api-testing")

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -6,7 +6,7 @@ from requests.exceptions import HTTPError
 from jobserver.github import GitHubAPI, RepoAlreadyExists, RepoNotYetCreated
 from jobserver.models.common import new_ulid_str
 
-from ..fakes import FakeGitHubAPI
+from ..fakes import FakeGitHubAPI, FakeGitHubAPIWithErrors
 from .utils import assert_deep_type_equality, assert_public_method_signature_equality
 
 
@@ -19,6 +19,17 @@ def test_fake_public_method_signatures():
     assert_public_method_signature_equality(
         GitHubAPI,
         FakeGitHubAPI,
+        # delete_repo is only used in testing.
+        ignored_methods=["delete_repo"],
+    )
+
+
+def test_fake_with_errors_public_method_signatures():
+    """Test that the fake `WithErrors` API has the same public methods with the
+    same signatures as the real one."""
+    assert_public_method_signature_equality(
+        GitHubAPI,
+        FakeGitHubAPIWithErrors,
         # delete_repo is only used in testing.
         ignored_methods=["delete_repo"],
     )

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -7,10 +7,21 @@ from jobserver.github import GitHubAPI, RepoAlreadyExists, RepoNotYetCreated
 from jobserver.models.common import new_ulid_str
 
 from ..fakes import FakeGitHubAPI
-from .utils import assert_deep_type_equality
+from .utils import assert_deep_type_equality, assert_public_method_signature_equality
 
 
 pytestmark = [pytest.mark.verification, pytest.mark.disable_db]
+
+
+def test_fake_public_method_signatures():
+    """Test that `FakeGitHubAPI` has the same public methods with the same
+    signatures as the real one."""
+    assert_public_method_signature_equality(
+        GitHubAPI,
+        FakeGitHubAPI,
+        # delete_repo is only used in testing.
+        ignored_methods=["delete_repo"],
+    )
 
 
 @pytest.fixture

--- a/tests/verification/test_opencodelists.py
+++ b/tests/verification/test_opencodelists.py
@@ -3,10 +3,19 @@ import pytest
 from jobserver.opencodelists import OpenCodelistsAPI
 
 from ..fakes import FakeOpenCodelistsAPI
-from .utils import assert_deep_type_equality
+from .utils import assert_deep_type_equality, assert_public_method_signature_equality
 
 
 pytestmark = [pytest.mark.verification, pytest.mark.disable_db]
+
+
+def test_fake_public_method_signatures():
+    """Test that `FakeOpenCodelistsAPI` has the same public methods with the
+    same signatures as the real one."""
+    assert_public_method_signature_equality(
+        OpenCodelistsAPI,
+        FakeOpenCodelistsAPI,
+    )
 
 
 @pytest.fixture

--- a/tests/verification/test_opencodelists.py
+++ b/tests/verification/test_opencodelists.py
@@ -3,7 +3,7 @@ import pytest
 from jobserver.opencodelists import OpenCodelistsAPI
 
 from ..fakes import FakeOpenCodelistsAPI
-from .utils import compare
+from .utils import assert_deep_type_equality
 
 
 pytestmark = [pytest.mark.verification, pytest.mark.disable_db]
@@ -21,7 +21,7 @@ def test_get_codelists(enable_network, opencodelists_api):
     real = opencodelists_api.get_codelists(*args)
     fake = FakeOpenCodelistsAPI().get_codelists(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
     assert real is not None
 
@@ -32,7 +32,7 @@ def test_get_codelists_with_unknown_coding_system(enable_network, opencodelists_
     real = opencodelists_api.get_codelists(*args)
     fake = FakeOpenCodelistsAPI().get_codelists(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)
 
     assert real == []
 
@@ -43,4 +43,4 @@ def test_check_codelists(enable_network, opencodelists_api):
     real = opencodelists_api.check_codelists(*args)
     fake = FakeOpenCodelistsAPI().check_codelists(*args)
 
-    compare(fake, real)
+    assert_deep_type_equality(fake, real)

--- a/tests/verification/test_opencodelists.py
+++ b/tests/verification/test_opencodelists.py
@@ -9,6 +9,7 @@ from .utils import assert_deep_type_equality, assert_public_method_signature_equ
 pytestmark = [pytest.mark.verification, pytest.mark.disable_db]
 
 
+@pytest.mark.disable_db
 def test_fake_public_method_signatures():
     """Test that `FakeOpenCodelistsAPI` has the same public methods with the
     same signatures as the real one."""
@@ -24,6 +25,7 @@ def opencodelists_api():
     return OpenCodelistsAPI()
 
 
+@pytest.mark.disable_db
 def test_get_codelists(enable_network, opencodelists_api):
     args = ["snomedct"]
 
@@ -35,6 +37,7 @@ def test_get_codelists(enable_network, opencodelists_api):
     assert real is not None
 
 
+@pytest.mark.disable_db
 def test_get_codelists_with_unknown_coding_system(enable_network, opencodelists_api):
     args = ["test"]
 
@@ -46,6 +49,7 @@ def test_get_codelists_with_unknown_coding_system(enable_network, opencodelists_
     assert real == []
 
 
+@pytest.mark.disable_db
 def test_check_codelists(enable_network, opencodelists_api):
     args = ["{}", ""]
 

--- a/tests/verification/test_utils.py
+++ b/tests/verification/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 from .utils import assert_public_method_signature_equality
 
 
+@pytest.mark.disable_db
 class TestPublicMethodSignatureEquality:
     def test_identity(self):
         """Test when applied against the same class."""

--- a/tests/verification/test_utils.py
+++ b/tests/verification/test_utils.py
@@ -1,0 +1,102 @@
+"""Tests of this test package's utils module."""
+
+import pytest
+
+from .utils import assert_public_method_signature_equality
+
+
+#####################################################################
+# Classes for tests of assert_public_method_signature_equality
+
+
+class ClassA:
+    def method_one(self, x, y):
+        pass
+
+    def method_two(self, z):
+        pass
+
+
+# The same as A.
+class ClassB:
+    def method_one(self, x, y):
+        pass
+
+    def method_two(self, z):
+        pass
+
+
+# The same as A, but a method has a different signature.
+class ClassC:
+    # Different signature to A.method_one.
+    def method_one(self, x):
+        pass
+
+    def method_two(self, z):
+        pass
+
+
+# The same as A, but with an extra method.
+class ClassD:
+    def method_one(self, x, y):
+        pass
+
+    def method_two(self, z):
+        pass
+
+    def method_three(self):
+        pass
+
+
+# The same as A, but with a private method.
+class ClassE:
+    def method_one(self, x, y):
+        pass
+
+    def method_two(self, z):
+        pass
+
+    def _private_method(self):
+        pass
+
+
+#####################################################################
+
+
+class TestPublicMethodSignatureEquality:
+    def test_identity(cls):
+        """Test when applied against the same class."""
+        for cls in (ClassA, ClassB, ClassC, ClassD, ClassE):
+            assert_public_method_signature_equality(cls, cls)
+
+    def test_matching_methods(cls):
+        """Test when methods match between classes."""
+        assert_public_method_signature_equality(ClassA, ClassB)
+
+    def test_signature_mismatch(cls):
+        """Test when method signatures differ between classes."""
+        with pytest.raises(AssertionError, match="signature mismatch"):
+            assert_public_method_signature_equality(ClassA, ClassC)
+
+    def test_extra_method(cls):
+        """Test when the second class has an extra method."""
+        with pytest.raises(AssertionError, match="methods mismatch"):
+            assert_public_method_signature_equality(ClassA, ClassD)
+
+    def test_missing_method(cls):
+        """Test when a method is missing in the second class."""
+        with pytest.raises(AssertionError, match="methods mismatch"):
+            assert_public_method_signature_equality(ClassD, ClassA)
+
+    def test_ignore_methods(cls):
+        """Test when certain methods are ignored in the comparison."""
+        assert_public_method_signature_equality(
+            ClassA, ClassD, ignored_methods=["method_three"]
+        )
+
+    def test_ignore_private_methods(cls):
+        """Test that extra private methods are ignored."""
+        assert_public_method_signature_equality(ClassA, ClassE)
+
+
+#####################################################################

--- a/tests/verification/test_utils.py
+++ b/tests/verification/test_utils.py
@@ -64,37 +64,37 @@ class ClassE:
 
 
 class TestPublicMethodSignatureEquality:
-    def test_identity(cls):
+    def test_identity(self):
         """Test when applied against the same class."""
         for cls in (ClassA, ClassB, ClassC, ClassD, ClassE):
             assert_public_method_signature_equality(cls, cls)
 
-    def test_matching_methods(cls):
+    def test_matching_methods(self):
         """Test when methods match between classes."""
         assert_public_method_signature_equality(ClassA, ClassB)
 
-    def test_signature_mismatch(cls):
+    def test_signature_mismatch(self):
         """Test when method signatures differ between classes."""
         with pytest.raises(AssertionError, match="signature mismatch"):
             assert_public_method_signature_equality(ClassA, ClassC)
 
-    def test_extra_method(cls):
+    def test_extra_method(self):
         """Test when the second class has an extra method."""
         with pytest.raises(AssertionError, match="methods mismatch"):
             assert_public_method_signature_equality(ClassA, ClassD)
 
-    def test_missing_method(cls):
+    def test_missing_method(self):
         """Test when a method is missing in the second class."""
         with pytest.raises(AssertionError, match="methods mismatch"):
             assert_public_method_signature_equality(ClassD, ClassA)
 
-    def test_ignore_methods(cls):
+    def test_ignore_methods(self):
         """Test when certain methods are ignored in the comparison."""
         assert_public_method_signature_equality(
             ClassA, ClassD, ignored_methods=["method_three"]
         )
 
-    def test_ignore_private_methods(cls):
+    def test_ignore_private_methods(self):
         """Test that extra private methods are ignored."""
         assert_public_method_signature_equality(ClassA, ClassE)
 

--- a/tests/verification/test_utils.py
+++ b/tests/verification/test_utils.py
@@ -5,98 +5,123 @@ import pytest
 from .utils import assert_public_method_signature_equality
 
 
-#####################################################################
-# Classes for tests of assert_public_method_signature_equality
-
-
-class ClassA:
-    def method_one(self, x, y):
-        pass
-
-    def method_two(self, z):
-        pass
-
-
-# The same as A.
-class ClassB:
-    def method_one(self, x, y):
-        pass
-
-    def method_two(self, z):
-        pass
-
-
-# The same as A, but a method has a different signature.
-class ClassC:
-    # Different signature to A.method_one.
-    def method_one(self, x):
-        pass
-
-    def method_two(self, z):
-        pass
-
-
-# The same as A, but with an extra method.
-class ClassD:
-    def method_one(self, x, y):
-        pass
-
-    def method_two(self, z):
-        pass
-
-    def method_three(self):
-        pass
-
-
-# The same as A, but with a private method.
-class ClassE:
-    def method_one(self, x, y):
-        pass
-
-    def method_two(self, z):
-        pass
-
-    def _private_method(self):
-        pass
-
-
-#####################################################################
-
-
 class TestPublicMethodSignatureEquality:
     def test_identity(self):
         """Test when applied against the same class."""
-        for cls in (ClassA, ClassB, ClassC, ClassD, ClassE):
-            assert_public_method_signature_equality(cls, cls)
+
+        class ClassA:
+            def method_one(self, x, y): ...
+
+            def method_two(self, z): ...
+
+        assert_public_method_signature_equality(ClassA, ClassA)
 
     def test_matching_methods(self):
         """Test when methods match between classes."""
+
+        class ClassA:
+            def method_one(self, x, y): ...
+
+            def method_two(self, z): ...
+
+        # This class is identical to Class A.
+        class ClassB:
+            def method_one(self, x, y): ...
+
+            def method_two(self, z): ...
+
         assert_public_method_signature_equality(ClassA, ClassB)
 
     def test_signature_mismatch(self):
         """Test when method signatures differ between classes."""
+
+        class ClassA:
+            def method_one(self, x, y): ...
+
+            def method_two(self, z): ...
+
+        # The same as A, but a method has a different signature.
+        class ClassC:
+            # Different signature to A.method_one.
+            def method_one(self, x): ...
+
+            def method_two(self, z): ...
+
         with pytest.raises(AssertionError, match="signature mismatch"):
             assert_public_method_signature_equality(ClassA, ClassC)
 
     def test_extra_method(self):
         """Test when the second class has an extra method."""
+
+        class ClassA:
+            def method_one(self, x, y): ...
+
+            def method_two(self, z): ...
+
+        # The same as A, but with an extra method.
+        class ClassD:
+            def method_one(self, x, y): ...
+
+            def method_two(self, z): ...
+
+            def method_three(self): ...
+
         with pytest.raises(AssertionError, match="methods mismatch"):
             assert_public_method_signature_equality(ClassA, ClassD)
 
     def test_missing_method(self):
         """Test when a method is missing in the second class."""
+
+        class ClassA:
+            def method_one(self, x, y): ...
+
+            def method_two(self, z): ...
+
+        # The same as A, but with an extra method.
+        class ClassD:
+            def method_one(self, x, y): ...
+
+            def method_two(self, z): ...
+
+            def method_three(self): ...
+
         with pytest.raises(AssertionError, match="methods mismatch"):
             assert_public_method_signature_equality(ClassD, ClassA)
 
     def test_ignore_methods(self):
         """Test when certain methods are ignored in the comparison."""
+
+        class ClassA:
+            def method_one(self, x, y): ...
+
+            def method_two(self, z): ...
+
+        # The same as A, but with an extra method.
+        class ClassD:
+            def method_one(self, x, y): ...
+
+            def method_two(self, z): ...
+
+            def method_three(self): ...
+
         assert_public_method_signature_equality(
             ClassA, ClassD, ignored_methods=["method_three"]
         )
 
     def test_ignore_private_methods(self):
         """Test that extra private methods are ignored."""
+
+        class ClassA:
+            def method_one(self, x, y): ...
+
+            def method_two(self, z): ...
+
+        # The same as A, but with a private method.
+        class ClassE:
+            def method_one(self, x, y): ...
+
+            def method_two(self, z): ...
+
+            def _private_method(self): ...
+
         assert_public_method_signature_equality(ClassA, ClassE)
-
-
-#####################################################################

--- a/tests/verification/utils.py
+++ b/tests/verification/utils.py
@@ -1,3 +1,6 @@
+import inspect
+
+
 def assert_deep_type_equality(fake, real):
     """
     Do two objects have the same types, compared deeply?
@@ -27,3 +30,26 @@ def assert_deep_type_equality(fake, real):
 
         if isinstance(value, dict):
             assert_deep_type_equality(fake[key], real[key])
+
+
+def _get_public_method_signatures(cls, ignored_methods):
+    return {
+        name: inspect.signature(method)
+        for name, method in inspect.getmembers(cls, predicate=inspect.isfunction)
+        if not name.startswith("_") and name not in ignored_methods
+    }
+
+
+def assert_public_method_signature_equality(first, second, ignored_methods=None):
+    """Do two objects have the same public methods and signatures?"""
+    if not ignored_methods:
+        ignored_methods = []
+    first_methods = _get_public_method_signatures(first, ignored_methods)
+    second_methods = _get_public_method_signatures(second, ignored_methods)
+
+    assert set(first_methods) == set(second_methods), "methods mismatch"
+
+    # Check if every public method of the first class is in the second class
+    # with the same signature.
+    for name, sig in first_methods.items():
+        assert second_methods[name] == sig, "signature mismatch"

--- a/tests/verification/utils.py
+++ b/tests/verification/utils.py
@@ -1,27 +1,29 @@
-def compare(fake, real):
+def assert_deep_type_equality(fake, real):
     """
-    Compare outputs of Fake* instances to those from API instances
+    Do two objects have the same types, compared deeply?
 
-    Fake API instances return partial, non-real data from the methods they
-    implement.  For tests we haven't found the need to have those responses be
-    real data, but we still what their shape and values to be correct in terms
-    of the API response schemas.  This function checks the correctness of those
-    values.
+    Fake API instances return dummy data from the methods they implement.  We
+    want to be able to validate that at least the returned types are the same.
+
+    For example, if `fake` is a list, is `real` a list, and do the
+    corresponding elements of those lists also have the same types?
+
+    Works for str, int, list, dict, recursively. These are currently the types
+    we expect the relevant API endpoints to return.
     """
 
     assert type(fake) is type(real)
 
     if isinstance(fake, list):
         for x, y in zip(fake, real):
-            compare(x, y)
+            assert_deep_type_equality(x, y)
         return
 
     if isinstance(fake, str | int):
         return
 
     for key, value in fake.items():
-        assert key in real
-        assert isinstance(value, type(real[key]))
+        assert key in real and isinstance(value, type(real[key]))
 
         if isinstance(value, dict):
-            compare(fake[key], real[key])
+            assert_deep_type_equality(fake[key], real[key])


### PR DESCRIPTION
Fixes #4635.

This standardizes error handling across views that use the GitHub API by transforming common connection/request-related exceptions into subclasses of `GitHubError`. As a result, views can now catch these exceptions consistently without depending on the internal details of `github.py`.

Views previously catching various `requests` exceptions are now updated to handle `GitHubError`, providing the same improvement applied in #4591 to one particular case.

Updating all API clients is substantial and should likely be tracked as a separate issue.

I introduced an additional fake API that raises such errors and changed tests to use it instead of each test ad-hoc defining their own. This is more consistent and less duplication.

I would further like to:

* Make the fakes into fixtures like `github_api`.
* Move `delete_repo` into test code as it's only used there and has pragma: no cover applied.

But have run out of time for now.