### PR TITLE
Remove inaccessible `ValidationError`

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -175,11 +175,6 @@ class WorkspaceCreateForm(forms.Form):
             msg = "Unknown repo, please reload the page and try again"
             raise forms.ValidationError(msg)
 
-        # normalise branch names so we can do a case insensitive match
-        branches = [b.lower() for b in repo["branches"]]
-        if branch.lower() not in branches:
-            raise forms.ValidationError(f'Unknown branch "{branch}"')
-
     def clean_name(self):
         name = self.cleaned_data["name"].lower()
 

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -213,12 +213,12 @@ def test_workspacecreateform_unknown_branch_validation_fails():
             "branches": ["test-branch"],
         }
     ]
-    form = WorkspaceCreateForm(repos_with_branches)
-    form.cleaned_data = {
+    data = {
         "name": "test",
         "repo": "http://example.com/derp/test-repo",
         "branch": "unknown-branch",
     }
+    form = WorkspaceCreateForm(repos_with_branches, data)
 
     assert not form.is_valid()
 

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -217,6 +217,7 @@ def test_workspacecreateform_unknown_branch_validation_fails():
         "name": "test",
         "repo": "http://example.com/derp/test-repo",
         "branch": "unknown-branch",
+        "purpose": "For testing",
     }
     form = WorkspaceCreateForm(repos_with_branches, data)
 

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -222,6 +222,7 @@ def test_workspacecreateform_unknown_branch_validation_fails():
     form = WorkspaceCreateForm(repos_with_branches, data)
 
     assert not form.is_valid()
+    assert "branch" in form.errors
 
 
 def test_workspacecreateform_unknown_repo_validation_fails():

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -220,10 +220,7 @@ def test_workspacecreateform_unknown_branch_validation_fails():
         "branch": "unknown-branch",
     }
 
-    with pytest.raises(ValidationError) as e:
-        form.clean()
-
-    assert e.value.message.startswith("Unknown branch")
+    assert not form.is_valid()
 
 
 def test_workspacecreateform_unknown_repo_validation_fails():


### PR DESCRIPTION
`WorkspaceCreateForm.branch` is a `ChoiceField`, meaning that its `validate` method, which validates that the input is in its `choices` property, is called before its `clean` method. Consequently, unless its `clean` method is called directly, the `ValidationError` is inaccessible.

To put that another way, the `ValidationError` is inaccessible because it's raised by `Form.clean()`, but validation failed at `Field.validate()`. Django's [Form and field validation](https://docs.djangoproject.com/en/5.1/ref/forms/validation/) page would benefit from a diagram. Essentially:

1. `Field.clean()`
    1. `Field.to_python()`
    1. `Field.validate()`
    1. `Field.run_validators()`
1. `Form.clean_<fieldname>()`
2. `Form.clean()`

I'd suggest working backwards through this PRs commits.