### PR TITLE
Filter by global roles

### DIFF
--- a/jobserver/authorization/global_roles.py
+++ b/jobserver/authorization/global_roles.py
@@ -1,0 +1,10 @@
+from ..models import User
+from .utils import roles_for
+
+
+# A global role can be assigned to a User independently of ProjectMembership.
+# It either does not relate to Projects or grants permissions across ALL projects.
+
+GLOBAL_ROLES = roles_for(User)
+
+GLOBAL_ROLE_NAMES = [role.__name__ for role in GLOBAL_ROLES]

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -1,5 +1,3 @@
-import inspect
-
 import structlog
 from django.core.exceptions import FieldError
 from django.db import transaction
@@ -14,9 +12,10 @@ from social_django.models import UserSocialAuth
 from interactive.commands import create_user
 from interactive.emails import send_welcome_email
 from jobserver.auditing.presenters.lookup import get_presenter
-from jobserver.authorization import permissions, roles
+from jobserver.authorization import permissions
 from jobserver.authorization.decorators import require_permission
 from jobserver.authorization.forms import RolesForm
+from jobserver.authorization.global_roles import GLOBAL_ROLE_NAMES
 from jobserver.authorization.utils import roles_for, strings_to_roles
 from jobserver.commands import users
 from jobserver.models import (
@@ -243,14 +242,12 @@ class UserList(ListView):
     queryset = User.objects.prefetch_related("project_memberships", "org_memberships")
 
     def get_context_data(self, **kwargs):
-        all_roles = [name for name, value in inspect.getmembers(roles, inspect.isclass)]
-
         return super().get_context_data(**kwargs) | {
             "backends": Backend.objects.order_by("slug"),
             "missing_names": ["backend", "org", "project"],
             "orgs": Org.objects.order_by("name"),
             "q": self.request.GET.get("q", ""),
-            "roles": all_roles,
+            "roles": GLOBAL_ROLE_NAMES,
         }
 
     def get_queryset(self):

--- a/tests/unit/jobserver/authorization/test_global_roles.py
+++ b/tests/unit/jobserver/authorization/test_global_roles.py
@@ -1,0 +1,15 @@
+from jobserver.authorization.global_roles import GLOBAL_ROLE_NAMES
+
+
+def test_global_role_names():
+    assert set(GLOBAL_ROLE_NAMES) & set(
+        [
+            "DeploymentAdministrator",
+            "InteractiveReporter",
+            "OutputChecker",
+            "OutputPublisher",
+            "ProjectCollaborator",
+            "SignOffRepoWithOutputs",
+            "StaffAreaAdministrator",
+        ]
+    )


### PR DESCRIPTION
Fixes #4632

Previously the Users page in the Staff Area had a "Filter by global roles" option which displayed all roles rather than just globally assignable roles. This commit adds a `global_roles` module so that the view does not need to know the details of the implementation.