### PR TITLE
Remove unreachable `WorkspaceCreateForm` validation

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -167,14 +167,6 @@ class WorkspaceCreateForm(forms.Form):
         if not (repo_url and branch):  # pragma: no cover
             return
 
-        repo = next(
-            (r for r in self.repos_with_branches if r["url"] == repo_url),
-            None,
-        )
-        if repo is None:
-            msg = "Unknown repo, please reload the page and try again"
-            raise forms.ValidationError(msg)
-
     def clean_name(self):
         name = self.cleaned_data["name"].lower()
 

--- a/tests/unit/jobserver/test_forms.py
+++ b/tests/unit/jobserver/test_forms.py
@@ -225,8 +225,8 @@ def test_workspacecreateform_unknown_branch_validation_fails():
     assert "branch" in form.errors
 
 
-def test_workspacecreateform_unknown_repo_validation_fails():
-    """When the form cleaned_data has an unknown repo, validation fails."""
+def test_workspacecreateform_unknown_repo_creation_fails():
+    """When a bound form's data has an unknown repo, form creation fails."""
     repos_with_branches = [
         {
             "name": "test-repo",
@@ -234,17 +234,16 @@ def test_workspacecreateform_unknown_repo_validation_fails():
             "branches": ["test-branch"],
         }
     ]
-    form = WorkspaceCreateForm(repos_with_branches)
-    form.cleaned_data = {
+    data = {
         "name": "test",
         "repo": "unknown-repo",
         "branch": "test-branch",
     }
 
     with pytest.raises(ValidationError) as e:
-        form.clean()
+        WorkspaceCreateForm(repos_with_branches, data)
 
-    assert e.value.message.startswith("Unknown repo")
+    assert e.value.message.startswith("No matching repos")
 
 
 def test_workspacecreateform_duplicate_name_validation_fails():


### PR DESCRIPTION
Inspired by #4725, this PR removes more unreachable validation code in `WorkspaceCreateForm`.

The validation in question is already covered by identical checks in `__init__`, making it redundant and unreachable during the form’s normal lifecycle.

The previous test accessed it by creating an unbound form (without a `data` parameter) and then manually altering `cleaned_data` before calling `clean` directly. That's not a reasonable form lifecycle. An unbound form shouldn't invoke `clean`, nor should it be 'converted' to bound by adjusting variables post-instantiation. `cleaned_data` is public for reading purposes, not writing. Code that uses this form would not be able to reach these lines of code without being unreasonable.