### PR TITLE
Upgrade `whitenoise` from 6.3.0 to 6.8.2

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -36,5 +36,7 @@ structlog
 # 2.1.0 appears to be causing some problems with exporting
 # https://github.com/opensafely-core/job-server/issues/3955
 urllib3<=2.2.3
-whitenoise[brotli]
+# Serves static files. Dependabot wasn't updating past 6.3.0 for
+# unclear reasons, and we want fix #612 from 6.8.0.
+whitenoise[brotli]>=6.8.0
 xkcdpass

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -920,9 +920,9 @@ urllib3==2.2.3 \
     #   -r requirements.prod.in
     #   requests
     #   sentry-sdk
-whitenoise==6.3.0 \
-    --hash=sha256:cf8ecf56d86ba1c734fdb5ef6127312e39e92ad5947fef9033dc9e43ba2777d9 \
-    --hash=sha256:fe0af31504ab08faa1ec7fc02845432096e40cc1b27e6a7747263d7b30fb51fa
+whitenoise==6.8.2 \
+    --hash=sha256:486bd7267a375fa9650b136daaec156ac572971acc8bf99add90817a530dd1d4 \
+    --hash=sha256:df12dce147a043d1956d81d288c6f0044147c6d2ab9726e5772ac50fb45d2280
     # via -r requirements.prod.in
 wrapt==1.16.0 \
     --hash=sha256:0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc \


### PR DESCRIPTION
We suspect [whitenoise PR #612](https://github.com/evansd/whitenoise/pull/612) may resolve an issue with the database connection intermittently and randomly closing during [requests observed in production](https://ebm-datalab.sentry.io/issues/?project=5443358&query=%22the%20connection%20is%20closed%22&referrer=issue-list&statsPeriod=90d).

For some reason, Dependabot did not automatically make this upgrade, but it appears to work without issue in local testing.

Investigation done:

- I didn't see anything obvious in requirements*.txt or pyproject.toml or dependabot.yaml explicitly limiting the version update. I don't see a *.lock file.
- Dependabot seemingly did manage to raise this PR to update Airlock from 6.6 to 6.7 but the change was made manually along with many others in Upgrade all the things #422 for reasons that aren't clear from the PR. No obvious changes between Airlock's dependabot.yaml / requirements.txts and Job Server's.
  - opensafely-github-bot made a 6.8 upgrade. 
- Attempting to prompt an update to a prod set of requirements via various routes locally seems to work without issue.
- I don't know how to debug/understand the failure to bump. This GitHub doc talks about Dependabot logs but they didn't seem useful for this.
- I checked packages that haven't had a version bump since 2023-06, then checked if there were updates available. There are a few missing bumps, but I haven't gone into detail to understand if there are conflicting dependencies or other reasons for the lack of updates.
  - environs hasn't gone from 9.5.0 to 11.1.0
  - django-anymail hasn't gone from 9.0 to 12.0
  - requests-oauthlib hasn't gone from 1.3.1 to 2.0.0
  - pycparser hasn't gone from 2.21 to 2.22
- I started trying to get dependabot running locally to debug it but that seemed like too much work.

Overall I would probably rather we try opensafely-github-bot than do further investigation into why Dependabot isn't updating some packages, if we think that's the way we're going anyway.