### PR TITLE
Remove Python distutils

### DIFF
--- a/docker/dependencies.txt
+++ b/docker/dependencies.txt
@@ -2,6 +2,5 @@
 git
 postgresql-client
 python3.12
-python3.12-distutils
 python3.12-venv
 tzdata


### PR DESCRIPTION
The distutils module has been deprecated for some time and was removed in Python3.12[^1]. A recent update to deadsnakes means that the package is no longer available at all and is breaking the build. Removing the package doesn't appear to break anything and it's likely that everything has already been moved over to setup tools.

[^1]: https://peps.python.org/pep-0632/#migration-advice