### PR TITLE
Increase bot crawl delay

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-Crawl-delay: 1
+Crawl-delay: 2
 Disallow: /api/
 Disallow: /applications/
 Disallow: /complete/


### PR DESCRIPTION
Tell bots to hit our site no more than one every two seconds.

We're currently seeing higher than normal traffic on the website and we think that may be due to a high number of bots. This should reduce the impact of any bot traffic and reduce the load on our server.