### PR TITLE
Allow release file reuploads to different workspaces

### DIFF
--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -69,23 +69,24 @@ def build_outputs_zip(release_files, url_builder_func):
     return in_memory_zf
 
 
-def check_not_already_uploaded(filename, filehash, backend):
-    """Check if this filename/filehash combination has been uploaded before."""
+def check_not_already_uploaded(workspace, filename, filehash, backend):
+    """Check if this workspace/filename/filehash combination has been uploaded before."""
     duplicate = ReleaseFile.objects.filter(
         release__backend=backend,
+        workspace=workspace,
         name=filename,
         filehash=filehash,
     )
     if duplicate.exists():
         raise ReleaseFileAlreadyExists(
-            f"This version of '{filename}' has already been uploaded from backend '{backend.slug}'"
+            f"This version of '{filename}' in workspace {workspace} has already been uploaded from backend '{backend.slug}'"
         )
 
 
 @transaction.atomic
 def create_release(workspace, backend, created_by, requested_files, **kwargs):
     for f in requested_files:
-        check_not_already_uploaded(f["name"], f["sha256"], backend)
+        check_not_already_uploaded(workspace, f["name"], f["sha256"], backend)
 
     release = Release.objects.create(
         workspace=workspace,

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -818,10 +818,10 @@ def test_releaseworkspaceapi_post_create_release_with_oversized_file(
 
 def test_releaseworkspaceapi_post_release_already_exists(api_rf, project_membership):
     user = UserFactory(roles=[OutputChecker])
-
     release = ReleaseFactory()
     rfile = ReleaseFileFactory(
         release=release,
+        workspace=release.workspace,
         created_by=user,
         name="file.txt",
         filehash="hash",


### PR DESCRIPTION
Reuploads of the same release file (with same filename and same content) are prohibited. However, a file  with the same name/content may legitimately be reuploaded to a different workspace. Update the check for already uploaded files to check for the same filename/content within the target workspace only.

See [slack thread](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1736855700176509)