### PR TITLE
Revert urllib3 back to v1

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -35,7 +35,7 @@ social-auth-core
 structlog
 # 2.1.0 appears to be causing some problems with exporting
 # https://github.com/opensafely-core/job-server/issues/3955
-urllib3<=2.3.0
+urllib3~=1.26
 # Serves static files. Dependabot wasn't updating past 6.3.0 for
 # unclear reasons, and we want fix #612 from 6.8.0.
 whitenoise[brotli]>=6.8.0

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -919,9 +919,9 @@ typing-extensions==4.12.2 \
     #   opentelemetry-sdk
     #   psycopg
     #   slippers
-urllib3==2.3.0 \
-    --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
-    --hash=sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d
+urllib3==1.26.20 \
+    --hash=sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e \
+    --hash=sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32
     # via
     #   -r requirements.prod.in
     #   requests


### PR DESCRIPTION
This is the latest v1 release.

See #4715. Hopefully this stops the Sentry issue described there from appearing again. This is a short-to-medium term sticking plaster as at some point we'll have to switch to v2.