### PR TITLE
Allow release reuploads

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -302,12 +302,9 @@ class ReleaseWorkspaceAPI(APIView):
         metadata = serializer.validated_data["metadata"]
         release_id = metadata.pop("airlock_id", None)
 
-        try:
-            release = releases.create_release(
-                workspace, backend, user, files, metadata=metadata, id=release_id
-            )
-        except releases.ReleaseFileAlreadyExists as exc:
-            raise ValidationError({"detail": str(exc)})
+        release = releases.create_release(
+            workspace, backend, user, files, metadata=metadata, id=release_id
+        )
 
         slacks.notify_release_created(release)
 

--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -69,25 +69,8 @@ def build_outputs_zip(release_files, url_builder_func):
     return in_memory_zf
 
 
-def check_not_already_uploaded(workspace, filename, filehash, backend):
-    """Check if this workspace/filename/filehash combination has been uploaded before."""
-    duplicate = ReleaseFile.objects.filter(
-        release__backend=backend,
-        workspace=workspace,
-        name=filename,
-        filehash=filehash,
-    )
-    if duplicate.exists():
-        raise ReleaseFileAlreadyExists(
-            f"This version of '{filename}' in workspace {workspace} has already been uploaded from backend '{backend.slug}'"
-        )
-
-
 @transaction.atomic
 def create_release(workspace, backend, created_by, requested_files, **kwargs):
-    for f in requested_files:
-        check_not_already_uploaded(workspace, f["name"], f["sha256"], backend)
-
     release = Release.objects.create(
         workspace=workspace,
         backend=backend,

--- a/tests/unit/jobserver/test_releases.py
+++ b/tests/unit/jobserver/test_releases.py
@@ -114,6 +114,37 @@ def test_create_release_reupload_allowed():
     rfile.size == 4
 
 
+def test_create_release_already_exists():
+    workspace = WorkspaceFactory(name="workspace")
+    rfile = ReleaseFileFactory(workspace=workspace, name="file1.txt", filehash="hash")
+
+    files = [
+        {
+            "name": "file1.txt",
+            "path": "path/to/file1.txt",
+            "url": "",
+            "size": 4,
+            "sha256": "hash",
+            "date": "2022-08-17T13:37Z",
+            "metadata": {},
+        }
+    ]
+
+    release = releases.create_release(
+        workspace,
+        rfile.release.backend,
+        rfile.release.created_by,
+        files,
+    )
+
+    assert release.requested_files == files
+    assert release.files.count() == 1
+
+    rfile = release.files.first()
+    rfile.filehash == "hash"
+    rfile.size == 4
+
+
 def test_create_release_success():
     backend = BackendFactory()
     workspace = WorkspaceFactory()

--- a/tests/unit/jobserver/test_releases.py
+++ b/tests/unit/jobserver/test_releases.py
@@ -83,34 +83,8 @@ def test_build_outputs_zip_with_missing_files(build_release_with_files):
             assert "This file was redacted by" in zipped_contents, zipped_contents
 
 
-def test_create_release_reupload():
+def test_create_release_reupload_allowed():
     workspace = WorkspaceFactory(name="workspace")
-    rfile = ReleaseFileFactory(workspace=workspace, name="file1.txt", filehash="hash")
-
-    files = [
-        {
-            "name": "file1.txt",
-            "path": "path/to/file1.txt",
-            "url": "",
-            "size": 4,
-            "sha256": "hash",
-            "date": "2022-08-17T13:37Z",
-            "metadata": {},
-        }
-    ]
-
-    with pytest.raises(releases.ReleaseFileAlreadyExists):
-        releases.create_release(
-            workspace,
-            rfile.release.backend,
-            rfile.release.created_by,
-            files,
-        )
-
-
-def test_create_release_reupload_to_different_workspace():
-    workspace = WorkspaceFactory(name="workspace")
-    another_workspace = WorkspaceFactory(name="another_workspace")
     rfile = ReleaseFileFactory(workspace=workspace, name="file1.txt", filehash="hash")
 
     files = [
@@ -126,11 +100,12 @@ def test_create_release_reupload_to_different_workspace():
     ]
 
     release = releases.create_release(
-        another_workspace,
+        workspace,
         rfile.release.backend,
         rfile.release.created_by,
         files,
     )
+
     assert release.requested_files == files
     assert release.files.count() == 1
 


### PR DESCRIPTION
Airlock prevents users from adding an already released (via Airlock) file to a release request. This avoids unnecessary output-checking work re-reviewing files that have already been released. We may want to revisit that on Airlock later, but not just now.

However, currently Airlock only knows about files released via Airlock. If a file has been released pre-Airlock, Airlock will allow it to be added to the release request, and the job-server's check for already uploaded files prevents the release from being created.

This PR removes the check for already uploaded files, and also changes the `create_request` to a `get_or_create_request`, so we return an existing release with the same data if one matches.  It allows for the endpoint to be called by a different user (in the event that a release is created by one output-checker, and then a re-release attempt is made by another
output-checker). This can happen if not all files successfully upload from Airlock.

The create_release is wrapped in transaction.atomic, so if we found an existing matching release, we should be able to safely assume that all the request files have already been created.