### PR TITLE
Auto upgrade pipeline

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,29 @@
+name: Update python dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  "0 23 * * *"
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - uses: "opensafely-core/setup-action@v1"
+      with:
+        python-version: "3.12"
+        install-just: true
+
+    - uses: actions/create-github-app-token@v1
+      id: generate-token
+      with:
+        app-id: 1031449  # opensafely-core Create PR app
+        private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+
+    - uses: bennettoxford/update-dependencies-action@v1
+      with:
+        token: ${{ steps.generate-token.outputs.token }}
+        # Note: just update pipeline library for now, as job-server uses dependabot for python upgrades
+        update_command: |
+          just upgrade-pipeline

--- a/justfile
+++ b/justfile
@@ -91,7 +91,6 @@ devenv: prodenv requirements-dev && install-precommit
     $PIP install --no-deps -r requirements.dev.txt
     touch $VIRTUAL_ENV/.dev
 
-
 # ensure precommit is installed
 install-precommit:
     #!/usr/bin/env bash
@@ -110,6 +109,9 @@ upgrade env package="": virtualenv
     test -z "{{ package }}" || opts="--upgrade-package {{ package }}"
     FORCE=true {{ just_executable() }} requirements-{{ env }} $opts
 
+# upgrade our internal pipeline library
+upgrade-pipeline:
+    ./scripts/upgrade-pipeline.sh requirements.prod.in
 
 update-interactive-templates tag="": && prodenv
     #!/usr/bin/env bash

--- a/scripts/upgrade-pipeline.sh
+++ b/scripts/upgrade-pipeline.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu
+
+file=$1
+github_package_url="opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/"
+latest=$(git ls-remote -h --refs --tags --heads https://github.com/opensafely-core/pipeline | grep -o "v20.*$" | sort | tail -1)
+echo "Latest version of pipeline is $latest"
+
+# exit early if we are at the latest version
+if grep -q "$latest" "$file"; then
+    echo "$file already contains latest version"
+    exit
+fi
+
+sed -i "s#$github_package_url.*\.zip#$github_package_url$latest.zip#" "$file"
+echo "Updated $file to pipline $latest"


### PR DESCRIPTION
The internal pipeline library is not published to PyPI, and not tracked by dependabot.

Have been adding tooling to all repos that consume the pipeline library to automate bumping to new versions, as it's tedious and out of date version have caused issues in the past.