### PR TITLE
Use `urllib3` v2

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -448,9 +448,9 @@ tokenize-rt==5.2.0 \
     --hash=sha256:9fe80f8a5c1edad2d3ede0f37481cc0cc1538a2f442c9c2f9e4feacd2792d054 \
     --hash=sha256:b79d41a65cfec71285433511b50271b05da3584a1da144a0752e9c621a285289
     # via django-upgrade
-urllib3==1.26.20 \
-    --hash=sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e \
-    --hash=sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32
+urllib3==2.3.0 \
+    --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
+    --hash=sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d
     # via
     #   -c requirements.prod.txt
     #   requests

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -33,9 +33,6 @@ slippers
 social-auth-app-django
 social-auth-core
 structlog
-# 2.1.0 appears to be causing some problems with exporting
-# https://github.com/opensafely-core/job-server/issues/3955
-urllib3~=1.26
 # Serves static files. Dependabot wasn't updating past 6.3.0 for
 # unclear reasons, and we want fix #612 from 6.8.0.
 whitenoise[brotli]>=6.8.0

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -861,11 +861,10 @@ typing-extensions==4.12.2 \
     #   opentelemetry-sdk
     #   psycopg
     #   slippers
-urllib3==1.26.20 \
-    --hash=sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e \
-    --hash=sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32
+urllib3==2.3.0 \
+    --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
+    --hash=sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d
     # via
-    #   -r requirements.prod.in
     #   requests
     #   sentry-sdk
 whitenoise==6.8.2 \


### PR DESCRIPTION
Fixes #4715.

We reverted to urllib v1 in #4806 to try and stop errors originating from OpenTelemetry's use of `urllib3`, via `requests`.

Apparently these errors did not occur with `urllib3` v1 previously, but that is no longer the case, and we'll have to find another solution to stop the errors, as in #4839.