### PR TITLE
Add copilot data in level4 api, and cleanups

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -585,7 +585,6 @@ def build_level4_user(user):
         if has_permission(user, permissions.unreleased_outputs_view, project=project):
             for workspace in project.workspaces.all().values("name", "is_archived"):
                 workspaces[workspace["name"]] = {
-                    "project": project.name,  # for backwards compatibility with Airlock
                     "project_details": {
                         "name": project.name,
                         "ongoing": project.status in ongoing_project_statuses,

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -567,10 +567,10 @@ class WorkspaceStatusAPI(RetrieveAPIView):
 
 class Level4AuthenticatedUser(serializers.Serializer):
     username = serializers.CharField()
-    fullname = serializers.CharField()
+    fullname = serializers.CharField(default=None, allow_blank=True)
     workspaces = serializers.DictField(default={})
-    output_checker = serializers.BooleanField()
-    staff = serializers.BooleanField()
+    output_checker = serializers.BooleanField(default=False)
+    staff = serializers.BooleanField(default=False)
 
 
 def build_level4_user(user):
@@ -606,8 +606,8 @@ def build_level4_user(user):
             output_checker=has_role(user, OutputChecker),
         )
     )
-    # we must validate this or DRF will refuse to serializer it.
-    level4_user.is_valid()
+    # we must validate this or DRF will refuse to serialize it
+    assert level4_user.is_valid(), level4_user.errors
 
     return level4_user
 

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -28,7 +28,13 @@ from interactive.models import AnalysisRequest
 from interactive.slacks import notify_report_uploaded
 from jobserver import releases, slacks
 from jobserver.api.authentication import get_backend_from_token
-from jobserver.authorization import OutputChecker, has_permission, has_role, permissions
+from jobserver.authorization import (
+    OutputChecker,
+    StaffAreaAdministrator,
+    has_permission,
+    has_role,
+    permissions,
+)
 from jobserver.commands import users
 from jobserver.models import (
     Project,
@@ -621,7 +627,7 @@ def build_level4_user(user):
             # list the explicit workspaces that the user has this permission
             # for.
             output_checker=has_role(user, OutputChecker),
-            staff=False,
+            staff=has_role(user, StaffAreaAdministrator),
         )
     )
     assert level4_user.is_valid(), level4_user.errors

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1764,6 +1764,7 @@ def test_level4tokenauthenticationapi_success(
             },
         },  # should not include workspace3
         "output_checker": False,
+        "staff": False,
     }
 
 
@@ -1810,6 +1811,7 @@ def test_level4tokenauthenticationapi_success_privileged(
             },
         },  # should not include workspace3
         "output_checker": True,
+        "staff": False,
     }
 
 
@@ -1952,6 +1954,7 @@ def test_level4authorisationapi_success(
             },
         },  # should not include workspace3
         "output_checker": False,
+        "staff": False,
     }
 
 

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1763,6 +1763,7 @@ def test_level4tokenauthenticationapi_success(
                 "archived": False,
             },
         },  # should not include workspace3
+        "copiloted_workspaces": {},
         "output_checker": False,
         "staff": False,
     }
@@ -1810,6 +1811,7 @@ def test_level4tokenauthenticationapi_success_privileged(
                 "archived": False,
             },
         },  # should not include workspace3
+        "copiloted_workspaces": {},
         "output_checker": True,
         "staff": False,
     }
@@ -1929,6 +1931,10 @@ def test_level4authorisationapi_success(
     WorkspaceFactory(project=project2)
     project_membership(user=token_login_user, project=project2)
 
+    # another project, where user is the copilot
+    project3 = ProjectFactory(copilot=token_login_user)
+    workspace3 = WorkspaceFactory(project=project3)
+
     backend = token_login_user.backends.first()
     request_data = {"user": token_login_user.username}
     request = api_rf.post(
@@ -1953,6 +1959,12 @@ def test_level4authorisationapi_success(
                 "archived": False,
             },
         },  # should not include workspace3
+        "copiloted_workspaces": {
+            workspace3.name: {
+                "project_details": {"name": project3.name, "ongoing": True},
+                "archived": False,
+            },
+        },
         "output_checker": False,
         "staff": False,
     }

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1755,12 +1755,10 @@ def test_level4tokenauthenticationapi_success(
         "fullname": token_login_user.fullname,
         "workspaces": {
             workspace1.name: {
-                "project": project1.name,
                 "project_details": {"name": project1.name, "ongoing": ongoing},
                 "archived": True,
             },
             workspace2.name: {
-                "project": project1.name,
                 "project_details": {"name": project1.name, "ongoing": ongoing},
                 "archived": False,
             },
@@ -1803,12 +1801,10 @@ def test_level4tokenauthenticationapi_success_privileged(
         "fullname": token_login_user.fullname,
         "workspaces": {
             workspace1.name: {
-                "project": project.name,
                 "project_details": {"name": project.name, "ongoing": True},
                 "archived": False,
             },
             workspace2.name: {
-                "project": project.name,
                 "project_details": {"name": project.name, "ongoing": True},
                 "archived": False,
             },
@@ -1947,12 +1943,10 @@ def test_level4authorisationapi_success(
         "fullname": token_login_user.fullname,
         "workspaces": {
             workspace1.name: {
-                "project": project1.name,
                 "project_details": {"name": project1.name, "ongoing": True},
                 "archived": False,
             },
             workspace2.name: {
-                "project": project1.name,
                 "project_details": {"name": project1.name, "ongoing": True},
                 "archived": False,
             },

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1813,7 +1813,7 @@ def test_level4tokenauthenticationapi_success_privileged(
         },  # should not include workspace3
         "copiloted_workspaces": {},
         "output_checker": True,
-        "staff": False,
+        "staff": True,
     }
 
 


### PR DESCRIPTION
This adds copiloted workspace data, so we can use that in airlock.

It also cleans up a few small issues, and completes the implementation of the staff field.

Fixes #4837 