### PR TITLE
Remove staff information from level 4 auth API

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -30,7 +30,6 @@ from jobserver import releases, slacks
 from jobserver.api.authentication import get_backend_from_token
 from jobserver.authorization import (
     OutputChecker,
-    StaffAreaAdministrator,
     has_permission,
     has_role,
     permissions,
@@ -577,7 +576,6 @@ class Level4AuthenticatedUser(serializers.Serializer):
     workspaces = serializers.DictField(default={})
     copiloted_workspaces = serializers.DictField(default={})
     output_checker = serializers.BooleanField(default=False)
-    staff = serializers.BooleanField(default=False)
 
 
 ONGOING_PROJECT_STATUSES = {
@@ -627,7 +625,6 @@ def build_level4_user(user):
             # list the explicit workspaces that the user has this permission
             # for.
             output_checker=has_role(user, OutputChecker),
-            staff=has_role(user, StaffAreaAdministrator),
         )
     )
     assert level4_user.is_valid(), level4_user.errors

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -27,7 +27,6 @@ from jobserver.api.releases import (
 from jobserver.authorization import (
     OutputChecker,
     ProjectCollaborator,
-    StaffAreaAdministrator,
     permissions,
 )
 from jobserver.commands.users import generate_login_token
@@ -1765,7 +1764,6 @@ def test_level4tokenauthenticationapi_success(
         },  # should not include workspace3
         "copiloted_workspaces": {},
         "output_checker": False,
-        "staff": False,
     }
 
 
@@ -1774,7 +1772,6 @@ def test_level4tokenauthenticationapi_success_privileged(
 ):
     # enable privileges for user
     token_login_user.roles.append(OutputChecker)
-    token_login_user.roles.append(StaffAreaAdministrator)
     token_login_user.save()
 
     project = ProjectFactory()
@@ -1813,7 +1810,6 @@ def test_level4tokenauthenticationapi_success_privileged(
         },  # should not include workspace3
         "copiloted_workspaces": {},
         "output_checker": True,
-        "staff": True,
     }
 
 
@@ -1966,7 +1962,6 @@ def test_level4authorisationapi_success(
             },
         },
         "output_checker": False,
-        "staff": False,
     }
 
 


### PR DESCRIPTION
It is currently unclear how we are going to configure this, but it is definitely not related to StaffAreaAdministrator.

Removing it to avoid potential footguns.