### PR TITLE
Send notifications for Airlock approved events

### DIFF
--- a/airlock/emails.py
+++ b/airlock/emails.py
@@ -5,25 +5,39 @@ from incuna_mail import send
 from jobserver.models import Release
 
 
-def get_email_context(airlock_event):
+def get_email_context(airlock_event, include_release_url=False):
     # The first update is the event itself, don't include this in emails
-    updates = airlock_event.describe_updates()[1:]
-    return {
+    event_descriptions = airlock_event.describe_updates()
+    updates = event_descriptions[1:]
+
+    context = {
         "release_request_id": airlock_event.release_request_id,
         "request_author": airlock_event.request_author.name,
         "workspace": airlock_event.workspace.name,
         "updates": updates,
     }
+    if include_release_url:
+        release = Release.objects.get(id=airlock_event.release_request_id)
+        f = furl(settings.BASE_URL)
+        f.path = release.get_absolute_url()
+        context["url"] = f.url
+    return context
+
+
+def send_request_approved_email(airlock_event):
+    context = get_email_context(airlock_event, include_release_url=True)
+    send(
+        to=airlock_event.request_author.email,
+        sender="notifications@jobs.opensafely.org",
+        subject=f"Release request approved for workspace {airlock_event.workspace.name}",
+        template_name="airlock/emails/request_approved.txt",
+        html_template_name="airlock/emails/request_approved.html",
+        context=context,
+    )
 
 
 def send_request_released_email(airlock_event):
-    release = Release.objects.get(id=airlock_event.release_request_id)
-    f = furl(settings.BASE_URL)
-    f.path = release.get_absolute_url()
-
-    context = get_email_context(airlock_event)
-    context["url"] = f.url
-
+    context = get_email_context(airlock_event, include_release_url=True)
     send(
         to=airlock_event.request_author.email,
         sender="notifications@jobs.opensafely.org",

--- a/templates/airlock/emails/request_approved.html
+++ b/templates/airlock/emails/request_approved.html
@@ -1,0 +1,11 @@
+{% extends "emails/base.html" %}
+
+{% block content %}
+<p>Dear {{ request_author }},</p>
+<p>Your release request for workspace {{ workspace }} has been approved.</p>
+<p>Your files will be uploaded <a href="{{ url }}">here</a>.
+    You will receive a notification when file uploads are complete.</p>
+
+{% include "airlock/emails/includes/updates.html" %}
+
+{% endblock content %}

--- a/templates/airlock/emails/request_approved.txt
+++ b/templates/airlock/emails/request_approved.txt
@@ -1,0 +1,14 @@
+{% extends "emails/base.txt" %}
+
+{% block content %}
+
+Dear {{ request_author }},
+
+Your release request for workspace {{ workspace }} has been approved.
+Your files will be uploaded here:
+    {{ url }}
+
+You will receive a notification when file uploads are complete.
+{% include "airlock/emails/includes/updates.txt" %}
+
+{% endblock content %}

--- a/templates/airlock/emails/request_released.txt
+++ b/templates/airlock/emails/request_released.txt
@@ -7,7 +7,8 @@ Dear {{ request_author }},
 Your files for workspace {{ workspace }} have been released.
 {% include "airlock/emails/includes/updates.txt" %}
 
-You can now view your <a href="{{ url }}">released files here.
+You can now view your released files here:
 
     {{ url }}
+
 {% endblock content %}

--- a/tests/unit/airlock/test_emails.py
+++ b/tests/unit/airlock/test_emails.py
@@ -2,6 +2,7 @@ import pytest
 from django.core import mail
 
 from airlock.emails import (
+    send_request_approved_email,
     send_request_rejected_email,
     send_request_released_email,
     send_request_returned_email,
@@ -69,6 +70,20 @@ def test_rejected_email(airlock_event, updates, expected_email_updates):
     event = airlock_event(EventType.REQUEST_REJECTED, updates=updates)
     send_request_rejected_email(event)
     assert_email(event, "Release request rejected", expected_email_updates)
+
+
+@pytest.mark.parametrize(
+    "updates,expected_email_updates",
+    [
+        ([], []),
+        ([{"update": "comment added", "user": "test"}], ["comment added by user test"]),
+    ],
+)
+def test_approved_email(airlock_event, updates, expected_email_updates):
+    ReleaseFactory(id="request-id")
+    event = airlock_event(EventType.REQUEST_APPROVED, updates=updates)
+    send_request_approved_email(event)
+    assert_email(event, "Release request approved", expected_email_updates)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -16,28 +16,17 @@ from tests.fakes import FakeGitHubAPI, FakeGitHubAPIWithErrors
 @pytest.mark.parametrize(
     "event_type,author_is_user,updates,email_sent,slack_notified",
     [
-        # No action for request_approved
-        ("request_approved", True, None, False, False),
-        # author and user are different; emails are sent for rejected/released/returned
+        # emails are sent for approved/rejected/released/returned
         # slack notifications are sent for resubmitted/partially_reviewed/reviewed
-        ("request_submitted", False, None, False, False),
+        ("request_submitted", True, None, False, False),
         ("request_rejected", False, None, True, False),
-        ("request_withdrawn", False, None, False, False),
+        ("request_withdrawn", True, None, False, False),
+        ("request_approved", False, None, True, True),
         ("request_released", False, None, True, False),
         ("request_returned", False, None, True, False),
-        ("request_resubmitted", False, None, False, True),
+        ("request_resubmitted", True, None, False, True),
         ("request_partially_reviewed", False, None, False, True),
         ("request_reviewed", False, None, False, True),
-        # author and user are the same; emails are still sent for rejected/released/returned
-        # slack notifications are still sent for resubmitted/partially_reviewed/reviewed
-        ("request_submitted", True, None, False, False),
-        ("request_rejected", True, None, True, False),
-        ("request_withdrawn", True, None, False, False),
-        ("request_released", True, None, True, False),
-        ("request_returned", True, None, True, False),
-        ("request_resubmitted", True, None, False, True),
-        ("request_partially_reviewed", True, None, False, True),
-        ("request_reviewed", True, None, False, True),
     ],
 )
 @patch("airlock.views._get_github_api", FakeGitHubAPI)
@@ -60,7 +49,7 @@ def test_api_post_release_request_post_by_non_author(
     backend = BackendFactory(auth_token="test", name="test-backend")
     BackendMembershipFactory(backend=backend, user=user)
 
-    if event_type == "request_released":
+    if event_type in ["request_approved", "request_released"]:
         ReleaseFactory(id="01AAA1AAAAAAA1AAAAA11A1AAA")
 
     data = {


### PR DESCRIPTION
Fixes #4855 

Airlock now releases files asynchronously, so an Approved request means that the release request has been approved and files will be uploaded in due course. Only when the last file is uploaded will the request change to Released. It therefore makes sense to send users notifications of the change of status to Approved.

This sends an email to the request author, adds a comment to the GitHub issue, and posts a notification to slack about the status change.