### PR TITLE
Notify slack for returned release requests

### DIFF
--- a/airlock/views.py
+++ b/airlock/views.py
@@ -183,7 +183,7 @@ EVENT_NOTIFICATIONS = {
     EventType.REQUEST_APPROVED: [email_author, update_issue_and_slack],
     EventType.REQUEST_RELEASED: [email_author, close_issue],
     EventType.REQUEST_REJECTED: [email_author, close_issue],
-    EventType.REQUEST_RETURNED: [email_author, update_issue],
+    EventType.REQUEST_RETURNED: [email_author, update_issue_and_slack],
     EventType.REQUEST_RESUBMITTED: [update_issue_and_slack],
     EventType.REQUEST_PARTIALLY_REVIEWED: [update_issue_and_slack],
     EventType.REQUEST_REVIEWED: [update_issue_and_slack],

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -21,16 +21,22 @@ from tests.fakes import FakeGitHubAPI, FakeGitHubAPIWithErrors
         ("request_submitted", True, None, False, False),
         ("request_rejected", False, None, True, False),
         ("request_withdrawn", True, None, False, False),
-        ("request_approved", False, None, True, True),
+        (
+            "request_approved",
+            False,
+            [{"update": "3 files will be uploaded"}],
+            True,
+            True,
+        ),
         ("request_released", False, None, True, False),
-        ("request_returned", False, None, True, False),
+        ("request_returned", False, None, True, True),
         ("request_resubmitted", True, None, False, True),
         ("request_partially_reviewed", False, None, False, True),
         ("request_reviewed", False, None, False, True),
     ],
 )
 @patch("airlock.views._get_github_api", FakeGitHubAPI)
-def test_api_post_release_request_post_by_non_author(
+def test_api_post_release_request_event(
     api_rf,
     mailoutbox,
     slack_messages,


### PR DESCRIPTION
Some updates to airlock notifications:

1) updates slack when a request is returned. 
Previously we didn't notifiy slack for returned requests, on the basis that the author gets emailed anyway, and the output-checker
already know that they returned it. However, it's useful to see the progress of a request if all notifications come to slack, either via issue creation/close or via an explicit post to slack. Currently the returned request is the only status change that doesn't update slack, so other output checkers would need to go to the issue or to L4 in order to check if someone else has returned it. This is more important now that a request can be returned before it's been fully approved.

2) Add tests for custom updates to come with the approved notification events from Airlock. We weren't using these previously (they were initially there for updates to the group comments/context/controls, which we no longer send notification for), but it will be useful for context e.g. how many files are scheduled to be uploaded