### PR TITLE
Remove homepage analysis requests card

### DIFF
--- a/jobserver/views/index.py
+++ b/jobserver/views/index.py
@@ -26,10 +26,6 @@ class Index(View):
                 },
             )
 
-        analysis_requests = self.request.user.analysis_requests.select_related(
-            "project"
-        ).order_by("-created_at")
-
         applications = self.request.user.applications.order_by("-created_at")
 
         projects = [
@@ -62,7 +58,6 @@ class Index(View):
 
         context = {
             "all_job_requests": job_requests[:10],
-            "analysis_requests": analysis_requests[:5],
             "applications": applications[:5],
             "counts": counts,
             "job_requests": user_job_requests[:5],

--- a/templates/index-authenticated.html
+++ b/templates/index-authenticated.html
@@ -59,26 +59,6 @@
 </div>
 
 <div class="grid gap-4 lg:grid-cols-2 mb-6">
-  {% if user.is_interactive_only or analysis_requests %}
-    {% #card title="Analysis requests" subtitle="OpenSAFELY Interactive analysis requests you have created" %}
-      {% #list_group %}
-        {% for analysis_request in analysis_requests %}
-          {% #list_group_item href=analysis_request.get_absolute_url %}
-            {{ analysis_request.title }}
-            {% pill class="ml-2" text=analysis_request.status variant=analysis_request.status|match:"pending:info,running:primary,awaiting report:info,succeeded:success,failed:danger"|default:"info" %}
-          {% /list_group_item %}
-        {% empty %}
-          {% list_group_empty icon=True title="No requests" description="You have not created any analysis requests" %}
-        {% endfor %}
-      {% /list_group %}
-
-      {# {% #card_footer no_container=True %} #}
-        {# {% url "interactive:list" as request_list_url %} #}
-        {# {% link href=request_list_url text="View all requests →" %} #}
-      {# {% /card_footer %} #}
-    {% /card %}
-  {% endif %}
-
   {% if not user.is_interactive_only %}
     {% #card title="Job requests" subtitle="Your most recent job requests" %}
       {% #list_group %}

--- a/tests/unit/jobserver/views/test_index.py
+++ b/tests/unit/jobserver/views/test_index.py
@@ -3,7 +3,6 @@ from django.contrib.auth.models import AnonymousUser
 from jobserver.views.index import Index
 
 from ....factories import (
-    AnalysisRequestFactory,
     JobRequestFactory,
     ProjectFactory,
     UserFactory,
@@ -22,8 +21,6 @@ def test_index_authenticated(
 
     complete_application.created_by = user
     complete_application.save()
-
-    AnalysisRequestFactory(created_by=user)
 
     project1 = ProjectFactory()
     project_membership(project=project1, user=user)
@@ -50,11 +47,10 @@ def test_index_authenticated(
     request = rf.get("/")
     request.user = user
 
-    with django_assert_num_queries(15):
+    with django_assert_num_queries(14):
         response = Index.as_view()(request)
 
         assert len(response.context_data["all_job_requests"]) == 10
-        assert len(response.context_data["analysis_requests"]) == 1
         assert len(response.context_data["applications"]) == 1
         assert len(response.context_data["job_requests"]) == 2
         assert len(response.context_data["projects"]) == 5
@@ -71,7 +67,7 @@ def test_index_authenticated_client(client, django_assert_num_queries):
     user = UserFactory()
     JobRequestFactory.create_batch(10)
 
-    with django_assert_num_queries(42):
+    with django_assert_num_queries(41):
         client.force_login(user)
         response = client.get("/")
         assert response.status_code == 200


### PR DESCRIPTION
Closes #4871.

Confirmed that previous interactive analysis requests can still be seen in the event log.
