### PR TITLE
Add `justfile` recipe: run Django management command

### DIFF
--- a/justfile
+++ b/justfile
@@ -118,6 +118,9 @@ upgrade-pipeline: && requirements-prod
 run-telemetry: devenv
     $BIN/opentelemetry-instrument $BIN/python manage.py runserver --noreload
 
+# run a Django management command
+manage command *args:
+    $BIN/python manage.py {{command}} {{args}}
 
 test-ci *args: assets
     #!/bin/bash


### PR DESCRIPTION
I regularly find myself wanting to run a Django management command with the devenv's environment with something like `.venv/bin/python3.12 manage.py command`. Let's add a recipe to make that slightly easier.  I was going to add a `dbshell` management command, then realized a general-purpose `manage` command is probably more useful than adding separate recipes.