### PR TITLE
Replace use of `INTERACTIVE_GITHUB_TOKEN`

### DIFF
--- a/services/sentry.py
+++ b/services/sentry.py
@@ -73,7 +73,6 @@ def parse(data):
         "GITHUB_TOKEN",
         "GITHUB_TOKEN_TESTING",
         "GITHUB_WRITEABLE_TOKEN",
-        "INTERACTIVE_GITHUB_TOKEN",
         "JOBSERVER_GITHUB_TOKEN",
         "SECRET_KEY",
         "SENTRY_DSN",

--- a/tests/unit/services/test_sentry.py
+++ b/tests/unit/services/test_sentry.py
@@ -23,7 +23,7 @@ def test_monitor_config():
 
 
 def test_parse_with_envvar(monkeypatch, event):
-    monkeypatch.setenv("INTERACTIVE_GITHUB_TOKEN", "ghp_testing")
+    monkeypatch.setenv("GITHUB_TOKEN_TESTING", "ghp_testing")
 
     data = event()
 


### PR DESCRIPTION
Relates to #4858.

This has now been removed entirely from the code, the token removed from the deployment environment and the token deleted (was already expired).