### PR TITLE
Better airlock notification error handling

### DIFF
--- a/airlock/issues.py
+++ b/airlock/issues.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from furl import furl
 
+from jobserver.github import GitHubError
 from jobserver.utils import strip_whitespace
 
 from .slack import post_slack_update
@@ -60,20 +61,27 @@ def update_output_checking_issue(
     updates_string = "\n".join([f"- {update}" for update in updates])
     body = f"Release request updated:\n{updates_string}"
 
-    data = github_api.create_issue_comment(
-        org=org,
-        repo=repo,
-        title_text=release_request_id,
-        body=body,
-    )
-
-    comment_url = data["html_url"]
-    if notify_slack:
-        post_slack_update(
-            org,
-            comment_url,
-            get_issue_title(workspace_name, release_request_id),
-            updates_string,
+    github_error_msg = None
+    try:
+        data = github_api.create_issue_comment(
+            org=org,
+            repo=repo,
+            title_text=release_request_id,
+            body=body,
         )
-
-    return comment_url
+        comment_url = data["html_url"]
+    except GitHubError as error:
+        comment_url = None
+        github_error_msg = str(error)
+        raise error
+    finally:
+        if notify_slack:
+            post_slack_update(
+                org,
+                comment_url,
+                get_issue_title(workspace_name, release_request_id),
+                updates_string,
+                github_error=github_error_msg,
+            )
+        if comment_url is not None:
+            return comment_url

--- a/airlock/slack.py
+++ b/airlock/slack.py
@@ -3,9 +3,16 @@ from services import slack
 from .config import ORG_SLACK_CHANNELS
 
 
-def post_slack_update(org, update_url, issue_title, update_text):
+def post_slack_update(org, update_url, issue_title, update_text, github_error):
     channel = ORG_SLACK_CHANNELS.get(org, ORG_SLACK_CHANNELS["default"])
 
-    title_link = slack.link(update_url, f"{issue_title} has been updated")
-    message_text = f"{title_link}\n{update_text}"
+    if update_url is not None:
+        title = slack.link(update_url, f"{issue_title} has been updated")
+    else:
+        title = f"{issue_title} has been updated"
+    message_text = f"{title}\n{update_text}"
+
+    if github_error:
+        message_text += f"\nA GitHub error occurred: {github_error}"
+
     slack.post(message_text, channel)


### PR DESCRIPTION
This improves the airlock notifications so that when there are multiple notification actions (github/email/slack), an error in one action doesn't prevent others happening. 