### PR TITLE
Remove some Interactive report functionality

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -24,7 +24,6 @@
 - [Components](#components)
 - [Backends](#backends)
 - [Rotating the GitHub token](#rotating-the-github-token)
-- [Interactive testing](#interactive-testing)
 - [Dumping co-pilot reporting data](#dumping-copilot-reporting-data)
 - [Ensuring paired field state with CheckConstraints](#ensuring-paired-field-state-with-checkconstraint)
   - [Common patterns](#common-patterns)

--- a/interactive/models.py
+++ b/interactive/models.py
@@ -90,27 +90,6 @@ class AnalysisRequest(models.Model):
         return super().save(*args, **kwargs)
 
     @property
-    def status(self):
-        """
-        Expose the status of an Analysis
-
-        This builds on top of JobRequest.status, which is deriving a single
-        state from its related Jobs.  However we also need to account for the
-        job having finished but the output not having been released.
-        """
-        jr_status = self.job_request.status
-        if jr_status != "succeeded":
-            return jr_status
-
-        # when the JobRequest has succeeded we still need to check if there has
-        # been a file released by looking for a related Report.
-        # TODO: handle manual overrides here too
-        if not self.report:
-            return "awaiting report"
-
-        return jr_status
-
-    @property
     def ulid(self):
         return ULID.from_str(self.id)
 

--- a/interactive/models.py
+++ b/interactive/models.py
@@ -84,21 +84,6 @@ class AnalysisRequest(models.Model):
         return f"{self.title}"
 
     @property
-    def publish_request(self):
-        """
-        Return the publish request tied to this AnalysisRequest's report
-
-        We don't want to relate an AnalysisRequest to a PublishRequest since
-        that will couple it to Interactive, when a PublishRequest is intended
-        to be a generic object for reports.  However, an AnalysisRequest has a
-        nullable relation to Report so we can use that.
-        """
-        if not self.report:
-            return None
-
-        return self.report.publish_requests.order_by("-created_at").first()
-
-    @property
     def report_content(self):
         if not self.report:
             return ""

--- a/interactive/models.py
+++ b/interactive/models.py
@@ -83,17 +83,6 @@ class AnalysisRequest(models.Model):
     def __str__(self):
         return f"{self.title}"
 
-    @property
-    def report_content(self):
-        if not self.report:
-            return ""
-
-        path = self.report.release_file.absolute_path()
-        if not path.exists():
-            return ""
-
-        return path.read_text()
-
     def save(self, *args, **kwargs):
         if not self.slug:
             self.slug = f"{slugify(self.title)}-{self.pk}"

--- a/tests/unit/interactive/test_models.py
+++ b/tests/unit/interactive/test_models.py
@@ -5,9 +5,6 @@ from interactive.models import AnalysisRequest
 
 from ...factories import (
     AnalysisRequestFactory,
-    JobFactory,
-    JobRequestFactory,
-    ReportFactory,
     UserFactory,
 )
 
@@ -32,48 +29,6 @@ def test_analysisrequest_constraints_missing_updated_at_or_updated_by():
 def test_analysisrequest_created_check_constraint_missing_one(field):
     with pytest.raises(IntegrityError):
         AnalysisRequestFactory(**{field: None})
-
-
-def test_analysisrequest_status_awaiting_report():
-    job_request = JobRequestFactory()
-    JobFactory(job_request=job_request, status="succeeded")
-    analysis_request = AnalysisRequestFactory(job_request=job_request)
-
-    assert analysis_request.status == "awaiting report"
-
-
-def test_analysisrequest_status_failed():
-    job_request = JobRequestFactory()
-    JobFactory(job_request=job_request, status="failed")
-    analysis_request = AnalysisRequestFactory(job_request=job_request)
-
-    assert analysis_request.status == "failed"
-
-
-def test_analysisrequest_status_pending():
-    job_request = JobRequestFactory()
-    JobFactory(job_request=job_request, status="pending")
-    analysis_request = AnalysisRequestFactory(job_request=job_request)
-
-    assert analysis_request.status == "pending"
-
-
-def test_analysisrequest_status_running():
-    job_request = JobRequestFactory()
-    JobFactory(job_request=job_request, status="running")
-    analysis_request = AnalysisRequestFactory(job_request=job_request)
-
-    assert analysis_request.status == "running"
-
-
-def test_analysisrequest_status_succeeded():
-    job_request = JobRequestFactory()
-    JobFactory(job_request=job_request, status="succeeded")
-    analysis_request = AnalysisRequestFactory(
-        job_request=job_request, report=ReportFactory()
-    )
-
-    assert analysis_request.status == "succeeded"
 
 
 def test_analysisrequest_str():

--- a/tests/unit/interactive/test_models.py
+++ b/tests/unit/interactive/test_models.py
@@ -7,7 +7,6 @@ from ...factories import (
     AnalysisRequestFactory,
     JobFactory,
     JobRequestFactory,
-    ReleaseFileFactory,
     ReportFactory,
     UserFactory,
 )
@@ -99,27 +98,6 @@ def test_analysisrequest_visible_to_other_user():
     analysis_request = AnalysisRequestFactory()
 
     assert not analysis_request.visible_to(UserFactory())
-
-
-def test_analysisrequest_report_content_success():
-    rfile = ReleaseFileFactory()
-    rfile.absolute_path().write_text("testing")
-    report = ReportFactory(release_file=rfile)
-    analysis_request = AnalysisRequestFactory(report=report)
-
-    assert analysis_request.report_content == "testing"
-
-
-def test_analysisrequest_report_content_with_no_release_file():
-    rfile = ReleaseFileFactory()
-    report = ReportFactory(release_file=rfile)
-    analysis_request = AnalysisRequestFactory(report=report)
-
-    assert analysis_request.report_content == ""
-
-
-def test_analysisrequest_report_content_with_no_report():
-    assert AnalysisRequestFactory().report_content == ""
 
 
 def test_analysisrequest_ulid():

--- a/tests/unit/interactive/test_models.py
+++ b/tests/unit/interactive/test_models.py
@@ -7,10 +7,8 @@ from ...factories import (
     AnalysisRequestFactory,
     JobFactory,
     JobRequestFactory,
-    PublishRequestFactory,
     ReleaseFileFactory,
     ReportFactory,
-    SnapshotFactory,
     UserFactory,
 )
 
@@ -35,29 +33,6 @@ def test_analysisrequest_constraints_missing_updated_at_or_updated_by():
 def test_analysisrequest_created_check_constraint_missing_one(field):
     with pytest.raises(IntegrityError):
         AnalysisRequestFactory(**{field: None})
-
-
-def test_analysisrequest_publish_request_success():
-    report = ReportFactory()
-    snapshot = SnapshotFactory()
-    snapshot.files.set([report.release_file])
-    publish_request = PublishRequestFactory(report=report, snapshot=snapshot)
-    analysis_request = AnalysisRequestFactory(report=report)
-
-    assert analysis_request.publish_request == publish_request
-
-
-def test_analysisrequest_publish_request_without_report():
-    analysis_request = AnalysisRequestFactory()
-
-    assert analysis_request.publish_request is None
-
-
-def test_analysisrequest_publish_request_without_publish_request():
-    report = ReportFactory()
-    analysis_request = AnalysisRequestFactory(report=report)
-
-    assert analysis_request.publish_request is None
 
 
 def test_analysisrequest_status_awaiting_report():


### PR DESCRIPTION
We can no longer publish an Interactive report or view its content, so these methods are unused and can be removed.