### PR TITLE
Remove vestigial `interactive_workspace` property

### DIFF
--- a/jobserver/models/project.py
+++ b/jobserver/models/project.py
@@ -161,14 +161,6 @@ class Project(models.Model):
     def get_staff_edit_url(self):
         return reverse("staff:project-edit", kwargs={"slug": self.slug})
 
-    @property
-    def interactive_slug(self):
-        return f"{self.slug}-interactive"
-
-    @property
-    def interactive_workspace(self):
-        return self.workspaces.get(name=self.interactive_slug)
-
     def save(self, *args, **kwargs):
         if not self.slug:
             self.slug = slugify(self.name)

--- a/tests/unit/jobserver/models/test_project.py
+++ b/tests/unit/jobserver/models/test_project.py
@@ -10,7 +10,6 @@ from ....factories import (
     ProjectCollaborationFactory,
     ProjectFactory,
     UserFactory,
-    WorkspaceFactory,
 )
 
 
@@ -159,13 +158,3 @@ def test_project_org():
     lead_org = OrgFactory()
     ProjectCollaborationFactory(org=lead_org, project=project, is_lead=True)
     assert project.org == lead_org
-
-
-# Remove this as part of the OpenSAFELY Interactive removal.
-# This is a temporarily added test to placate coverage,
-# before removing the remaining OpenSAFELY Interactive functionality
-# that uses the Project.interactive_workspace property.
-def test_get_interactive_workspace():
-    project = ProjectFactory(slug="test-get-workspace")
-    workspace = WorkspaceFactory(project=project, name="test-get-workspace-interactive")
-    assert workspace == project.interactive_workspace


### PR DESCRIPTION
This is no longer used following
69515eb6284ca77f019f8f266239dfc7d37597bd, but was overlooked.

This also removes the `interactive_slug` property which was only used in `interactive_workspace`.