### PR TITLE
Remove `LoginWithToken`

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -61,11 +61,6 @@ class JobRequestCreateForm(forms.ModelForm):
                 )
 
 
-class TokenLoginForm(forms.Form):
-    user = forms.CharField()
-    token = forms.CharField()
-
-
 class RequireNameForm(forms.Form):
     name = forms.CharField()
 

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -60,7 +60,6 @@ from .views.repos import RepoHandler, SignOffRepo
 from .views.status import DBAvailability, PerBackendStatus, Status
 from .views.users import (
     Login,
-    LoginWithToken,
     RequireName,
     Settings,
     UserDetail,
@@ -299,7 +298,6 @@ urlpatterns = [
     ),
     path("jobs/<identifier>/", JobDetailRedirect.as_view(), name="job-redirect"),
     path("login/", Login.as_view(), name="login"),
-    path("login-with-token/", LoginWithToken.as_view(), name="login-with-token"),
     path("logout/", LogoutView.as_view(), name="logout"),
     path("organisations/", OrgList.as_view(), name="org-list"),
     path("orgs/", include(org_urls)),


### PR DESCRIPTION
Fixes #4939.

This removes the `LoginWithToken` view and `TokenLoginForm`. These are no longer needed since users now login to Airlock with tokens.