### PR TITLE
Increase sentry cron failure threshold

### DIFF
--- a/services/sentry.py
+++ b/services/sentry.py
@@ -46,7 +46,7 @@ def monitor_config(schedule):
         "max_runtime": 10,
         # It'll take `failure_issue_threshold` consecutive failed
         # check-ins to create an issue
-        "failure_issue_threshold": 1,
+        "failure_issue_threshold": 2,
         # It'll take `recovery_threshold` OK check-ins to resolve
         # an issue
         "recovery_threshold": 1,


### PR DESCRIPTION
We get sporadic single failures of the dump_db job.

This generates a lot of noise of new issues in Sentry.

They tend to be singular failures (i.e. followed by a successful run), by making the failure threshold 2 we will only get notified if two in a row fail.