### PR TITLE
Remove unused templatetag `redirect_with_querystring`

### DIFF
--- a/jobserver/templatetags/querystring_tools.py
+++ b/jobserver/templatetags/querystring_tools.py
@@ -1,18 +1,8 @@
 from django import template
-from django.urls import reverse
 from furl import furl
 
 
 register = template.Library()
-
-
-@register.simple_tag(takes_context=True)
-def redirect_with_querystring(context, view_name):
-    request = context["request"]
-    f = furl(request.get_full_path())
-    f.path = reverse(view_name)
-
-    return f.url
 
 
 @register.simple_tag(takes_context=True)

--- a/tests/unit/jobserver/templatetags/test_querystring_tools.py
+++ b/tests/unit/jobserver/templatetags/test_querystring_tools.py
@@ -1,22 +1,7 @@
 from jobserver.templatetags.querystring_tools import (
-    redirect_with_querystring,
     url_with_querystring,
     url_without_querystring,
 )
-
-
-def test_redirect_with_querystring(rf, mocker):
-    # patch here so we don't couple this test to any configured URL
-    mocker.patch(
-        "jobserver.templatetags.querystring_tools.reverse",
-        autospec=True,
-        return_value="/an_url",
-    )
-
-    context = {"request": rf.get("/?foo=bar")}
-    output = redirect_with_querystring(context, view_name="derp")
-
-    assert output == "/an_url?foo=bar"
 
 
 def test_url_with_querystring_setting_other_arg_set_with_no_page(rf):


### PR DESCRIPTION
This isn't used anywhere.

Looks like the last/only client was removed in:

- pull https://github.com/opensafely-core/job-server/pull/199
- commit 13858142d117a3d3e3ee1b39f121f45e1b61e7f7