### PR TITLE
Remove `Workspace.is_interactive`

### DIFF
--- a/jobserver/models/workspace.py
+++ b/jobserver/models/workspace.py
@@ -267,7 +267,3 @@ class Workspace(models.Model):
         with connection.cursor() as cursor:
             cursor.execute(sql, [self.name])
             return dict(cursor.fetchall())
-
-    @property
-    def is_interactive(self):
-        return self.name.endswith("-interactive")

--- a/tests/unit/jobserver/models/test_workspace.py
+++ b/tests/unit/jobserver/models/test_workspace.py
@@ -380,11 +380,6 @@ def test_workspace_get_action_status_lut_without_backend():
     assert output == expected
 
 
-def test_workspace_is_interactive():
-    assert WorkspaceFactory(name="test-interactive").is_interactive
-    assert not WorkspaceFactory().is_interactive
-
-
 def test_workspace_str():
     workspace = WorkspaceFactory(name="corellian-engineering-corporation")
     assert str(workspace) == "corellian-engineering-corporation"


### PR DESCRIPTION
There are no remaining clients of this.

It looks like #4905 removed the last client: `show_interactive_button = is_interactive_user and workspace.is_interactive` in `WorkspaceDetail.get`.

Partially fixes #4873.