### PR TITLE
Re-name tests

### DIFF
--- a/tests/unit/jobserver/commands/test_projects.py
+++ b/tests/unit/jobserver/commands/test_projects.py
@@ -9,7 +9,7 @@ from tests.factories import (
 )
 
 
-def test_add_interactive_project():
+def test_add_project_with_copilot_and_application():
     org1 = OrgFactory()
     org2 = OrgFactory()
 
@@ -51,7 +51,7 @@ def test_add_interactive_project():
     assert collaboration2.updated_by == actor
 
 
-def test_add_standard_project():
+def test_add_project_without_copilot_and_application():
     org1 = OrgFactory()
     org2 = OrgFactory()
 


### PR DESCRIPTION
The difference between these tests is that one of them passes the optional `copilot` and `application_url` parameters to the command and one of them doesn't. Change the names to reflect that.

I don't see how these differences should lead to a project being called "interactive" or "standard". And in any case, we're sunsetting Interactive (docs/adr/0029-sunset-osi-interactive.md), but it's still valid for a `Project` to have these attributes, or not; and the command still has those options. We will still want this for testing projects, for example.

Part of  #4873.