### PR TITLE
Mark some `slow_tests`

### DIFF
--- a/tests/integration/test_applications.py
+++ b/tests/integration/test_applications.py
@@ -1,4 +1,5 @@
 import factory
+import pytest
 from django.urls import reverse
 
 from ..factories import UserFactory
@@ -20,6 +21,7 @@ def url_builder(application):
     return url
 
 
+@pytest.mark.slow_test
 def test_successful_application(client, mailoutbox, slack_messages):
     user = UserFactory()
 

--- a/tests/unit/applications/test_models.py
+++ b/tests/unit/applications/test_models.py
@@ -22,6 +22,7 @@ def test_application_constraints_deleted_at_and_deleted_by_neither_set():
     ApplicationFactory(deleted_at=None, deleted_by=None)
 
 
+@pytest.mark.slow_test
 @pytest.mark.django_db(transaction=True)
 def test_application_constraints_missing_approved_at_or_approved_by():
     msg = '^new row for relation "applications_application" violates check constraint "applications_application_both_approved_at_and_approved_by_set"'
@@ -33,6 +34,7 @@ def test_application_constraints_missing_approved_at_or_approved_by():
         ApplicationFactory(approved_at=None, approved_by=UserFactory())
 
 
+@pytest.mark.slow_test
 @pytest.mark.django_db(transaction=True)
 def test_application_constraints_missing_deleted_at_or_deleted_by():
     with pytest.raises(IntegrityError):

--- a/tests/unit/jobserver/models/test_project.py
+++ b/tests/unit/jobserver/models/test_project.py
@@ -17,6 +17,7 @@ def test_project_constraints_created_at_and_created_by_both_set():
     ProjectFactory(created_at=timezone.now(), created_by=UserFactory())
 
 
+@pytest.mark.slow_test
 @pytest.mark.django_db(transaction=True)
 def test_project_constraints_created_at_and_created_by_only_one_set():
     with pytest.raises(IntegrityError):
@@ -30,6 +31,7 @@ def test_project_constraints_updated_at_and_updated_by_both_set():
     ProjectFactory(updated_at=timezone.now(), updated_by=UserFactory())
 
 
+@pytest.mark.slow_test
 @pytest.mark.django_db(transaction=True)
 def test_project_constraints_updated_at_and_updated_by_only_one_set():
     with pytest.raises(IntegrityError):

--- a/tests/unit/jobserver/models/test_release_file.py
+++ b/tests/unit/jobserver/models/test_release_file.py
@@ -36,6 +36,7 @@ def test_releasefile_constraints_deleted_at_and_deleted_by_neither_set():
     ReleaseFileFactory(deleted_at=None, deleted_by=None)
 
 
+@pytest.mark.slow_test
 @pytest.mark.django_db(transaction=True)
 def test_releasefile_constraints_missing_deleted_at_or_deleted_by():
     with pytest.raises(IntegrityError):

--- a/tests/unit/jobserver/models/test_repo.py
+++ b/tests/unit/jobserver/models/test_repo.py
@@ -16,6 +16,7 @@ def test_repo_constraints_internal_signed_off_at_and_internal_signed_off_by_neit
     RepoFactory(internal_signed_off_at=None, internal_signed_off_by=None)
 
 
+@pytest.mark.slow_test
 @pytest.mark.django_db(transaction=True)
 def test_repo_constraints_missing_internal_signed_off_at_or_internal_signed_off_by():
     with pytest.raises(IntegrityError):
@@ -35,6 +36,7 @@ def test_repo_constraints_researcher_signed_off_at_and_researcher_signed_off_by_
     RepoFactory(researcher_signed_off_at=None, researcher_signed_off_by=None)
 
 
+@pytest.mark.slow_test
 @pytest.mark.django_db(transaction=True)
 def test_repo_constraints_missing_researcher_signed_off_at_or_researcher_signed_off_by():
     with pytest.raises(IntegrityError):

--- a/tests/unit/jobserver/models/test_user.py
+++ b/tests/unit/jobserver/models/test_user.py
@@ -44,6 +44,7 @@ def test_user_constraints_pat_token_and_pat_expires_at_neither_set():
     UserFactory(pat_token=None, pat_expires_at=None)
 
 
+@pytest.mark.slow_test
 @pytest.mark.django_db(transaction=True)
 def test_user_constraints_missing_pat_token_or_pat_expires_at():
     with pytest.raises(IntegrityError):

--- a/tests/unit/jobserver/models/test_workspace.py
+++ b/tests/unit/jobserver/models/test_workspace.py
@@ -30,6 +30,7 @@ def test_workspace_constraints_signed_off_at_and_signed_off_by_neither_set():
     WorkspaceFactory(signed_off_at=None, signed_off_by=None)
 
 
+@pytest.mark.slow_test
 @pytest.mark.django_db(transaction=True)
 def test_workspace_constraints_missing_signed_off_at_or_signed_off_by():
     with pytest.raises(IntegrityError):
@@ -43,6 +44,7 @@ def test_workspace_constraints_updated_at_and_updated_by_both_set():
     WorkspaceFactory(updated_by=UserFactory())
 
 
+@pytest.mark.slow_test
 @pytest.mark.django_db(transaction=True)
 def test_workspace_constraints_missing_updated_at_or_updated_by():
     with pytest.raises(IntegrityError):

--- a/tests/unit/redirects/test_models.py
+++ b/tests/unit/redirects/test_models.py
@@ -59,6 +59,7 @@ def test_redirect_constraints_deleted_at_and_deleted_by_neither_set():
     )
 
 
+@pytest.mark.slow_test
 @pytest.mark.django_db(transaction=True)
 def test_redirect_constraints_deleted_at_and_deleted_by_only_one_set():
     with pytest.raises(IntegrityError):


### PR DESCRIPTION
Marking the dozen slowest test cases not already marked as `slow_test` speeds `just test` from about 20-25s to 12-16s for me locally (six workers). This shortens some feedback loops when doing local development. Delaying these tests to CI (or `just test-ci`) has low cost because they are testing isolated bits of code we're not actively developing.

Related to #4972.