### PR TITLE
Remove `incuna_mail` dependency

### DIFF
--- a/airlock/emails.py
+++ b/airlock/emails.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from furl import furl
-from incuna_mail import send
 
+from jobserver.emails import send_html_email
 from jobserver.models import Release
 
 
@@ -26,11 +26,11 @@ def get_email_context(airlock_event, include_release_url=False):
 
 def send_request_approved_email(airlock_event):
     context = get_email_context(airlock_event, include_release_url=True)
-    send(
+    send_html_email(
         to=airlock_event.request_author.email,
-        sender="notifications@jobs.opensafely.org",
+        from_email="notifications@jobs.opensafely.org",
         subject=f"Release request approved for workspace {airlock_event.workspace.name}",
-        template_name="airlock/emails/request_approved.txt",
+        text_template_name="airlock/emails/request_approved.txt",
         html_template_name="airlock/emails/request_approved.html",
         context=context,
     )
@@ -38,11 +38,11 @@ def send_request_approved_email(airlock_event):
 
 def send_request_released_email(airlock_event):
     context = get_email_context(airlock_event, include_release_url=True)
-    send(
+    send_html_email(
         to=airlock_event.request_author.email,
-        sender="notifications@jobs.opensafely.org",
+        from_email="notifications@jobs.opensafely.org",
         subject=f"Files released for workspace {airlock_event.workspace.name}",
-        template_name="airlock/emails/request_released.txt",
+        text_template_name="airlock/emails/request_released.txt",
         html_template_name="airlock/emails/request_released.html",
         context=context,
     )
@@ -50,11 +50,11 @@ def send_request_released_email(airlock_event):
 
 def send_request_rejected_email(airlock_event):
     context = get_email_context(airlock_event)
-    send(
+    send_html_email(
         to=airlock_event.request_author.email,
-        sender="notifications@jobs.opensafely.org",
+        from_email="notifications@jobs.opensafely.org",
         subject=f"Release request rejected: {airlock_event.workspace.name} ({airlock_event.release_request_id})",
-        template_name="airlock/emails/request_rejected.txt",
+        text_template_name="airlock/emails/request_rejected.txt",
         html_template_name="airlock/emails/request_rejected.html",
         context=context,
     )
@@ -62,11 +62,11 @@ def send_request_rejected_email(airlock_event):
 
 def send_request_returned_email(airlock_event):
     context = get_email_context(airlock_event)
-    send(
+    send_html_email(
         to=airlock_event.request_author.email,
-        sender="notifications@jobs.opensafely.org",
+        from_email="notifications@jobs.opensafely.org",
         subject=f"Release request returned: {airlock_event.workspace.name} ({airlock_event.release_request_id})",
-        template_name="airlock/emails/request_returned.txt",
+        text_template_name="airlock/emails/request_returned.txt",
         html_template_name="airlock/emails/request_returned.html",
         context=context,
     )

--- a/applications/emails.py
+++ b/applications/emails.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from furl import furl
-from incuna_mail import send
+
+from jobserver.emails import send_html_email
 
 
 def send_submitted_application_email(email, application):
@@ -13,11 +14,11 @@ def send_submitted_application_email(email, application):
         "reference": application.pk_hash,
     }
 
-    send(
+    send_html_email(
         to=email,
-        sender="notifications@jobs.opensafely.org",
+        from_email="notifications@jobs.opensafely.org",
         subject="Acknowledgement of New COVID-19 Project Application",
-        template_name="applications/emails/submission_confirmation.txt",
+        text_template_name="applications/emails/submission_confirmation.txt",
         html_template_name="applications/emails/submission_confirmation.html",
         context=context,
     )

--- a/jobserver/emails.py
+++ b/jobserver/emails.py
@@ -1,8 +1,34 @@
 from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import render_to_string
 from furl import furl
-from incuna_mail import send
 
 from .models import User
+
+
+def send_html_email(
+    to,
+    from_email,
+    subject,
+    text_template_name,
+    html_template_name,
+    context=None,
+    bcc=None,
+    reply_to=None,
+):
+    """Send an HTML e-mail with a text fallback rendered from templates."""
+    email = EmailMultiAlternatives(
+        to=[to],
+        reply_to=reply_to or None,
+        bcc=bcc or None,
+        from_email=from_email,
+        subject=subject,
+        body=render_to_string(text_template_name, context or {}),
+    )
+    email.attach_alternative(
+        render_to_string(html_template_name, context or {}), "text/html"
+    )
+    email.send()
 
 
 def send_finished_notification(email, job):
@@ -20,11 +46,11 @@ def send_finished_notification(email, job):
         "workspace": workspace_name,
     }
 
-    send(
+    send_html_email(
         to=email,
-        sender="notifications@jobs.opensafely.org",
+        from_email="notifications@jobs.opensafely.org",
         subject=f"{job.status}: [os {workspace_name}] {job.action}",
-        template_name="emails/notify_finished.txt",
+        text_template_name="emails/notify_finished.txt",
         html_template_name="emails/notify_finished.html",
         context=context,
     )
@@ -34,12 +60,12 @@ def send_repo_signed_off_notification_to_researchers(repo):
     creators = User.objects.filter(workspaces__repo=repo)
     emails = [u.email for u in creators]
 
-    send(
+    send_html_email(
         to="notifications@jobs.opensafely.org",
         bcc=emails,
-        sender="notifications@jobs.opensafely.org",
+        from_email="notifications@jobs.opensafely.org",
         subject=f"Repo {repo.name} was signed off by {repo.researcher_signed_off_by.name}",
-        template_name="emails/notify_researcher_repo_signed_off.txt",
+        text_template_name="emails/notify_researcher_repo_signed_off.txt",
         html_template_name="emails/notify_researcher_repo_signed_off.html",
         context={"repo": repo},
     )
@@ -54,33 +80,33 @@ def send_repo_signed_off_notification_to_staff(repo):
 
     staff_url = (furl(settings.BASE_URL) / repo.get_staff_url()).url
 
-    send(
-        to=["publications@opensafely.org"],
-        sender="notifications@jobs.opensafely.org",
+    send_html_email(
+        to="publications@opensafely.org",
+        from_email="notifications@jobs.opensafely.org",
         subject=subject,
-        template_name="emails/notify_staff_repo_signed_off.txt",
+        text_template_name="emails/notify_staff_repo_signed_off.txt",
         html_template_name="emails/notify_staff_repo_signed_off.html",
         context={"repo": repo, "staff_url": staff_url},
     )
 
 
 def send_token_login_generated_email(user):
-    send(
+    send_html_email(
         to=user.email,
         subject="New OpenSAFELY login token generated",
-        sender="notifications@jobs.opensafely.org",
+        from_email="notifications@jobs.opensafely.org",
         reply_to=["OpenSAFELY Team <team@opensafely.org>"],
-        template_name="emails/login_token_generated.txt",
+        text_template_name="emails/login_token_generated.txt",
         html_template_name="emails/login_token_generated.html",
     )
 
 
 def send_token_login_used_email(user):
-    send(
+    send_html_email(
         to=user.email,
         subject="OpenSAFELY account login with token",
-        sender="notifications@jobs.opensafely.org",
+        from_email="notifications@jobs.opensafely.org",
         reply_to=["OpenSAFELY Team <team@opensafely.org>"],
-        template_name="emails/login_token_used.txt",
+        text_template_name="emails/login_token_used.txt",
         html_template_name="emails/login_token_used.html",
     )

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -96,9 +96,6 @@ furl
 # Search 'pipeline' in jobserver/
 opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/v2025.03.06.161237.zip
 
-# Email utilities/wrappers. See jobserver/emails.py and airlock/emails.py.
-incuna-mail
-
 # Handling markdown. Used in some views and snippets.
 markdown
 

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -418,10 +418,6 @@ importlib-metadata==8.6.1 \
     --hash=sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e \
     --hash=sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580
     # via opentelemetry-api
-incuna-mail==4.1.1 \
-    --hash=sha256:4071949a7cc70f88c1acea5f06ac8ba439029f655ff5d8c98277bbc8cc8d4bd5 \
-    --hash=sha256:d8ef4979264fba729fa1478819d71f66af17a795e82d9607d8e7ccd7edaafe10
-    # via -r requirements.prod.in
 markdown==3.7 \
     --hash=sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2 \
     --hash=sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -305,7 +305,7 @@ def test_api_airlock_event_error(
 
 
 @patch("airlock.views._get_github_api", FakeGitHubAPIWithErrors)
-@patch("airlock.emails.send")
+@patch("airlock.emails.send_html_email")
 def test_api_airlock_event_multiple_errors(mock_send, api_rf, slack_messages):
     mock_send.side_effect = Exception("Error sending email")
     author = UserFactory()


### PR DESCRIPTION
The only thing we use the `incuna_mail` dependency for is wrapping creating and sending `EmailMultiAlternatives`. This is just a few lines of code we can write ourselves, so let's do that instead. The version added here is simpler than the `incuna_mail` wrapper and handles all our present use cases.

Resolves #4977.