### PR TITLE
Remove unused `size` variable

### DIFF
--- a/jobserver/slacks.py
+++ b/jobserver/slacks.py
@@ -54,10 +54,6 @@ def notify_release_file_uploaded(rfile, channel=settings.RELEASES_SLACK_CHANNEL)
     release_url = slack.link(release.get_absolute_url(), "release")
     file_url = slack.link(rfile.get_absolute_url(), rfile.name)
 
-    size = round(rfile.size, 1)
-    if size < 1:  # pragma: no cover
-        size = "<1"
-
     message = f"{user_url} uploaded {file_url} ({rfile:Mb}) to a {release_url} for {workspace_url} from `{release.backend.name}`"
     slack.post(message, channel)
 


### PR DESCRIPTION
This was used in the format message, as in:

4cfbec4bf32338c994bd9cc16f7d7ee914bea186.

but later replaced with use of the format specifier in:

475e00adfbdf326fe92e276a0a4962c6346b608c.

However, the vestigial code was not removed.

As a bonus, this eliminates a use of `no cover`.