### PR TITLE
Switch from Dependabot to update-dependencies-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -3,7 +3,7 @@ name: Update python dependencies
 on:
   workflow_dispatch:
   schedule:
-    - cron:  "0 23 * * *"
+    - cron:  "0 23 * * SUN"
 
 jobs:
   update-dependencies:
@@ -24,6 +24,6 @@ jobs:
     - uses: bennettoxford/update-dependencies-action@v1
       with:
         token: ${{ steps.generate-token.outputs.token }}
-        # Note: just update pipeline library for now, as job-server uses dependabot for python upgrades
         update_command: |
           just upgrade-pipeline
+          just update-dependencies

--- a/justfile
+++ b/justfile
@@ -109,6 +109,13 @@ upgrade env package="": virtualenv
     test -z "{{ package }}" || opts="--upgrade-package {{ package }}"
     FORCE=true {{ just_executable() }} requirements-{{ env }} $opts
 
+# Upgrade all dev and prod dependencies.
+# This is the default input command to update-dependencies action
+# https://github.com/bennettoxford/update-dependencies-action
+update-dependencies:
+    just upgrade prod
+    just upgrade dev
+
 # upgrade our internal pipeline library
 upgrade-pipeline: && requirements-prod
     ./scripts/upgrade-pipeline.sh requirements.prod.in

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,0 +1,42 @@
+# Taken from Airlock:
+# https://github.com/opensafely-core/airlock/blob/ca23669bcf22bf719bd79103ecc53da0a7c53e2f/tests/test_requirements.py
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).parents[1]
+
+
+def test_requirements_are_consistent():
+    # The production and development dependencies aren't intended to overlap (the dev
+    # dependencies are supposed to be _extra_ packages needed for development) but
+    # due to transitive dependencies the `requirements.dev.txt` file can end up
+    # including packages which are also included in `requirements.prod.txt`.
+    #
+    # We use a `--constraint` argument in `requirements.dev.in` to ensure that whenever
+    # we compile the development dependencies we stay consistent with the current
+    # production dependencies. However it's still possible, by doing things in a certain
+    # order, to accidentally end up with divergent versions. This can lead to confusion
+    # and makes the actual installed set of packages dependent on the order in which the
+    # files are read, which is bad.
+    #
+    # The below test ensures that wherever the two files specify the same dependency
+    # they agree on the version.
+    prod_packages = parse_requirements(PROJECT_ROOT / "requirements.prod.txt")
+    dev_packages = parse_requirements(PROJECT_ROOT / "requirements.dev.txt")
+    common_packages = prod_packages.keys() & dev_packages.keys()
+    for package in common_packages:
+        assert prod_packages[package] == dev_packages[package], (
+            f"Inconsistent versions of '{package}' in "
+            f"requirements.prod.txt and requirements.dev.txt"
+        )
+
+
+def parse_requirements(filename):
+    packages = {}
+    for line in filename.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith(("#", "--")):
+            continue
+        package, _, version = line.partition(" ")[0].partition("==")
+        packages[package] = version
+    return packages


### PR DESCRIPTION
Fixes #4412.

This switches from Dependabot to opensafely-core/update-dependencies-action for updating Python dependencies.

It reuses the existing workflow that was updating the `pipeline` dependency, and switches to updating weekly.

While looking at how this works for Airlock, it also borrow an improvements from Airlock with respect to updating dependencies. Specifically:

* the two `requirements.*.txt` files are checked for consistency of package versions, where packages are listed in both requirements files