### PR TITLE
Refactor user.all_roles

### DIFF
--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -149,6 +149,15 @@ class User(AbstractBaseUser):
         return self.name
 
     @cached_property
+    def has_any_roles(self):
+        project_roles = list(
+            itertools.chain.from_iterable(
+                [m.roles for m in self.project_memberships.all()]
+            )
+        )
+        return any(self.roles + project_roles)
+
+    @cached_property
     def all_roles(self):
         """
         All roles, including those given via memberships, for the User.

--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -157,26 +157,6 @@ class User(AbstractBaseUser):
         )
         return any(self.roles + project_roles)
 
-    @cached_property
-    def all_roles(self):
-        """
-        All roles, including those given via memberships, for the User.
-
-        Typically we look up whether the user has permission or a role in the
-        context of another object (eg a project).  However there are times when
-        we want to check all the roles available to a user.  This property
-        allows us to use typical python membership checks when doing that, eg:
-
-            if ProjectDeveloper not in user.all_roles:
-        """
-        membership_roles = list(
-            itertools.chain.from_iterable(
-                [m.roles for m in self.project_memberships.all()]
-            )
-        )
-
-        return set(self.roles + membership_roles)
-
     @property
     def initials(self):
         if self.name == self.username:

--- a/services/logging.py
+++ b/services/logging.py
@@ -84,7 +84,6 @@ class MissingVariableErrorFilter(logging.Filter):
         "q",
         # The following is a property on User but not AnonymousUser. It's non-trivial to
         # extend the latter to provide it, so we ignore it.
-        "all_roles",
         "has_any_roles",
     }
 

--- a/services/logging.py
+++ b/services/logging.py
@@ -85,6 +85,7 @@ class MissingVariableErrorFilter(logging.Filter):
         # The following is a property on User but not AnonymousUser. It's non-trivial to
         # extend the latter to provide it, so we ignore it.
         "all_roles",
+        "has_any_roles",
     }
 
     def filter(self, record):  # pragma: no cover

--- a/templates/job/detail.html
+++ b/templates/job/detail.html
@@ -209,7 +209,7 @@
       </dl>
     {% /card %}
 
-    {% if request.user.all_roles %}
+    {% if request.user.has_any_roles %}
     {% #card title="Job metrics" subtitle="Computed for the time spent running on the backend" %}
       <dl class="border-t border-slate-200 sm:divide-y sm:divide-slate-200">
         {% #description_item title="Mean CPU usage" %}

--- a/templates/staff/user/list.html
+++ b/templates/staff/user/list.html
@@ -138,7 +138,7 @@
                 </div>
               {% endif %}
             {% endif %}
-            {% if not user.all_roles %}
+            {% if not user.has_any_roles %}
               {% pill variant="info" text="User has no roles assigned" class="self-start" %}
             {% endif %}
           {% /list_group_item %}

--- a/tests/unit/jobserver/models/test_user.py
+++ b/tests/unit/jobserver/models/test_user.py
@@ -18,22 +18,6 @@ from ....factories import (
 )
 
 
-def test_user_all_roles(project_membership):
-    org = OrgFactory()
-    project = ProjectFactory(orgs=[org])
-    user = UserFactory(roles=[OutputChecker])
-
-    project_membership(project=project, user=user, roles=[ProjectCollaborator])
-
-    expected = {OutputChecker, ProjectCollaborator}
-
-    assert user.all_roles == expected
-
-
-def test_user_all_roles_empty():
-    assert UserFactory().all_roles == set()
-
-
 def test_user_has_any_roles_with_a_global_role():
     user = UserFactory(roles=[OutputChecker])
     assert user.has_any_roles

--- a/tests/unit/jobserver/models/test_user.py
+++ b/tests/unit/jobserver/models/test_user.py
@@ -34,6 +34,36 @@ def test_user_all_roles_empty():
     assert UserFactory().all_roles == set()
 
 
+def test_user_has_any_roles_with_a_global_role():
+    user = UserFactory(roles=[OutputChecker])
+    assert user.has_any_roles
+
+
+def test_user_has_any_roles_with_a_project_role(project_membership):
+    user = UserFactory()
+    project_membership(user=user, roles=[ProjectCollaborator])
+
+    assert user.has_any_roles
+
+
+def test_user_has_any_roles_with_project_membership_but_no_role(project_membership):
+    user = UserFactory()
+    project_membership(user=user, roles=[])
+
+    assert not user.has_any_roles
+
+
+def test_user_has_any_roles_with_global_and_project_roles(project_membership):
+    user = UserFactory(roles=[OutputChecker])
+    project_membership(user=user, roles=[ProjectCollaborator])
+
+    assert user.has_any_roles
+
+
+def test_user_has_any_roles_with_no_roles():
+    assert not UserFactory().has_any_roles
+
+
 def test_user_constraints_pat_token_and_pat_expires_at_both_set():
     UserFactory(pat_token="test", pat_expires_at=timezone.now())
 


### PR DESCRIPTION
This replaces the `user.all_roles` property with a `user.has_any_roles` property. It's effectively a rename because there should be no functional difference in practice.

Looking at the individual commits might be easier than the whole diff. I used an expand and contract strategy to add the new property and replace all usages of it, before removing the old one.

Fixes #4986.