### PR TITLE
Remove references to `Project.application url`

### DIFF
--- a/jobserver/commands/projects.py
+++ b/jobserver/commands/projects.py
@@ -4,12 +4,11 @@ from ..models import Project, ProjectCollaboration
 
 
 @transaction.atomic()
-def add(*, by, name, number, orgs, application_url="", copilot=None):
+def add(*, by, name, number, orgs, copilot=None):
     project = Project.objects.create(
         name=name,
         number=number,
         copilot=copilot,
-        application_url=application_url,
         created_by=by,
         updated_by=by,
     )

--- a/staff/forms.py
+++ b/staff/forms.py
@@ -99,7 +99,6 @@ class ProjectEditForm(forms.ModelForm):
 
     class Meta:
         fields = [
-            "application_url",
             "copilot",
             "copilot_notes",
             "copilot_support_ends_at",
@@ -115,7 +114,6 @@ class ProjectEditForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields["application_url"].required = False
         self.fields["number"].required = False
 
         self.fields["copilot"] = UserModelChoiceField(

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -141,15 +141,6 @@ class ProjectEdit(UpdateView):
 
         return redirect(new.get_staff_url())
 
-    def get_context_data(self, **kwargs):
-        # we don't have a nice way to override the type of text input
-        # components yet so doing this here is a bit of a hack because we can't
-        # construct dicts in a template
-        return super().get_context_data(**kwargs) | {
-            "application_url_attributes": {"type": "url"},
-            "number_attributes": {"type": "number"},
-        }
-
 
 @method_decorator(require_role(StaffAreaAdministrator), name="dispatch")
 class ProjectLinkApplication(UpdateView):

--- a/templates/staff/project/detail.html
+++ b/templates/staff/project/detail.html
@@ -55,8 +55,6 @@
         {% #description_item title="Application" %}
           {% if application %}
             {% link href=application.get_staff_url text=application.pk_hash|add:" by "|add:application.created_by.name %}
-          {% elif project.application_url %}
-            {% link href=project.application_url text="View application" %}
           {% else %}
             {% url "staff:project-link-application" slug=project.slug as staff_link_application_url %}
             {% link href=staff_link_application_url text="Find and Link" %}

--- a/templates/staff/project/edit.html
+++ b/templates/staff/project/edit.html
@@ -73,7 +73,6 @@
           If you are looking to link to an application created on this site use "Find and Link"
           {% link href=project.get_staff_url text="on the Project page" append_after="." %}
         {% /alert %}
-        {% form_input field=form.application_url label="Application URL" type="url" %}
       {% endif %}
     {% /form_fieldset %}
   {% /card %}

--- a/tests/unit/jobserver/commands/test_projects.py
+++ b/tests/unit/jobserver/commands/test_projects.py
@@ -9,7 +9,7 @@ from tests.factories import (
 )
 
 
-def test_add_project_with_copilot_and_application():
+def test_add_project_with_copilot():
     org1 = OrgFactory()
     org2 = OrgFactory()
 
@@ -21,14 +21,12 @@ def test_add_project_with_copilot_and_application():
         number=31337,
         orgs=[org1, org2],
         copilot=copilot,
-        application_url="http://example.com",
         by=actor,
     )
 
     assert project.name == "test"
     assert project.number == 31337
     assert project.copilot == copilot
-    assert project.application_url == "http://example.com"
     assert project.created_at
     assert project.created_by == actor
     assert project.updated_at
@@ -51,7 +49,7 @@ def test_add_project_with_copilot_and_application():
     assert collaboration2.updated_by == actor
 
 
-def test_add_project_without_copilot_and_application():
+def test_add_project_without_copilot():
     org1 = OrgFactory()
     org2 = OrgFactory()
 
@@ -62,7 +60,6 @@ def test_add_project_without_copilot_and_application():
     assert project.name == "test"
     assert project.number == 31337
     assert project.copilot is None
-    assert project.application_url == ""
     assert project.created_at
     assert project.created_by == actor
     assert project.updated_at


### PR DESCRIPTION
This was never used so we should remove it.

As part of the Sunsetting OSI initiative (see `docs/adr/0029-sunset-osi-interactive.md`), we removed all OpenSAFELY
Interactive functionality from Job Server. The `application_url` field on a `Project` was added specifically for Interactive project applications. However, the standard application process was actually used, so this field was never
populated. We have no intention of using it in future.

See #5008. The model property and data migration will be in a separate commit/PR (https://github.com/opensafely-core/job-server/pull/5038), to reduce the risk of code relying on them being live while the migration has been deployed.

Note that the following instances of the string `application_url` do not need to be removed:

```
staff/urls.py:application_urls = [
staff/urls.py:    path("applications/", include(application_urls)),
```

These are referring to URLs for the applications app, and should remain.

```
templates/staff/project/detail.html:            {% url "staff:project-link-application" slug=project.slug as staff_link_application_url %}
templates/staff/project/detail.html:            {% link href=staff_link_application_url text="Find and Link" %}
```

These are referring to the URL staff use to link an Application to a Project, not an `application_url`.