### PR TITLE
Replace `pytest-network` with `pytest-socket`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ skip_covered = true
 show_contexts = true
 
 [tool.pytest.ini_options]
-addopts = "--disable-network --tb=native --ignore=./release-hatch --maxprocesses=6"
+addopts = "--disable-socket --tb=native --ignore=./release-hatch --maxprocesses=6"
 DJANGO_SETTINGS_MODULE = "jobserver.settings"
 env = [
   "JOBSERVER_GITHUB_TOKEN=empty",

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -16,7 +16,7 @@ pytest-env
 pytest-freezer
 pytest-icdiff
 pytest-mock
-pytest-network
+pytest-socket
 pytest-xdist[psutil]
 responses
 ruff

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -309,7 +309,7 @@ pytest==8.3.5 \
     #   pytest-freezer
     #   pytest-icdiff
     #   pytest-mock
-    #   pytest-network
+    #   pytest-socket
     #   pytest-xdist
 pytest-django==4.10.0 \
     --hash=sha256:1091b20ea1491fd04a310fc9aaff4c01b4e8450e3b157687625e16a6b5f3a366 \
@@ -331,9 +331,9 @@ pytest-mock==3.14.0 \
     --hash=sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f \
     --hash=sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0
     # via -r requirements.dev.in
-pytest-network==0.0.1 \
-    --hash=sha256:7b109e2ad27f4ab0f13c1796a9b419bab1d503ea3b5ae3ca37363486ccceaa3f
-    # via -r requirements.dev.in
+pytest-socket==0.7.0 \
+    --hash=sha256:71ab048cbbcb085c15a4423b73b619a8b35d6a307f46f78ea46be51b1b7e11b3 \
+    --hash=sha256:7e0f4642177d55d317bbd58fc68c6bd9048d6eadb2d46a89307fa9221336ce45
 pytest-xdist==3.6.1 \
     --hash=sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7 \
     --hash=sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,7 @@ slack_test_channel = os.environ.get("SLACK_TEST_CHANNEL")
 
 
 @pytest.fixture
-def slack_messages(monkeypatch, enable_network):
+def slack_messages(monkeypatch, socket_enabled):
     """A mailoutbox style fixture for slack messages"""
     messages = []
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,26 @@
+import socket
+import urllib
+
+import pytest
+import requests
+from pytest_network import NetworkUsageException
+
+
+@pytest.mark.django_db(False)
+class TestNetworkBlocked:
+    """Test that network/socket access is blocked during tests."""
+
+    def test_network_blocked_socket(self):
+        """Test that network/socket access is blocked via `socket`."""
+        with pytest.raises(SocketBlockedError):
+            socket.socket()
+
+    def test_network_blocked_requests(self):
+        """Test that network/socket access is blocked via `requests`."""
+        with pytest.raises(NetworkUsageException):
+            requests.get("https://example.com")
+
+    def test_network_blocked_urllib(self):
+        """Test that network/socket access is blocked via `urllib`."""
+        with pytest.raises(NetworkUsageException):
+            urllib.request.urlopen("https://example.com")

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -3,7 +3,7 @@ import urllib
 
 import pytest
 import requests
-from pytest_network import NetworkUsageException
+from pytest_socket import SocketBlockedError
 
 
 @pytest.mark.django_db(False)
@@ -17,10 +17,10 @@ class TestNetworkBlocked:
 
     def test_network_blocked_requests(self):
         """Test that network/socket access is blocked via `requests`."""
-        with pytest.raises(NetworkUsageException):
+        with pytest.raises(SocketBlockedError):
             requests.get("https://example.com")
 
     def test_network_blocked_urllib(self):
         """Test that network/socket access is blocked via `urllib`."""
-        with pytest.raises(NetworkUsageException):
+        with pytest.raises(SocketBlockedError):
             urllib.request.urlopen("https://example.com")

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -2,10 +2,13 @@
 # https://github.com/opensafely-core/airlock/blob/ca23669bcf22bf719bd79103ecc53da0a7c53e2f/tests/test_requirements.py
 from pathlib import Path
 
+import pytest
+
 
 PROJECT_ROOT = Path(__file__).parents[1]
 
 
+@pytest.mark.django_db(False)
 def test_requirements_are_consistent():
     # The production and development dependencies aren't intended to overlap (the dev
     # dependencies are supposed to be _extra_ packages needed for development) but

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -82,7 +82,7 @@ def github_api():
     return GitHubAPI(token=Env().str("GITHUB_TOKEN_TESTING"))
 
 
-@pytest.mark.usefixtures("enable_network")
+@pytest.mark.usefixtures("socket_enabled")
 class TestGithubAPIPrivate:
     """Tests of the real GitHubAPI that require permissions on a private
     repo."""
@@ -244,7 +244,7 @@ class TestGithubAPIPrivate:
         assert repo["topics"] == ["testing"]
 
 
-@pytest.mark.usefixtures("enable_network")
+@pytest.mark.usefixtures("socket_enabled")
 class TestGithubAPINonPrivate:
     """Tests of the real GitHubAPI that don't require permissions on a private
     repo."""

--- a/tests/verification/test_opencodelists.py
+++ b/tests/verification/test_opencodelists.py
@@ -24,7 +24,7 @@ def opencodelists_api():
     return OpenCodelistsAPI()
 
 
-def test_get_codelists(enable_network, opencodelists_api):
+def test_get_codelists(socket_enabled, opencodelists_api):
     args = ["snomedct"]
 
     real = opencodelists_api.get_codelists(*args)
@@ -35,7 +35,7 @@ def test_get_codelists(enable_network, opencodelists_api):
     assert real is not None
 
 
-def test_get_codelists_with_unknown_coding_system(enable_network, opencodelists_api):
+def test_get_codelists_with_unknown_coding_system(socket_enabled, opencodelists_api):
     args = ["test"]
 
     real = opencodelists_api.get_codelists(*args)
@@ -46,7 +46,7 @@ def test_get_codelists_with_unknown_coding_system(enable_network, opencodelists_
     assert real == []
 
 
-def test_check_codelists(enable_network, opencodelists_api):
+def test_check_codelists(socket_enabled, opencodelists_api):
     args = ["{}", ""]
 
     real = opencodelists_api.check_codelists(*args)


### PR DESCRIPTION
Fixes #4989.

The two packages do broadly the same thing -- ensure tests don't access the network. `pytest-network` is not being actively developed, `pytest-socket` is. We probably benefit only marginally from updates to this package, but we may as well.

We could have instead written our own code to disable socket access to remove the dependency, but it's just tricky enough to get this right that it seems worth a development dependency (which has a lower cost-benefit barrier than a production dependency).