### PR TITLE
Fix flaky test by waiting for file to be visible

### DIFF
--- a/assets/src/scripts/outputs-viewer/__tests__/App.test.jsx
+++ b/assets/src/scripts/outputs-viewer/__tests__/App.test.jsx
@@ -68,8 +68,10 @@ describe("<App />", () => {
     fetch.mockResponseOnce("hello,world");
     await user.click(screen.queryAllByRole("link")[0]);
 
-    expect(screen.getByText("Last modified at:")).toBeVisible();
-    expect(screen.getByText("hello")).toBeVisible();
-    expect(screen.getByText("world")).toBeVisible();
+    await waitFor(() => {
+      expect(screen.getByText("Last modified at:")).toBeVisible();
+      expect(screen.getByText("hello")).toBeVisible();
+      expect(screen.getByText("world")).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
As the test is sometimes not waiting long enough to see the test, and therefore failing.