### PR TITLE
Fix header logo outline ring

### DIFF
--- a/templates/_components/header.html
+++ b/templates/_components/header.html
@@ -9,7 +9,7 @@
       {% url 'home' as url %}
       <a
         class="
-          group relative bg-transparent rounded flex flex-row items-center gap-1 focus:text-bn-strawberry-600 focus:outline-hidden focus:ring-2
+          group relative bg-transparent rounded flex flex-row items-center gap-1 focus:text-bn-strawberry-600 focus:outline-2 focus:outline-offset-8
         "
         href="{% url 'home' %}"
       >


### PR DESCRIPTION
## Before

![Outline focus styles cutting off parts of the OpenSAFELY logo in the header](https://github.com/user-attachments/assets/e2319b22-301f-4f7f-8eb6-3ce4b87e5eb2)

## After

![Fixed outline styles shows a ring around the logo](https://github.com/user-attachments/assets/62e98e04-4996-4aed-a29a-eaca3b4fcc66)
