### PR TITLE
Update Honeycomb links for new telemetry

### DIFF
--- a/jobserver/honeycomb.py
+++ b/jobserver/honeycomb.py
@@ -133,8 +133,6 @@ def jobrequest_link(job_request):
         breakdowns=["job", "name"],
         calculations=[
             {"op": "CONCURRENCY"},
-            {"op": "MAX", "column": "cpu_percentage"},
-            {"op": "MAX", "column": "memory_used"},
         ],
         orders=[{"op": "CONCURRENCY", "order": "descending"}],
         stacked=True,

--- a/jobserver/honeycomb.py
+++ b/jobserver/honeycomb.py
@@ -104,6 +104,26 @@ def trace_link(job):
     return trace_link.url
 
 
+def metrics_link(job):
+    """We change the cpu/mem telemetry was generated on 15/05/2025, jobs running after this will need this link"""
+    start, end = format_honeycomb_timestamps(job)
+    url = TemplatedUrl(
+        start_time=start,
+        end_time=end,
+        calculations=[
+            {"op": "MAX", "column": "cpu_percentage"},
+            {"op": "MAX", "column": "memory_used"},
+        ],
+        stacked=True,
+        omit_missing=True,
+        filters=[
+            {"column": "name", "op": "=", "value": "METRICS"},
+            {"column": "job", "op": "=", "value": job.identifier},
+        ],
+    )
+    return url.url
+
+
 def status_link(job):
     start, end = format_honeycomb_timestamps(job)
     url = TemplatedUrl(

--- a/jobserver/honeycomb.py
+++ b/jobserver/honeycomb.py
@@ -105,7 +105,9 @@ def trace_link(job):
 
 
 def metrics_link(job):
-    """We change the cpu/mem telemetry was generated on 15/05/2025, jobs running after this will need this link"""
+    """We changed the way cpu/mem telemetry are generated on 15/05/2025.
+
+    Jobs that are run after this date will need this link for metrics"""
     start, end = format_honeycomb_timestamps(job)
     url = TemplatedUrl(
         start_time=start,

--- a/jobserver/views/jobs.py
+++ b/jobserver/views/jobs.py
@@ -81,7 +81,10 @@ class JobDetail(View):
             trace_link = honeycomb.trace_link(job)
             if trace_link:  # pragma: no cover
                 honeycomb_links["Job Trace"] = trace_link
-            honeycomb_links["Status and Resources"] = honeycomb.status_link(job)
+            honeycomb_links["Job Metrics"] = honeycomb.metrics_link(job)
+            honeycomb_links["Status and Resources [DEPRECATED]"] = (
+                honeycomb.status_link(job)
+            )
 
             # Look this up manually, because if we use job.job_request, the
             # JobRequest will not have prefetched all associated Jobs, and

--- a/tests/unit/jobserver/test_honeycomb.py
+++ b/tests/unit/jobserver/test_honeycomb.py
@@ -117,8 +117,6 @@ def test_jobrequest_link(freezer):
         "breakdowns": ["job", "name"],
         "calculations": [
             {"op": "CONCURRENCY"},
-            {"op": "MAX", "column": "cpu_percentage"},
-            {"op": "MAX", "column": "memory_used"},
         ],
         "end_time": 1665594060,
         "filter_combination": "AND",

--- a/tests/unit/jobserver/test_honeycomb.py
+++ b/tests/unit/jobserver/test_honeycomb.py
@@ -96,6 +96,34 @@ def test_status_link(freezer):
     }
 
 
+def test_metrics_link(freezer):
+    freezer.move_to("2022-10-12 17:00")
+
+    job = JobFactory(completed_at=timezone.now(), identifier="test_identifier")
+    url = honeycomb.metrics_link(job)
+    parsed = honeycomb.TemplatedUrl.parse(url)
+
+    assert parsed.stacked
+    assert parsed.query == {
+        "breakdowns": [],
+        "calculations": [
+            {"op": "MAX", "column": "cpu_percentage"},
+            {"op": "MAX", "column": "memory_used"},
+        ],
+        "end_time": 1665594060,
+        "filter_combination": "AND",
+        "filters": [
+            {"column": "name", "op": "=", "value": "METRICS"},
+            {"column": "job", "op": "=", "value": "test_identifier"},
+        ],
+        "granularity": 0,
+        "havings": [],
+        "limit": 1000,
+        "orders": [],
+        "start_time": 1665593940,
+    }
+
+
 def test_jobrequest_link(freezer):
     freezer.move_to("2022-10-12 17:00")
 

--- a/tests/unit/jobserver/views/test_jobs.py
+++ b/tests/unit/jobserver/views/test_jobs.py
@@ -220,6 +220,9 @@ def test_jobdetail_with_staff_area_administrator(rf, freezer):
     assert url in response.rendered_content
     assert job_request.identifier in response.rendered_content
 
+    assert honeycomb.metrics_link(job) in response.rendered_content
+    assert honeycomb.status_link(job) in response.rendered_content
+
 
 def test_jobdetail_with_staff_area_administrator_with_completed_at(rf, freezer):
     freezer.move_to("2022-06-15 13:00")


### PR DESCRIPTION
We have changed the way cpu/memory telemetry is emitted in jobrunner, which breaks a couple of the current honeycomb links.

This change adds a new metrics link that uses the new metrics, and deprecates the old one.

These links are only shown to staff users, and typically only used by tech team members on tech-support or similar duties, as they require honeycomb access to work.

Related discussion: https://bennettoxford.slack.com/archives/C069YDR4NCA/p1747305282116539


