### PR TITLE
Updated email template to remove references to COVID > non-COVID transition

### DIFF
--- a/templates/applications/emails/submission_confirmation.html
+++ b/templates/applications/emails/submission_confirmation.html
@@ -4,8 +4,6 @@
 <p>Dear {{ applicant }},</p>
 <p>Thank you for submitting your project application (ref: {{ reference }}) to OpenSAFELY.</p>
 <p>You can now view your <a href="{{ url }}">submitted application here</a>.</p>
-<p>We are working with NHS England to agree a date to reopen OpenSAFELY to new research projects. As a result we cannot guarantee when your project will be assessed, but we will keep you updated about our timescales on a regular basis.</p>
 <p>We will be in touch if we have any questions regarding your application.</p>
-<p>In the meantime, please know that we appreciate your patience and understanding during this transition period.</p>
 <p>If you have any questions or require further assistance, please don't hesitate to reach out to us at applications@opensafely.org and quote your project application reference (shown above) in the subject of the email.</p>
 {% endblock content %}


### PR DESCRIPTION
A previous PR updated the text part but not the html part. This brings them back in line.