### PR TITLE
Ignore labels for airlock issues if they don't exist for the repo

### DIFF
--- a/airlock/issues.py
+++ b/airlock/issues.py
@@ -31,12 +31,21 @@ def create_output_checking_issue(
 
     body = strip_whitespace(body)
 
+    labels = {"internal" if is_internal else "external"}
+    # Ensure that we don't try to add labels if they don't exist for the repo
+    try:
+        repo_labels = set(github_api.get_labels(org=org, repo=repo))
+    except GitHubError:
+        repo_labels = set()
+
+    labels = labels & repo_labels
+
     data = github_api.create_issue(
         org=org,
         repo=repo,
         title=get_issue_title(workspace.name, release_request_id),
         body=body,
-        labels=["internal" if is_internal else "external"],
+        labels=list(labels),
     )
 
     return data["html_url"]

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -571,6 +571,27 @@ class GitHubAPI:
 
         return repo["private"]
 
+    def get_labels(self, org, repo):
+        path_segments = [
+            "repos",
+            org,
+            repo,
+            "labels",
+        ]
+        url = self._url(path_segments)
+
+        headers = {
+            "Accept": "application/vnd.github.v3+json",
+        }
+        r = self._get(url, headers=headers)
+
+        if r.status_code == 404:
+            return []
+
+        self._raise_for_status(r)
+
+        return [label["name"] for label in r.json()]
+
     def get_repos_with_branches(self, org):
         """
         Get Repos (with branches) from the OpenSAFELY Researchers Team

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,6 +322,9 @@ def github_api():
                 "html_url": "http://example.com/issues/comment",
             }
 
+        def get_labels(self, org, repo):
+            return ["internal", "external"]
+
     return CapturingGitHubAPI()
 
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -80,6 +80,9 @@ class FakeGitHubAPI:
     def get_repo_is_private(self, org, repo):
         return self.get_repo(org, repo)["private"]
 
+    def get_labels(self, org, repo):
+        return ["internal", "external"]
+
     def get_repos_with_branches(self, org):
         return [
             {
@@ -213,6 +216,9 @@ class FakeGitHubAPIWithErrors:
         raise GitHubError()
 
     def get_repo_is_private(self, org, repo):
+        raise GitHubError()
+
+    def get_labels(self, org, repo):
         raise GitHubError()
 
     def get_repos_with_branches(self, org):


### PR DESCRIPTION
When a new release request is submitted on Airlock, we create a new issue for it. By default, this has either the "internal" or "external" label applied. However, non-opensafely output-checking repos may not have these labels, and if we try to create an issue with a non-existent label, we get a 403 from the github API.  We now check for labels on the relevant repo, and ignore any that don't already exist.

This was [reported](https://bennettoxford.slack.com/archives/C01UJLWNZJT/p1748510923798329) by a Bristol user (the only other org that currently do their own output checking)
