### PR TITLE
Fix logo disappearing in the mobile nav view

### DIFF
--- a/templates/_components/header.html
+++ b/templates/_components/header.html
@@ -5,7 +5,7 @@
   "
 >
   <nav class="relative container xl:max-w-(--breakpoint-xl) flex justify-center items-center flex-wrap py-3 gap-y-2">
-    <p class="relative z-20 shrink-0 flex items-center mr-4 text-xl font-extrabold tracking-tight leading-none text-stone-700">
+    <p class="relative z-30 shrink-0 flex items-center mr-4 text-xl font-extrabold tracking-tight leading-none text-stone-700">
       {% url 'home' as url %}
       <a
         class="


### PR DESCRIPTION
When the mobile nav is open, currently the logo doesn't show. This updates the z-index of the logo to fix that.