### PR TITLE
Bump gunicorn timeout to 40s

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -24,6 +24,9 @@ workers = 9
 port = 8000
 bind = "0.0.0.0"
 
+# request timeout - more than the default of 30 for slow API requests
+timeout = 40
+
 
 def post_fork(server, worker):
     # opentelemetry initialisation needs these env vars to be set, so ensure they are


### PR DESCRIPTION
With large amounts of jobs running, we need a little extra headroom for
api requests to complete.
