### PR TITLE
Only call `refresh_from_db()` when actually needed

### DIFF
--- a/jobserver/api/jobs.py
+++ b/jobserver/api/jobs.py
@@ -175,12 +175,11 @@ class JobAPIUpdate(APIView):
                         setattr(job, key, value)
                     job.save()
 
-                # round trip the Job to the db so all fields are converted to
-                # their python representations
-                job.refresh_from_db()
-
                 # We only send notifications or alerts for newly completed jobs
                 if newly_completed:
+                    # round trip the Job to the db so all fields are converted to their
+                    # python representations as expected by the notification code
+                    job.refresh_from_db()
                     handle_job_notifications(job_request, job)
 
         logger.info(


### PR DESCRIPTION
This endpoint is having some performance issues when called with very large numbers of jobs and so reducing unnecessary work seems like a good idea. There's not an easy way to determine the production impact here ahead of time but:

 * this is obviously safe because if we don't take the `newly_completed` branch then the `job` object is immediately discarded;

 * it can't _hurt_ performance to not call `refresh_from_db()`.

So overall this seems worth trying.

Also worth noting that this call was only [introduced][1] to deal with problems with the notifications, so it's only ever been needed for this branch.

Slack discussion at:
https://bennettoxford.slack.com/archives/C069SADHP1Q/p1750839710327239?thread_ts=1750768496.173799&cid=C069SADHP1Q

[1]: https://github.com/opensafely-core/job-server/pull/345