### PR TITLE
Ignore security warning security.W019

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -264,6 +264,7 @@ MESSAGE_TAGS = {
 SILENCED_SYSTEM_CHECKS = [
     "security.W004",  # (SECURE_HSTS_SECONDS) TLS is handled by Nginx
     "security.W008",  # (SECURE_SSL_REDIRECT) HTTPS redirection is handled by CloudFlare
+    "security.W019",  # (X_FRAME_OPTIONS) Set to SAMEORIGIN to allow iframe elements in the outputs viewer
 ]
 
 # Security


### PR DESCRIPTION
We set `X_FRAME_OPTIONS = "SAMEORIGIN"` to allow Job Server to iframe files on the Outputs Viewer application ([source](https://github.com/opensafely-core/job-server/blob/1d18a366aa4b78d048505b5bd7b3324d19c2f500/assets/src/scripts/outputs-viewer/components/Iframe/Iframe.jsx)) – therefore changing that setting to deny is not right for us.