### PR TITLE
For failed jobs add status and message to request

### DIFF
--- a/templates/job_request/detail.html
+++ b/templates/job_request/detail.html
@@ -175,6 +175,13 @@
                       {{ job.identifier }}
                     </code>
                   </dd>
+                  {% if job.status == "failed" and job.status_message %}
+                    <dt class="sr-only">Error:</dt>
+                    <dd class="mt-1 bg-red-50 text-red-900 border-red-200 break-words font-mono text-sm pt-2 pb-1.5 px-3 rounded border">
+                      {% if job.status_code %}<strong>{{ job.status_code }}:</strong>{% endif %}
+                      <span>{{ job.status_message }}</span>
+                    </dd>
+                  {% endif %}
                 </dl>
               </li>
             {% endfor %}


### PR DESCRIPTION
So that the job list can be used to debug the issue, rather than needing to click in to each job from the request to see the errors.

<img src="https://github.com/user-attachments/assets/535a0469-d39f-43be-a598-03a4ab001c5e" width="652" />
