### PR TITLE
Enable `db` for unit/integration tests. Remove `disable_db`.

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -62,12 +62,10 @@ We have a custom `@pytest.mark.slow_test` marker that should be used on test
 that take more than about 0.1s to run. These are excluded from `just test` to
 provide a quicker feedback loop.
 
-All tests have access to the database by default. You should mark up tests that
-don't require such access with `@pytest.mark.disable_db`. This significantly
-speeds up executing the tests in isolation as the test DB doesn't need to be
-spun up and prepared. Note that you can apply this marker at test, class, or
-module level. [See the pytest
-docs](https://docs.pytest.org/en/7.1.x/example/markers.html).
+All unit and integration tests have access to the database by default. You can
+use the `db` fixture fixture to provide access to other tests if required. Or
+search `enable_db_access_for_all_tests`to see how to enable it for a directory
+(via conftest.py) or in a module.
 
 Avoid writing to the database when this isn't necessary, as this is costly.
 Model instances can be created with FactoryBoy's `build` rather than `create`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ filterwarnings = [
 markers = [
   "slow_test: mark test as being slow running",
   "verification: tests that verify fakes",
-  "disable_db: test that do not require a database",
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,17 +54,6 @@ def get_trace():
 
 
 @pytest.fixture(autouse=True)
-def enable_db_access_for_all_tests(request):
-    disable_db = request.node.get_closest_marker("disable_db")
-    if disable_db:
-        # e.g. verification tests don't need the db
-        # CI tests won't hit this line so no cover
-        yield  # pragma: no cover
-    else:
-        yield request.getfixturevalue("db")
-
-
-@pytest.fixture(autouse=True)
 def clear_all_traces():
     test_exporter.clear()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def enable_db_access_for_all_tests(db):
+    pass

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def enable_db_access_for_all_tests(db):
+    pass

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -21,7 +21,7 @@ from ..fakes import FakeGitHubAPI, FakeGitHubAPIWithErrors
 from .utils import assert_deep_type_equality, assert_public_method_signature_equality
 
 
-pytestmark = [pytest.mark.verification, pytest.mark.disable_db]
+pytestmark = [pytest.mark.verification]
 
 
 class TestGitHubAPIAgainstFakes:

--- a/tests/verification/test_opencodelists.py
+++ b/tests/verification/test_opencodelists.py
@@ -6,7 +6,7 @@ from ..fakes import FakeOpenCodelistsAPI
 from .utils import assert_deep_type_equality, assert_public_method_signature_equality
 
 
-pytestmark = [pytest.mark.verification, pytest.mark.disable_db]
+pytestmark = [pytest.mark.verification]
 
 
 def test_fake_public_method_signatures():

--- a/tests/verification/test_utils.py
+++ b/tests/verification/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 from .utils import assert_public_method_signature_equality
 
 
-pytestmark = [pytest.mark.verification, pytest.mark.disable_db]
+pytestmark = [pytest.mark.verification]
 
 
 class TestPublicMethodSignatureEquality:


### PR DESCRIPTION
The `enable_db_access_for_all_tests` fixture in `tests/conftest.py` wasn't working when tests were run in isolation. Change the approach to instead put `autouse=True` `db` fixtures in `tests/unit/conftest.py` and `test/integration/conftest.py` where they are needed.

Remove `disable_db` marker that disallowed test scopes from accessing the DB. There were no tests other than the verification ones that were marked up. They can get the same effect more simply by not being affected by the new `conftest.py`. They won't spin up a test database when run separately from the unit/integration tests.