### PR TITLE
Use non-default Vite `port` to avoid clashes

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -213,7 +213,7 @@ To run the development server:
 1. Update the `.env` file to `ASSETS_DEV_MODE=True`
 2. Run `just assets-run`
 
-This will start the Vite dev server at [localhost:5173](http://localhost:5173/) and inject the relevant scripts into the Django templates.
+This will start the Vite dev server at [localhost:8001](http://localhost:8001/) and inject the relevant scripts into the Django templates.
 
 ### Compiling assets
 

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -293,9 +293,9 @@ STYLE_SRC = [SELF]
 
 # configure django-csp to work with Vite when using it in dev mode
 if ASSETS_DEV_MODE:
-    CONNECT_SRC = SCRIPT_SRC + ["ws://localhost:5173/static/"]
-    FONT_SRC = FONT_SRC + ["http://localhost:5173"]
-    SCRIPT_SRC = SCRIPT_SRC + ["http://localhost:5173"]
+    CONNECT_SRC = SCRIPT_SRC + ["ws://localhost:8001/static/"]
+    FONT_SRC = FONT_SRC + ["http://localhost:8001"]
+    SCRIPT_SRC = SCRIPT_SRC + ["http://localhost:8001"]
     STYLE_SRC = STYLE_SRC + [UNSAFE_INLINE]
 
 CONTENT_SECURITY_POLICY = {

--- a/templates/_includes/outputs-spa.html
+++ b/templates/_includes/outputs-spa.html
@@ -15,7 +15,7 @@
 {% block extra_js %}
   {% if debug %}
     <script type="module" nonce="{{ request.csp_nonce }}">
-      import RefreshRuntime from 'http://localhost:5173/static/@react-refresh'
+      import RefreshRuntime from 'http://localhost:8001/static/@react-refresh'
       RefreshRuntime.injectIntoGlobalHook(window)
       window.$RefreshReg$ = () => {}
       window.$RefreshSig$ = () => (type) => type

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -25,7 +25,9 @@ export default defineConfig(({ mode }) => ({
     emptyOutDir: true,
   },
   server: {
-    origin: "http://localhost:5173",
+    origin: "http://localhost:8001",
+    port: 8001,
+    strictPort: true,
   },
   clearScreen: false,
   plugins: [


### PR DESCRIPTION
Before this change, if you ran `run-assets` while another Vite server was running somewhere on your local development system on also on the default port, the new Vite server would automatically pick another free port, which would then not match the origin configured and assets wouldn't load.

This would happen if trying to run `job-server` alongside `opencodelists`, for example.

Using port `8001` as this one more than `8000` used by the `just run` webserver, so it's in the same "namespace".

Some templates and settings have the port hardcoded in dev mode. Change those and therefore use `strictPort` as it's required for those to work.