### PR TITLE
Use the official Hadolint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         entry: djhtml --tabwidth 2 # Use a tabwidth of 2 for HTML files
         files: ^templates/.*\.html$ # Indent only HTML files in template directories
 
-  - repo: https://github.com/stratasan/hadolint-pre-commit
-    rev: cdefcb096e520a6daa9552b1d4636f5f1e1729cd
+  - repo: https://github.com/hadolint/hadolint
+    rev: b3555ba9c2bfd9401e79f2f0da68dd1ae38e10c7 # v2.12.0
     hooks:
-    - id: hadolint
+    - id: hadolint-docker


### PR DESCRIPTION
The one we were using is archived, and failing to run in my environment.

This is the officially suggested way of adding a pre-commit hook with Docker:

https://github.com/hadolint/hadolint/blob/0a3cedd0dc556e79d7298e5080642f02047ca1f5/docs/INTEGRATION.md#pre-commit

This uses the commit corresponding to the latest current release, v2.12.0, which is from 2022-10-09.

(There are new beta tags, though in practice, the
`.pre-commit-hooks.yaml` in the `hadolint` repository has not changed since 2022-04 anyway, so we're effectively on the latest version for our purposes. The version of the Docker image used by the hook is always the latest:

https://github.com/hadolint/hadolint/commit/4db5d18d0115b7faeb122206b207866edbb5344e)