### PR TITLE
Switch to base-docker 24.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG NODE_VERSION
 # the latest base image, by design.
 #
 # hadolint ignore=DL3007
-FROM ghcr.io/opensafely-core/base-docker:22.04 as base-python
+FROM ghcr.io/opensafely-core/base-docker:24.04 as base-python
 
 # we are going to use an apt cache on the host, so disable the default debian
 # docker clean up that deletes that cache on every apt install
@@ -19,7 +19,7 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # see: https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
 # use space efficient utility from base image
 RUN --mount=type=cache,target=/var/cache/apt \
-    echo "deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
+    echo "deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu noble main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
     /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc
 
 # install any additional system dependencies


### PR DESCRIPTION
This upgrades to newer Ubuntu and gets us a newer version of the
PostgreSQL client which should be backwards compatible with our existing
database, while allowing us to upgrade to PostgreSQL 16 in future.

This avoids the additional step of having to use the PostgreSQL
repository with Ubuntu 22.04 to get a suitable PostgreSQL client.