### PR TITLE
Handle rate limit for unauthenticated request test

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -130,7 +130,7 @@ class GitHubAPI:
         try:
             request.raise_for_status()
         except requests.HTTPError as exc:
-            raise HTTPError(exc)
+            raise HTTPError from exc
 
     def _get_query_page(self, *, query, session, cursor, **kwargs):
         """

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -476,8 +476,9 @@ class TestGithubAPINonPrivate:
         try:
             assert GitHubAPI().get_repo("opensafely-testing", "github-api-testing")
         except HTTPError as e:  # pragma: no cover
-            forbidden = e.response.status_code == 403
-            rate_limited = "rate limit exceeded for url" in str(e)
+            requests_exception = e.__cause__
+            forbidden = requests_exception.response.status_code == 403
+            rate_limited = "rate limit exceeded for url" in str(requests_exception)
 
             if forbidden and rate_limited:
                 # being rate limited is still a valid access of the API


### PR DESCRIPTION
We were seeing failures for job-server's verification tests more frequently recently.

It's easy when reading the logs to think that this is a rate limit issue on unauthenticated requests.

It *is*. But it also isn't.

This test specifically doesn't use the PAT that we use for testing. That means we're:

* subject to GitHub's low rate limits for unauthenticated users
* and running in GitHub Actions runners that probably often end up using GitHub's API frequently

Those two issues combined mean we often exceed the rate limit.

Our test in fact is supposed to handle the case where we're rate limited by GitHub, and pass successfully instead.

The problem is that our code doesn't quite handle the wrapping of the exception properly. It treats our custom `HTTPError` exception as the `requests` exception, tries to access the status code and fails.