### PR TITLE
Fix verification test failures introduced in #5184

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -315,6 +315,8 @@ class GitHubAPI:
 
         if count > 0:
             return items[0]["number"]
+        else:
+            raise IssueNotFound()
 
     def create_issue_comment(
         self, org, repo, title_text, body, latest=True, issue_number=None, labels=None


### PR DESCRIPTION
This fixes a failing verification test  introduced in #5184 that expects a `IssueNotFound` to be raised when no issues matching the given title are found. Prior to this, the non-existence of the issue was not handled correctly and subsequent API calls would try to append a comment to a nonexistent issue, resulting in an unhandled HTTP 404 error.
