### PR TITLE
Fix github verification tests

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -304,9 +304,6 @@ class GitHubAPI:
         }
         r = self._get(url, headers=headers, params=payload)
 
-        if r.status_code == 404:
-            raise IssueNotFound()
-
         self._raise_for_status(r)
 
         results = r.json()
@@ -315,6 +312,7 @@ class GitHubAPI:
 
         if count > 0:
             return items[0]["number"]
+        raise IssueNotFound()
 
     def create_issue_comment(
         self, org, repo, title_text, body, latest=True, issue_number=None, labels=None

--- a/tests/verification/test_github.py
+++ b/tests/verification/test_github.py
@@ -141,8 +141,8 @@ class TestGithubAPIPrivate:
 
     def test_get_issue_number_no_matches(self, github_api):
         args = ["opensafely-testing", "github-api-testing-private", new_ulid_str()]
-        real = github_api.get_issue_number_from_title(*args)
-        assert real is None
+        with pytest.raises(IssueNotFound):
+            github_api.get_issue_number_from_title(*args)
 
     @pytest.mark.parametrize("labels", [["Under review"], None])
     def test_create_issue_comment(self, github_api, labels):


### PR DESCRIPTION
[8aadbd4](https://github.com/opensafely-core/job-server/pull/5184/commits/8aadbd4d8a49d134427734ec016043551c6d2b53) sensibly moved the point at which an IssueNotFound error was raised, however, it needed to also update the check that should raise it. Fetching issue numbers by issue title returns a 200 with a count of 0 if the issue does not exist.

Verification tests are now [passing](https://github.com/opensafely-core/job-server/actions/runs/16720526450)