### PR TITLE
Change the honeycomb queries to query all datasets

### DIFF
--- a/jobserver/honeycomb.py
+++ b/jobserver/honeycomb.py
@@ -8,7 +8,7 @@ from furl import furl
 def honeycomb_furl():
     # TODO: make this configurable?
     return furl(
-        "https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production/datasets/jobrunner"
+        "https://ui.honeycomb.io/bennett-institute-for-applied-data-science/environments/production"
     )
 
 


### PR DESCRIPTION
With the controller/agent split, we renamed the honeycomb datasets, but
the honeycomb links were specifically using the old jobrunner dataset.

Instead, run the query across all datasets, so we don't need to worry
about the name, and a resilient to future dataset/service name changes.
