### PR TITLE
Exclude test backend job Requests on homepage

### DIFF
--- a/jobserver/views/index.py
+++ b/jobserver/views/index.py
@@ -14,6 +14,7 @@ class Index(View):
                 "workspace__project",
             )
             .prefetch_related("workspace__project__orgs")
+            .filter(backend__is_active=True)
             .order_by("-pk")
         )
 

--- a/templates/_partials/latest-job-requests-table.html
+++ b/templates/_partials/latest-job-requests-table.html
@@ -2,7 +2,7 @@
 
 {% url "job-list" as job_list_url %}
 <div id="events" class="max-w-[1500px] w-full mx-auto">
-  {% #card class="mx-4" no_container=True title="Latest job requests" subtitle="Most recent job requests on the OpenSAFELY platform" button=True button_text="View all job requests" button_href=job_list_url %}
+  {% #card class="mx-4" no_container=True title="Latest Analyses on Active Backend" subtitle="Most recent job requests run against active backends on the OpenSAFELY platform" button=True button_text="View all job requests" button_href=job_list_url %}
     <div class="relative overflow-hidden px-4 py-2 border-t border-slate-200 md:px-6">
       <div class="flow-root">
         <div class="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">


### PR DESCRIPTION
## Description
This fixes #5183 which prevents `JobRequest` that come from inactive backends from appearing on the homepage.

### Acceptance Criteria
1. _We've communicated our intent to do this to the service team so they're aware and can let us know if they think this damages transparency/publicity_ - Discussed this on [nod channel](https://bennettoxford.slack.com/archives/C068NDYALSF/p1756458662888819) and the team is happy with this change.

2. _We've decided how/which backends to exclude._ - We have decided to only display jobs run against backends that are marked as `is_active`. For now, tpp is the only one marked as active. More info on [this](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1755689793592179) and [this](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1756303389720579?thread_ts=1754379227.101509&cid=C069SADHP1Q) thread.
3.  _Jobs from those backends no longer appear in the table._ - The issue also mentions that such jobs should be hidden for researchers or non-logged-in users. Therefore, I have filtered `job_requests` earlier in the code so that both aunthenticated and unathenticated users will not see `Test` backend job requests.
4. _Wording above the table is tweaked to mention something about now being specifically analysis against patient data (as test backend isn't). Maybe don't mention phrase "job request" as not that meaningful to a public audience._ - I have updated the title and subtitle of the table. I have used the word **Analyses** instead of **job requests** but I also feel the word job requests is used everywhere else so either we should change all or nothing. Would love to know what the reviewer thinks.

## Testing
1. Added a unit test to ensure it is working as expected.
2. For testing (both logged and non-logged-in views), I increased the job_requests limit on homepage to 100 and was able to test that job servers with `Test` backend were not displayed. We could also create a new job server with test backend and ensure it is not shown on homepage.
Before:

<img width="1796" height="385" alt="Screenshot from 2025-08-29 15-46-52" src="https://github.com/user-attachments/assets/7d77df18-1133-4717-861f-91b42b6538c1" />

After:

<img width="1787" height="311" alt="Screenshot from 2025-08-29 15-48-43" src="https://github.com/user-attachments/assets/d6dd10be-f8ea-4906-b40b-3bf64e1dd860" />


