### PR TITLE
Allow cancellation of a job request with cancelled jobs

### DIFF
--- a/templates/job_request/detail.html
+++ b/templates/job_request/detail.html
@@ -35,7 +35,7 @@
 
   {% if job_request.cancelled_actions and not job_request.is_completed %}
     {% #alert variant="info" title="Cancellation requested" class="mb-4" %}
-      A User has requested this job is cancelled.
+      A User has requested that jobs in this request are cancelled.
     {% /alert %}
   {% endif %}
 
@@ -87,13 +87,13 @@
         {% if user_can_cancel_jobs %}
           <form class="d-inline-block" method="POST" action="{{ job_request.get_cancel_url }}">
             {% csrf_token %}
-            {% if job_request.is_completed or job_request.cancelled_actions %}
+            {% if job_request.is_completed or not job_request.has_cancellable_actions %}
               {% #button type="submit" disabled=True tooltip="This job request can no longer be cancelled" %}
-                Cancel this job
+                Cancel this job request
               {% /button %}
             {% else %}
               {% #button type="submit" variant="danger" %}
-                Cancel this job
+                Cancel this job request
               {% /button %}
             {% endif %}
           </form>

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -231,6 +231,55 @@ def test_jobrequest_request_cancellation():
     assert set(job_request.cancelled_actions) == {"job1", "job2"}
 
 
+def test_jobrequest_request_cancellation_with_existing_cancelled_jobs():
+    job_request = JobRequestFactory(cancelled_actions=[])
+    JobFactory(job_request=job_request, action="job1", status="pending")
+    JobFactory(job_request=job_request, action="job2", status="running")
+    JobFactory(job_request=job_request, action="job3", status="failed")
+    JobFactory(job_request=job_request, action="job4", status="succeeded")
+
+    job_request.request_cancellation()
+
+    job_request.refresh_from_db()
+    assert set(job_request.cancelled_actions) == {"job1", "job2"}
+
+
+def test_jobrequest_has_cancellable_actions():
+    # An action is cancellable if it is pending or running and has not
+    # already been cancelled
+    # This job has no cancelled actions
+    job_request = JobRequestFactory(cancelled_actions=["job1"])
+    JobFactory(job_request=job_request, action="job1", status="pending")
+    JobFactory(job_request=job_request, action="job2", status="running")
+    JobFactory(job_request=job_request, action="job3", status="running")
+    JobFactory(job_request=job_request, action="job3", status="failed")
+    JobFactory(job_request=job_request, action="job4", status="succeeded")
+
+    job_request.refresh_from_db()
+    assert job_request.has_cancellable_actions
+
+    # cancel one job
+    job_request.cancelled_actions = ["job1"]
+    job_request.save()
+    assert job_request.has_cancellable_actions
+
+    # cancel the remaining jobs
+    job_request.request_cancellation()
+    job_request.refresh_from_db()
+    assert not job_request.has_cancellable_actions
+
+
+def test_completed_jobrequest_has_cancellable_actions():
+    # An action is cancellable if it is pending or running and has not
+    # already been cancelled
+    job_request = JobRequestFactory(cancelled_actions=[])
+    JobFactory(job_request=job_request, action="job1", status="failed")
+    JobFactory(job_request=job_request, action="job2", status="succeeded")
+
+    job_request.refresh_from_db()
+    assert not job_request.has_cancellable_actions
+
+
 def test_jobrequest_runtime_one_job_missing_completed_at(freezer):
     job_request = JobRequestFactory()
 

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -1227,7 +1227,7 @@ def test_jobrequestdetail_with_permission_num_queries(
         )
         assert response.status_code == 200
 
-    with django_assert_num_queries(5):
+    with django_assert_num_queries(6):
         response.render()
 
 


### PR DESCRIPTION
This allows users to cancel an entire job request as long as there are still some cancellable actions (actions that are pending/running and haven't already been requested for cancellation).

Previously, if a single job in a job request was cancelled, the cancel button for the entire job request was disabled.

Cancelling a single job just adds it to the job request's cancelled actions. Cancelling an entire job request adds all active actions to the job request's cancelled actions, so this doesn't cause any issues.

Also drive-by update to the slightly misleading button wording on the job request page (Cancel this job -> Cancel this job request).