### PR TITLE
Fix: correct cancel job request button text

### DIFF
--- a/templates/job/detail.html
+++ b/templates/job/detail.html
@@ -51,11 +51,11 @@
           {% csrf_token %}
           {% if job.is_completed or job.action in job.job_request.cancelled_actions %}
             {% #button type="submit" disabled=True tooltip="This job can no longer be cancelled" %}
-              Cancel this job
+         Cancel this job request
             {% /button %}
           {% else %}
             {% #button type="submit" variant="danger" %}
-              Cancel this job
+              Cancel this job request
             {% /button %}
           {% endif %}
         </form>


### PR DESCRIPTION
This pull request fixes the text on the "Cancel this job request" button in the `detail.html` template. 

### Changes:
- Updated button label when the job can still be cancelled.
- Improves clarity for end users interacting with job requests.

No functional logic was changed — this is a UI text fix only.
