### PR TITLE
Add `jobserver/rap_api.py` and `cancel_jobs` management command.

### DIFF
--- a/jobserver/management/commands/cancel_jobs.py
+++ b/jobserver/management/commands/cancel_jobs.py
@@ -1,0 +1,37 @@
+"""Management command to cancel Jobs via the RAP API."""
+
+import structlog
+from django.core.management.base import BaseCommand
+
+from jobserver import rap_api
+
+
+class Command(BaseCommand):
+    """Management command to cancel Jobs via the RAP API."""
+
+    help = "Cancel RAP jobs via the RAP API."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "job_request_id",
+            type=str,
+            help="ID of the JobRequest to cancel.",
+        )
+        parser.add_argument(
+            "actions",
+            nargs="+",
+            type=str,
+            help="List of actions to cancel for the given JobRequest.",
+        )
+
+    def handle(self, *args, **options):
+        logger = structlog.get_logger(__name__)
+        try:
+            logger.info(
+                rap_api.cancel(
+                    options["job_request_id"],
+                    options["actions"],
+                )
+            )
+        except Exception as exc:
+            logger.error(exc)

--- a/jobserver/management/commands/cancel_jobs.py
+++ b/jobserver/management/commands/cancel_jobs.py
@@ -13,15 +13,15 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "job_request_id",
+            "rap_id",
             type=str,
-            help="ID of the JobRequest to cancel.",
+            help="ID of the RAP to cancel. Equivalent to JobRequest.identifier.",
         )
         parser.add_argument(
             "actions",
             nargs="+",
             type=str,
-            help="List of actions to cancel for the given JobRequest.",
+            help="List of actions to cancel for the given RAP.",
         )
 
     def handle(self, *args, **options):
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         try:
             logger.info(
                 rap_api.cancel(
-                    options["job_request_id"],
+                    options["rap_id"],
                     options["actions"],
                 )
             )

--- a/jobserver/management/commands/check_rap_api_status.py
+++ b/jobserver/management/commands/check_rap_api_status.py
@@ -1,39 +1,14 @@
-from urllib.parse import urljoin
-
-import requests
 import structlog
-from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
+
+from jobserver import rap_api
 
 
 class Command(BaseCommand):
-    @staticmethod
-    def check_rap_api_status():
-        if not (settings.RAP_API_BASE_URL and settings.RAP_API_TOKEN):
-            raise CommandError(
-                "Required environment variables RAP_API_BASE_URL and RAP_API_TOKEN are not set"
-            )
-
-        try:
-            response = requests.get(
-                urljoin(settings.RAP_API_BASE_URL, "backend/status/"),
-                headers={"Authorization": settings.RAP_API_TOKEN},
-            )
-
-        except requests.exceptions.RequestException as e:
-            raise CommandError(f"RAP API endpoint not available {e}")
-
-        if response.status_code != 200:
-            raise CommandError(
-                f"RAP API endpoint returned an error {response.status_code}"
-            )
-
-        return response.content
-
     def handle(self, *args, **options):
         logger = structlog.get_logger(__name__)
 
         try:
-            logger.info(self.check_rap_api_status())
-        except CommandError as e:
-            logger.error(e)
+            logger.info(rap_api.backend_status())
+        except Exception as exc:
+            logger.error(exc)

--- a/jobserver/rap_api.py
+++ b/jobserver/rap_api.py
@@ -1,0 +1,87 @@
+"""Methods to interact with the RAP Controller via its API.
+
+These allow control and query of Reproducible Analytics Pipelines executed in a
+Backend to service a Job Request.
+
+Reference for how the server defines the API endpoints:
+https://controller.opensafely.org/controller/v1/docs/
+https://github.com/opensafely-core/job-runner/tree/main/controller/webapp/api_spec
+
+The functions corresponding to each endpoint should not leak HTTP-layer
+information or the implementation detail that we use the requests library. So
+they should return subclasses of RapAPIError for relevant status codes or other
+errors, for example. They should probably not need to transform the response
+body defined in the spec. Clients of this module will interpret those further.
+"""
+
+from urllib.parse import urljoin
+
+import requests
+from django.conf import settings
+
+
+class RapAPIError(Exception):
+    """Base exception for this module. A problem contacting or using the RAP
+    API."""
+
+
+class RapAPISettingsError(RapAPIError):
+    """There was a problem with the relevant Django settings."""
+
+
+class RapAPICommunicationError(RapAPIError):
+    """A request to the RAP API failed to return a response."""
+
+
+class RapAPIResponseError(RapAPIError):
+    """A response to a RAP API request indicated an error."""
+
+
+def _api_call(request_method, endpoint_path):
+    """Communicate with a remote RAP API endpoint and return the response.
+
+    Args:
+        request_method: One of the requests.request HTTP helper methods.
+        endpoint_path: Subpath of the endpoint. No leading slash.
+
+    Raises:
+        RapAPISettingsError
+        RapAPICommunicationError
+    """
+    # Check the required settings early.
+    if not (settings.RAP_API_BASE_URL and settings.RAP_API_TOKEN):
+        raise RapAPISettingsError(
+            "A required environment variable RAP_API_BASE_URL and/or RAP_API_TOKEN is not set"
+        )
+
+    # Do the request-response cycle.
+    try:
+        response = request_method(
+            urljoin(settings.RAP_API_BASE_URL, endpoint_path),
+            headers={"Authorization": settings.RAP_API_TOKEN},
+        )
+    except requests.exceptions.RequestException as exc:
+        raise RapAPICommunicationError(f"RAP API endpoint not available: {exc}")
+
+    return response
+
+
+def backend_status():
+    """
+    Query the RAP API to get status flags for all allowed backends.
+
+    Refer to the specification (see module docstring) for how to interpret the result.
+
+    Raises:
+        RapAPISettingsError
+        RapAPICommunicationError
+        RapAPIResponseError
+    """
+    response = _api_call(requests.get, "backend/status/")
+
+    if response.status_code != 200:
+        raise RapAPIResponseError(
+            f"RAP API endpoint returned an error {response.status_code}"
+        )
+
+    return response.json()

--- a/jobserver/rap_api.py
+++ b/jobserver/rap_api.py
@@ -58,6 +58,18 @@ def _api_call(request_method, endpoint_path, json=None):
             "A required environment variable RAP_API_BASE_URL and/or RAP_API_TOKEN is not set"
         )
 
+    # Check the method is one covered in the tests of this module.
+    allowed_methods = {
+        requests.get,
+        requests.post,
+    }
+    if (
+        request_method not in allowed_methods
+        # Special method name allowed for tests that aren't about a specific requests method.
+        and request_method.__name__ != "fake_request_method"
+    ):
+        raise ValueError(f"request_method not allowed: {request_method.__qualname__}")
+
     # Do the request-response cycle.
     try:
         response = request_method(
@@ -105,7 +117,7 @@ def cancel(job_request_id, actions):
         RapAPIResponseError
     """
     request_body = {"rap_id": job_request_id, "actions": actions}
-    response = _api_call(requests.post, "rap/cancel/", request_body)
+    response = _api_call(requests.put, "rap/cancel/", request_body)
 
     if response.status_code != 200:
         raise RapAPIResponseError(

--- a/jobserver/rap_api.py
+++ b/jobserver/rap_api.py
@@ -71,6 +71,12 @@ def _api_call(request_method, endpoint_path, json=None):
     ):
         raise ValueError(f"request_method not allowed: {request_method.__qualname__}")
 
+    if request_method == requests.get and json is not None:
+        # A payload within a GET request message has no defined semantics.
+        raise ValueError(
+            "request_method requests.get and json parameter not allowed together"
+        )
+
     # Do the request-response cycle.
     try:
         response = request_method(

--- a/jobserver/rap_api.py
+++ b/jobserver/rap_api.py
@@ -29,12 +29,13 @@ class RapAPISettingsError(RapAPIError):
     """There was a problem with the relevant Django settings."""
 
 
-class RapAPICommunicationError(RapAPIError):
-    """A request to the RAP API failed to return a response."""
+class RapAPIRequestError(RapAPIError):
+    """A request to the RAP API failed. Could be due to a problem communicating the
+    request or receiving no response."""
 
 
 class RapAPIResponseError(RapAPIError):
-    """A response to a RAP API request indicated an error."""
+    """A response to a RAP API request was received but indicated an error."""
 
     def __init__(self, message, body=None):
         super().__init__(message)
@@ -50,7 +51,7 @@ def _api_call(request_method, endpoint_path, json=None):
 
     Raises:
         RapAPISettingsError
-        RapAPICommunicationError
+        RapAPIRequestError
     """
     # Check the required settings early.
     if not (settings.RAP_API_BASE_URL and settings.RAP_API_TOKEN):
@@ -78,7 +79,7 @@ def _api_call(request_method, endpoint_path, json=None):
             json=json,
         )
     except requests.exceptions.RequestException as exc:
-        raise RapAPICommunicationError(f"RAP API endpoint not available: {exc}")
+        raise RapAPIRequestError(f"RAP API endpoint not available: {exc}")
 
     return response
 
@@ -91,7 +92,7 @@ def backend_status():
 
     Raises:
         RapAPISettingsError
-        RapAPICommunicationError
+        RapAPIRequestError
         RapAPIResponseError
     """
     response = _api_call(requests.get, "backend/status/")
@@ -113,7 +114,7 @@ def cancel(job_request_id, actions):
 
     Raises:
         RapAPISettingsError
-        RapAPICommunicationError
+        RapAPIRequestError
         RapAPIResponseError
     """
     request_body = {"rap_id": job_request_id, "actions": actions}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -423,8 +423,6 @@ def site_alert():
     return SiteAlertFactory(level=SiteAlert.Level.WARNING)
 
 
-RAP_API_BASE_URL = "http://example.com/rap/"
-
 # These fixtures are autouse so that no test this conftest applies to can
 # accidentally use the real API URL/token from an environment variable via
 # normal settings.py. Individual tests can use the settings fixture to change
@@ -442,5 +440,6 @@ def rap_api_token(settings):
 @pytest.fixture(autouse=True)
 def rap_api_base_url(settings):
     """Django settting for the base URL for communicating with the RAP API."""
-    settings.RAP_API_BASE_URL = RAP_API_BASE_URL
-    return RAP_API_BASE_URL
+    rap_api_base_url = "http://example.com/rap/"
+    settings.RAP_API_BASE_URL = rap_api_base_url
+    return rap_api_base_url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -421,3 +421,26 @@ def role_factory():
 def site_alert():
     """A fixture providing a SiteAlert with a fixed level."""
     return SiteAlertFactory(level=SiteAlert.Level.WARNING)
+
+
+RAP_API_BASE_URL = "http://example.com/rap/"
+
+# These fixtures are autouse so that no test this conftest applies to can
+# accidentally use the real API URL/token from an environment variable via
+# normal settings.py. Individual tests can use the settings fixture to change
+# the settings to some other value or blank.
+
+
+@pytest.fixture(autouse=True)
+def rap_api_token(settings):
+    """Django settting for the token for communicating with the RAP API."""
+    token = "rap_token"
+    settings.RAP_API_TOKEN = token
+    return token
+
+
+@pytest.fixture(autouse=True)
+def rap_api_base_url(settings):
+    """Django settting for the base URL for communicating with the RAP API."""
+    settings.RAP_API_BASE_URL = RAP_API_BASE_URL
+    return RAP_API_BASE_URL

--- a/tests/unit/jobserver/management/commands/test_cancel_jobs.py
+++ b/tests/unit/jobserver/management/commands/test_cancel_jobs.py
@@ -9,7 +9,7 @@ def test_command(monkeypatch, log_output):
 
     monkeypatch.setattr(
         "jobserver.rap_api.cancel",
-        lambda job_request_id, actions: test_response_body,
+        lambda rap_id, actions: test_response_body,
     )
 
     call_command("cancel_jobs", *_FAKE_ARGS)
@@ -21,7 +21,7 @@ def test_command(monkeypatch, log_output):
 
 
 def test_command_error(monkeypatch, log_output):
-    def fake_cancel(job_request_id, actions):
+    def fake_cancel(rap_id, actions):
         raise Exception("something went wrong")
 
     monkeypatch.setattr("jobserver.rap_api.cancel", fake_cancel)

--- a/tests/unit/jobserver/management/commands/test_cancel_jobs.py
+++ b/tests/unit/jobserver/management/commands/test_cancel_jobs.py
@@ -1,0 +1,32 @@
+from django.core.management import call_command
+
+
+_FAKE_ARGS = ("abcde1234", "action1", "action2")
+
+
+def test_command(monkeypatch, log_output):
+    test_response_body = b'{"foo": "bar"}'
+
+    monkeypatch.setattr(
+        "jobserver.rap_api.cancel",
+        lambda job_request_id, actions: test_response_body,
+    )
+
+    call_command("cancel_jobs", *_FAKE_ARGS)
+
+    assert log_output.entries[0] == {
+        "event": test_response_body,
+        "log_level": "info",
+    }
+
+
+def test_command_error(monkeypatch, log_output):
+    def fake_cancel(job_request_id, actions):
+        raise Exception("something went wrong")
+
+    monkeypatch.setattr("jobserver.rap_api.cancel", fake_cancel)
+
+    call_command("cancel_jobs", *_FAKE_ARGS)
+
+    assert "error" == log_output.entries[0]["log_level"]
+    assert "something went wrong" in str(log_output.entries[0]["event"])

--- a/tests/unit/jobserver/management/commands/test_check_rap_api_status.py
+++ b/tests/unit/jobserver/management/commands/test_check_rap_api_status.py
@@ -1,83 +1,30 @@
-import pytest
-import responses
-import responses.matchers
-from django.core.management import CommandError, call_command
-
-from jobserver.management.commands.check_rap_api_status import Command as cd
-from tests.conftest import RAP_API_BASE_URL
+from django.core.management import call_command
 
 
-TEST_STATUS_URL = f"{RAP_API_BASE_URL}backend/status/"
 TEST_RESPONSE_BODY = b'{"backends":[{"name":"test","last_seen":{"since":"2025-08-12T06:57:43.039078Z"},"paused":{"status":"off","since":"2025-08-12T14:33:57.413881Z"},"db_maintenance":{"status":"off","since":null,"type":null}}]}'
 
 
-def test_check_rap_api_status(rap_api_token):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            TEST_STATUS_URL,
-            body=TEST_RESPONSE_BODY,
-            match=[responses.matchers.header_matcher({"Authorization": rap_api_token})],
-            status=200,
-        )
+def test_command(monkeypatch, log_output):
+    monkeypatch.setattr(
+        "jobserver.rap_api.backend_status",
+        lambda: TEST_RESPONSE_BODY,
+    )
 
-        result = cd.check_rap_api_status()
-        assert result == TEST_RESPONSE_BODY
+    call_command("check_rap_api_status")
 
-
-def test_check_rap_api_status_bad_token(rap_api_token):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            TEST_STATUS_URL,
-            match=[responses.matchers.header_matcher({"Authorization": rap_api_token})],
-            status=401,
-        )
-
-        with pytest.raises(CommandError, match="returned an error"):
-            cd.check_rap_api_status()
+    assert log_output.entries[0] == {
+        "event": TEST_RESPONSE_BODY,
+        "log_level": "info",
+    }
 
 
-def test_check_rap_api_status_not_available():
-    # Ask responses to intercept requests, but do not define any
-    with responses.RequestsMock():
-        with pytest.raises(CommandError, match="not available"):
-            cd.check_rap_api_status()
+def test_command_error(monkeypatch, log_output):
+    def fake_backend_status():
+        raise Exception("something went wrong")
 
+    monkeypatch.setattr("jobserver.rap_api.backend_status", fake_backend_status)
 
-def test_check_rap_api_status_env_vars_not_set(settings):
-    # override the autouse rap_api_base_url and rap_api_token fixtures
-    settings.RAP_API_TOKEN = ""
-    settings.RAP_API_BASE_URL = ""
+    call_command("check_rap_api_status")
 
-    # settings errors are the first raised
-    with responses.RequestsMock():
-        with pytest.raises(
-            CommandError, match="RAP_API_BASE_URL and RAP_API_TOKEN are not set"
-        ):
-            cd.check_rap_api_status()
-
-
-def test_command(rap_api_token, log_output):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            TEST_STATUS_URL,
-            body=TEST_RESPONSE_BODY,
-            match=[responses.matchers.header_matcher({"Authorization": rap_api_token})],
-            status=200,
-        )
-        call_command("check_rap_api_status")
-
-        assert log_output.entries[0] == {
-            "event": TEST_RESPONSE_BODY,
-            "log_level": "info",
-        }
-
-
-def test_command_error(log_output):
-    with responses.RequestsMock():
-        call_command("check_rap_api_status")
-
-        assert "error" == log_output.entries[0]["log_level"]
-        assert "not available" in str(log_output.entries[0]["event"])
+    assert "error" == log_output.entries[0]["log_level"]
+    assert "something went wrong" in str(log_output.entries[0]["event"])

--- a/tests/unit/jobserver/test_rap_api.py
+++ b/tests/unit/jobserver/test_rap_api.py
@@ -70,7 +70,7 @@ class TestApiCall:
         def fake_request_method(url, **kwargs):
             return (url, kwargs)
 
-        response = _api_call(fake_request_method, "some/path/", json=json)
+        response = _api_call(fake_request_method, path, json=json)
 
         assert response[0] == f"{rap_api_base_url}{path}"
         assert response[1]["json"] == json
@@ -87,7 +87,7 @@ class TestApiCall:
         def fake_request_method(url, **kwargs):
             return (url, kwargs)
 
-        response = _api_call(fake_request_method, "some/path/")
+        response = _api_call(fake_request_method, path)
 
         assert response[0] == f"{rap_api_base_url}{path}"
         assert response[1]["json"] is None

--- a/tests/unit/jobserver/test_rap_api.py
+++ b/tests/unit/jobserver/test_rap_api.py
@@ -50,6 +50,9 @@ class TestApiCall:
     def test_request_exception(self):
         """Test that a requests module RequestException is transformed and re-raised."""
 
+        # Using a fake method here helps avoid conflating issues about how we invoke
+        # the actual requests methods with issues in the _api_call code.
+        # Note that this magic method name is specifically allowed in api_call.
         def fake_request_method(*args, **kwargs):
             raise requests.exceptions.RequestException("boom")
 
@@ -63,6 +66,7 @@ class TestApiCall:
 
         # Using a fake method here helps avoid conflating issues about how we invoke
         # the actual requests methods with issues in the _api_call code.
+        # Note that this magic method name is specifically allowed in api_call.
         def fake_request_method(url, **kwargs):
             return (url, kwargs)
 
@@ -79,6 +83,7 @@ class TestApiCall:
 
         # Using a fake method here helps avoid conflating issues about how we invoke
         # the actual requests methods with issues in the _api_call code.
+        # Note that this magic method name is specifically allowed in api_call.
         def fake_request_method(url, **kwargs):
             return (url, kwargs)
 
@@ -87,6 +92,12 @@ class TestApiCall:
         assert response[0] == f"{rap_api_base_url}{path}"
         assert response[1]["json"] is None
         assert response[1]["headers"] == {"Authorization": rap_api_token}
+
+    def test_disallowed_method(self):
+        """Test that a disallowed request_method raises right Exception."""
+        path = "some/path/"
+        with pytest.raises(ValueError, match="request_method not allowed"):
+            _api_call(requests.put, path)
 
     def test_requests_get(self, rap_api_base_url, rap_api_token):
         """Test that the actual requests.get method handles headers correctly."""

--- a/tests/unit/jobserver/test_rap_api.py
+++ b/tests/unit/jobserver/test_rap_api.py
@@ -119,7 +119,16 @@ class TestApiCall:
         assert response.status_code == 200
         assert response.json() == response_body
 
-    def test_headers_requests_post(self, rap_api_base_url, rap_api_token):
+    def test_request_get_and_json(self):
+        """Test that request_method requests.get disallowed with JSON parameter.
+
+        A payload within a GET request message has no defined semantics.
+        """
+        path = "some/path/"
+        with pytest.raises(ValueError, match="requests.get and json parameter"):
+            _api_call(requests.get, path, json={})
+
+    def test_requests_post(self, rap_api_base_url, rap_api_token):
         """Test that the actual requests.post method handles headers and body correctly."""
         path = "some/path/"
         request_body = {"hello": "world"}

--- a/tests/unit/jobserver/test_rap_api.py
+++ b/tests/unit/jobserver/test_rap_api.py
@@ -14,7 +14,7 @@ import responses
 import responses.matchers
 
 from jobserver.rap_api import (
-    RapAPICommunicationError,
+    RapAPIRequestError,
     RapAPIResponseError,
     RapAPISettingsError,
     _api_call,
@@ -56,7 +56,7 @@ class TestApiCall:
         def fake_request_method(*args, **kwargs):
             raise requests.exceptions.RequestException("boom")
 
-        with pytest.raises(RapAPICommunicationError):
+        with pytest.raises(RapAPIRequestError):
             _api_call(fake_request_method, "some/path/")
 
     def test_success_fake_request_method(self, rap_api_base_url, rap_api_token):

--- a/tests/unit/jobserver/test_rap_api.py
+++ b/tests/unit/jobserver/test_rap_api.py
@@ -1,0 +1,142 @@
+"""Unit tests of jobserver.rap_api.
+
+It is a design goal of this module that the unit tests of the clients of the
+endpoint functions should not need to know anything about how we actually make
+the API call. They should mock the endpoint functions to return the required
+objects or exceptions. They should not be patching the requests module.
+
+When adding an endpoint make sure that the request method you use has tests for
+it in TestAPICall."""
+
+import pytest
+import requests
+import responses
+import responses.matchers
+
+from jobserver.rap_api import (
+    RapAPICommunicationError,
+    RapAPIResponseError,
+    RapAPISettingsError,
+    _api_call,
+    backend_status,
+)
+
+
+class TestApiCall:
+    """Tests of api_call. Separating the commonality allows the individual
+    endpoint function tests to focus on the response status code and body,
+    which they should mock using patch_api_call."""
+
+    def test_missing_url_setting(self, settings):
+        """Test that missing the URL setting raises right Exception."""
+        settings.RAP_API_BASE_URL = None
+        with pytest.raises(RapAPISettingsError):
+            _api_call(requests.get, "some/path/")
+
+    def test_missing_token_setting(self, settings):
+        """Test that missing the token setting raises right Exception."""
+        settings.RAP_API_TOKEN = None
+        with pytest.raises(RapAPISettingsError):
+            _api_call(requests.get, "some/path/")
+
+    def test_missing_both_settings(self, settings):
+        """Test that missing both settings raises right Exception."""
+        settings.RAP_API_BASE_URL = None
+        settings.RAP_API_TOKEN = None
+        with pytest.raises(RapAPISettingsError):
+            _api_call(requests.get, "some/path/")
+
+    def test_request_exception(self):
+        """Test that a requests module RequestException is transformed and re-raised."""
+
+        def fake_request_method(*args, **kwargs):
+            raise requests.exceptions.RequestException("boom")
+
+        with pytest.raises(RapAPICommunicationError):
+            _api_call(fake_request_method, "some/path/")
+
+    def test_success_fake_request_method(self, rap_api_base_url, rap_api_token):
+        """Test that a fake request_method is called as expected."""
+        path = "some/path/"
+
+        # Using a fake method here helps avoid conflating issues about how we invoke
+        # the actual requests methods with issues in the _api_call code.
+        def fake_request_method(url, **kwargs):
+            return (url, kwargs)
+
+        response = _api_call(fake_request_method, "some/path/")
+
+        assert response[0] == f"{rap_api_base_url}{path}"
+        assert response[1]["headers"] == {"Authorization": rap_api_token}
+
+    def test_headers_requests_get(self, rap_api_base_url, rap_api_token):
+        """Test that the actual requests.get method handles headers correctly."""
+        path = "some/path/"
+        response_body = {"foo": 123}
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.GET,
+                f"{rap_api_base_url}{path}",
+                json=response_body,
+                status=200,
+                match=[
+                    responses.matchers.header_matcher({"Authorization": rap_api_token})
+                ],
+            )
+            response = _api_call(requests.get, path)
+        assert response.status_code == 200
+        assert response.json() == response_body
+
+
+class FakeResponse:
+    """Lightweight fake response similar enough to requests.Response for these tests."""
+
+    def __init__(self, json_data, status_code=200):
+        self._json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture
+def patch_api_call(monkeypatch):
+    """
+    Fixture to patch _api_call with a fake response. Use this to test the
+    individual endpoint functions. TestApiCall has tests of _api_call and that
+    the requests methods are applied as expected.
+
+    Usage:
+        patch_api_call(fake_json, status_code=200)
+    """
+
+    def _do_patch(fake_json=None, status_code=200):
+        fake_response = FakeResponse(fake_json, status_code=status_code)
+        monkeypatch.setattr(
+            "jobserver.rap_api._api_call", lambda *args, **kwargs: fake_response
+        )
+        return fake_response
+
+    return _do_patch
+
+
+class TestBackendStatus:
+    """Tests of backend_status.
+
+    This just returns the response and doesn't distinguish between non-200
+    error codes, so these are pretty simple."""
+
+    def test_success(self, patch_api_call):
+        """Test content from api_call returned."""
+        fake_json = {"some": "content"}
+        patch_api_call(fake_json)
+
+        assert backend_status() == fake_json
+
+    def test_bad_status_code(self, patch_api_call):
+        """Test a non-200 status raises right Exception."""
+        patch_api_call(status_code=500)
+
+        with pytest.raises(RapAPIResponseError):
+            backend_status()


### PR DESCRIPTION
Fixes #5206.

Also adds `jobserver/rap_api.py` to centralize the code that actually makes the different API calls and their shared functionality.
