### PR TITLE
Fix `cancel` API wrapper method and improve tests

### DIFF
--- a/jobserver/rap_api.py
+++ b/jobserver/rap_api.py
@@ -124,7 +124,7 @@ def cancel(job_request_id, actions):
         RapAPIResponseError
     """
     request_body = {"rap_id": job_request_id, "actions": actions}
-    response = _api_call(requests.put, "rap/cancel/", request_body)
+    response = _api_call(requests.post, "rap/cancel/", request_body)
 
     if response.status_code != 200:
         raise RapAPIResponseError(


### PR DESCRIPTION
`cancel` needs to send a POST request to the RAP API.

Add tests that the endpoints actually use the right parameters, as well as how they handle the different status codes.