### PR TITLE
Add the ability to unpublish a snapshot

### DIFF
--- a/jobserver/management/commands/unpublish_snapshot.py
+++ b/jobserver/management/commands/unpublish_snapshot.py
@@ -1,0 +1,47 @@
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from jobserver.models import Snapshot
+
+
+class Command(BaseCommand):
+    help = (
+        "Retrospectively reject the most recent approved request to publish a snapshot"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("snapshot_id", type=int, help="The ID of the snapshot")
+        parser.add_argument(
+            "username",
+            help="The username of the user who will retrospectively reject the request",
+        )
+
+    def handle(self, *args, **kwargs):
+        snapshot_id = kwargs["snapshot_id"]
+        username = kwargs["username"]
+
+        try:
+            snapshot = Snapshot.objects.get(pk=snapshot_id)
+        except Snapshot.DoesNotExist:
+            raise CommandError(f"Snapshot '{snapshot_id}' does not exist")
+
+        User = get_user_model()
+        try:
+            user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            raise CommandError(f"User '{username}' does not exist")
+
+        if not snapshot.is_published:
+            raise CommandError(f"Snapshot '{snapshot.pk}' is not published")
+
+        most_recent_publish_request = snapshot.publish_requests.order_by(
+            "created_at"
+        ).last()
+
+        self.stdout.write(
+            f"User '{user.username}' is about to reject the most recent approved request to publish snapshot '{snapshot.pk}'"
+        )
+        most_recent_publish_request.reject(user=user)
+        self.stdout.write(
+            f"User '{user.username}' has rejected the most recent approved request to publish snapshot '{snapshot.pk}'"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ omit = [
   "jobserver/management/commands/list_missing_repos.py",
   "jobserver/management/commands/publish_files.py",
   "jobserver/management/commands/release.py",
+  "jobserver/management/commands/unpublish_snapshot.py",
   "jobserver/settings.py",
   "jobserver/wsgi.py",
 ]


### PR DESCRIPTION
We add a management command for unpublishing a snapshot, which is shorthand for retrospectively rejecting the most recent approved request to publish a snapshot.

We use an existing method (`PublishRequest.reject()`) to do so, so most of the management command is error handling. In common with most other management commands, we exclude this management command from coverage.