### PR TITLE
Cancel endpoint: use in UI for `Test` backend

### DIFF
--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -10,6 +10,8 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from furl import furl
 
+from jobserver import rap_api
+
 from ..permissions.t1oo import project_is_permitted_to_use_t1oo_data
 from ..runtime import Runtime
 
@@ -257,6 +259,9 @@ class JobRequest(models.Model):
 
         if not actions_to_cancel:
             raise self.NoActionsToCancel
+
+        if self.backend.name == "Test":
+            rap_api.cancel(self.identifier, actions_to_cancel)
 
         self.cancelled_actions.extend(actions_to_cancel)
         self.save(update_fields=["cancelled_actions"])

--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -243,6 +243,9 @@ class JobRequest(models.Model):
         # been requested for cancellation (i.e. are not already in self.cancelled_actions
         return self.get_active_actions() - set(self.cancelled_actions)
 
+    class NoActionsToCancel(Exception):
+        pass
+
     def request_cancellation(self, actions_to_cancel=None):
         active_actions = self.get_active_actions()
         if actions_to_cancel is None:
@@ -251,6 +254,9 @@ class JobRequest(models.Model):
             actions_to_cancel = list(
                 set(actions_to_cancel).intersection(active_actions)
             )
+
+        if not actions_to_cancel:
+            raise self.NoActionsToCancel
 
         self.cancelled_actions.extend(actions_to_cancel)
         self.save(update_fields=["cancelled_actions"])

--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -248,6 +248,9 @@ class JobRequest(models.Model):
     class NoActionsToCancel(Exception):
         pass
 
+    class NotStartedYet(Exception):
+        pass
+
     def request_cancellation(self, actions_to_cancel=None):
         active_actions = self.get_active_actions()
         if actions_to_cancel is None:
@@ -258,6 +261,10 @@ class JobRequest(models.Model):
             )
 
         if not actions_to_cancel:
+            if self.jobs_status == JobRequestStatus.UNKNOWN:
+                # Probably this was called before we got any `Job` information
+                # from the RAP side. Let's distinguish that from other cases.
+                raise self.NotStartedYet
             raise self.NoActionsToCancel
 
         if self.backend.name == "Test":

--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -243,9 +243,16 @@ class JobRequest(models.Model):
         # been requested for cancellation (i.e. are not already in self.cancelled_actions
         return self.get_active_actions() - set(self.cancelled_actions)
 
-    def request_cancellation(self):
-        # Exclude succeeded jobs (failed or succeeded status, consistent with Job.is_completed method)
-        self.cancelled_actions = list(self.get_active_actions())
+    def request_cancellation(self, actions_to_cancel=None):
+        active_actions = self.get_active_actions()
+        if actions_to_cancel is None:
+            actions_to_cancel = list(active_actions)
+        else:
+            actions_to_cancel = list(
+                set(actions_to_cancel).intersection(active_actions)
+            )
+
+        self.cancelled_actions.extend(actions_to_cancel)
         self.save(update_fields=["cancelled_actions"])
 
     @property

--- a/jobserver/rap_api.py
+++ b/jobserver/rap_api.py
@@ -20,8 +20,6 @@ from urllib.parse import urljoin
 import requests
 from django.conf import settings
 
-from jobserver.models import JobRequest
-
 
 class RapAPIError(Exception):
     """Base exception for this module. A problem contacting or using the RAP
@@ -169,7 +167,7 @@ def status(job_request_ids):
     return response.json()
 
 
-def create(job_request: JobRequest):
+def create(job_request):
     """
     Trigger RAP API to request creation of Jobs for a Job Request's requested actions.
 

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -67,6 +67,12 @@ class JobRequestCancel(View):
             # condition. Not much the user can do except retry.
             # TODO: logging and emit sentry event
             messages.error(request, error_msg)
+        except JobRequest.NotStartedYet:
+            messages.error(
+                request,
+                "Could not cancel as job information not available. "
+                "If this is a recent Job Request, please wait a minute and retry",
+            )
 
         return self.redirect()
 

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -38,6 +38,12 @@ from ..pipeline_config import (
 
 
 class JobRequestCancel(View):
+    """View for requesting JobRequest cancellation via the RAP API.
+
+    This is written as an extensible view so it can be reused in a couple of
+    other places in the UI we allow users to cancel all or part of
+    JobRequest."""
+
     def __init__(self, *args, **kwargs):
         self.job_request = None
         super().__init__(*args, **kwargs)
@@ -75,6 +81,9 @@ class JobRequestCancel(View):
             )
 
         return self.redirect()
+
+    # These functions can be overriden by derived classes to tweak how the view behaves.
+    # Effectively private functions but no leading _ for readability.
 
     def get_objects(self):
         self.job_request = get_object_or_404(JobRequest, pk=self.kwargs["pk"])

--- a/jobserver/views/jobs.py
+++ b/jobserver/views/jobs.py
@@ -30,8 +30,7 @@ class JobCancel(View):
         if job.is_completed or job.action in job.job_request.cancelled_actions:
             return redirect(job)
 
-        job.job_request.cancelled_actions.append(job.action)
-        job.job_request.save()
+        job.job_request.request_cancellation([job.action])
 
         messages.success(
             request, f'Your request to cancel "{job.action}" was successful'

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -387,7 +387,7 @@ def test_jobrequest_has_cancellable_actions():
     # An action is cancellable if it is pending or running and has not
     # already been cancelled
     # This job has no cancelled actions
-    job_request = JobRequestFactory(cancelled_actions=["job1"])
+    job_request = JobRequestFactory(cancelled_actions=[])
     JobFactory(job_request=job_request, action="job1", status="pending")
     JobFactory(job_request=job_request, action="job2", status="running")
     JobFactory(job_request=job_request, action="job3", status="running")

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -276,6 +276,32 @@ def test_jobrequest_request_cancellation_specify_action():
     assert set(job_request.cancelled_actions) == {"job1", "job2"}
 
 
+def test_jobrequest_request_cancellation_not_started_yet():
+    """Test request_cancellation when there are no associated job objects. We
+    expect a `NotStartedYet` error as the status is unknown."""
+    job_request = JobRequestFactory(cancelled_actions=[])
+    # No associated `Job` objects
+
+    with pytest.raises(JobRequest.NotStartedYet):
+        job_request.request_cancellation()
+
+    job_request.refresh_from_db()
+    assert set(job_request.cancelled_actions) == set()
+
+
+def test_jobrequest_request_cancellation_not_started_yet_specific_action():
+    """Test request_cancellation with parameters when there are no associated
+    job objects. We expect a `NotStartedYet` error as the status is unknown."""
+    job_request = JobRequestFactory(cancelled_actions=[])
+    # No associated `Job` objects
+
+    with pytest.raises(JobRequest.NotStartedYet):
+        job_request.request_cancellation(actions_to_cancel=["job1"])
+
+    job_request.refresh_from_db()
+    assert set(job_request.cancelled_actions) == set()
+
+
 def test_jobrequest_request_cancellation_nothing_to_do_specific_action():
     """Test request_cancellation with parameters when there are active
     jobs but only inactive jobs are specified."""

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -240,6 +240,9 @@ def test_jobrequest_request_cancellation_all():
 
     job_request.refresh_from_db()
     assert set(job_request.cancelled_actions) == {"job1", "job2"}
+    # Note request_cancellation only affects cancelled_actions, not the
+    # Job.status -- that will get update later after an update from the RAP
+    # API.
 
 
 def test_jobrequest_request_cancellation_with_existing_cancelled_jobs():

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -242,6 +242,19 @@ def test_jobrequest_request_cancellation_all():
     assert set(job_request.cancelled_actions) == {"job1", "job2"}
 
 
+def test_jobrequest_request_cancellation_with_existing_cancelled_jobs():
+    """Test request_cancellation with a previously cancelled job and no
+    parameters leads to all jobs being cancelled."""
+    job_request = JobRequestFactory(cancelled_actions=["job1"])
+    JobFactory(job_request=job_request, action="job1", status="pending")
+    JobFactory(job_request=job_request, action="job2", status="running")
+
+    job_request.request_cancellation()
+
+    job_request.refresh_from_db()
+    assert set(job_request.cancelled_actions) == {"job1", "job2"}
+
+
 def test_jobrequest_request_cancellation_nothing_to_do():
     """Test request_cancellation with no parameters when there are no active
     jobs."""

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -276,20 +276,22 @@ def test_jobrequest_request_cancellation_nothing_to_do():
 
 def test_jobrequest_request_cancellation_specify_action():
     """Test request_cancellation with parameters cancels only those active jobs
-    passed in."""
-    job_request = JobRequestFactory(cancelled_actions=[])
+    passed in, and already cancelled jobs remain cancelled."""
+    job_request = JobRequestFactory(cancelled_actions=["job5"])
     JobFactory(job_request=job_request, action="job1", status="pending")
     JobFactory(job_request=job_request, action="job2", status="running")
     JobFactory(job_request=job_request, action="job3", status="running")
     JobFactory(job_request=job_request, action="job4", status="succeeded")
+    JobFactory(job_request=job_request, action="job5", status="running")
 
     job_request.request_cancellation(actions_to_cancel=["job1", "job2", "job4", "job7"])
 
     job_request.refresh_from_db()
     # job3 was running but not specified for cancellation, so not cancelled
     # job4 was already finished so should not be changed
+    # job5 pre-existing cancel request shouldn't be overwritten
     # job7 didn't exist so should be ignored
-    assert set(job_request.cancelled_actions) == {"job1", "job2"}
+    assert set(job_request.cancelled_actions) == {"job1", "job2", "job5"}
 
 
 def test_jobrequest_request_cancellation_not_started_yet():

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -239,19 +239,6 @@ def test_jobrequest_request_cancellation():
     assert set(job_request.cancelled_actions) == {"job1", "job2"}
 
 
-def test_jobrequest_request_cancellation_with_existing_cancelled_jobs():
-    job_request = JobRequestFactory(cancelled_actions=[])
-    JobFactory(job_request=job_request, action="job1", status="pending")
-    JobFactory(job_request=job_request, action="job2", status="running")
-    JobFactory(job_request=job_request, action="job3", status="failed")
-    JobFactory(job_request=job_request, action="job4", status="succeeded")
-
-    job_request.request_cancellation()
-
-    job_request.refresh_from_db()
-    assert set(job_request.cancelled_actions) == {"job1", "job2"}
-
-
 def test_jobrequest_has_cancellable_actions():
     # An action is cancellable if it is pending or running and has not
     # already been cancelled


### PR DESCRIPTION
Fixes #5216.

### Background

Currently the controller finds cancelled actions by looking at `JobRequest.cancelled_actions` via the `job-requests` API.

I searched for `cancelled_actions` and found that Jobs can be added to it from `JobCancel` and `JobRequestCancel` views. There are two versions of the latter, one in the staff area. All three are very similar. `JobCancel` directly edits `job.job_request.cancelled_actions` and `JobRequestCancel` calls `JobRequest.request_cancellation`.

The pages that use them (`Job` and `JobRequest` `DetailViews`) show a link to the `Cancel` views and accessing it does the work (if allowed) and redirects back to the same page, with messages.success and updated UI due to the changed DB state communicating the change to the user.

### Plan

- make `request_cancellation` accept an optional `actions` parameter to limit the actions it applies to. 
- make `JobCancel` use it so that all three are using the same code path for doing the cancelling.
- reduce duplication in the three class based views via inheritance so the following step can be implemented and tested in just one place, as we're making the views increasingly complicated. This is strictly a refactor initially - no existing tests needed to change.
- make that code path call the `rap_api.cancel` function if `self.Backend.name == 'Test'`. This should happen before `cancelled_actions` is updated so it stays unchanged if there is an exception.
	- The views should each catch RapApiError and call `messages.error` rather than `messages.success` in that case.
	- Because we're planning to remove the Controller sync loop but keep `cancelled_actions` as a way of recording what we have requested of the RAP API, we only want to update `cancelled_actions` once we have a success response. That allows retry in the event of failure.

We should also emit a sentry event and log in the views in the error cases when calling `request_cancellation`. I'm deferring that to #5237 #5238 so this can get to review sooner.

I noticed that what the `JobRequest` doesn't have jobs yet its status is a fallback `"Unknown"`. Handle this case slightly differently but also note it as tech debt as we should be able to distinguish this case into its own status.

Added to https://github.com/opensafely-core/job-server/issues/5254 several things:

  - Reduce duplication of tests for views based on `JobRequestCreate` using a layered approach.
  - When a JobRequest has no Jobs yet, its status is the failsafe "Unknown" and UI elements are missing (eg status badge) or confusing. This could be a more specific status ("Not started") and have its own UI badge etc.
  -   Disable staff Job Request page Cancel this job button (and relabel it) in the same cases as the main site one.

### UI changes

Most of the UI is unchanged. Couple new error messages:

When there's an error contacting the API, or no work to do (unexpected):

<img width="1001" height="345" alt="image" src="https://github.com/user-attachments/assets/ed48f33b-bc97-47b9-a8f2-5c7b676b6db5" />

When cancelling a Job Request we don't have any Job info for yet:

<img width="1000" height="264" alt="image" src="https://github.com/user-attachments/assets/e388ae27-0caf-40c7-a307-fbb1703dc07c" />
