### PR TITLE
Test the `unpublish_snapshot` management command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ omit = [
   "jobserver/management/commands/list_missing_repos.py",
   "jobserver/management/commands/publish_files.py",
   "jobserver/management/commands/release.py",
-  "jobserver/management/commands/unpublish_snapshot.py",
   "jobserver/settings.py",
   "jobserver/wsgi.py",
 ]

--- a/tests/unit/jobserver/management/commands/test_unpublish_snapshot.py
+++ b/tests/unit/jobserver/management/commands/test_unpublish_snapshot.py
@@ -1,0 +1,42 @@
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from tests.factories import PublishRequestFactory, SnapshotFactory, UserFactory
+
+
+def test_command_no_snapshot():
+    with pytest.raises(CommandError, match="Snapshot '1' does not exist"):
+        call_command("unpublish_snapshot", 1, "a-username")
+
+
+def test_command_no_user():
+    snapshot = SnapshotFactory()
+    with pytest.raises(CommandError, match="User 'a-username' does not exist"):
+        call_command("unpublish_snapshot", snapshot.pk, "a-username")
+
+
+def test_command_snapshot_not_published():
+    snapshot = SnapshotFactory()
+    user = UserFactory()
+    with pytest.raises(CommandError, match=r"Snapshot '\d+' is not published"):
+        call_command("unpublish_snapshot", snapshot.pk, user.username)
+
+
+def test_command(capsys):
+    # We explicitly create different users to approve (publish) and retrospectively
+    # reject (unpublish) the request. These users are not the user who created
+    # the request. The user who created the request is created implicitly by
+    # the factory. We do this to demonstrate that *any user* can retrospectively reject
+    # the request.
+    publish_request = PublishRequestFactory()
+    publish_request.approve(user=UserFactory())
+    rejector = UserFactory()
+
+    call_command("unpublish_snapshot", publish_request.snapshot.pk, rejector.username)
+
+    assert not publish_request.snapshot.is_published
+    out, _ = capsys.readouterr()
+    out_line_1, out_line_2 = out.splitlines()
+    assert out_line_1.startswith(f"User '{rejector.username}' is about to reject")
+    assert out_line_2.startswith(f"User '{rejector.username}' has rejected")


### PR DESCRIPTION
46c67c7 added the `unpublish_snapshot` management command. For expediency, however, it did not add any tests. This commit adds them, and no longer omits `unpublish_snapshot` from coverage.