### PR TITLE
Handle unknown job statuses in job_request.job_status

### DIFF
--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -80,8 +80,9 @@ class JobRequestStatus(models.TextChoices):
 
     @classmethod
     def is_completed(cls, value):
+        value = value.lower()
         completed_states = [cls.FAILED, cls.SUCCEEDED, cls.NOTHING_TO_DO]
-        return value and cls(value) in completed_states
+        return value in cls.values and cls(value) in completed_states
 
 
 class JobRequest(models.Model):

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -157,10 +157,18 @@ def test_jobrequest_get_staff_cancel_url():
 def test_jobrequest_is_completed():
     job_request = JobRequestFactory()
     JobFactory(job_request=job_request, status="failed")
-    JobFactory(job_request=job_request, status="succeeded")
+    JobFactory(job_request=job_request, status="Succeeded")
 
     jr = JobRequest.objects.get(pk=job_request.pk)
     assert jr.is_completed
+
+
+def test_jobrequest_is_completed_unknown_status():
+    job_request = JobRequestFactory()
+    JobFactory(job_request=job_request, status="0")
+
+    jr = JobRequest.objects.get(pk=job_request.pk)
+    assert not jr.is_completed
 
 
 def test_jobrequest_num_completed_no_jobs():


### PR DESCRIPTION
Jobs should always have a status that is one of the controller's Job.State (pending,running,failed,succeeded). However, old jobs have some other statuses:

```
>>> set(Job.objects.values_list("status"))
{('running',), ('Failed',), ('succeeded',), ('pending',), ('0',), ('failed',), ('Succeeded',)}
```

jobs_status() now handles job statuses that are different cases, and returns unknown if all job statuses are an unknown statues (i.e. "0", which applies to only some very old jobs (in the first 130 job requests ever run)