### PR TITLE
Fix `JobRequest` negative duration bug

### DIFF
--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -306,7 +306,11 @@ class JobRequest(models.Model):
             return Runtime(0, 0, 0)
 
         def runtime_in_seconds(job):
-            if job.started_at is None or job.completed_at is None:
+            if (
+                job.started_at is None
+                or job.completed_at is None
+                or job.completed_at <= job.started_at
+            ):
                 return 0
 
             return (job.completed_at - job.started_at).total_seconds()

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -530,7 +530,6 @@ def test_jobrequest_runtime_not_started():
     assert not JobRequest.objects.with_started_at().first().runtime
 
 
-@pytest.mark.xfail(reason="Demonstrate bug in JobRequest.runtime", strict=True)
 def test_runtime_negative_duration():
     jr = JobRequestFactory()
     now = timezone.now()


### PR DESCRIPTION
If `completed_at` is before `started_at` then `runtime` attempts to create an
invalid `Runtime` instance with negative duration, failing validation during
instantiation. In this situation something has gone wrong. Let us return zero.

Fixes https://github.com/opensafely-core/job-server/issues/5291.