### PR TITLE
Remove old environment variables from Sentry

### DIFF
--- a/services/sentry.py
+++ b/services/sentry.py
@@ -82,9 +82,7 @@ def parse(data):
 
     # tokens with values we want to strip
     tokens = [
-        "GITHUB_TOKEN",
         "GITHUB_TOKEN_TESTING",
-        "GITHUB_WRITEABLE_TOKEN",
         "JOBSERVER_GITHUB_TOKEN",
         "RAP_API_TOKEN",
         "SECRET_KEY",


### PR DESCRIPTION
Fixes #5290, in conjunction with actually ensuring the variables are removed from Dokku.
    
This ensured they don't get sent to Sentry, but is not required when the variables no longer exist in Dokku.