### PR TITLE
Add cooldown for Dependabot GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
To match our dependency updates policy.