### PR TITLE
Refactor the management command to perform case insensitive matching

### DIFF
--- a/jobserver/management/commands/check_rap_api_status.py
+++ b/jobserver/management/commands/check_rap_api_status.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
             for backend_states in backends:
                 backend_name = backend_states["name"]
 
-                backend_object = Backend.objects.get(name=backend_name)
+                backend_object = Backend.objects.get(name__iexact=backend_name)
 
                 # Record the time we're told this backend was last seen alive, for availability
                 # reporting purposes

--- a/tests/unit/jobserver/management/commands/test_check_rap_api_status.py
+++ b/tests/unit/jobserver/management/commands/test_check_rap_api_status.py
@@ -61,6 +61,21 @@ def test_command(log_output, patch_backend_status_api_call):
     }
 
 
+def test_backend_name_case_insensitive(log_output, patch_backend_status_api_call):
+    backend = BackendFactory(name="TEST")
+
+    test_response_body = patch_backend_status_api_call("test")
+
+    call_command("check_rap_api_status")
+
+    backend.refresh_from_db()
+
+    assert log_output.entries[0] == {
+        "event": test_response_body,
+        "log_level": "info",
+    }
+
+
 def test_command_error(monkeypatch, log_output):
     def fake_backend_status():
         raise Exception("something went wrong")


### PR DESCRIPTION
Fixes #5306

RAP API returns backend names in lower case however, in the jobserver database, backend names are stored with mixed capitalisation. We have temporarily implemented a case insensitive matching on the backend_name. This is a quick fix for now because we were getting lots of errors from it.
