### PR TITLE
Disable Sentry integration when running `shell`

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -6,6 +6,13 @@ import sys
 
 
 def main():
+    # Disable Sentry when running the shell. This is mainly used by devs to
+    # interrogate the database and typing code manually is error-prone.
+    # Unhandled exceptions caused by this activity are unlikely to be
+    # interesting, so let us not raise Sentry issues in this case.
+    if len(sys.argv) > 1 and sys.argv[1] == "shell":
+        os.environ.pop("SENTRY_DSN", None)
+
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "jobserver.settings")
     try:
         from django.core.management import execute_from_command_line

--- a/tests/unit/test_manage.py
+++ b/tests/unit/test_manage.py
@@ -1,0 +1,45 @@
+"""Tests of custom manage.py behaviour."""
+
+import os
+import sys
+from unittest.mock import patch
+
+import manage
+
+
+def test_sentry_setting_removed_for_shell_command(monkeypatch):
+    """Test that calling the shell command removes the Sentry setting, so the
+    Sentry integration is not active when using the interactive shell."""
+    monkeypatch.setenv("SENTRY_DSN", "https://example@dsn")
+    monkeypatch.setattr(sys, "argv", ["manage.py", "shell"])
+
+    with patch("django.core.management.execute_from_command_line") as mock_func:
+        manage.main()
+
+    assert "SENTRY_DSN" not in os.environ
+    mock_func.assert_called_once_with(["manage.py", "shell"])
+
+
+def test_sentry_setting_not_removed_for_other_command(monkeypatch):
+    """Test that calling a non-shell command does not alter the Sentry setting."""
+    monkeypatch.setenv("SENTRY_DSN", "https://example@dsn")
+    monkeypatch.setattr(sys, "argv", ["manage.py", "other_command"])
+
+    with patch("django.core.management.execute_from_command_line") as mock_func:
+        manage.main()
+
+    assert os.environ.get("SENTRY_DSN") == "https://example@dsn"
+    mock_func.assert_called_once_with(["manage.py", "other_command"])
+
+
+def test_no_sentry_setting_with_shell_command(monkeypatch):
+    """Test that calling the shell command does not REQUIRE the Sentry setting
+    to be set."""
+    monkeypatch.setattr(sys, "argv", ["manage.py", "shell"])
+    assert "SENTRY_DSN" not in os.environ
+
+    with patch("django.core.management.execute_from_command_line") as mock_func:
+        manage.main()
+
+    assert "SENTRY_DSN" not in os.environ
+    mock_func.assert_called_once_with(["manage.py", "shell"])


### PR DESCRIPTION
This command is mainly used by devs to interrogate the database and entering code manually is error-prone. Unhandled exceptions caused by this activity are unlikely to be interesting, so let's not raise Sentry issues in this case.

For example, [this ](https://ebm-datalab.sentry.io/issues/6918084872/?alert_rule_id=10884789&alert_type=issue&project=5443358&referrer=slack) Sentry issue was raised due to an ad hoc use of the script.