### PR TITLE
Add `rap_api` logging

### DIFF
--- a/jobserver/rap_api.py
+++ b/jobserver/rap_api.py
@@ -18,7 +18,12 @@ from json.decoder import JSONDecodeError
 from urllib.parse import urljoin
 
 import requests
+import structlog
 from django.conf import settings
+from structlog.contextvars import bound_contextvars
+
+
+logger = structlog.get_logger(__name__)
 
 
 class RapAPIError(Exception):
@@ -54,41 +59,54 @@ def _api_call(request_method, endpoint_path, json=None):
         RapAPISettingsError
         RapAPIRequestError
     """
-    # Check the required settings early.
-    if not (settings.RAP_API_BASE_URL and settings.RAP_API_TOKEN):
-        raise RapAPISettingsError(
-            "A required environment variable RAP_API_BASE_URL and/or RAP_API_TOKEN is not set"
-        )
-
-    # Check the method is one covered in the tests of this module.
-    allowed_methods = {
-        requests.get,
-        requests.post,
-    }
-    if (
-        request_method not in allowed_methods
-        # Special method name allowed for tests that aren't about a specific requests method.
-        and request_method.__name__ != "fake_request_method"
+    with bound_contextvars(
+        request_method=request_method.__name__,
+        endpoint_path=endpoint_path,
     ):
-        raise ValueError(f"request_method not allowed: {request_method.__qualname__}")
+        logger.debug(json=json)
 
-    if request_method == requests.get and json is not None:
-        # A payload within a GET request message has no defined semantics.
-        raise ValueError(
-            "request_method requests.get and json parameter not allowed together"
-        )
+        # Check the required settings early.
+        if not (settings.RAP_API_BASE_URL and settings.RAP_API_TOKEN):
+            logger.error("Missing settings")
+            raise RapAPISettingsError(
+                "A required environment variable RAP_API_BASE_URL and/or RAP_API_TOKEN is not set"
+            )
 
-    # Do the request-response cycle.
-    try:
-        response = request_method(
-            urljoin(settings.RAP_API_BASE_URL, endpoint_path),
-            headers={"Authorization": settings.RAP_API_TOKEN},
-            json=json,
-        )
-    except requests.exceptions.RequestException as exc:
-        raise RapAPIRequestError(f"RAP API endpoint not available: {exc}")
+        # Check the method is one covered in the tests of this module.
+        allowed_methods = {
+            requests.get,
+            requests.post,
+        }
+        if (
+            request_method not in allowed_methods
+            # Special method name allowed for tests that aren't about a specific requests method.
+            and request_method.__name__ != "fake_request_method"
+        ):
+            logger.error("Bad request_method")
+            raise ValueError(
+                f"request_method not allowed: {request_method.__qualname__}"
+            )
 
-    return response
+        if request_method == requests.get and json is not None:
+            # A payload within a GET request message has no defined semantics.
+            logger.error("Bad paramter combination")
+            raise ValueError(
+                "request_method requests.get and json parameter not allowed together"
+            )
+
+        # Do the request-response cycle.
+        try:
+            response = request_method(
+                urljoin(settings.RAP_API_BASE_URL, endpoint_path),
+                headers={"Authorization": settings.RAP_API_TOKEN},
+                json=json,
+            )
+        except requests.exceptions.RequestException as exc:
+            logger.error("RequestException", exc=exc)
+            raise RapAPIRequestError(f"RAP API endpoint not available: {exc}")
+
+        logger.info("Success")
+        return response
 
 
 def backend_status():
@@ -105,6 +123,7 @@ def backend_status():
     response = _api_call(requests.get, "backend/status/")
 
     if response.status_code != 200:
+        logger.error(status_code=response.status_code)
         raise RapAPIResponseError(
             f"RAP API endpoint returned an error {response.status_code}"
         )
@@ -128,6 +147,7 @@ def cancel(job_request_id, actions):
     response = _api_call(requests.post, "rap/cancel/", request_body)
 
     if response.status_code != 200:
+        logger.error(status_code=response.status_code)
         try:
             body = response.json()
             raise RapAPIResponseError(
@@ -159,6 +179,7 @@ def status(job_request_ids):
     response = _api_call(requests.post, "rap/status/", request_body)
 
     if response.status_code != 200:
+        logger.error(status_code=response.status_code)
         raise RapAPIResponseError(
             f"RAP API endpoint returned an error {response.status_code}",
             body=response.content,
@@ -197,6 +218,7 @@ def create(job_request):
     response = _api_call(requests.post, "rap/create/", request_body)
 
     if response.status_code not in [200, 201]:
+        logger.error(status_code=response.status_code)
         try:
             body = response.json()
             raise RapAPIResponseError(


### PR DESCRIPTION
On enter/exit main function. `json` is `DEBUG` level as may be large. And one log per error condition.

Simple enough automated tests don't seem worth it.

Success:
```
[debug    ] [jobserver.rap_api] endpoint_path=rap/cancel/ ip=127.0.0.1 json={'rap_id': 'upkadceiseprucwz', 'actions': ['generate_dataset']} request_id=017737a3-a9cf-446b-b709-e010ed0b0054 request_method=post user_id=348
[info     ] Success - exiting              [jobserver.rap_api] endpoint_path=rap/cancel/ ip=127.0.0.1 request_id=017737a3-a9cf-446b-b709-e010ed0b0054 request_method=post user_id=348
```

Error (webapp not available):
```
[debug    ] [jobserver.rap_api] endpoint_path=rap/cancel/ ip=127.0.0.1 json={'rap_id': 'upkadceiseprucwz', 'actions': ['generate_dataset']} request_id=10f9cb35-a4eb-4dd2-95d7-aa882a7c7e7d request_method=post user_id=348
[error    ] RequestException               [jobserver.rap_api] endpoint_path=rap/cancel/ exc=ConnectionError(MaxRetryError("HTTPConnectionPool(host='localhost', port=3000): Max retries exceeded with url: /controller/v1/rap/cancel/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7512b4cfa3f0>: Failed to establish a new connection: [Errno 111] Connection refused'))")) ip=127.0.0.1 request_id=10f9cb35-a4eb-4dd2-95d7-aa882a7c7e7d request_method=post user_id=348
```

