### PR TITLE
Ensure logging context is captured in tests

### DIFF
--- a/services/logging.py
+++ b/services/logging.py
@@ -35,18 +35,23 @@ pre_chain = [
     timestamper,
 ]
 
+# These processors are also used in testing
+base_processors = [
+    structlog.contextvars.merge_contextvars,
+    structlog.stdlib.filter_by_level,
+    timestamper,
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.PositionalArgumentsFormatter(),
+    structlog.processors.StackInfoRenderer(),
+    structlog.processors.format_exc_info,
+    structlog.processors.UnicodeDecoder(),
+    structlog.processors.ExceptionPrettyPrinter(),
+]
+
 structlog.configure(
     processors=[
-        structlog.contextvars.merge_contextvars,
-        structlog.stdlib.filter_by_level,
-        timestamper,
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
-        structlog.processors.UnicodeDecoder(),
-        structlog.processors.ExceptionPrettyPrinter(),
+        *base_processors,
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
     ],
     logger_factory=structlog.stdlib.LoggerFactory(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,12 +73,16 @@ def staff_area_administrator():
 
 @pytest.fixture(name="log_output")
 def fixture_log_output():
-    return LogCapture()
+    yield LogCapture()
+    # Clear any local context so tests don't pollute each other
+    structlog.contextvars.clear_contextvars()
 
 
 @pytest.fixture(autouse=True)
 def fixture_configure_structlog(log_output):
-    structlog.configure(processors=[log_output])
+    structlog.configure(
+        processors=[structlog.contextvars.merge_contextvars, log_output]
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from applications.form_specs import form_specs
 from jobserver.authorization.roles import StaffAreaAdministrator
 from jobserver.commands import project_members
 from jobserver.models import SiteAlert
+from services.logging import base_processors
 
 from .factories import (
     BackendFactory,
@@ -80,9 +81,7 @@ def fixture_log_output():
 
 @pytest.fixture(autouse=True)
 def fixture_configure_structlog(log_output):
-    structlog.configure(
-        processors=[structlog.contextvars.merge_contextvars, log_output]
-    )
+    structlog.configure(processors=[*base_processors, log_output])
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/jobserver/management/commands/test_cancel_jobs.py
+++ b/tests/unit/jobserver/management/commands/test_cancel_jobs.py
@@ -14,9 +14,12 @@ def test_command(monkeypatch, log_output):
 
     call_command("cancel_jobs", *_FAKE_ARGS)
 
+    log_output.entries[0].pop("timestamp")
     assert log_output.entries[0] == {
         "event": test_response_json,
         "log_level": "info",
+        "level": "info",
+        "logger": "jobserver.management.commands.cancel_jobs",
     }
 
 

--- a/tests/unit/jobserver/management/commands/test_check_rap_api_status.py
+++ b/tests/unit/jobserver/management/commands/test_check_rap_api_status.py
@@ -55,9 +55,12 @@ def test_command(log_output, patch_backend_status_api_call):
 
     backend.refresh_from_db()
 
+    log_output.entries[0].pop("timestamp")
     assert log_output.entries[0] == {
         "event": test_response_body,
         "log_level": "info",
+        "level": "info",
+        "logger": "jobserver.management.commands.check_rap_api_status",
     }
 
 
@@ -70,10 +73,8 @@ def test_backend_name_case_insensitive(log_output, patch_backend_status_api_call
 
     backend.refresh_from_db()
 
-    assert log_output.entries[0] == {
-        "event": test_response_body,
-        "log_level": "info",
-    }
+    assert log_output.entries[0]["event"] == test_response_body
+    assert log_output.entries[0]["log_level"] == "info"
 
 
 def test_command_error(monkeypatch, log_output):

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -724,9 +724,12 @@ def test_jobrequest_request_rap_creation(
     job_count = job_request.request_rap_creation()
     assert job_count == 1
 
+    log_output.entries[0].pop("timestamp")
     assert log_output.entries[0] == {
         "event": test_response_json,
         "log_level": "info",
+        "level": "info",
+        "logger": "jobserver.models.job_request",
     }
     job_request.refresh_from_db()
     assert JobRequestStatus(job_request.jobs_status) == JobRequestStatus.PENDING
@@ -746,10 +749,8 @@ def test_jobrequest_request_rap_creation_nothing_to_do(
 
     job_request.request_rap_creation()
 
-    assert log_output.entries[0] == {
-        "event": test_response_json,
-        "log_level": "info",
-    }
+    assert log_output.entries[0]["event"] == test_response_json
+    assert log_output.entries[0]["log_level"] == "info"
 
     job_request.refresh_from_db()
     assert JobRequestStatus(job_request.jobs_status) == JobRequestStatus.NOTHING_TO_DO

--- a/tests/unit/jobserver/test_copiloting.py
+++ b/tests/unit/jobserver/test_copiloting.py
@@ -45,10 +45,13 @@ def test_notify_impending_copilot_windows_closing_no_projects(
 
     # check we logged the lack of projects
     assert len(log_output.entries) == 1, log_output.entries
+    log_output.entries[0].pop("timestamp")
     assert log_output.entries[0] == {
         "event": "No projects with copilot support windows closing within 5 days",
+        "level": "info",
         "log_level": "info",
-    }
+        "logger": "jobserver.copiloting",
+    }, log_output.entries[0]
 
 
 def test_notify_impending_copilot_windows_closing_one_project(slack_messages):

--- a/tests/unit/services/test_slack.py
+++ b/tests/unit/services/test_slack.py
@@ -24,12 +24,14 @@ def test_post_error(mocker, log_output):
 
     # check we logged the slack failure
     assert len(log_output.entries) == 1, log_output.entries
+    log_output.entries[0].pop("timestamp")
     assert log_output.entries[0] == {
         "channel": "channel",
-        "exc_info": True,
         "event": "Failed to notify slack in channel: channel",
         "log_level": "error",
-    }
+        "level": "error",
+        "logger": "services.slack",
+    }, log_output.entries[0]
 
 
 def test_link():


### PR DESCRIPTION
The `log_output` fixture uses `LoggingCapture()` with doesn't merge in local context vars by default. In order to do so, we need to configure it with `merge_contexvars` as the first processor
https://www.structlog.org/en/stable/api.html#structlog.contextvars.merge_contextvars