### PR TITLE
Switch BackendManager and tests to use new database field

### DIFF
--- a/jobserver/models/backend.py
+++ b/jobserver/models/backend.py
@@ -39,14 +39,11 @@ class BackendManager(models.Manager):
             backend_statuses = (
                 self.get_queryset()
                 .filter(slug__in=allowed_backends)
-                .values("slug", "jobrunner_state")
+                .values("slug", "is_in_maintenance_mode")
             )
 
             statuses = {
-                backend["slug"]: (backend["jobrunner_state"] or {})
-                .get("mode", {})
-                .get("v")
-                == "db-maintenance"
+                backend["slug"]: backend["is_in_maintenance_mode"]
                 for backend in backend_statuses
             }
 

--- a/tests/integration/test_context_processors.py
+++ b/tests/integration/test_context_processors.py
@@ -14,8 +14,8 @@ class TestDbMaintenanceModeContextProcessor:
 
     @pytest.mark.usefixtures("clear_cache", "enable_db_maintenance_context_processor")
     def test_banner_in_rendered_template_for_db_in_maintenance(self, client):
-        BackendFactory(slug="tpp", jobrunner_state={"mode": {"v": "db-maintenance"}})
-        BackendFactory(slug="emis", jobrunner_state={"paused": {"v": ""}})
+        BackendFactory(slug="tpp", is_in_maintenance_mode=True)
+        BackendFactory(slug="emis", is_in_maintenance_mode=False)
 
         request_url = reverse(
             "job-detail",
@@ -34,8 +34,8 @@ class TestDbMaintenanceModeContextProcessor:
 
     @pytest.mark.usefixtures("clear_cache", "enable_db_maintenance_context_processor")
     def test_banner_not_in_rendered_template_for_db_not_in_maintenance(self, client):
-        BackendFactory(slug="tpp", jobrunner_state={"mode": {"v": ""}})
-        BackendFactory(slug="emis", jobrunner_state={"paused": {"v": ""}})
+        BackendFactory(slug="tpp", is_in_maintenance_mode=False)
+        BackendFactory(slug="emis", is_in_maintenance_mode=False)
 
         request_url = reverse(
             "job-detail",

--- a/tests/unit/jobserver/test_context_processors.py
+++ b/tests/unit/jobserver/test_context_processors.py
@@ -111,13 +111,9 @@ class TestDbMaintenanceModeContextProcessor:
     """Tests of the db_maintenance_mode context processor."""
 
     def setup_method(self):
-        self.tpp = BackendFactory(
-            slug="tpp", jobrunner_state={"mode": {"v": "db-maintenance"}}
-        )
-        self.emis = BackendFactory(slug="emis", jobrunner_state={"paused": {"v": ""}})
-        self.other = BackendFactory(
-            slug="other", jobrunner_state={"mode": {"v": "db-maintenance"}}
-        )
+        self.tpp = BackendFactory(slug="tpp", is_in_maintenance_mode=True)
+        self.emis = BackendFactory(slug="emis", is_in_maintenance_mode=False)
+        self.other = BackendFactory(slug="other", is_in_maintenance_mode=True)
 
     @pytest.mark.usefixtures("clear_cache", "enable_db_maintenance_context_processor")
     def test_expected_attribute_values_for_banner_display_url(self, rf):


### PR DESCRIPTION
We are updating the jobserver codebase so its database is updated with information provided by the RAP API (see [API docs](https://controller.opensafely.org/controller/v1/docs/#tag/backends) for the new structure of the backend status data). A new database field was added in #5324 and its data can now be used to render maintenance mode status information in the templates. As such, the `jobrunner_state` field in the database will soon become redundant.

Following the work done in #5285, this PR updates BackendManager and associated tests so that queries are now using the `is_in_maintenance_mode` field instead.