### PR TITLE
Extract default tracing to a services module

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -27,6 +27,11 @@ RAP_API_TOKEN=rap_token
 # Token for frontend Sentry error tracking DSN
 VITE_SENTRY_DSN=
 
+# Opentelemetry
+# Set to True to log opentelemetry traces to the console in local env
+# Warning can be verbose:
+OTEL_EXPORTER_CONSOLE=False
+
 # To send to honecomb in dev, create a token for the development and set it here.
 # OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=TOKEN34"
 

--- a/manage.py
+++ b/manage.py
@@ -4,6 +4,8 @@
 import os
 import sys
 
+from services.tracing import setup_default_tracing
+
 
 def main():
     # Disable Sentry when running the shell. This is mainly used by devs to
@@ -14,6 +16,8 @@ def main():
         os.environ.pop("SENTRY_DSN", None)
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "jobserver.settings")
+    setup_default_tracing()
+
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/services/tracing.py
+++ b/services/tracing.py
@@ -1,0 +1,49 @@
+import os
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+
+def get_provider():
+    # https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#service
+    resource = Resource.create(
+        attributes={"service.name": os.environ.get("OTEL_SERVICE_NAME", "job-server")}
+    )
+    return TracerProvider(resource=resource)
+
+
+def add_exporter(provider, exporter, processor=BatchSpanProcessor):
+    """Utility method to add an exporter.
+
+    We use the BatchSpanProcessor by default, which is the default for
+    production. This is asynchronous, and queues and retries sending telemetry.
+
+    In testing, we instead use SimpleSpanProcessor, which is synchronous and
+    easy to inspect the output of within a test.
+    """
+    # Note: BatchSpanProcessor is configured via env vars:
+    # https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.export.html#opentelemetry.sdk.trace.export.BatchSpanProcessor
+    provider.add_span_processor(processor(exporter))
+
+
+def setup_default_tracing(set_global=True):
+    provider = get_provider()
+
+    if "OTEL_EXPORTER_OTLP_ENDPOINT" in os.environ:
+        add_exporter(provider, OTLPSpanExporter())
+
+    if os.environ.get("OTEL_EXPORTER_CONSOLE", "").lower() == "true":
+        add_exporter(provider, ConsoleSpanExporter())
+
+    if set_global:  # pragma: nocover
+        trace.set_tracer_provider(provider)
+    # bug: this code requires some envvars to be set, so ensure they are
+    os.environ.setdefault("PYTHONPATH", "")
+    from opentelemetry.instrumentation.auto_instrumentation import (  # noqa: F401
+        sitecustomize,
+    )
+
+    return provider

--- a/tests/unit/services/test_tracing.py
+++ b/tests/unit/services/test_tracing.py
@@ -1,0 +1,44 @@
+import os
+
+import opentelemetry.exporter.otlp.proto.http.trace_exporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+
+from services.tracing import setup_default_tracing
+
+
+def test_setup_default_tracing_empty_env(monkeypatch):
+    env = {"PYTHONPATH": ""}
+    monkeypatch.setattr(os, "environ", env)
+    provider = setup_default_tracing(set_global=False)
+    assert provider._active_span_processor._span_processors == ()
+
+
+def test_setup_default_tracing_console(monkeypatch):
+    env = {"PYTHONPATH": "", "OTEL_EXPORTER_CONSOLE": "true"}
+    monkeypatch.setattr(os, "environ", env)
+    provider = setup_default_tracing(set_global=False)
+
+    processor = provider._active_span_processor._span_processors[0]
+    assert isinstance(processor.span_exporter, ConsoleSpanExporter)
+
+
+def test_setup_default_tracing_otlp_with_env(monkeypatch):
+    env = {
+        "PYTHONPATH": "",
+        "OTEL_EXPORTER_OTLP_HEADERS": "foo=bar",
+        "OTEL_SERVICE_NAME": "service",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "https://endpoint",
+    }
+    monkeypatch.setattr(os, "environ", env)
+    monkeypatch.setattr(
+        opentelemetry.exporter.otlp.proto.http.trace_exporter, "environ", env
+    )
+    provider = setup_default_tracing(set_global=False)
+    assert provider.resource.attributes["service.name"] == "service"
+
+    exporter = provider._active_span_processor._span_processors[0].span_exporter
+
+    assert isinstance(exporter, OTLPSpanExporter)
+    assert exporter._endpoint == "https://endpoint/v1/traces"
+    assert exporter._headers == {"foo": "bar"}


### PR DESCRIPTION
Extracts the tracing configuration from gunicorn.conf.py to a separate module. 

This means the tracing config is set up similarly to other projects (e.g. airlock and jobrunner), and is tested. It also allows us to add an option to export tracing to the console, useful for debugging in local environments.