### PR TITLE
Update text on Job Request page for test backends

### DIFF
--- a/templates/job_request/detail.html
+++ b/templates/job_request/detail.html
@@ -104,34 +104,46 @@
     <div class="space-y-6 md:space-y-6 lg:col-span-2">
       {% #card container=True %}
         <div class="prose prose-oxford">
-          <p>
-            This page shows the technical details of what happened when
-            the authorised researcher
-            <strong>{{ job_request.created_by.fullname }}</strong>
-            requested one or more actions to be run against real patient data within a secure environment.
-          </p>
-          <p>
-            By cross-referencing the list of jobs with the pipeline section below, you can infer what
-            <a href="https://docs.opensafely.org/security-levels/">security level</a>
-            the outputs were written to.
-          </p>
-          <p>The output security levels are:</p>
-          <ul>
-            <li>
-              <strong>highly_sensitive</strong>
-              <ul>
-                <li>Researchers can never directly view these outputs</li>
-                <li>Researchers can only request code is run against them</li>
-              </ul>
-            </li>
-            <li>
-              <strong>moderately_sensitive</strong>
-              <ul>
-                <li>Can be viewed by an approved researcher by logging into a highly secure environment</li>
-                <li>These are the only outputs that can be requested for public release via a controlled output review service.</li>
-              </ul>
-            </li>
-          </ul>
+          {% if job_request.backend.name == "Test" %}
+            <p>
+              This page shows the technical details of what happened when
+              the authorised researcher
+              <strong>{{ job_request.created_by.fullname }}</strong>
+              requested one or more actions to be run against the OpenSAFELY test environment.
+            </p>
+            <p>
+              None of the code was run against real patient data.
+            </p>
+          {% else %}
+            <p>
+              This page shows the technical details of what happened when
+              the authorised researcher
+              <strong>{{ job_request.created_by.fullname }}</strong>
+              requested one or more actions to be run against real patient data within a secure environment.
+            </p>
+            <p>
+              By cross-referencing the list of jobs with the pipeline section below, you can infer what
+              <a href="https://docs.opensafely.org/security-levels/">security level</a>
+              the outputs were written to.
+            </p>
+            <p>The output security levels are:</p>
+            <ul>
+              <li>
+                <strong>highly_sensitive</strong>
+                <ul>
+                  <li>Researchers can never directly view these outputs</li>
+                  <li>Researchers can only request code is run against them</li>
+                </ul>
+              </li>
+              <li>
+                <strong>moderately_sensitive</strong>
+                <ul>
+                  <li>Can be viewed by an approved researcher by logging into a highly secure environment</li>
+                  <li>These are the only outputs that can be requested for public release via a controlled output review service.</li>
+                </ul>
+              </li>
+            </ul>
+          {% endif %}
         </div>
       {% /card %}
 


### PR DESCRIPTION
Closes #5255

- Reformats the existing text for job requests run against secure backends
- Adds new text for job requests run against the test environment

## Screenshots

### Before

<img width="1205" alt="Screenshot of secure environment job request on production" src="https://github.com/user-attachments/assets/30da5584-0f61-455b-a59d-ac6a367eb0c2" />

<img width="1217" alt="Screenshot of test backend job request on production" src="https://github.com/user-attachments/assets/9ac0a0a2-399d-439e-848a-76ce388d1449" />

### After

<img width="1182" alt="Screenshot of secure environment job request with text changes" src="https://github.com/user-attachments/assets/0fb4e729-deed-4312-9c52-600cfbd02742" />

<img width="1179" alt="Screenshot of test backend job request with text changes" src="https://github.com/user-attachments/assets/bfdcde07-8061-48b7-b8af-45d309df996b" />
