### PR TITLE
Update management command to query backend using only 'slug' key

### DIFF
--- a/jobserver/management/commands/check_rap_api_status.py
+++ b/jobserver/management/commands/check_rap_api_status.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
             backends = backend_status_response["backends"]
 
             for backend_states in backends:
-                backend_slug = backend_states.get("slug") or backend_states.get("name")
+                backend_slug = backend_states["slug"]
 
                 backend_object = Backend.objects.get(slug=backend_slug)
 


### PR DESCRIPTION
Fixes #5308

In #5351, both the backend name and slug were used to query the backend to prevent conflicts and errors during deployment. After the successful deployment, only the slug key is required for querying.