### PR TITLE
Remove old code that updates the backend status in the database

### DIFF
--- a/jobserver/api/jobs.py
+++ b/jobserver/api/jobs.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 from collections import defaultdict
 
 import structlog
@@ -14,7 +13,7 @@ from rest_framework.views import APIView
 
 from jobserver.api.authentication import get_backend_from_token
 from jobserver.emails import send_finished_notification
-from jobserver.models import Job, JobRequest, Stats, User, Workspace
+from jobserver.models import Job, JobRequest, User, Workspace
 
 
 COMPLETED_STATES = {"failed", "succeeded"}
@@ -38,29 +37,6 @@ class CoercingCharFieldSerializer(serializers.CharField):
         value = self.to_internal_value(data)
         self.run_validators(value)
         return value
-
-
-def update_backend_state(backend, request):
-    # Retrieve backend state sent up from job-runner. We might rename the header this is
-    # passed in at some point but for now this is good enough.
-    flags = request.headers.get("Flags", "")
-    if not flags:
-        return
-
-    jobrunner_state = json.loads(flags)
-
-    # Record the time we're told this backend was last seen alive, for availability
-    # reporting purposes
-    if last_seen_at_flag := jobrunner_state.get("last-seen-at"):
-        last_seen_at_dt = datetime.datetime.fromisoformat(last_seen_at_flag["v"])
-        Stats.objects.update_or_create(
-            backend=backend,
-            url=request.path,
-            defaults={"api_last_seen": last_seen_at_dt},
-        )
-
-    backend.jobrunner_state = jobrunner_state
-    backend.save(update_fields=["jobrunner_state"])
 
 
 class JobAPIUpdate(APIView):
@@ -184,8 +160,6 @@ class JobAPIUpdate(APIView):
             updated_job_ids=",".join(updated_job_ids),
         )
 
-        update_backend_state(self.backend, request)
-
         return Response({"status": "success"}, status=200)
 
 
@@ -258,10 +232,6 @@ class JobRequestAPIList(ListAPIView):
 
     def get(self, request, *args, **kwargs):
         response = super().get(request, *args, **kwargs)
-
-        # only update state when authenticated and response is 2xx
-        if self.backend and response.status_code >= 200 and response.status_code < 300:
-            update_backend_state(self.backend, request)
 
         return response
 

--- a/tests/factories/backend.py
+++ b/tests/factories/backend.py
@@ -11,5 +11,4 @@ class BackendFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f"Backend {n}")
     is_active = True
     level_4_url = factory.Sequence(lambda n: f"http://example.com/{n}")
-    jobrunner_state = {}
     rap_api_state = {}

--- a/tests/unit/jobserver/management/commands/test_check_rap_api_status.py
+++ b/tests/unit/jobserver/management/commands/test_check_rap_api_status.py
@@ -131,17 +131,24 @@ def test_update_backend_state_new_url(patch_backend_status_api_call, settings):
     backend.refresh_from_db()
 
     assert backend.stats.count() == 1
+    stat = backend.stats.first()
+    assert stat.api_last_seen == datetime.fromisoformat("2025-08-12T06:57:43.039078Z")
 
     # patch a new url path using the settings fixture
     settings.RAP_API_BASE_URL = "http://example.com/rap/new"
 
-    patch_backend_status_api_call(backend.slug)
+    patch_backend_status_api_call(backend.slug, "2025-08-12T14:33:57.413881Z")
     call_command("check_rap_api_status")
 
     backend.refresh_from_db()
 
     # check there are now two Stats for backend
     assert backend.stats.count() == 2
+
+    # Confirm stats timestamp is updated after second api call
+    stat = backend.stats.last()
+    assert stat.api_last_seen == datetime.fromisoformat("2025-08-12T14:33:57.413881Z")
+
     assert backend.stats.last().url == "http://example.com/rap/new"
 
 


### PR DESCRIPTION
Fixes #5346

This PR is the first step in removing the old way of updating the database. A second step will involve safely dropping the redundant model field, following the [risky migrations](https://github.com/opensafely-core/job-server/blob/main/DEVELOPERS.md#risky-migrations) guidance. 