### PR TITLE
Replace DOKKU_SCALE with formation in app.json

### DIFF
--- a/DOKKU_SCALE
+++ b/DOKKU_SCALE
@@ -1,2 +1,0 @@
-web=1
-rapstatus=1

--- a/app.json
+++ b/app.json
@@ -34,5 +34,13 @@
         "timeout": 60
       }
     ]
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    },
+    "rapstatus": {
+      "quantity": 1
+    }
   }
 }


### PR DESCRIPTION
The DOKKU_SCALE file was ignored when we deployed, possibly because we deploy with git:from-image (I have a vague recollection that a CHECKS file will also be ignored). Add the scaling config to app.json instead using the [formation key](https://dokku.com/docs/processes/process-management/#manually-managing-process-scaling).