### PR TITLE
Call RAP API when cancelling against all backends.

### DIFF
--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -313,11 +313,8 @@ class JobRequest(models.Model):
                 )
                 logger.debug(actions_sent=actions_to_cancel)
 
-            # Special case for the RAP API v2 initiative. We intend to remove the
-            # conditionality if this works well in production.
-            if self.backend.name == "Test":
-                # Invoke the API. This might raise a RapAPIError.
-                rap_api.cancel(self.identifier, actions_to_cancel)
+            # Invoke the API. This might raise a RapAPIError.
+            rap_api.cancel(self.identifier, actions_to_cancel)
 
             # Track that we cancelled the actions.
             self.cancelled_actions.extend(actions_to_cancel)

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages import get_messages
@@ -73,7 +75,8 @@ def test_jobrequestcancel_already_completed(rf, project_membership, role_factory
     assert job_request.cancelled_actions == []
 
 
-def test_jobrequestcancel_success(rf, project_membership, role_factory):
+@patch("jobserver.models.job_request.rap_api.cancel")
+def test_jobrequestcancel_success(_, rf, project_membership, role_factory):
     job_request = JobRequestFactory(cancelled_actions=[])
     JobFactory(job_request=job_request, action="test1", status="pending")
     JobFactory(job_request=job_request, action="test2", status="running")
@@ -110,7 +113,8 @@ def test_jobrequestcancel_success(rf, project_membership, role_factory):
     assert str(messages[0]) == "The requested actions have been cancelled"
 
 
-def test_jobrequestcancel_partially_completed(rf, project_membership, role_factory):
+@patch("jobserver.models.job_request.rap_api.cancel")
+def test_jobrequestcancel_partially_completed(_, rf, project_membership, role_factory):
     job_request = JobRequestFactory(cancelled_actions=[])
     JobFactory(job_request=job_request, action="test1", status="failed")
     JobFactory(job_request=job_request, action="test2", status="succeeded")
@@ -145,7 +149,8 @@ def test_jobrequestcancel_partially_completed(rf, project_membership, role_facto
     assert str(messages[0]) == "The requested actions have been cancelled"
 
 
-def test_jobrequestcancel_with_job_request_creator(rf):
+@patch("jobserver.models.job_request.rap_api.cancel")
+def test_jobrequestcancel_with_job_request_creator(_, rf):
     user = UserFactory()
     job_request = JobRequestFactory(cancelled_actions=[], created_by=user)
     JobFactory(job_request=job_request, action="test1", status="pending")

--- a/tests/unit/jobserver/views/test_jobs.py
+++ b/tests/unit/jobserver/views/test_jobs.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
@@ -61,7 +63,8 @@ def test_jobcancel_already_completed(rf, user, project_membership, role_factory)
     assert job_request.cancelled_actions == ["another-action"]
 
 
-def test_jobcancel_success(rf, project_membership, role_factory):
+@patch("jobserver.models.job_request.rap_api.cancel")
+def test_jobcancel_success(_, rf, project_membership, role_factory):
     job_request = JobRequestFactory(cancelled_actions=[])
     job = JobFactory(job_request=job_request, action="test", status="pending")
     user = UserFactory()
@@ -92,7 +95,8 @@ def test_jobcancel_success(rf, project_membership, role_factory):
     assert str(messages[0]) == 'Your request to cancel "test" was successful'
 
 
-def test_jobcancel_with_job_creator(rf):
+@patch("jobserver.models.job_request.rap_api.cancel")
+def test_jobcancel_with_job_creator(_, rf):
     user = UserFactory()
     job_request = JobRequestFactory(cancelled_actions=[], created_by=user)
     job = JobFactory(job_request=job_request, action="test", status="pending")

--- a/tests/unit/staff/views/test_job_requests.py
+++ b/tests/unit/staff/views/test_job_requests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.exceptions import PermissionDenied
@@ -18,7 +20,8 @@ from ....factories import (
 )
 
 
-def test_jobrequestcancel_success(rf, staff_area_administrator):
+@patch("jobserver.models.job_request.rap_api.cancel")
+def test_jobrequestcancel_success(_, rf, staff_area_administrator):
     job_request = JobRequestFactory(cancelled_actions=[])
     JobFactory(job_request=job_request, action="test1", status="failed")
     JobFactory(job_request=job_request, action="test2", status="succeeded")


### PR DESCRIPTION
We have tested sufficiently against the test backend in production so can enable this in general now. We should merge this before the corresponding change in the RAP controller as it is okay to cancel the same action multiple times.

fixes #5239