### PR TITLE
Emit a sentry event for any errors caught by the rap_status_service manage command

### DIFF
--- a/jobserver/management/commands/rap_status_service.py
+++ b/jobserver/management/commands/rap_status_service.py
@@ -3,6 +3,7 @@
 import argparse
 import time
 
+import sentry_sdk
 import structlog
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -33,3 +34,4 @@ class Command(BaseCommand):
                 time.sleep(settings.RAP_API_POLL_INTERVAL)
             except Exception as exc:
                 logger.error(exc)
+                sentry_sdk.capture_exception(exc)


### PR DESCRIPTION
The service management command catches all unhandled errors so the service isn't interrupted, so it's not easy to altert on these in honeycomb. Instead we just emit a sentry event for the exception.

Fixes #5244 