### PR TITLE
Replace use of backend.stats.api_last_seen with backend.last_seen_at

### DIFF
--- a/jobserver/views/status.py
+++ b/jobserver/views/status.py
@@ -32,11 +32,8 @@ class PerBackendStatus(View):
     def get(self, request, *args, **kwargs):
         backend = get_object_or_404(Backend, slug=self.kwargs["backend"])
 
-        try:
-            last_seen = backend.stats.order_by("-api_last_seen").first().api_last_seen
-        except AttributeError:
-            # don't show Backends which have never checked in as an error
-            last_seen = timezone.now()
+        # don't show Backends which have never checked in as an error
+        last_seen = backend.last_seen_at or timezone.now()
 
         # how long ago did we last see this backend?
         time_since_last_seen = timezone.now() - last_seen
@@ -79,12 +76,7 @@ class Status(View):
                 if result["status"] == "running":
                     running = result["count"]
 
-            try:
-                last_seen = (
-                    backend.stats.order_by("-api_last_seen").first().api_last_seen
-                )
-            except AttributeError:
-                last_seen = None
+            last_seen = backend.last_seen_at
 
             return {
                 "name": backend.name,


### PR DESCRIPTION
They are now the same thing, and both updated only in the backend status loop by the response from the backend status API, so use the new field on the actual Backend model.

Doesn't yet remove the now-obsolete Stats model entirely yet.

Fixes #5368 