### PR TITLE
s/success/result in rap api test responses

### DIFF
--- a/tests/integration/test_rap_api.py
+++ b/tests/integration/test_rap_api.py
@@ -176,7 +176,7 @@ def test_jobrequestcancel_post_success(client, setup_backend_workspace_user):
     responses.post(
         url=f"{settings.RAP_API_BASE_URL}rap/cancel/",
         status=200,
-        json={"success": "ok", "details": "1 action cancelled", "count": 1},
+        json={"result": "Success", "details": "1 action cancelled", "count": 1},
         match=[
             responses.matchers.header_matcher({"Authorization": settings.RAP_API_TOKEN})
         ],


### PR DESCRIPTION
Reflect updates in RAP API responses 
https://github.com/opensafely-core/job-runner/pull/1228