### PR TITLE
Update `_status` flag indicating `NotStartedYet`

### DIFF
--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -293,7 +293,10 @@ class JobRequest(models.Model):
 
             # Handle nothing to do.
             if not actions_to_cancel:
-                if self.jobs_status == JobRequestStatus.UNKNOWN:
+                if self.jobs_status in (
+                    JobRequestStatus.PENDING,
+                    JobRequestStatus.UNKNOWN_ERROR_CREATING_JOBS,
+                ):
                     # Probably this was called before we got any `Job` information
                     # from the RAP side. Let's distinguish that from other cases.
                     logger.error("Not started yet")

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -377,11 +377,13 @@ def test_jobrequest_request_cancellation_specify_action(mocker):
     assert set(args[1]) == {"job1", "job2", "job6"}  # Order invariant
 
 
-def test_jobrequest_request_cancellation_not_started_yet():
-    """Test request_cancellation when there are no associated job objects. We
-    expect a `NotStartedYet` error as the status is unknown."""
-    job_request = JobRequestFactory(cancelled_actions=[])
-    # No associated `Job` objects
+def test_jobrequest_request_cancellation_not_started_yet_unknown_error():
+    """Test request_cancellation when there are no associated job objects and
+    status is unknown error during creation. We expect a NotStartedYet."""
+    job_request = JobRequestFactory(
+        cancelled_actions=[], _status=JobRequestStatus.UNKNOWN_ERROR_CREATING_JOBS
+    )
+    # No associated Job objects
 
     with pytest.raises(JobRequest.NotStartedYet):
         job_request.request_cancellation()
@@ -390,11 +392,30 @@ def test_jobrequest_request_cancellation_not_started_yet():
     assert set(job_request.cancelled_actions) == set()
 
 
-def test_jobrequest_request_cancellation_not_started_yet_specific_action(log_output):
+def test_jobrequest_request_cancellation_not_started_yet_pending():
+    """Test request_cancellation when there are no associated job objects and
+    status is pending. We expect a NotStartedYet."""
+    job_request = JobRequestFactory(
+        cancelled_actions=[], _status=JobRequestStatus.PENDING
+    )
+    # No associated Job objects
+
+    with pytest.raises(JobRequest.NotStartedYet):
+        job_request.request_cancellation()
+
+    job_request.refresh_from_db()
+    assert set(job_request.cancelled_actions) == set()
+
+
+def test_jobrequest_request_cancellation_not_started_yet_specific_action_pending(
+    log_output,
+):
     """Test request_cancellation with parameters when there are no associated
-    job objects. We expect a `NotStartedYet` error as the status is unknown."""
-    job_request = JobRequestFactory(cancelled_actions=[])
-    # No associated `Job` objects
+    job objects and status is pending. We expect a NotStartedYet error."""
+    job_request = JobRequestFactory(
+        cancelled_actions=[], _status=JobRequestStatus.PENDING
+    )
+    # No associated Job objects
 
     with pytest.raises(JobRequest.NotStartedYet):
         job_request.request_cancellation(actions_to_cancel=["job1"])


### PR DESCRIPTION
[Slack discussion breadcrumbs](https://bennettoxford.slack.com/archives/C093H4M6TE2/p1761137374276379?thread_ts=1761131274.345479&cid=C093H4M6TE2).

The semantics were updated in
https://github.com/opensafely-core/job-server/commit/f092e76f10200d9b18cde60752ec1cb24bdc2d3e and https://github.com/opensafely-core/job-server/commit/0061adf53e27a679db03dace43f7ad9001457098.

`JobRequest` with no jobs should be in either one of these statuses or `NOTHING_TO_DO` after `request_rap_creation`.  This is the corrsponding change to the cancel function.

Ignoring any possible `JobRequest` created any other way in this PR. Possibly that is for https://github.com/opensafely-core/job-server/issues/5275.