### PR TITLE
Pin pip to version 25.2

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,8 +24,8 @@ virtualenv: _dotenv
     # allow users to specify python version in .env
     PYTHON_VERSION=${PYTHON_VERSION:-python3.12}
 
-    # create venv and upgrade pip
-    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install --upgrade pip; }
+    # create venv and install latest pip compatible with pip-tools
+    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install pip==25.2; }
 
     # ensure we have pip-tools so we can run pip-compile
     test -e $BIN/pip-compile || $PIP install pip-tools

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -21,3 +21,7 @@ pytest-socket
 pytest-xdist[psutil]
 responses
 ruff
+
+# Pin pip due to incompatibility of later releases with pip-tools
+# https://github.com/jazzband/pip-tools/issues/2252
+pip==25.2


### PR DESCRIPTION
The latest version of pip (v25.3) is incompatible with the current version of pip-tools.