### PR TITLE
Update `DBAvailability()` to return a `200` status code when DB maintenance mode is on

### DIFF
--- a/jobserver/views/status.py
+++ b/jobserver/views/status.py
@@ -24,7 +24,7 @@ class DBAvailability(View):
             suffix = f" (since {time_since_maintenance_mode}) "
 
         if backend.is_in_maintenance_mode:
-            return HttpResponse(f"DB maintenance mode on{suffix}", status=503)
+            return HttpResponse(f"DB maintenance mode on{suffix}", status=200)
         return HttpResponse(f"DB maintenance mode off{suffix}")
 
 

--- a/tests/unit/jobserver/views/test_status.py
+++ b/tests/unit/jobserver/views/test_status.py
@@ -24,7 +24,7 @@ def test_dbavailability_in_db_maintenance(rf):
 
     response = DBAvailability.as_view()(request, backend=backend.slug)
 
-    assert response.status_code == 503
+    assert response.status_code == 200
 
 
 def test_dbavailability_non_tpp(rf):


### PR DESCRIPTION
Closes #5196.

Following TeamREX [discussion](https://github.com/opensafely-core/job-server/issues/5196#issuecomment-3178620851) of #5196 , it was agreed that `DBAvailability()` should be updated to return a `200` status code. 