### PR TITLE
Document `RAP_API_*` settings

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -559,6 +559,9 @@ in the header of any request to the [RAP API]. The [RAP API] uses this token to 
 
 Refer to the [RAP API Auth] for details on how the [RAP Controller] handles client tokens.
 
+This token was generated and configured in production for both components
+ad-hoc during the initiative that created the API. We don't rotate the token.
+
 #### Creating a job request
 
 When users initiate a [Job Request] in the UI, Job Server calls the [RAP API] (`POST /controller/v1/rap/create/`)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,8 @@ dokku config:set job-server SENTRY_DSN='https://xxx@xxx.ingest.sentry.io/xxx'
 dokku config:set job-server SENTRY_ENVIRONMENT='production'
 dokku config:set job-server SOCIAL_AUTH_GITHUB_KEY='xxx'
 dokku config:set job-server SOCIAL_AUTH_GITHUB_SECRET='xxx'
+dokku config:set job-server RAP_API_TOKEN='xxx'
+dokku config:set job-server RAP_API_BASE_URL=https://controller.opensafely.org/controller/v1/
 
 # Disable zero-downtime deploys for the rapstatus process (which runs the rap_status_service
 # manangement command). We don't ever want two of these loops running simultaneously


### PR DESCRIPTION
DEVELOPERS.md didn't have some relevant details about the token.

INSTALL.md should mention we need the token and URL to be able to contact the RAP API and create jobs etc.