### PR TITLE
Move sleep statement to top

### DIFF
--- a/jobserver/management/commands/rap_status_service.py
+++ b/jobserver/management/commands/rap_status_service.py
@@ -28,10 +28,10 @@ class Command(BaseCommand):
         run_fn = options["run_fn"]
         while run_fn():
             try:
+                time.sleep(settings.RAP_API_POLL_INTERVAL)
                 active_job_requests_ids = get_active_job_request_identifiers()
                 logger.info("Active rap ids", rap_ids=active_job_requests_ids)
                 rap_status_update(active_job_requests_ids)
-                time.sleep(settings.RAP_API_POLL_INTERVAL)
             except Exception as exc:
                 logger.error(exc)
                 sentry_sdk.capture_exception(exc)


### PR DESCRIPTION
We recently saw a large number of errors from this service (10 per second) when we had some routine database maintenance. This was because the code threw an exception before reaching the sleep statement. Moving the sleep statement to the top of the code block ensures that it always executes.