### PR TITLE
Update virtualenv creation to use `uv venv`

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,11 +21,8 @@ virtualenv: _dotenv
     #!/usr/bin/env bash
     set -euo pipefail
 
-    # allow users to specify python version in .env
-    PYTHON_VERSION=${PYTHON_VERSION:-python3.12}
-
     # create venv and install latest pip
-    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install --upgrade pip; }
+    test -d $VIRTUAL_ENV || { uv venv $VIRTUAL_ENV && uv pip install --upgrade pip; }
 
 
 # create a default .env file


### PR DESCRIPTION
Part of the ongoing migration described in #5049 

This work updates our `just virtualenv` recipe to use `uv`. This is a “midpoint” in our transition to using the full `uv sync` / `uv.lock`  workflow.

For reference, more detailed discussion of this work can be found [here](https://bennettoxford.slack.com/archives/C080XJJ0KDJ/p1764248706357589?thread_ts=1764165966.954289&cid=C080XJJ0KDJ).