### PR TITLE
Add additional flags to `uv pip install` command in `prodenv` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -65,7 +65,10 @@ prodenv: requirements-prod
 
     # --no-deps so that we only install the packages explicitly listed in requirements.prod.txt.
     # https://docs.astral.sh/uv/reference/cli/#uv-pip-install--no-deps
-    uv pip install -r requirements.prod.txt
+    #--require-hashes enforces that every package has a hash entry in
+    # the requirements file, keeping installs deterministic
+    # https://docs.astral.sh/uv/reference/cli/#uv-pip-install--require-hashes
+    uv pip install --no-deps --require-hashes -r requirements.prod.txt
     touch $VIRTUAL_ENV/.prod
 
 


### PR DESCRIPTION
This work adds the `--no-deps` and `--require-hashes` flags to the `uv pip install` command (#5451 ) in our `just prodenv`, and updates the corresponding comment.

Rationale:
- `--no-deps` ensures we only install the resolved dependency tree recorded in requirements.prod.txt (no additional dependency resolution).
- `--require-hashes` enforces that every package has a hash entry in the requirements file, keeping installs deterministic

Testing:
- Ran `just clean`, then `just prodenv`, and then `just run-prod` locally.