### PR TITLE
Remove vestigial GitHub API remnants

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -50,14 +50,6 @@ class HTTPError(GitHubError):
     API."""
 
 
-class RepoAlreadyExists(HTTPError):
-    """Tried to create a repo that already existed."""
-
-
-class RepoNotYetCreated(HTTPError):
-    """Tried to delete a repo that did not already exist."""
-
-
 class IssueNotFound(HTTPError):
     """Tried to get an issue that did not already exist."""
 
@@ -415,67 +407,6 @@ class GitHubAPI:
         r.raise_for_status()
 
         return [label["name"] for label in r.json()]
-
-    def create_repo(self, org, repo):
-        path_segments = [
-            "orgs",
-            org,
-            "repos",
-        ]
-        url = self._url(path_segments)
-
-        payload = {
-            "name": repo,
-        }
-
-        headers = {
-            "Accept": "application/vnd.github.v3+json",
-        }
-        r = self._post(url, headers=headers, json=payload)
-        if r.status_code == 422:
-            raise RepoAlreadyExists()
-
-        self._raise_for_status(r)
-
-        return r.json()
-
-    def delete_repo(self, org, repo):  # pragma: no cover
-        """
-        Delete the given repo
-
-        This exists to help with testing create_repo().  Since it only runs
-        against the live GitHub API and we don't control state there we're
-        ignoring coverage for the whole method.
-        """
-        path_segments = [
-            "repos",
-            org,
-            repo,
-        ]
-        url = self._url(path_segments)
-
-        headers = {
-            "Accept": "application/vnd.github.v3+json",
-        }
-        r = self._delete(url, headers=headers)
-
-        if r.status_code == 404:
-            return
-
-        if not r.ok:
-            print(r.headers)
-            print(r.content)
-
-        if r.status_code == 403:
-            # It's possible for us to create and then attempt to delete a repo
-            # faster than GitHub can create it on disk, so lets wait and retry
-            # if that's happened.
-            # Note: 403 isn't just used for this state.
-            msg = "Repository cannot be deleted until it is done being created on disk."
-            if msg in r.json().get("message", ""):
-                raise RepoNotYetCreated()
-
-        self._raise_for_status(r)
 
     def get_branch(self, org, repo, branch):
         path_segments = [

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -44,12 +44,6 @@ class FakeGitHubAPI:
     def get_issue_labels(self, org, repo, issue_number):
         return ["Pending review"]
 
-    def create_repo(self, org, repo):
-        return {
-            "html_url": "http://example.com",
-            "topics": [],
-        }
-
     def get_branch(self, org, repo, branch):
         return {
             "commit": {
@@ -203,9 +197,6 @@ class FakeGitHubAPIWithErrors:
     ):
         # Some unit tests want to check the message.
         raise GitHubError("An error occurred")
-
-    def create_repo(self, org, repo):
-        raise GitHubError()
 
     def get_branch(self, org, repo, branch):
         raise GitHubError()


### PR DESCRIPTION
Relates to #5166.

This removes parts of the GitHub API and verification tests that were identified as no longer being in use. These relate to OpenSAFELY Interactive, and were never identified as candidates for removal then. Regardless, they are not used anywhere else in the code now.

(And, in some cases, the code may not work in production anyway, because it relied on the permissions of `opensafely-interactive-bot`. The `opensafely-interactive-bot` [account does not have access to write to repositories](https://github.com/opensafely-core/job-server/issues/4862) now.)