### PR TITLE
Install `uv` into Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,19 +100,24 @@ RUN --mount=type=cache,target=/var/cache/apt \
 # Pull in the binaries from the uv-cli stage
 COPY --from=uv-cli /uv /uvx /usr/local/bin/
 
-# Install everything in venv for isolation from system python libraries
-RUN python3.12 -m venv /opt/venv
+# Create a venv with uv
+# (https://docs.astral.sh/uv/guides/integration/docker/#using-the-pip-interface)
+RUN uv venv /opt/venv
+# Use the virtual environment automatically
+ENV VIRTUAL_ENV=/opt/venv
+# Place entry points in the environment at the front of the path
+ENV PATH="/opt/venv/bin:$PATH"
 
-# The cache mount means a) /root/.cache is not in the image, and b) it's preserved
-# between docker builds locally, for faster dev rebuild.
 COPY requirements.prod.txt /tmp/requirements.prod.txt
 
+# The cache mount means a) /root/.cache is not in the image, and b) it's
+# preserved between docker builds locally, for faster dev rebuild.
 # DL3042: using cache mount instead
-# DL3013: we always want latest pip/setuptools/wheel, at least for now
-# hadolint ignore=DL3042,DL3013
+# hadolint ignore=DL3042
+# install prod dependencies using the same flags we use in our `just
+# prodenv` recipe (see justfile)
 RUN --mount=type=cache,target=/root/.cache \
-    /opt/venv/bin/python -m pip install -U pip setuptools wheel && \
-    /opt/venv/bin/python -m pip install --no-deps --require-hashes --requirement /tmp/requirements.prod.txt
+    uv pip install --no-deps --require-hashes -r /tmp/requirements.prod.txt
 
 
 ##################################################
@@ -233,12 +238,16 @@ USER ${USERID}:${GROUPID}
 #
 FROM job-server-base as job-server-dev
 
-# install development requirements
+# Pull in the binaries from the uv-cli stage to install dev requirements
+COPY --from=uv-cli /uv /uvx /usr/local/bin/
+
 COPY requirements.dev.txt /tmp/requirements.dev.txt
 # using cache mount instead
 # hadolint ignore=DL3042
+# install dev dependencies using the same flags we use in our `just
+# devdenv` recipe (see justfile)
 RUN --mount=type=cache,target=/root/.cache \
-    python -m pip install --require-hashes --requirement /tmp/requirements.dev.txt
+    uv pip install --no-deps -r /tmp/requirements.dev.txt
 
 # Override ENTRYPOINT rather than CMD so we can pass arbitrary commands to the entrypoint script
 ENTRYPOINT ["/app/docker/entrypoints/dev.sh"]


### PR DESCRIPTION
This PR addresses the 4th step in #5049 : updating our Docker build pipeline so that virtual environment creation and package installation are handled via `uv` instead of `python -m venv` and `pip install`. 

This aligns our Docker requirements workflow with our local requirements workflow (https://github.com/opensafely-core/job-server/blob/main/justfile), and is another an incremental step: we continue to install from hashed `requirements.*.txt` rather than using `uv sync`, as jobserver does not currently use a `uv.lock` file. 

### Summary of work done:
1. Add `UV_VERSION` as a build ARG
2. Add relevant `uv` environment variables to the `base-python` stage  
3. Introduce a reusable `uv-cli` stage to install `uv` using the astral binary 
4. Use `uv venv` to create the project virtual environment
5. Use `uv pip install` to install production and development dependencies  

### Testing

1. `docker restart job-server-db-1`
2. `just docker-build`
3. `just docker-serve`
4. Went to http://localhost:8000/ ; logged in, checked various pages: Event logs, Status, Workspaces, Job detail, Job list, Staff Area (Users --> Audit log, Job requests)
6. `just docker-test`

To note, the approaches used in [airlock](https://github.com/opensafely-core/airlock/blob/main/docker/Dockerfile) and [repo-template](https://github.com/opensafely-core/repo-template/blob/3ec5612e9b55c08d8e6d8e9395a693ab692c5acc/docker/Dockerfile) have been followed where possible, but these services use a full `uv sync` + `uv.lock` workflow, so couldn't be followed exactly (differences noted in commit messages). FYI, internal discussion of the approach can be found in [this Slack thread](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1764773872836299?thread_ts=1763573364.089979&cid=C069SADHP1Q); this isn't required reading to review this PR.