### PR TITLE
Remove `_put` from GitHub API

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -92,9 +92,6 @@ class GitHubAPI:
     def _post(self, *args, **kwargs):
         return self._request("post", *args, **kwargs)
 
-    def _put(self, *args, **kwargs):
-        return self._request("put", *args, **kwargs)
-
     def _request(self, method, *args, **kwargs):
         """
         Make a request to the remote GitHub API.


### PR DESCRIPTION
Everything using this was removed in #5455.

The verification tests still failed, due to this code not being executed in the tests.