### PR TITLE
Remove `_delete` method from GitHub API

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -79,9 +79,6 @@ class GitHubAPI:
         self.session = _session
         self.token = token
 
-    def _delete(self, *args, **kwargs):
-        return self._request("delete", *args, **kwargs)
-
     def _get(self, *args, **kwargs):
         return self._request("get", *args, **kwargs)
 


### PR DESCRIPTION
This stopped being used following #5447.

This causes the verification test CI to fail due to missing coverage. (Though the tests pass.)