### PR TITLE
Use `EmailMultiAlternatives.body_contains()`

### DIFF
--- a/tests/unit/applications/test_emails.py
+++ b/tests/unit/applications/test_emails.py
@@ -10,13 +10,8 @@ def test_send_finished_notification(mailoutbox):
     send_submitted_application_email("test@example.com", application)
 
     m = mailoutbox[0]
-    text_content = m.body
-    html_content = m.alternatives[0][0]
 
     assert list(m.to) == ["test@example.com"]
-    assert application.get_absolute_url() in text_content
-    assert application.get_absolute_url() in html_content
-    assert application.submitted_by.fullname in text_content
-    assert application.submitted_by.fullname in html_content
-    assert f"ref: {application.pk_hash}" in text_content
-    assert f"ref: {application.pk_hash}" in html_content
+    assert m.body_contains(application.get_absolute_url())
+    assert m.body_contains(application.submitted_by.fullname)
+    assert m.body_contains(f"ref: {application.pk_hash}")

--- a/tests/unit/jobserver/test_emails.py
+++ b/tests/unit/jobserver/test_emails.py
@@ -36,8 +36,6 @@ def test_send_finished_notification(mailoutbox):
     send_finished_notification("test@example.com", job)
 
     m = mailoutbox[0]
-    text_content = m.body
-    html_content = m.alternatives[0][0]
 
     assert job.action in m.subject
     assert job.status in m.subject
@@ -45,18 +43,12 @@ def test_send_finished_notification(mailoutbox):
 
     assert list(m.to) == ["test@example.com"]
 
-    assert job.action in text_content
-    assert job.action in html_content
-    assert job.status in text_content
-    assert job.status in html_content
-    assert job.status_message in text_content
-    assert job.status_message in html_content
-    assert str(job.runtime.total_seconds) in text_content
-    assert str(job.runtime.total_seconds) in html_content
-    assert job.get_absolute_url() in text_content
-    assert job.get_absolute_url() in html_content
-    assert settings.BASE_URL in text_content
-    assert settings.BASE_URL in html_content
+    assert m.body_contains(job.action)
+    assert m.body_contains(job.status)
+    assert m.body_contains(job.status_message)
+    assert m.body_contains(str(job.runtime.total_seconds))
+    assert m.body_contains(job.get_absolute_url())
+    assert m.body_contains(settings.BASE_URL)
 
 
 def test_send_repo_signed_off_notification_to_researchers(mailoutbox):
@@ -75,16 +67,12 @@ def test_send_repo_signed_off_notification_to_researchers(mailoutbox):
     send_repo_signed_off_notification_to_researchers(repo)
 
     m = mailoutbox[0]
-    text_content = m.body
-    html_content = m.alternatives[0][0]
 
     assert list(m.to) == ["notifications@jobs.opensafely.org"]
     assert set(m.bcc) == {user1.email, user2.email, user3.email}
 
-    assert repo.name in text_content
-    assert repo.name in html_content
-    assert repo.researcher_signed_off_by.fullname in text_content
-    assert repo.researcher_signed_off_by.fullname in html_content
+    assert m.body_contains(repo.name)
+    assert m.body_contains(repo.researcher_signed_off_by.fullname)
 
 
 def test_send_repo_signed_off_notification_to_staff(mailoutbox):
@@ -100,15 +88,10 @@ def test_send_repo_signed_off_notification_to_staff(mailoutbox):
     send_repo_signed_off_notification_to_staff(repo)
 
     m = mailoutbox[0]
-    text_content = m.body
-    html_content = m.alternatives[0][0]
 
     assert list(m.to) == ["publications@opensafely.org"]
     assert "7,42" in m.subject
 
-    assert repo.name in text_content
-    assert repo.name in html_content
-    assert repo.researcher_signed_off_by.fullname in text_content
-    assert repo.researcher_signed_off_by.fullname in html_content
-    assert repo.get_staff_url() in text_content
-    assert repo.get_staff_url() in html_content
+    assert m.body_contains(repo.name)
+    assert m.body_contains(repo.researcher_signed_off_by.fullname)
+    assert m.body_contains(repo.get_staff_url())


### PR DESCRIPTION
Fixes #5064.

This was added in Django 5.2, which we recently upgraded to.

https://docs.djangoproject.com/en/5.2/topics/email/#django.core.mail.EmailMultiAlternatives.body_contains

> Returns a boolean indicating whether the provided `text` is
> contained in the email `body` and in all attached MIME type
> `text/*` alternatives.

It allows us to remove the duplication of checks in text and HTML content:

https://adamj.eu/tech/2025/04/07/django-whats-new-5.2/#emailmultialternatives-body-contains