### PR TITLE
Add `ServiceAdministrator` role and fixture.

### DIFF
--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -38,6 +38,18 @@ class StaffAreaAdministrator:
     ]
 
 
+class ServiceAdministrator:
+    display_name = "Service Administrator"
+    description = """DO NOT ASSIGN IN PRODUCTION.
+    Access the Create Project page.
+    Create projects.
+    Assign users to projects and project roles."""
+    models = [
+        "jobserver.models.user.User",
+    ]
+    permissions = []
+
+
 class OutputChecker:
     display_name = "Output Checker"
     description = """View, upload, and delete any outputs that have been released to Job Server.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ import jobserver.authorization.roles
 import services.slack
 from applications.form_specs import form_specs
 from jobserver.actions import project_members
-from jobserver.authorization.roles import StaffAreaAdministrator
+from jobserver.authorization.roles import ServiceAdministrator, StaffAreaAdministrator
 from jobserver.models import SiteAlert
 from services.logging import base_processors
 from services.tracing import add_exporter, get_provider
@@ -70,6 +70,12 @@ def api_rf():
 @pytest.fixture
 def staff_area_administrator():
     return UserFactory(roles=[StaffAreaAdministrator])
+
+
+@pytest.fixture
+def service_administrator():
+    # Not used in any tests yet, so, for now, exclude from coverage:
+    return UserFactory(roles=[ServiceAdministrator])  # pragma: no cover
 
 
 @pytest.fixture(name="log_output")


### PR DESCRIPTION
This role will eventually allow someone to create projects without an associated application, add researchers to the project, and assign project-level roles to those researchers. Fixes https://github.com/opensafely-core/job-server/issues/5474, which I've taken the values from. The description is slightly inaccurate right now but that doesn't seem to matter; it will be accurate when we finish the work around this and before it's used for real.

This is part of [`initiative:manual-projects`](https://github.com/opensafely-core/job-server/issues?q=label%3A%22initiative%3Amanual-projects%22), and a step towards a general effort to split up `StaffAreaAdministrator`.

Add a fixture as tests may want to use this role once it has more than one permission. Often, a `UserFactory` for the specific relevant permissions will make the test more precise and less brittle, though.