### PR TITLE
Change Slack channel used for alerts

### DIFF
--- a/.github/workflows/verification-tests.yml
+++ b/.github/workflows/verification-tests.yml
@@ -49,6 +49,6 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
-          channel_id: C069SADHP1Q
+          channel_id: C0A8AJA249K
           status: "Verification Test Failure"
           color: danger


### PR DESCRIPTION
We have a new team channel, #team-rex-alerts for this as agreed in [Slack](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1768305166422649?thread_ts=1767895570.135169&cid=C069SADHP1Q).