### PR TITLE
Remove `datetime` warning filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,11 +185,6 @@ filterwarnings = [
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:",
     "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning:",
     "ignore:The FORMS_URLFIELD_ASSUME_HTTPS transitional setting is deprecated.:django.utils.deprecation.RemovedInDjango60Warning:",
-
-    # this is actually in protobuf, via the opentelemetry stack vendored into
-    # opensafely, but is likely also coming from the opentelemetry stack also
-    # installed with this project
-    "ignore:datetime.datetime.utcfromtimestamp\\(\\) is deprecated.*:DeprecationWarning:opensafely",
 ]
 markers = [
   "slow_test: mark test as being slow running",


### PR DESCRIPTION
This was added in 52613fb6159d2a088ba55de9f81a98536131bc7d.

It no longer seems to be required, so let's remove it, as whatever underlying dependency update has resolved the warning.