### PR TITLE
Remove `coverage-enable-subprocess`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,7 +246,6 @@ exclude-newer-package = {}
 
 [dependency-groups]
 dev = [
-    "coverage-enable-subprocess",
     "coverage[toml]",
     "django-debug-toolbar",
     "django-upgrade",

--- a/uv.lock
+++ b/uv.lock
@@ -315,18 +315,6 @@ wheels = [
 ]
 
 [[package]]
-name = "coverage-enable-subprocess"
-version = "1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "coverage" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/31/f4/57693bcf041ba641501b7a2fafc9d3d2de647355d78c6a2e07fb53648eaa/coverage_enable_subprocess-1.0.tar.gz", hash = "sha256:fdbd3dc9532007cd87ef84f38e16024c5b0ccb4ab2d1755225a7edf937acc011", size = 2695, upload-time = "2016-05-11T18:49:48.048Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/58/d8dd7edbf5e120942b6395b4c034506c68e56f656074522c83b59d9a4991/coverage_enable_subprocess-1.0-py2.py3-none-any.whl", hash = "sha256:27982522339ec77662965e0d859da5662162962c874d54d2250426506818cbdc", size = 4033, upload-time = "2016-05-11T18:48:49.701Z" },
-]
-
-[[package]]
 name = "cryptography"
 version = "46.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -807,7 +795,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
-    { name = "coverage-enable-subprocess" },
     { name = "django-debug-toolbar" },
     { name = "django-upgrade" },
     { name = "djhtml" },
@@ -866,7 +853,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", extras = ["toml"] },
-    { name = "coverage-enable-subprocess" },
     { name = "django-debug-toolbar" },
     { name = "django-upgrade" },
     { name = "djhtml" },


### PR DESCRIPTION
Fixes #5512.

* This is a very small third-party dependency that hasn't been updated in a while.
* We don't currently need it for our coverage to pass.
* If we do need it, `coverage` itself now has a `patch = subprocess` option which has the same functionality: https://github.com/coveragepy/coveragepy/commit/6d2e56209ebe3bb2595e8b180c99845c25576d53