### PR TITLE
Return org names in Level4 API auth

### DIFF
--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -544,6 +544,12 @@ def build_level4_workspace(workspace, project):
         "project_details": {
             "name": project.name,
             "ongoing": project.status in ONGOING_PROJECT_STATUSES,
+            # If we have more than one org, always return the lead org first
+            "orgs": list(
+                project.orgs.order_by("-collaborations__is_lead").values_list(
+                    "name", flat=True
+                )
+            ),
         },
         "archived": workspace["is_archived"],
     }


### PR DESCRIPTION
These are the authentication/authorization endpoints used by Airlock to authenticate users and retrieve their workspace/role information. We add Organisation names to the returned information so that they can be displayed in Airlock (see https://github.com/opensafely-core/airlock/issues/979).

Currently projects only belong to one Organisation. In future they could belong to multiple orgs, so we return a list of all orgs, with the lead org first.