### PR TITLE
Add the OS-internal project to the NDOO permissions file

### DIFF
--- a/jobserver/permissions/population_permissions/ndoo.py
+++ b/jobserver/permissions/population_permissions/ndoo.py
@@ -25,6 +25,8 @@
 ANALYSIS_SCOPE_KEY = "include_ndoo"
 
 PROJECTS_WITH_NDOO_PERMISSION = {
+    # Projects identified by slug (no project number)
+    "opensafely-internal",  # https://jobs.opensafely.org/opensafely-internal
     156,  # https://jobs.opensafely.org/investigating-events-following-sars-cov-2-infection-project-continuation-of-approved-project-no-12/
     157,  # https://jobs.opensafely.org/investigating-the-effectiveness-of-the-covid-19-vaccination-programme-in-the-uk-project-continuation-of-approved-project-no-22/
     158,  # https://jobs.opensafely.org/the-effect-of-covid-19-on-pancreatic-cancer-diagnosis-and-care-project-continuation-of-approved-project-no-27/
@@ -80,7 +82,7 @@ PROJECTS_WITH_NDOO_PERMISSION = {
 
 def project_has_permission(project):
     if not project.number:
-        return False
+        return project.slug in PROJECTS_WITH_NDOO_PERMISSION
     return project.number in PROJECTS_WITH_NDOO_PERMISSION
 
 


### PR DESCRIPTION
The OpenSAFELY Internal project is used for testing and data exploration, and should be permissted access to NDOO data. https://jobs.opensafely.org/opensafely-internal/

Involves a minimal update to the permissions logic as the OS Internal project does not have a project number, so we include it by slug instead.

Closes #5577 