### PR TITLE
Update Django version to 5.2.11 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,7 +246,7 @@ extend-ignore = [
 [tool.uv]
 required-version = ">=0.9"
 exclude-newer = "2026-02-01T00:00:00Z"
-exclude-newer-package = {}
+exclude-newer-package = { django = "2026-04-04T00:00:00Z" }
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,9 @@ resolution-markers = [
 [options]
 exclude-newer = "2026-02-01T00:00:00Z"
 
+[options.exclude-newer-package]
+django = "2026-04-04T00:00:00Z"
+
 [[package]]
 name = "argon2-cffi"
 version = "25.1.0"
@@ -408,16 +411,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.10"
+version = "5.2.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/e5/2671df24bf0ded831768ef79532e5a7922485411a5696f6d979568591a37/django-5.2.10.tar.gz", hash = "sha256:74df100784c288c50a2b5cad59631d71214f40f72051d5af3fdf220c20bdbbbe", size = 10880754, upload-time = "2026-01-06T18:55:26.817Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/f2/3e57ef696b95067e05ae206171e47a8e53b9c84eec56198671ef9eaa51a6/django-5.2.11.tar.gz", hash = "sha256:7f2d292ad8b9ee35e405d965fbbad293758b858c34bbf7f3df551aeeac6f02d3", size = 10885017, upload-time = "2026-02-03T13:52:50.554Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/de/f1a7cd896daec85832136ab509d9b2a6daed4939dbe26313af3e95fc5f5e/django-5.2.10-py3-none-any.whl", hash = "sha256:cf85067a64250c95d5f9067b056c5eaa80591929f7e16fbcd997746e40d6c45c", size = 8290820, upload-time = "2026-01-06T18:55:20.009Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a7/2b112ab430575bf3135b8304ac372248500d99c352f777485f53fdb9537e/django-5.2.11-py3-none-any.whl", hash = "sha256:e7130df33ada9ab5e5e929bc19346a20fe383f5454acb2cc004508f242ee92c0", size = 8291375, upload-time = "2026-02-03T13:52:42.47Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Summary:**

- We got another [uv / dependabot security update issue](https://github.com/opensafely-core/job-server/security/dependabot/187):
- We're running Django 5.2.10 in prod.The 5.2.11 [update](https://docs.djangoproject.com/en/6.0/releases/5.2.11/) was released on 03/10/2026, which fixes three security issues with severity “high”, two security issues with severity “moderate”, and one security issue with severity “low” in 5.2.10
- Our `uv.lock` and `pyproject.toml` currently have `exclude-newer = "2026-02-01T00:00:00Z"` which is preventing us updating to the latest Django version.

**Action taken:**
- Updated the setting `exclude-newer-package` in `pyproject.toml`
- Ran `just upgrade-package django`:
```
just upgrade-package django
uv lock --upgrade-package django
Ignoring existing lockfile due to change in timestamp cutoff: `global: 2026-02-01T00:00:00Z` vs. `global: 2026-02-01T00:00:00Z, django: 2026-04-04T00:00:00Z`
Resolved 119 packages in 8.58s
Updated django v5.2.10 -> v5.2.11
Resolved 119 packages in 363ms
Prepared 3 packages in 10.25s
Uninstalled 3 packages in 237ms
Installed 3 packages in 236ms
 - django==5.2.10
 + django==5.2.11
 - gunicorn==25.0.1
 + gunicorn==24.1.1
 ```
- Ran `just test-ci`, all tests passed locally

To note: we can see from the logs above that this has downgraded our version of [gunicorn](https://gunicorn.org/news/#testing):
```
- gunicorn==25.0.1
 + gunicorn==24.1.1
```

I haven't had time to look into why this is or the implications of this.