### PR TITLE
Ignore Django v6+ updates in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,6 @@ updates:
         dependency-type: "production"
       development-dependencies:
         dependency-type: "development"
+    ignore:
+      - dependency-name: "django"
+        versions: [">=6.0.0"]


### PR DESCRIPTION
As we will need to manually upgrade to v6.

[Documentation source for ignore syntax](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/controlling-dependencies-updated#ignoring-specific-dependencies)