### PR TITLE
Configure Dependabot for Python transitive dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,8 @@ updates:
         dependency-type: "production"
       development-dependencies:
         dependency-type: "development"
+    allow:
+      - dependency-type: "all"
     ignore:
       - dependency-name: "django"
         versions: [">=6.0.0"]


### PR DESCRIPTION
Specify that Python transitive dependencies should be regularly updated too.

This is how the previous update-dependencies action was configured.

Otherwise Dependabot only opens security PRs for transitive dependencies.