### PR TITLE
Display project number for user profiles

### DIFF
--- a/templates/staff/user/detail_with_oauth.html
+++ b/templates/staff/user/detail_with_oauth.html
@@ -134,7 +134,7 @@
       {% #list_group %}
         {% for project in projects %}
           {% #list_group_item href=project.get_staff_url %}
-            {{ project.name }}
+            {{ project.title }}
           {% /list_group_item %}
         {% empty %}
           {% list_group_empty icon=True title="No projects" description="This user is not a member of any projects" %}
@@ -166,7 +166,7 @@
       {% #list_group %}
         {% for project in copiloted_projects %}
           {% #list_group_item href=project.get_staff_url %}
-            {{ project.name }}
+            {{ project.title }}
           {% /list_group_item %}
         {% empty %}
           {% list_group_empty icon=True title="No co-piloted projects" description="This user has not co-piloted any projects" %}


### PR DESCRIPTION
In the Staff Area.

Fixes #5582.

It turns out that we already display the project number/identifier for users who logged in with email (that is, legacy OpenSAFELY Interactive users).

This is due to using `project.title`, so let's do the same for users who login via OAuth.