### PR TITLE
Add minimal project create form (second implementation)

### DIFF
--- a/staff/forms.py
+++ b/staff/forms.py
@@ -94,6 +94,45 @@ class ProjectAddMemberForm(PickUsersMixin, RolesForm):
     pass
 
 
+class ProjectCreateForm(forms.ModelForm):
+    """Form to create a Project."""
+
+    class Meta:
+        fields = [
+            "copilot",
+            "name",
+            "number",
+            "orgs",
+        ]
+        model = Project
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["orgs"].queryset = Org.objects.order_by(Lower("name"))
+        self.fields["copilot"].label = "Project Co-pilot"
+        self.fields[
+            "copilot"
+        ].help_text = (
+            "Ask the BI Co-pilot Lead to find out who is Co-piloting this new project."
+        )
+
+        self.fields["orgs"].label = "Link project to an organisation"
+        self.fields[
+            "orgs"
+        ].help_text = "This is the sponsoring organisation, found in Section 9 of the NHSE OpenSAFELY Project Application form."
+
+        self.fields["number"].label = "Project ID"
+        self.fields[
+            "number"
+        ].help_text = "Project ID can be found in the All Projects spreadsheet."
+
+        self.fields["name"].label = "Project title"
+        self.fields[
+            "name"
+        ].help_text = "This can be found in Section 7 of the NHSE OpenSAFELY Project Application form."
+
+
 class ProjectEditForm(forms.ModelForm):
     orgs = forms.ModelMultipleChoiceField(queryset=Org.objects.order_by(Lower("name")))
 

--- a/templates/_components/form/select.html
+++ b/templates/_components/form/select.html
@@ -2,10 +2,12 @@
   {% var label_for=id %}
   {% var select_id=id %}
   {% var select_name=name %}
+  {% var hint_text=hint_text %}
 {% else %}
   {% var label_for=field.id_for_label %}
   {% var select_id=field.auto_id %}
   {% var select_name=field.html_name %}
+  {% var hint_text=field.help_text %}
 {% endif %}
 
 <div {% attrs class %}>

--- a/templates/staff/project/create.html
+++ b/templates/staff/project/create.html
@@ -1,5 +1,7 @@
 {% extends "staff/base.html" %}
 
+{% load django_vite %}
+
 {% block metatitle %}Create a project: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
 
 {% block breadcrumbs %}
@@ -16,4 +18,75 @@
   {% staff_hero title="Create a project" %}
 {% endblock hero %}
 
-{% block content %}{% endblock content %}
+{% block content %}
+  <form method="POST" class="max-w-3xl flex flex-col gap-y-6">
+    {% csrf_token %}
+    {% if form.non_field_errors or form.errors %}
+      {% #alert variant="danger" %}
+        <ul>
+          {% for error in form.non_field_errors %}
+            <li>{{ error }}</li>
+          {% endfor %}
+          {% for field in form %}
+            {% if field.errors %}
+              <li>
+                <strong>{{ field.label }}:</strong>
+                <ul>
+                  {% for error in field.errors %}
+                    <li>{{ error }}</li>
+                  {% endfor %}
+                </ul>
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      {% /alert %}
+    {% endif %}
+
+    {# show readonly metadata above the form #}
+    <section class="mb-6">
+      <h3 class="sr-only">Project data</h3>
+      <p class="text-md">
+        When created, this project will automatically be saved with the following data:
+      </p>
+      <p>
+        <strong>Created by:</strong>
+        {{ request.user.fullname }}
+        &nbsp;|&nbsp;
+        <strong>Created at:</strong>
+        {% now "d/m/Y" %}
+        &nbsp;|&nbsp;
+        <strong>Status:</strong>
+        Ongoing
+      </p>
+    </section>
+
+    {% #card title="Project information" container=True %}
+      {% #form_fieldset class="w-full items-stretch gap-y-6" %}
+        {% form_legend text="Project information" class="sr-only" %}
+        {% form_input field=form.number %}
+        {% form_input field=form.name %}
+      {% /form_fieldset %}
+    {% /card %}
+
+    {% #card title="Job Server information" container=True %}
+      {% #form_fieldset class="w-full items-stretch gap-y-6" %}
+        {% form_legend text="Job Server information" class="sr-only" %}
+        {% form_select field=form.orgs choices=form.fields.orgs.choices hint_extra_class="max-w-full" %}
+      {% /form_fieldset %}
+    {% /card %}
+
+    {% #card title="Co-pilot details" container=True %}
+      {% #form_fieldset class="w-full items-stretch gap-y-6" %}
+        {% form_legend text="Co-pilot details" class="sr-only" %}
+        {% form_select field=form.copilot choices=form.fields.copilot.choices selected=form.copilot.value %}
+      {% /form_fieldset %}
+    {% /card %}
+    {% #button variant="success" type="submit" class="self-start" %}
+      Save
+    {% /button %}
+  </form>
+{% endblock content %}
+{% block extra_js %}
+  {% vite_asset "templates/_components/multiselect/multiselect.js" %}
+{% endblock extra_js %}

--- a/tests/unit/staff/test_forms.py
+++ b/tests/unit/staff/test_forms.py
@@ -2,6 +2,7 @@ from jobserver.models import Backend, Project
 from jobserver.utils import set_from_qs
 from staff.forms import (
     ApplicationApproveForm,
+    ProjectCreateForm,
     ProjectEditForm,
     ProjectLinkApplicationForm,
     UserForm,
@@ -104,6 +105,46 @@ def test_applicationapproveform_with_empty_project_slug():
     assert form.errors == {
         "project_name": ["Please use at least one letter or number in the title"]
     }
+
+
+def test_projectcreateform_unbound():
+    """
+    Test unbound state for ProjectCreate form.
+
+    When the form is instantiated then:
+        * The form is unbound.
+        * name and number fields do not have initial values.
+    """
+
+    form = ProjectCreateForm()
+
+    assert not form.is_bound
+    assert form.fields["name"].initial is None
+    assert form.fields["number"].initial is None
+
+
+def test_projectcreateform_success():
+    """
+    Test is_valid() success for ProjectCreate form.
+
+    When the form is populated by the user and submitted then:
+        * The form is bound with copilot, orgs, name, and number data input by the user.
+        * Validation succeeds.
+    """
+    copilot = UserFactory()
+    org = OrgFactory()
+
+    data = {
+        "name": "test1",
+        "number": 1234567832,
+        "orgs": [str(org.pk)],
+        "copilot": str(copilot.pk),
+    }
+
+    form = ProjectCreateForm(data=data)
+
+    assert form.is_bound
+    assert form.is_valid(), form.errors
 
 
 def test_projecteditform_number_is_not_required():


### PR DESCRIPTION
Addresses the fourth step in #5473

### Summary of work done in this PR

This PR introduces a minimal project creation form in the staff area, based on the mock-ups (#5444) and [wording](https://docs.google.com/document/d/16BSABtE56FGTD5xFgdK_7x-qEm1freEMLvJKO_O1OyA/edit?tab=t.0) agreed with the service team.

The form allows staff to create a new Project with the required fields (`name`, `number`, `orgs`, `copilot`) and persists the instance using the existing domain logic in `actions/projects.py`. On successful submission, users are redirected to the newly created project’s detail page (see screentshots).

This represents a second implementation approach to the form following discussion in #5578 and a subsequent Slack thread [here](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1770829238540769?thread_ts=1770660321.027139&cid=C069SADHP1Q).

### Design decisions

- Read-only fields removed from the form
  - The original mock-ups included read-only fields (`created_by`, `created_at`, `status`).
  - Implementing these as `disabled` form fields added significant complexity and verbosity.
  - Following discussion with the team [Slack thread here](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1771258348965509), this information is instead displayed as  text above the form.
  - Users can still see the information and cannot edit it.
- Field attribute refactor deferred
  - An attempt was made to move field label/help text configuration from ProjectCreateForm to the Project model.
  - This introduced additional complexity and required further migrations.
  - Further investigation and refactoring has been deferred to a follow-up issue (#5617).
- Validation and success page out of scope
  - Implementation of form validation is being addressed separately (#5510).
  - Redirecting to a dedicated “Project created” confirmation page (per the mock-ups (#5444)) is deferred to #5619.

### Testing

- Unit tests added for:
  - Unbound `ProjectCreateForm`
  - Valid form submission
  - Successful project creation via `ProjectCreate` view
- Ran `just test` and `just test-ci` (all tests passed locally)
- Ran a local dev server (`just run`)
  - Signed into jobserver 
  - Assigned myself the ServiceAdministrator role (Users > searched for myself > Edit roles)
  - Navigated to the [project creation form](http://localhost:8000/staff/projects/create/) via the [Staff Area Projects page](http://localhost:8000/staff/projects/)
  - Manually created 6-7 projects

<details>
  <summary>Screenshots</summary>
Project creation form:
<img width="1243" height="1048" alt="image" src="https://github.com/user-attachments/assets/c3b6e736-e1e9-4752-9c90-ba6b2727b52e" />

Redirects to the project detail page:
<img width="1224" height="951" alt="Screenshot from 2026-02-18 12-59-13" src="https://github.com/user-attachments/assets/12ae057c-81e6-4cc7-944e-72134f526a96" />

</details>
