### PR TITLE
Updating deploy.yaml to use the fully qualified RepoDigest to fix the failing workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,9 +69,12 @@ jobs:
 
       - name: Deploy image
         run: |
+            set -eu
             ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
             ssh-add - <<< "${{ secrets.DOKKU4_DEPLOY_SSH_KEY }}"
-            SHA=$(docker inspect --format='{{index .RepoDigests 0}}' "$PUBLIC_IMAGE_NAME:latest")
+            set -x
+            SHA=$(docker inspect --format='{{join .RepoDigests "\n"}}' "$PUBLIC_IMAGE_NAME:latest" | grep "$PUBLIC_IMAGE_NAME")
+            echo "Deploying $SHA to dokku4"
             ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" dokku@dokku4.ebmdatalab.net git:from-image job-server "$SHA"
 
       - name: Finalize Sentry release


### PR DESCRIPTION
On Thursday Feb 12, the deploy workflow for JobServer started failing. On Friday Feb 13, RAP team noticed that the workflow for bennettbot started failing too. They investigated the issue and found that the order of RepoDigests changed and was unreliable. Deploy was always getting the first one, which wasn't correct.
Replacing that logic with getting all repo digests and then selecting the fully qualified name worked for bennettbot in commit https://github.com/bennettoxford/bennettbot/commit/970e97026421fa25586bd62daca358c8c7ac3878.

Trying to do the same for JobServer to check if that will fix the deploy workflow for JobServer.

Thanks to PR https://github.com/bennettoxford/bennettbot/pull/828 and https://github.com/bennettoxford/bennettbot/pull/829