### PR TITLE
Make ordering of projects consistent

### DIFF
--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -165,7 +165,9 @@ class UserDetailWithOAuth(UpdateView):
 
     def get_context_data(self, **kwargs):
         applications = self.object.applications.order_by("-created_at")
-        copiloted_projects = self.object.copiloted_projects.order_by(Lower("name"))
+        copiloted_projects = self.object.copiloted_projects.order_by(
+            "number", Lower("name")
+        )
         jobs = Job.objects.filter(job_request__created_by=self.object).order_by(
             "-created_at"
         )


### PR DESCRIPTION
In the User Profiles viewable in the Staff Area, there are two sections where projects are listed:

* projects the user is a member of
* projects the user is co-piloting

The two had different ordering in the view. This change makes those consistent, and more logical for the co-piloting section.

(Previously, the co-piloted project section wasn't ordered by number, only name.)