### PR TITLE
Add unit tests of `notify_copilots_of_repo_sign_off`.

### DIFF
--- a/jobserver/slacks.py
+++ b/jobserver/slacks.py
@@ -123,7 +123,7 @@ def notify_copilots_of_repo_sign_off(
     copilot = project.copilot
     if copilot:
         copilot_link = slack.link(copilot.get_staff_url(), copilot.fullname)
-    else:  # pragma: no cover
+    else:
         copilot_link = "none"
     message.append(f"Copilot: {copilot_link}")
 

--- a/tests/unit/jobserver/test_slacks.py
+++ b/tests/unit/jobserver/test_slacks.py
@@ -1,0 +1,46 @@
+import pytest
+from django.utils import timezone
+
+from jobserver.slacks import notify_copilots_of_repo_sign_off
+from tests.factories import ProjectFactory, RepoFactory, UserFactory, WorkspaceFactory
+
+
+@pytest.mark.parametrize(
+    "copilot_assigned", [True, False], ids=["with_copilot", "without_copilot"]
+)
+def test_notify_copilots_of_repo_sign_off(copilot_assigned, slack_messages):
+    """Test output of notify_copilots_of_repo_sign_off. Parameterised: copilot vs no copilot."""
+    # Given a signed off repo with/without a copilot, linked to a project via workspace.
+    researcher = UserFactory()
+    repo = RepoFactory(
+        researcher_signed_off_by=researcher,
+        researcher_signed_off_at=timezone.now(),
+    )
+    # Create project with or without a copilot according to the parameter.
+    if copilot_assigned:
+        copilot = UserFactory()
+        project = ProjectFactory(copilot=copilot)
+        expected_copilot_fragment = copilot.fullname
+    else:
+        project = ProjectFactory()
+        expected_copilot_fragment = "Copilot: none"
+    WorkspaceFactory(repo=repo, project=project)
+
+    assert len(slack_messages) == 0
+
+    # When the function under test is called on the repo.
+    notify_copilots_of_repo_sign_off(repo)
+
+    # Then one Slack message gets sent to the right channel.
+    assert len(slack_messages) == 1
+    message, channel = slack_messages[0]
+    assert channel == "co-pilot-support"
+
+    # ...and message contains expected values, including right copilot fragment.
+    # Testing for the full message content would be too brittle to changes.
+    assert repo.name in message
+    assert project.slug in message
+    assert "<https://bennettinstitute-team-manual.pages.dev" in message
+    assert researcher.fullname in message
+    # Case-specific assertion, depending whether we have a copilot.
+    assert expected_copilot_fragment in message


### PR DESCRIPTION
Relates to our investigation of possible bug https://github.com/opensafely-core/job-server/issues/5590 - the code that we suspect may be buggy did not have detailed unit testing, including one logical branch being uncovered. So I wrote a more detailed unit test to convince myself that I cannot reproduce locally. We may as well keep it, as its absence was a testing weakness.

This function was only tested implicitly and at a low level of detail in the `SignOffRepo` view tests, which only test that the message has been sent to the right channel and that the `copilot.fullname` is included. The branch without a copilot was not tested.

Add a test for the message being sent, more details of values that should be included, and the difference between the two branches. This enabled removing a coverage pragma for the untested branch.