### PR TITLE
Remove links to removed `applications:start` URL.

### DIFF
--- a/templates/applications/confirmation.html
+++ b/templates/applications/confirmation.html
@@ -7,12 +7,10 @@
 {% block breadcrumbs %}
   {% url "home" as home_url %}
   {% url "applications:list" as applications_url %}
-  {% url "applications:start" as start_url %}
 
   {% #breadcrumbs %}
     {% breadcrumb title="Home" url=home_url %}
     {% breadcrumb title="Applications" url=applications_url %}
-    {% breadcrumb title="Apply for research access to OpenSAFELY" url=start_url %}
     {% breadcrumb title="Check your answers" active=True %}
   {% /breadcrumbs %}
 {% endblock breadcrumbs %}

--- a/templates/applications/page.html
+++ b/templates/applications/page.html
@@ -5,12 +5,10 @@
 {% block breadcrumbs %}
   {% url "home" as home_url %}
   {% url "applications:list" as applications_url %}
-  {% url "applications:start" as start_url %}
 
   {% #breadcrumbs %}
     {% breadcrumb title="Home" url=home_url %}
     {% breadcrumb title="Applications" url=applications_url %}
-    {% breadcrumb title="Apply for research access to OpenSAFELY" url=start_url %}
     {% breadcrumb title=title active=True %}
   {% /breadcrumbs %}
 {% endblock breadcrumbs %}

--- a/templates/applications/researcher_form.html
+++ b/templates/applications/researcher_form.html
@@ -7,12 +7,10 @@
 {% block breadcrumbs %}
   {% url "home" as home_url %}
   {% url "applications:list" as applications_url %}
-  {% url "applications:start" as start_url %}
 
   {% #breadcrumbs %}
     {% breadcrumb title="Home" url=home_url %}
     {% breadcrumb title="Applications" url=applications_url %}
-    {% breadcrumb title="Apply for research access to OpenSAFELY" url=start_url %}
     {% if is_edit %}
       {% breadcrumb title="Edit a researcher" active=True %}
     {% else %}

--- a/templates/index-authenticated.html
+++ b/templates/index-authenticated.html
@@ -114,27 +114,22 @@
       {% endif %}
     {% /card %}
 
-    {% #card title="Applications" subtitle="Previously completed or in progress applications" %}
-      {% #list_group %}
-        {% for application in applications %}
-          {% #list_group_item href=application.get_absolute_url %}
-            Application {{ application.pk_hash }} started on {{ application.created_at|date:"d M Y" }}
-          {% /list_group_item %}
-        {% empty %}
-          {% list_group_empty icon=True title="No applications" description="You have not started an application" %}
-        {% endfor %}
-      {% /list_group %}
+    {% if counts.applications %}
+      {% #card title="Applications" subtitle="Previously completed or in progress applications" %}
+        {% #list_group %}
+          {% for application in applications %}
+            {% #list_group_item href=application.get_absolute_url %}
+              Application {{ application.pk_hash }} started on {{ application.created_at|date:"d M Y" }}
+            {% /list_group_item %}
+          {% endfor %}
+        {% /list_group %}
 
-      {% #card_footer no_container=True %}
-        {% if counts.applications > applications|length %}
+        {% #card_footer no_container=True %}
           {% url "applications:list" as applications_url %}
           {% link href=applications_url text="View all your applications →" %}
-        {% else %}
-          {% url "applications:start" as applications_start_url %}
-          {% link href=applications_start_url text="Start an application →" %}
-        {% endif %}
-      {% /card_footer %}
-    {% /card %}
+        {% /card_footer %}
+      {% /card %}
+    {% endif %}
   </div>
 {% endblock content %}
 

--- a/tests/unit/jobserver/views/test_index.py
+++ b/tests/unit/jobserver/views/test_index.py
@@ -88,7 +88,7 @@ def test_index_authenticated_client(client, django_assert_num_queries):
     user = UserFactory()
     JobRequestFactory.create_batch(10)
 
-    with django_assert_num_queries(42):
+    with django_assert_num_queries(41):
         client.force_login(user)
         response = client.get("/")
         assert response.status_code == 200


### PR DESCRIPTION
This URL was removed in https://github.com/opensafely-core/job-server/pull/5613/ a295c554e15ee7677e7f4cdee35c411b38e49231. Some links to it were missed, so we should remove them now.

I searched for the application start and sign-in and terms page links. I only found remaining links to the start page.

For index-authenticated.html the card footer is now not displayed if no in-progress applications. That seems best, as that part of the dashboard no longer makes sense, except for those rare few special cases with in-progress applications.

For the other templates, just remove the breadcrumbs part with the broken link. That is simplest, and we don't need something better for these largely-defunct templates.

With an application

<img width="1091" height="580" alt="image" src="https://github.com/user-attachments/assets/e035b60b-b741-4963-8b68-2d5f989df7af" />


Without an application 

<img width="1188" height="515" alt="image" src="https://github.com/user-attachments/assets/e9e0bc56-8d5e-4531-9cbb-3be9a9634614" />

