### PR TITLE
Add Project created confirmation page

### DIFF
--- a/staff/urls.py
+++ b/staff/urls.py
@@ -35,6 +35,7 @@ from .views.projects import (
     ProjectAddMember,
     ProjectAuditLog,
     ProjectCreate,
+    ProjectCreated,
     ProjectDetail,
     ProjectEdit,
     ProjectLinkApplication,
@@ -137,6 +138,7 @@ org_urls = [
 project_urls = [
     path("", ProjectList.as_view(), name="project-list"),
     path("create/", ProjectCreate.as_view(), name="project-create"),
+    path("<slug:slug>/created/", ProjectCreated.as_view(), name="project-created"),
     path("<slug>/", ProjectDetail.as_view(), name="project-detail"),
     path("<slug>/add-member/", ProjectAddMember.as_view(), name="project-add-member"),
     path("<slug>/audit-log/", ProjectAuditLog.as_view(), name="project-audit-log"),

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -2,6 +2,7 @@ from django.contrib import messages
 from django.db import transaction
 from django.db.models.functions import Lower
 from django.shortcuts import get_object_or_404, redirect
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.generic import (
     CreateView,
@@ -51,7 +52,15 @@ class ProjectCreate(CreateView):
             orgs=list(data.get("orgs", [])),
             copilot=data.get("copilot"),
         )
-        return redirect(project.get_staff_url())
+        return redirect(reverse("staff:project-created", kwargs={"slug": project.slug}))
+
+
+@method_decorator(require_permission(Permission.PROJECT_CREATE), name="dispatch")
+class ProjectCreated(DetailView):
+    """Display confirmation page following new Project creation."""
+
+    model = Project
+    template_name = "staff/project/created.html"
 
 
 @method_decorator(

--- a/templates/staff/project/created.html
+++ b/templates/staff/project/created.html
@@ -1,0 +1,37 @@
+{% extends "staff/base.html" %}
+
+{% block metatitle %}Project created: Staff Area | OpenSAFELY Jobs{% endblock metatitle %}
+
+{% block breadcrumbs %}
+  {% #breadcrumbs %}
+    {% url "staff:index" as staff_url %}
+    {% url "staff:project-list" as staff_project_list_url %}
+    {% url "staff:project-create" as staff_project_create_url %}
+    {% breadcrumb title="Staff area" url=staff_url %}
+    {% breadcrumb title="Projects" url=staff_project_list_url %}
+    {% breadcrumb title="Create a project" url=staff_project_create_url %}
+    {% breadcrumb title="Project created: "|add:project.name active=True %}
+  {% /breadcrumbs %}
+{% endblock breadcrumbs %}
+
+{% block hero %}
+  {% #staff_hero title="Project created" %}
+    {{ project.number }}: {{ project.name }}
+  {% /staff_hero %}
+{% endblock hero %}
+
+{% block content %}
+  {% #card title="Next steps" container=True %}
+    <div class="prose prose-oxford mb-6">
+      <p>The project has been created and is now publicly visible.</p>
+      <ul>
+        <li><a href={{project.get_absolute_url}}>View project on Job Server</a></li>
+        <li><a href={{project.get_staff_url}}>View project in the Staff Area</a></li>
+      </ul>
+      <p>You can now add users to the project.</p>
+      <p>We sent a notification about the new project to the #co-pilot-support <a href="https://bennettoxford.slack.com/archives/C028EJH752A" target="_blank" class="whitespace-nowrap">#co-pilot-support</a> Slack channel so they can begin the project setup process.</p>
+    </div>
+    {% url "staff:project-add-member" slug=project.slug as staff_project_add_member_url %}
+    {% #button type="link" href=staff_project_add_member_url variant="success" %}Add members to project &rarr;{% /button %}
+  {% /card %}
+{% endblock content %}


### PR DESCRIPTION
Closes #5619

This PR introduces a dedicated 'Project created' confirmation page to route users to following successful project creation.  Design of this page is based on the mock-ups (#5444).

### Summary of work:
- Add `ProjectCreated(DetailView)`, url and template.
- Update `ProjectCreate.form_valid()` to redirect to the new confirmation page.
- Add unit tests asserting authorised and unauthorised access to the new page.

Note: Did not add an integration test, as this will be addressed in a separate unit of work testing the full create-a-project flow (#5621).

### Testing

- Ran `just test` and `just test-ci` (all tests passed locally)
- Ran a local dev server (`just run`)
  - Signed into jobserver 
  - Assigned myself the `ServiceAdministrator` role (Users > searched for myself > Edit roles)
  - Navigated to the [project creation form](http://localhost:8000/staff/projects/create/) via the [Staff Area Projects page](http://localhost:8000/staff/projects/)
  - Manually created projects, and checked that I was redirected to the new page
  - On the Project created page:
    - Checked the information for the project I had just created
    - Tested the two links and the "Add members to project" button

### Screenshot
Project created page:
<img width="1208" height="674" alt="image" src="https://github.com/user-attachments/assets/a96bcfd7-caec-4935-a9c5-6f79523b8c95" />
