### PR TITLE
Show db maintenance banner to logged in users only

### DIFF
--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -88,7 +88,8 @@ def db_maintenance_mode(request):
     views."""
 
     if (
-        request.resolver_match
+        request.user.is_authenticated
+        and request.resolver_match
         and request.resolver_match.url_name in BANNER_DISPLAY_URL_NAMES
     ):
         maintenance_statuses = Backend.objects.get_db_maintenance_mode_statuses()

--- a/tests/integration/test_context_processors.py
+++ b/tests/integration/test_context_processors.py
@@ -12,10 +12,34 @@ class TestDbMaintenanceModeContextProcessor:
         self.job_request = JobRequestFactory(created_by=self.user)
         self.job = JobFactory(job_request=self.job_request)
 
+    @pytest.mark.parametrize(
+        "is_user_authenticated, is_backend_in_maintenance, is_banner_expected",
+        [
+            (True, True, True),  # authenticated user + maintenance -> banner shown
+            (True, False, False),  # authenticated user + no maintenance -> no banner
+            (False, True, False),  # anonymous user + maintenance -> no banner
+            (False, False, False),  # anonymous user + no maintenance -> no banner
+        ],
+        ids=[
+            "authenticated+maintenance",
+            "authenticated+no-maintenance",
+            "anonymous+maintenance",
+            "anonymous+no-maintenance",
+        ],
+    )
     @pytest.mark.usefixtures("clear_cache", "enable_db_maintenance_context_processor")
-    def test_banner_in_rendered_template_for_db_in_maintenance(self, client):
-        BackendFactory(slug="tpp", is_in_maintenance_mode=True)
+    def test_db_maintenance_banner_visibility(
+        self,
+        client,
+        is_user_authenticated,
+        is_backend_in_maintenance,
+        is_banner_expected,
+    ):
         BackendFactory(slug="emis", is_in_maintenance_mode=False)
+        if is_backend_in_maintenance:
+            BackendFactory(slug="tpp", is_in_maintenance_mode=True)
+        else:
+            BackendFactory(slug="tpp", is_in_maintenance_mode=False)
 
         request_url = reverse(
             "job-detail",
@@ -27,27 +51,11 @@ class TestDbMaintenanceModeContextProcessor:
             },
         )
 
-        response = client.get(request_url)
-
-        assert response.status_code == 200
-        assert b"db-maintenance-banner" in response.content
-
-    @pytest.mark.usefixtures("clear_cache", "enable_db_maintenance_context_processor")
-    def test_banner_not_in_rendered_template_for_db_not_in_maintenance(self, client):
-        BackendFactory(slug="tpp", is_in_maintenance_mode=False)
-        BackendFactory(slug="emis", is_in_maintenance_mode=False)
-
-        request_url = reverse(
-            "job-detail",
-            kwargs={
-                "project_slug": self.job.job_request.workspace.project.slug,
-                "workspace_slug": self.job.job_request.workspace.name,
-                "pk": self.job.job_request.pk,
-                "identifier": self.job.identifier,
-            },
-        )
+        if is_user_authenticated:
+            client.force_login(self.user)
 
         response = client.get(request_url)
-
         assert response.status_code == 200
-        assert b"db-maintenance-banner" not in response.content
+
+        is_banner_present = b"db-maintenance-banner" in response.content
+        assert is_banner_present == is_banner_expected

--- a/tests/unit/jobserver/test_context_processors.py
+++ b/tests/unit/jobserver/test_context_processors.py
@@ -151,6 +151,7 @@ class TestDbMaintenanceModeContextProcessor:
         )
 
         request = rf.get(request_url)
+        request.user = user
         request.resolver_match = resolve(request.path_info)
 
         with (
@@ -172,6 +173,7 @@ class TestDbMaintenanceModeContextProcessor:
         """Returns empty dict for non-banner-display URLs."""
 
         request = rf.get(reverse("job-list"))
+        request.user = UserFactory()
         request.resolver_match = resolve(request.path_info)
 
         with (
@@ -187,5 +189,6 @@ class TestDbMaintenanceModeContextProcessor:
     def test_attributes_not_added_for_no_resolver_match_url(self, rf):
         """Returns empty dict if request has no resolver_match attribute."""
         request = rf.get("/no-match-url/")
+        request.user = UserFactory()
         context = db_maintenance_mode(request)
         assert context == {}


### PR DESCRIPTION
Fixes #5639.

Check that the user is authenticated before deciding whether or not to show the maintenance banner.

This commit also uses `parametrize` to consolidate the integration tests, testing all possible states in one test.