### PR TITLE
Move setuptools to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,12 +98,6 @@ dependencies = [
     # Client for error reporting and performance monitoring with Sentry.
     "sentry-sdk",
 
-    # setuptools is not an explicit dependency,
-    # but is pulled in via ruamel (because of using opensafely-pipeline).
-    # This is an attempt to have Dependabot not fail on updating it,
-    # which could relate to https://github.com/dependabot/dependabot-core/issues/14118
-    "setuptools",
-
     # Slack SDK for building integrations with Slack (e.g., bots, notifications).
     "slack-sdk",
 
@@ -270,4 +264,9 @@ dev = [
     "pytest-xdist[psutil]",
     "responses",
     "ruff",
+    # setuptools is not an explicit dependency,
+    # but is pulled in via ruamel (because of using opensafely-pipeline).
+    # This is an attempt to have Dependabot not fail on updating it,
+    # which could relate to https://github.com/dependabot/dependabot-core/issues/14118
+    "setuptools",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -780,7 +780,6 @@ dependencies = [
     { name = "python-ulid" },
     { name = "requests" },
     { name = "sentry-sdk" },
-    { name = "setuptools" },
     { name = "slack-sdk" },
     { name = "slippers" },
     { name = "social-auth-app-django" },
@@ -809,6 +808,7 @@ dev = [
     { name = "pytest-xdist", extra = ["psutil"] },
     { name = "responses" },
     { name = "ruff" },
+    { name = "setuptools" },
 ]
 
 [package.metadata]
@@ -839,7 +839,6 @@ requires-dist = [
     { name = "python-ulid" },
     { name = "requests" },
     { name = "sentry-sdk" },
-    { name = "setuptools" },
     { name = "slack-sdk" },
     { name = "slippers" },
     { name = "social-auth-app-django" },
@@ -868,6 +867,7 @@ dev = [
     { name = "pytest-xdist", extras = ["psutil"] },
     { name = "responses" },
     { name = "ruff" },
+    { name = "setuptools" },
 ]
 
 [[package]]


### PR DESCRIPTION
This actually fixes Dependabot to correctly upgrade setuptools, and has been tested in a fork of this repository.