### PR TITLE
Display empty state when there are no site alerts

### DIFF
--- a/templates/staff/site_alerts/list.html
+++ b/templates/staff/site_alerts/list.html
@@ -41,6 +41,8 @@
                 </div>
               </dl>
             {% /list_group_rich_item %}
+          {% empty %}
+            {% list_group_empty description="No site alerts active" %}
           {% endfor %}
         {% /list_group %}
       {% /card %}


### PR DESCRIPTION
## Before

<img width="2495" height="897" alt="Weird shadow showing on the page" src="https://github.com/user-attachments/assets/fe8038ac-bb6b-46f7-ab57-b0db5ac827d3" />

## After

<img width="2495" height="1002" alt="After this change showing an empty card with a message" src="https://github.com/user-attachments/assets/0aab6964-62ba-42d3-bdf9-394238ba6589" />
