### PR TITLE
Apply custom project identifier ordering across staff views and management commands

### DIFF
--- a/jobserver/management/commands/get_all_projects.py
+++ b/jobserver/management/commands/get_all_projects.py
@@ -10,7 +10,7 @@ from jobserver.models import Job, Project
 class Command(BaseCommand):
     def handle(self, *args, **options):
         data = []
-        for project in Project.apply_project_number_ordering():
+        for project in Project.objects.all().order_by_project_identifier():
             name = project.name
             number = project.number
             org = project.org.name if project.org else ""

--- a/jobserver/management/commands/get_transitional_projects.py
+++ b/jobserver/management/commands/get_transitional_projects.py
@@ -33,10 +33,12 @@ class Command(BaseCommand):
         # value to a date so even though we're passing in a datetime the ORM
         # does the right thing for us and passes down just the date portion of
         # six_months_ago so we can get 6mo ago for all of the target day.
-        projects = Project.apply_project_number_ordering(
+        projects = (
             Project.objects.filter(
                 workspaces__job_requests__jobs__started_at__date__gte=six_months_ago
-            ).distinct()
+            )
+            .distinct()
+            .order_by_project_identifier()
         )
 
         data = []

--- a/jobserver/models/project.py
+++ b/jobserver/models/project.py
@@ -1,7 +1,7 @@
 import structlog
 from django.db import models
-from django.db.models import Case, IntegerField, Q, Value, When
-from django.db.models.functions import Cast, Lower, Substr
+from django.db.models import Case, CharField, F, IntegerField, Q, Value, When
+from django.db.models.functions import Cast, Lower
 from django.urls import reverse
 from django.utils import functional, timezone
 from django.utils.text import slugify
@@ -9,7 +9,34 @@ from furl import furl
 
 
 logger = structlog.get_logger(__name__)
-NUMERIC_IDENTIFIER_REGEX = r"^[0-9]+$"
+
+
+class ProjectQuerySet(models.QuerySet):
+    def order_by_project_identifier(self):
+        """
+        Return projects ordered by project identifier.
+        Ordering rules:
+        1. POS-format identifiers sort first, in reverse lexical order.
+        2. Numeric identifiers sort next, by numeric value descending.
+        3. Blank or null identifiers sort last.
+        4. Project name is used as a case-insensitive tie-breaker.
+        """
+        return self.annotate(
+            pos_format_lex=Case(
+                When(number__startswith="POS-", then=F("number")),
+                default=Value("", output_field=CharField()),
+                output_field=CharField(),
+            ),
+            numeric_value=Case(
+                When(number__regex=r"^[0-9]+$", then=Cast("number", IntegerField())),
+                default=Value(None, output_field=IntegerField()),
+                output_field=IntegerField(),
+            ),
+        ).order_by(
+            "-pos_format_lex",
+            F("numeric_value").desc(nulls_last=True),
+            Lower("name"),
+        )
 
 
 class Project(models.Model):
@@ -73,6 +100,8 @@ class Project(models.Model):
         on_delete=models.PROTECT,
         related_name="projects_updated",
     )
+
+    objects = ProjectQuerySet.as_manager()
 
     class Meta:
         constraints = [
@@ -192,84 +221,3 @@ class Project(models.Model):
             return 1
 
         return max(numeric_values) + 1
-
-    @classmethod
-    def apply_project_number_ordering(cls, queryset=None, field_prefix=""):
-        """
-        Return a queryset ordered by project number in custom order.
-        Ordering rules:
-        1. Alphanumeric identifiers (e.g. POS-2025-2001) first, newest first
-        by year segment, then sequence segment.
-        2. Numeric identifiers next, highest numeric value first.
-        3. Missing identifiers (NULL/blank) last.
-        4. Project name (case-insensitive) as a final tie-breaker, alphabetical order.
-        """
-        qs = cls.objects.all() if queryset is None else queryset
-        number_field = f"{field_prefix}number"
-        name_field = f"{field_prefix}name"
-
-        # Classify each project number into cases to allow ordering:
-        # 0 = POS-style identifier, 1 = numeric identifier, 2 = missing/default.
-        qs = qs.annotate(
-            number_type=Case(
-                When(
-                    **{f"{number_field}__startswith": "POS-"},
-                    then=Value(0),
-                ),
-                When(
-                    **{f"{number_field}__regex": NUMERIC_IDENTIFIER_REGEX},
-                    then=Value(1),
-                ),
-                default=Value(2),
-                output_field=IntegerField(),
-            )
-        )
-
-        # For alphanumeric identifiers(e.g.POS-2025-2001), extract the year segment(2025)
-        # and cast it to integer so we can sort by year numerically.
-        qs = qs.annotate(
-            year=Case(
-                When(
-                    **{f"{number_field}__startswith": "POS-"},
-                    then=Cast(Substr(number_field, 5, 4), IntegerField()),
-                ),
-                default=Value(None, output_field=IntegerField()),
-                output_field=IntegerField(),
-            )
-        )
-
-        # For alphanumeric identifiers(e.g.POS-2025-2001), extract the sequence segment(2001)
-        #  and cast it to integer so we can sort by sequence numerically.
-        qs = qs.annotate(
-            sequence=Case(
-                When(
-                    **{f"{number_field}__startswith": "POS-"},
-                    then=Cast(Substr(number_field, 10), IntegerField()),
-                ),
-                default=Value(None, output_field=IntegerField()),
-                output_field=IntegerField(),
-            )
-        )
-
-        # For numeric identifiers(e.g "123"), cast the number to integer so we can sort
-        # numerically instead of lexically.
-        qs = qs.annotate(
-            numeric_value=Case(
-                When(
-                    **{f"{number_field}__regex": NUMERIC_IDENTIFIER_REGEX},
-                    then=Cast(number_field, IntegerField()),
-                ),
-                default=Value(None, output_field=IntegerField()),
-                output_field=IntegerField(),
-            )
-        )
-
-        qs = qs.order_by(
-            "number_type",
-            "-year",
-            "-sequence",
-            "-numeric_value",
-            Lower(name_field),
-        )
-
-        return qs

--- a/staff/forms.py
+++ b/staff/forms.py
@@ -325,7 +325,7 @@ class WorkspaceEditForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         self.fields["project"] = WorkspaceModelChoiceField(
-            queryset=Project.apply_project_number_ordering()
+            queryset=Project.objects.all().order_by_project_identifier()
         )
 
 

--- a/staff/views/job_requests.py
+++ b/staff/views/job_requests.py
@@ -52,7 +52,7 @@ class JobRequestList(ListView):
 
         projects = {
             "is_active": "project" in self.request.GET,
-            "items": list(Project.apply_project_number_ordering()),
+            "items": list(Project.objects.all().order_by_project_identifier()),
             "selected": self.request.GET.get("project"),
         }
 

--- a/staff/views/orgs.py
+++ b/staff/views/orgs.py
@@ -10,7 +10,7 @@ from furl import furl
 
 from jobserver.authorization.decorators import require_permission
 from jobserver.authorization.permissions import Permission
-from jobserver.models import Org, OrgMembership, Project, User
+from jobserver.models import Org, OrgMembership, User
 from jobserver.utils import is_safe_path
 
 from ..forms import OrgAddGitHubOrgForm, OrgAddMemberForm
@@ -120,9 +120,7 @@ class OrgDetail(FormView):
             "github_orgs": sorted(self.object.github_orgs),
             "members": self.object.members.all(),
             "org": self.object,
-            "projects": Project.apply_project_number_ordering(
-                self.object.projects.all()
-            ),
+            "projects": self.object.projects.all().order_by_project_identifier(),
             "redirects": self.object.redirects.order_by("-created_at"),
         }
 

--- a/staff/views/projects.py
+++ b/staff/views/projects.py
@@ -228,7 +228,7 @@ class ProjectLinkApplication(UpdateView):
 
 @method_decorator(require_permission(Permission.STAFF_AREA_ACCESS), name="dispatch")
 class ProjectList(ListView):
-    queryset = Project.apply_project_number_ordering()
+    queryset = Project.objects.all().order_by_project_identifier()
     paginate_by = 25
     template_name = "staff/project/list.html"
 

--- a/staff/views/users.py
+++ b/staff/views/users.py
@@ -1,7 +1,7 @@
 import structlog
 from django.core.exceptions import FieldError
 from django.db import transaction
-from django.db.models import Exists, OuterRef, Q, Sum
+from django.db.models import Exists, OuterRef, Prefetch, Q, Sum
 from django.db.models.functions import Lower
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
@@ -24,6 +24,7 @@ from jobserver.models import (
     Project,
     User,
 )
+from jobserver.models.project_membership import ProjectMembership
 from jobserver.utils import raise_if_not_int
 
 from ..forms import UserForm, UserOrgsForm
@@ -123,21 +124,25 @@ class UserDetailWithEmail(UpdateView):
             }
             for m in self.object.org_memberships.order_by("org__name")
         ]
-        memberships = self.object.project_memberships.select_related("project")
-
-        memberships = Project.apply_project_number_ordering(
-            memberships,
-            field_prefix="project__",
-        )
-
         projects = [
             {
-                "name": m.project.title,
-                "roles": sorted(r.display_name for r in m.roles),
-                "staff_url": m.project.get_staff_url(),
+                "name": project.title,
+                "roles": sorted(
+                    role.display_name for role in project.user_memberships[0].roles
+                ),
+                "staff_url": project.get_staff_url(),
             }
-            for m in memberships
+            for project in Project.objects.filter(memberships__user=self.object)
+            .order_by_project_identifier()
+            .prefetch_related(
+                Prefetch(
+                    "memberships",
+                    queryset=ProjectMembership.objects.filter(user=self.object),
+                    to_attr="user_memberships",
+                )
+            )
         ]
+
         return super().get_context_data(**kwargs) | {
             "orgs": orgs,
             "projects": projects,
@@ -170,15 +175,15 @@ class UserDetailWithOAuth(UpdateView):
 
     def get_context_data(self, **kwargs):
         applications = self.object.applications.order_by("-created_at")
-        copiloted_projects = Project.apply_project_number_ordering(
-            self.object.copiloted_projects.all()
+        copiloted_projects = (
+            self.object.copiloted_projects.all().order_by_project_identifier()
         )
 
         jobs = Job.objects.filter(job_request__created_by=self.object).order_by(
             "-created_at"
         )
         orgs = self.object.orgs.order_by(Lower("name"))
-        projects = Project.apply_project_number_ordering(self.object.projects.all())
+        projects = self.object.projects.all().order_by_project_identifier()
 
         return super().get_context_data(**kwargs) | {
             "applications": applications,
@@ -302,13 +307,29 @@ class UserRoleList(FormView):
         return redirect(self.user.get_staff_roles_url())
 
     def get_context_data(self, **kwargs):
-        project_memberships_with_roles = Project.apply_project_number_ordering(
-            self.user.project_memberships.exclude(roles=[]).select_related("project"),
-            field_prefix="project__",
+        project_memberships_with_roles = list(
+            self.user.project_memberships.exclude(roles=[]).select_related("project")
         )
 
+        # Build a lookup dictionary keyed by project_id.
+        memberships_by_project_id = {
+            membership.project_id: membership
+            for membership in project_memberships_with_roles
+        }
+
+        # Order the projects by their identifier
+        ordered_projects = (
+            Project.objects.filter(pk__in=memberships_by_project_id.keys())
+            .all()
+            .order_by_project_identifier()
+        )
+
+        ordered_project_memberships = [
+            memberships_by_project_id[project.pk] for project in ordered_projects
+        ]
+
         return super().get_context_data(**kwargs) | {
-            "projects": project_memberships_with_roles,
+            "projects": ordered_project_memberships,
             "user": self.user,
         }
 

--- a/staff/views/workspaces.py
+++ b/staff/views/workspaces.py
@@ -68,7 +68,7 @@ class WorkspaceList(ListView):
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {
             "orgs": Org.objects.order_by(Lower("name")),
-            "projects": Project.apply_project_number_ordering(),
+            "projects": Project.objects.all().order_by_project_identifier(),
             "q": self.request.GET.get("q", ""),
         }
 

--- a/tests/unit/jobserver/models/test_project.py
+++ b/tests/unit/jobserver/models/test_project.py
@@ -187,11 +187,13 @@ def test_next_project_identifier_returns_one_when_no_numeric_ids_exist():
                 {"name": "fourth_project", "number": "7"},
                 {"name": "fifth_project", "number": "42"},
                 {"name": "sixth_project", "number": None},
+                {"name": "seventh_project", "number": "POS-2023-2009"},
             ],
             [
                 "third_project",
                 "second_project",
                 "first_project",
+                "seventh_project",
                 "fifth_project",
                 "fourth_project",
                 "sixth_project",
@@ -214,13 +216,6 @@ def test_next_project_identifier_returns_one_when_no_numeric_ids_exist():
         ),
         (
             [
-                {"name": "first_project", "number": "POS-2023-2009"},
-                {"name": "second_project", "number": "POS-2024-2009"},
-            ],
-            ["second_project", "first_project"],
-        ),
-        (
-            [
                 {"name": "Beta Project", "number": ""},
                 {"name": "alpha project", "number": None},
             ],
@@ -228,50 +223,14 @@ def test_next_project_identifier_returns_one_when_no_numeric_ids_exist():
         ),
     ],
 )
-def test_apply_project_number_ordering(rows, expected):
+def test_order_by_project_identifier(rows, expected):
     for row in rows:
         ProjectFactory(**row)
 
     ordered_projects = list(
-        Project.apply_project_number_ordering().values_list("name", flat=True)
+        Project.objects.all()
+        .order_by_project_identifier()
+        .values_list("name", flat=True)
     )
 
     assert ordered_projects == expected
-
-
-def test_apply_project_number_ordering_accepts_queryset():
-    first_project = ProjectFactory(name="first_project", number="POS-2025-2001")
-    second_project = ProjectFactory(name="second_project", number="7")
-    ProjectFactory(name="third_project", number="POS-2026-2001")
-    queryset = Project.objects.filter(pk__in=[first_project.pk, second_project.pk])
-
-    ordered_projects = list(
-        Project.apply_project_number_ordering(queryset).values_list("name", flat=True)
-    )
-
-    assert ordered_projects == ["first_project", "second_project"]
-
-
-def test_apply_project_number_ordering_accepts_field_prefix(
-    project_membership, project_ordering_rows
-):
-    user = UserFactory()
-    project_rows, expected_order = project_ordering_rows
-
-    projects = [
-        ProjectFactory(name=row.name, number=row.number) for row in project_rows
-    ]
-
-    for project in projects:
-        project_membership(user=user, project=project)
-
-    memberships = user.project_memberships.select_related("project")
-
-    ordered_projects = list(
-        Project.apply_project_number_ordering(
-            queryset=memberships,
-            field_prefix="project__",
-        ).values_list("project__name", flat=True)
-    )
-
-    assert ordered_projects == expected_order

--- a/tests/unit/staff/views/test_job_requests.py
+++ b/tests/unit/staff/views/test_job_requests.py
@@ -378,25 +378,3 @@ def test_jobrequestlist_unauthorized(rf):
 
     with pytest.raises(PermissionDenied):
         JobRequestList.as_view()(request)
-
-
-def test_jobrequestlist_projects_items_are_ordered_by_identifier(
-    rf, staff_area_administrator, project_ordering_rows
-):
-    project_rows, expected_order = project_ordering_rows
-    created_projects = {
-        row.name: ProjectFactory(name=row.name, number=row.number)
-        for row in project_rows
-    }
-
-    request = rf.get("/")
-    request.user = staff_area_administrator
-
-    response = JobRequestList.as_view()(request)
-
-    assert response.status_code == 200
-    project_items = response.context_data["projects"]["items"]
-
-    assert [project.pk for project in project_items] == [
-        created_projects[name].pk for name in expected_order
-    ]

--- a/tests/unit/staff/views/test_orgs.py
+++ b/tests/unit/staff/views/test_orgs.py
@@ -17,7 +17,7 @@ from staff.views.orgs import (
     org_add_github_org,
 )
 
-from ....factories import OrgFactory, OrgMembershipFactory, ProjectFactory, UserFactory
+from ....factories import OrgFactory, OrgMembershipFactory, UserFactory
 
 
 def test_orgaddgithuborg_get_success(rf, staff_area_administrator):
@@ -221,30 +221,6 @@ def test_orgdetail_unauthorized(rf):
 
     with pytest.raises(PermissionDenied):
         OrgDetail.as_view()(request, slug=org.slug)
-
-
-def test_orgdetail_projects_are_ordered_by_project_identifier(
-    rf, staff_area_administrator, project_ordering_rows
-):
-    org = OrgFactory()
-    project_rows, expected_order = project_ordering_rows
-    created_projects = {
-        row.name: ProjectFactory(name=row.name, number=row.number, orgs=[org])
-        for row in project_rows
-    }
-    ProjectFactory(
-        name="other_org_project", number="POS-2026-2001", orgs=[OrgFactory()]
-    )
-
-    request = rf.get("/")
-    request.user = staff_area_administrator
-
-    response = OrgDetail.as_view()(request, slug=org.slug)
-
-    projects = list(response.context_data["projects"])
-    assert [p.pk for p in projects] == [
-        created_projects[name].pk for name in expected_order
-    ]
 
 
 def test_orgedit_get_success(rf, staff_area_administrator):

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -539,25 +539,6 @@ def test_projectlist_create_project_button_unauthorised(rf, staff_area_administr
     assert not response.context_data["can_create_project"]
 
 
-def test_projectlist_orders_projects_by_identifier_type_and_value(
-    rf, staff_area_administrator, project_ordering_rows
-):
-    project_rows, expected_order = project_ordering_rows
-    created_projects = {
-        row.name: ProjectFactory(name=row.name, number=row.number)
-        for row in project_rows
-    }
-
-    request = rf.get("/")
-    request.user = staff_area_administrator
-
-    response = ProjectList.as_view()(request)
-
-    assert [project.pk for project in response.context_data["project_list"]] == [
-        created_projects[name].pk for name in expected_order
-    ]
-
-
 @pytest.mark.parametrize(
     "user_fixture",
     ["staff_area_administrator", "service_administrator"],

--- a/tests/unit/staff/views/test_users.py
+++ b/tests/unit/staff/views/test_users.py
@@ -464,34 +464,6 @@ def test_userdetailwithoauth_without_permission(rf):
         UserDetailWithOAuth.as_view()(request, username="test")
 
 
-def test_userdetailwithoauth_orders_projects_and_copiloted_projects_by_identifier_rules(
-    rf, staff_area_administrator, project_membership, project_ordering_rows
-):
-    user = UserFactory()
-    UserSocialAuthFactory(user=user)
-    project_rows, expected_order = project_ordering_rows
-    created_projects = {
-        row.name: ProjectFactory(name=row.name, number=row.number, copilot=user)
-        for row in project_rows
-    }
-
-    for project in created_projects.values():
-        project_membership(user=user, project=project, roles=[ProjectDeveloper])
-
-    request = rf.get("/")
-    request.user = staff_area_administrator
-
-    response = UserDetailWithOAuth.as_view()(request, username=user.username)
-
-    assert response.status_code == 200
-    assert [p.pk for p in response.context_data["projects"]] == [
-        created_projects[name].pk for name in expected_order
-    ]
-    assert [p.pk for p in response.context_data["copiloted_projects"]] == [
-        created_projects[name].pk for name in expected_order
-    ]
-
-
 def test_userlist_filter_by_backend(rf, staff_area_administrator):
     backend = BackendFactory()
 

--- a/tests/unit/staff/views/test_workspaces.py
+++ b/tests/unit/staff/views/test_workspaces.py
@@ -182,24 +182,3 @@ def test_workspacelist_success(rf, staff_area_administrator):
     response = WorkspaceList.as_view()(request)
     assert response.status_code == 200
     assert len(response.context_data["object_list"]) == 5
-
-
-def test_workspacelist_projects_context_is_ordered_by_project_identifier_rules(
-    rf, staff_area_administrator, project_ordering_rows
-):
-    project_rows, expected_order = project_ordering_rows
-    created_projects = {
-        row.name: ProjectFactory(name=row.name, number=row.number)
-        for row in project_rows
-    }
-
-    request = rf.get("/")
-    request.user = staff_area_administrator
-
-    response = WorkspaceList.as_view()(request)
-
-    assert response.status_code == 200
-    projects = list(response.context_data["projects"])
-    assert [project.pk for project in projects] == [
-        created_projects[name].pk for name in expected_order
-    ]


### PR DESCRIPTION
## Description

Issue #5553 

As part of the `Project.number` transition to new identifier formats, simple ordering by number no longer gives the expected result. We now use the shared model helper` Project.apply_project_number_ordering()` so project lists are consistent across staff pages and management commands.

## Testing
Added unit tests wherever relevant.
Manually tested the changes. Please refer to [this](https://docs.google.com/document/d/1J22zyFTr04iW7QQA6sGKB1Fab1cUBuqrw1_TzePlXN8/edit?usp=sharing) doc to view screenshots.

