### PR TITLE
Update 'happy path' tests for project creation flow

### DIFF
--- a/tests/integration/staff/views/test_projects.py
+++ b/tests/integration/staff/views/test_projects.py
@@ -1,5 +1,10 @@
+import pytest
+from django.urls import reverse
+
 from jobserver.authorization.roles import ServiceAdministrator, StaffAreaAdministrator
-from tests.factories import UserFactory
+from jobserver.models import AuditableEvent, Project
+from jobserver.utils import set_from_qs
+from tests.factories import OrgFactory, ProjectFactory, UserFactory
 
 
 class TestProjectListCreateProjectButton:
@@ -28,3 +33,84 @@ class TestProjectListCreateProjectButton:
 
         assert response.status_code == 200
         assert "Create a project" not in response.text
+
+
+class TestProjectCreation:
+    """Tests of the project creation user flow."""
+
+    def test_projectcreate_authorized(self, client):
+        """
+        Test that a user with permission can access the ProjectCreate view.
+        """
+        user = UserFactory(roles=[ServiceAdministrator])
+
+        client.force_login(user)
+
+        response = client.get(reverse("staff:project-create"))
+
+        assert response.status_code == 200
+        assert not response.context_data["form"].is_bound
+
+    def test_projectcreated_authorized(self, client):
+        """
+        Test that a user with permission can access the ProjectCreated view.
+        """
+        user = UserFactory(roles=[ServiceAdministrator])
+        project = ProjectFactory()
+
+        client.force_login(user)
+
+        response = client.get(
+            reverse("staff:project-created", kwargs={"slug": project.slug})
+        )
+
+        assert response.status_code == 200
+
+    @pytest.mark.django_db(transaction=True)
+    def test_projectcreate_post_success(self, client, slack_messages):
+        """
+        Test a successful POST to the ProjectCreate view.
+
+        * A user with permission can access the ProjectCreate view.
+        * When valid data is submitted then:
+            * The user is redirected to the ProjectCreated page
+            * A new project is saved to the db with:
+                * created_by and updated_by = current user.
+                * copilot, orgs, name, and number fields have the values from the form data.
+                * created_by, updated_by and status are populated by Project model default values
+            * An AuditableEvent is created for the new project instance.
+            * A Slack message is sent to the copilot support channel.
+        """
+        user = UserFactory(roles=[ServiceAdministrator])
+        copilot = UserFactory()
+        org = OrgFactory()
+
+        data = {
+            "name": "test1",
+            "number": "1234567832",
+            "orgs": [str(org.pk)],
+            "copilot": str(copilot.pk),
+        }
+
+        client.force_login(user)
+
+        response = client.post(reverse("staff:project-create"), data, follow=True)
+
+        new_project = Project.objects.first()
+        url = reverse("staff:project-created", kwargs={"slug": new_project.slug})
+
+        assert response.status_code == 200
+        assert response.redirect_chain == [(url, 302)]
+
+        assert new_project.copilot == copilot
+        assert new_project.created_by == user
+        assert new_project.name == data["name"]
+        assert new_project.number == data["number"]
+        assert set_from_qs(new_project.orgs.all()) == {org.pk}
+        assert new_project.updated_by == user
+
+        assert AuditableEvent.objects.filter(target_id=new_project.pk).count() == 1
+
+        assert len(slack_messages) == 1
+        message, channel = slack_messages[0]
+        assert channel == "co-pilot-support"

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock, patch
+
 import pytest
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.exceptions import PermissionDenied
@@ -668,7 +670,7 @@ def test_projectmembershipremove_unknown_membership(request, rf, user_fixture):
 
 def test_projectcreate_authorised(rf):
     request = rf.get("/")
-    request.user = UserFactory(roles=[ServiceAdministrator, StaffAreaAdministrator])
+    request.user = UserFactory(roles=[ServiceAdministrator])
 
     response = ProjectCreate.as_view()(request)
 
@@ -683,19 +685,15 @@ def test_projectcreate_unauthorised(rf, staff_area_administrator):
         ProjectCreate.as_view()(request)
 
 
-@pytest.mark.django_db(transaction=True)
-def test_projectcreate_post_success(rf, slack_messages):
+@patch("staff.views.projects.projects.add")
+def test_projectcreate_post_success(mock_add, rf, slack_messages):
     """
-    Test a successful POST to the ProjectCreate form.
+    Test a successful POST to the ProjectCreate view.
 
-    When the form is populated by the user and submitted then:
-        * The user is redirected
+    When the form is populated with valid data and submitted then:
+        * The user is redirected to the ProjectCreated view
         * The form is in the response context data
-        * A new project is saved to the db with:
-            * created_by and updated_by = current user.
-            * copilot, orgs, name, and number fields have the values from the form data.
-            * created_by, updated_by and status are populated by Project model default values
-        * A Slack message is sent to the copilot support channel.
+        * mock_add is called once (mocking saving of new project instance to db).
     """
     user = UserFactory(roles=[ServiceAdministrator])
     copilot = UserFactory()
@@ -708,30 +706,28 @@ def test_projectcreate_post_success(rf, slack_messages):
         "copilot": str(copilot.pk),
     }
 
+    fake_project = Mock(slug="test-slug")
+    mock_add.return_value = fake_project
+
     request = rf.post("/", data)
     request.user = user
 
-    response = ProjectCreate.as_view()(request, data=data)
+    response = ProjectCreate.as_view()(request)
 
-    new_project = Project.objects.first()
+    mock_add.assert_called_once()
+    called_kwargs = mock_add.call_args.kwargs
 
-    assert response.status_code == 302, response.context_data["form"].errors
+    assert called_kwargs["by"] == user
+    assert called_kwargs["name"] == data["name"]
+    assert called_kwargs["number"] == data["number"]
+    assert called_kwargs["orgs"] == [org]
+    assert called_kwargs["copilot"] == copilot
+
+    assert response.status_code == 302
     assert response.url == reverse(
         "staff:project-created",
-        kwargs={"slug": new_project.slug},
+        kwargs={"slug": fake_project.slug},
     )
-
-    assert new_project.copilot == copilot
-    assert new_project.created_by == user
-    assert new_project.name == data["name"]
-    assert new_project.number == data["number"]
-    assert set_from_qs(new_project.orgs.all()) == {org.pk}
-    assert new_project.updated_by == user
-
-    # Then one Slack message gets sent. Don't test message details here.
-    assert len(slack_messages) == 1
-    message, channel = slack_messages[0]
-    assert channel == "co-pilot-support"
 
 
 def test_projectcreated_authorised(rf):


### PR DESCRIPTION
Addresses part of #5621.

This PR updates the 'happy path' unit and integration testing for the project creation flow.

### Summary of changes
**Unit tests:**
- Improve unit test isolation by mocking projects.add(), and move slack_messages assertions to the integration test.
- Remove unrequired role from test_projectcreate_authorised

**Integration tests:**
- Add a 'happy path' integration test for the project creation flow