### PR TITLE
Add COVID project to permissions

### DIFF
--- a/jobserver/permissions/dataset_permissions/datasets.py
+++ b/jobserver/permissions/dataset_permissions/datasets.py
@@ -73,6 +73,8 @@ PROJECTS_WITH_PERMISSION = {
         "sgss_covid_all_tests",
         "occupation_on_covid_vaccine_record",
     ],
+    # https://jobs.opensafely.org/identify-risk-factors-associated-with-disparities-for-resistant-bloodstream-infections-before-during-and-after-the-global-covid-19-pandemic-a-national-case-control-and-cohort-study/
+    "198": ["sgss_covid_all_tests"],
     # https://jobs.opensafely.org/sars-covid-19-vaccination-and-risk-of-major-adverse-cardiac-events-after-hip-fracture/
     "209": ["sgss_covid_all_tests"],
 }


### PR DESCRIPTION
Following the changes implemented in https://github.com/opensafely-core/job-runner/issues/1206, this [existing project which had a job run for the first time](https://jobs.opensafely.org/identify-risk-factors-associated-with-disparities-for-resistant-bloodstream-infections-before-during-and-after-the-global-covid-19-pandemic-a-national-case-control-and-cohort-study/) encountered an error because it was not yet on the list of permitted COVID projects.

[Confirmation for COVID project to access dataset](https://bennettoxford.slack.com/archives/C090LJWDGLE/p1770375308821009?thread_ts=1768565084.373159&cid=C090LJWDGLE)