### PR TITLE
Update project purpose button URL

### DIFF
--- a/jobserver/models/project.py
+++ b/jobserver/models/project.py
@@ -184,12 +184,10 @@ class Project(models.Model):
         )
 
     def get_approved_url(self):
-        f = furl("https://www.opensafely.org/approved-projects")
-
         if self.number:
-            f.fragment = f"project-{self.number}"
+            return furl(f"https://www.opensafely.org/project/{self.number}/")
 
-        return f.url
+        return "https://www.opensafely.org/projects/not-found/"
 
     def get_edit_url(self):
         return reverse(

--- a/tests/unit/jobserver/models/test_project.py
+++ b/tests/unit/jobserver/models/test_project.py
@@ -144,16 +144,15 @@ def test_project_get_absolute_url():
 def test_project_get_approved_url_with_number():
     project = ProjectFactory(number=42)
 
-    assert (
-        project.get_approved_url()
-        == "https://www.opensafely.org/approved-projects#project-42"
-    )
+    assert str(project.get_approved_url()) == "https://www.opensafely.org/project/42/"
 
 
 def test_project_get_approved_url_without_number():
     project = ProjectFactory()
 
-    assert project.get_approved_url() == "https://www.opensafely.org/approved-projects"
+    assert (
+        project.get_approved_url() == "https://www.opensafely.org/projects/not-found/"
+    )
 
 
 def test_project_get_edit_url():


### PR DESCRIPTION
Closes #5643

- Changed `Project.get_approved_url` so it now:
  - returns `furl("https://www.opensafely.org/project/{number}/")` when `project.number` is set
  - points to <https://www.opensafely.org/projects/not-found/> when `project.number` is missing
- Updated model unit tests for `get_approved_url` to match the new behaviour 
- Set up a redirect in WordPress so that any 404s which match `^/project/.*$` get redirected to [opensafely.org/projects/not-found/](https://www.opensafely.org/projects/not-found/)
    - Test it yourself <https://www.opensafely.org/project/hello-world/>)