### PR TITLE
Add unhappy path integration tests and unit tests for the project creation flow

### DIFF
--- a/tests/factories/project.py
+++ b/tests/factories/project.py
@@ -32,3 +32,39 @@ class ProjectFactory(factory.django.DjangoModelFactory):
 
     org = factory.PostGeneration(_project_collaboration_factory)
     orgs = factory.PostGeneration(_project_collaboration_factory)
+
+
+class CreateProjectFormDataFactory(factory.Factory):
+    """
+    Generate a default data dict for post requests to the ProjectCreateForm.
+
+    By default:
+    - Returns a valid data dict:
+        data = {
+            "name": "test1",
+            "number": "1234567832",
+            "orgs": "1",
+            "copilot": "1",
+        }
+    - Will create an org & a user (copilot) instance in the db.
+    """
+
+    class Meta:
+        model = dict
+
+    name = factory.Sequence(lambda n: f"Test Project {n}")
+    number = factory.Sequence(lambda n: str(1000000 + n))
+
+    @factory.lazy_attribute
+    def orgs(self):
+        from tests.factories.org import OrgFactory
+
+        org = OrgFactory()
+        return str(org.pk)
+
+    @factory.lazy_attribute
+    def copilot(self):
+        from tests.factories.user import UserFactory
+
+        user = UserFactory()
+        return str(user.pk)

--- a/tests/integration/staff/views/test_projects.py
+++ b/tests/integration/staff/views/test_projects.py
@@ -4,7 +4,12 @@ from django.urls import reverse
 from jobserver.authorization.roles import ServiceAdministrator, StaffAreaAdministrator
 from jobserver.models import AuditableEvent, Project
 from jobserver.utils import set_from_qs
-from tests.factories import OrgFactory, ProjectFactory, UserFactory
+from tests.factories import (
+    CreateProjectFormDataFactory,
+    OrgFactory,
+    ProjectFactory,
+    UserFactory,
+)
 
 
 class TestProjectListCreateProjectButton:
@@ -38,18 +43,13 @@ class TestProjectListCreateProjectButton:
 class TestProjectCreation:
     """Tests of the project creation user flow."""
 
-    def test_projectcreate_authorized(self, client):
-        """
-        Test that a user with permission can access the ProjectCreate view.
-        """
-        user = UserFactory(roles=[ServiceAdministrator])
+    def test_projectcreate_unauthorised(self, client, staff_area_administrator):
+        user = staff_area_administrator
 
         client.force_login(user)
 
-        response = client.get(reverse("staff:project-create"))
-
-        assert response.status_code == 200
-        assert not response.context_data["form"].is_bound
+        response = client.post(reverse("staff:project-create"))
+        assert response.status_code == 403
 
     def test_projectcreate_selects_org_from_url_when_multiple_orgs_exist(self, client):
         user = UserFactory(roles=[ServiceAdministrator])
@@ -67,23 +67,10 @@ class TestProjectCreation:
         selected_orgs = response.context_data["form"]["orgs"].value()
         assert selected_orgs == [bennett_org.pk]
 
-    def test_projectcreated_authorized(self, client):
-        """
-        Test that a user with permission can access the ProjectCreated view.
-        """
-        user = UserFactory(roles=[ServiceAdministrator])
-        project = ProjectFactory()
-
-        client.force_login(user)
-
-        response = client.get(
-            reverse("staff:project-created", kwargs={"slug": project.slug})
-        )
-
-        assert response.status_code == 200
-
     @pytest.mark.django_db(transaction=True)
-    def test_projectcreate_post_success(self, client, slack_messages):
+    def test_projectcreate_post_success(
+        self, client, slack_messages, service_administrator
+    ):
         """
         Test a successful POST to the ProjectCreate view.
 
@@ -97,16 +84,8 @@ class TestProjectCreation:
             * An AuditableEvent is created for the new project instance.
             * A Slack message is sent to the copilot support channel.
         """
-        user = UserFactory(roles=[ServiceAdministrator])
-        copilot = UserFactory()
-        org = OrgFactory()
-
-        data = {
-            "name": "test1",
-            "number": "1234567832",
-            "orgs": [str(org.pk)],
-            "copilot": str(copilot.pk),
-        }
+        user = service_administrator
+        data = CreateProjectFormDataFactory()
 
         client.force_login(user)
 
@@ -118,11 +97,11 @@ class TestProjectCreation:
         assert response.status_code == 200
         assert response.redirect_chain == [(url, 302)]
 
-        assert new_project.copilot == copilot
+        assert new_project.copilot.pk == int(data["copilot"])
         assert new_project.created_by == user
         assert new_project.name == data["name"]
         assert new_project.number == data["number"]
-        assert set_from_qs(new_project.orgs.all()) == {org.pk}
+        assert set_from_qs(new_project.orgs.all()) == {int(data["orgs"])}
         assert new_project.updated_by == user
 
         assert AuditableEvent.objects.filter(target_id=new_project.pk).count() == 1
@@ -130,6 +109,62 @@ class TestProjectCreation:
         assert len(slack_messages) == 1
         message, channel = slack_messages[0]
         assert channel == "co-pilot-support"
+
+    # parametrisation covers both empty and omitted values for each
+    # required field when POSTing to the ProjectCreateForm.
+    @pytest.mark.parametrize("field", ["name", "orgs", "copilot"])
+    @pytest.mark.parametrize("missing_data", ["empty", "omitted"])
+    def test_projectcreate_post_with_missing_data(
+        self, client, slack_messages, service_administrator, field, missing_data
+    ):
+        """
+        Test an unsuccessful POST to the ProjectCreate view with missing data.
+
+        * When the form is submitted with missing data:
+            * ProjectCreate view successfully re-renders
+            * The bound form and error are in the response context
+            * A new project is not created in the db
+            * A new AuditableEvent is not created
+            * A Slack message is not sent to the copilot support channel.
+        """
+        user = service_administrator
+        projects_count = Project.objects.count()
+        aes_count = AuditableEvent.objects.count()
+
+        data = CreateProjectFormDataFactory()
+
+        if missing_data == "empty":
+            if field == "orgs":
+                data[field] = []
+            else:
+                data[field] = ""
+        else:
+            data.pop(field, None)
+
+        client.force_login(user)
+
+        response = client.post(reverse("staff:project-create"), data)
+
+        assert response.status_code == 200
+        form = response.context_data["form"]
+        assert form.is_bound
+        assert field in form.errors
+
+        assert Project.objects.count() == projects_count
+
+        assert AuditableEvent.objects.count() == aes_count
+
+        assert len(slack_messages) == 0
+
+    def test_projectcreated_unauthorised(self, client, staff_area_administrator):
+        user = staff_area_administrator
+
+        client.force_login(user)
+
+        response = client.post(
+            reverse("staff:project-created", kwargs={"slug": "new-project-slug"})
+        )
+        assert response.status_code == 403
 
 
 class TestProjectDetail:

--- a/tests/unit/staff/test_forms.py
+++ b/tests/unit/staff/test_forms.py
@@ -14,6 +14,7 @@ from staff.forms import (
 from ...factories import (
     ApplicationFactory,
     BackendFactory,
+    CreateProjectFormDataFactory,
     OrgFactory,
     ProjectFactory,
     UserFactory,
@@ -189,20 +190,69 @@ def test_projectcreateform_success():
         * The form is bound with copilot, orgs, name, and number data input by the user.
         * Validation succeeds.
     """
-    copilot = UserFactory()
-    org = OrgFactory()
-
-    data = {
-        "name": "test1",
-        "number": 1234567832,
-        "orgs": str(org.pk),
-        "copilot": str(copilot.pk),
-    }
+    data = CreateProjectFormDataFactory()
 
     form = ProjectCreateForm(data=data)
 
     assert form.is_bound
     assert form.is_valid(), form.errors
+
+
+@pytest.mark.parametrize(
+    "invalid_data_type,data,field",
+    [
+        ("duplicate_name", {}, "name"),
+        ("unknown_org", {"orgs": ["99999"]}, "orgs"),
+        ("unknown_copilot", {"copilot": "99999"}, "copilot"),
+    ],
+)
+def test_projectcreateform_invalid_data(invalid_data_type, data, field):
+    """
+    Test invalid data submission to ProjectCreateForm
+
+    Parametrised invalid data: duplicate project name, an unknown organisation, and an unknown copilot user.
+
+    When invalid data are submitted:
+    - is_valid() fails
+    - we get a form error for the expected field
+    """
+
+    existing_project = ProjectFactory()
+
+    invalid_data = CreateProjectFormDataFactory(**data)
+
+    if invalid_data_type == "duplicate_name":
+        invalid_data["name"] = existing_project.name
+
+    form = ProjectCreateForm(data=invalid_data)
+    assert not form.is_valid()
+    assert field in form.errors
+
+
+@pytest.mark.parametrize("field", ["name", "orgs", "copilot"])
+@pytest.mark.parametrize("missing_type", ["empty", "omitted"])
+def test_projectcreateform_without_required_data(field, missing_type):
+    """
+    Test submission of empty and omitted values for each required field in the ProjectCreateForm.
+
+    When empty or omitted values are submitted:
+    - is_valid() fails
+    - we get a form error for the expected field
+    """
+    data = CreateProjectFormDataFactory()
+
+    if missing_type == "empty":
+        if field == "orgs":
+            data[field] = []
+        else:
+            data[field] = ""
+    else:
+        data.pop(field, None)
+
+    form = ProjectCreateForm(data=data)
+
+    assert not form.is_valid()
+    assert form.errors == {field: ["This field is required."]}
 
 
 def test_projecteditform_number_is_not_required():

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -1,10 +1,7 @@
-from unittest.mock import Mock, patch
-
 import pytest
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
-from django.urls import reverse
 
 from applications.models import Application
 from jobserver.actions import project_members
@@ -680,36 +677,9 @@ def test_projectmembershipremove_unknown_membership(request, rf, user_fixture):
         ProjectMembershipRemove.as_view()(req, slug=project.slug, pk=0)
 
 
-def test_projectcreate_authorised(rf):
-    request = rf.get("/")
-    request.user = UserFactory(roles=[ServiceAdministrator])
-
-    response = ProjectCreate.as_view()(request)
-
-    assert response.status_code == 200
-
-
-def test_projectcreate_with_known_org_slug(rf):
-    org = OrgFactory()
-    request = rf.get(f"/?org-slug={str(org.slug)}")
-    request.user = UserFactory(roles=[ServiceAdministrator])
-
-    response = ProjectCreate.as_view()(request)
-
-    assert response.status_code == 200
-    assert "orgs" in response.context_data["form"].initial
-
-
-def test_projectcreate_with_unknown_org_slug(rf):
-    request = rf.get("/?org-slug=unknown-org")
-    request.user = UserFactory(roles=[ServiceAdministrator])
-
-    response = ProjectCreate.as_view()(request)
-
-    assert response.status_code == 200
-    assert "orgs" not in response.context_data["form"].initial
-
-
+# The amount of custom code in the ProjectCreate and ProjectCreated
+# views is minimal. The rest of the behaviour in the project creation
+# workflow is covered by integration tests and form unit tests.
 def test_projectcreate_unauthorised(rf, staff_area_administrator):
     request = rf.get("/")
     request.user = staff_area_administrator
@@ -718,59 +688,16 @@ def test_projectcreate_unauthorised(rf, staff_area_administrator):
         ProjectCreate.as_view()(request)
 
 
-@patch("staff.views.projects.projects.add")
-def test_projectcreate_post_success(mock_add, rf, slack_messages):
-    """
-    Test a successful POST to the ProjectCreate view.
+def test_projectcreate_get_initial_with_nonexistent_org(rf, service_administrator):
+    request = rf.get("/staff/projects/create/?org-slug=nonexistent-org")
+    request.user = service_administrator
 
-    When the form is populated with valid data and submitted then:
-        * The user is redirected to the ProjectCreated view
-        * The form is in the response context data
-        * mock_add is called once (mocking saving of new project instance to db).
-    """
-    user = UserFactory(roles=[ServiceAdministrator])
-    copilot = UserFactory()
-    org = OrgFactory()
+    view = ProjectCreate()
+    view.request = request
 
-    data = {
-        "name": "test1",
-        "number": "1234567832",
-        "orgs": str(org.pk),
-        "copilot": str(copilot.pk),
-    }
+    initial = view.get_initial()
 
-    fake_project = Mock(slug="test-slug")
-    mock_add.return_value = fake_project
-
-    request = rf.post("/", data)
-    request.user = user
-
-    response = ProjectCreate.as_view()(request)
-
-    mock_add.assert_called_once()
-    called_kwargs = mock_add.call_args.kwargs
-
-    assert called_kwargs["by"] == user
-    assert called_kwargs["name"] == data["name"]
-    assert called_kwargs["number"] == data["number"]
-    assert called_kwargs["orgs"] == [org]
-    assert called_kwargs["copilot"] == copilot
-
-    assert response.status_code == 302
-    assert response.url == reverse(
-        "staff:project-created",
-        kwargs={"slug": fake_project.slug},
-    )
-
-
-def test_projectcreated_authorised(rf):
-    project = ProjectFactory()
-    request = rf.get(reverse("staff:project-created", kwargs={"slug": project.slug}))
-    request.user = UserFactory(roles=[ServiceAdministrator])
-
-    response = ProjectCreated.as_view()(request, slug=project.slug)
-
-    assert response.status_code == 200
+    assert "orgs" not in initial or initial.get("orgs") in ([], None)
 
 
 def test_projectcreated_unauthorised(rf, staff_area_administrator):


### PR DESCRIPTION
This PR address part of #5621

### General approach to testing taken in this PR: 
The `ProjectCreate` and `ProjectCreated` views contain minimal custom logic. Most of the project creation workflow can therefore be covered by two integration tests: one happy path and one unhappy path.

Integration tests provide good end-to-end coverage but are slower to run. To keep the test suite efficient, we limit integration coverage to core workflow behaviour and use unit tests to cover:

- Form validation
- Unauthorised view access 
- View branches not exercised in the integration tests

There is some overlap between unit and integration tests, but unit tests are inexpensive.

### Summary of work done
New tests added to cover:
- Invalid form data:
  - Duplicate project name
  - Empty values or missing fields
  - Unknown orgs or coppilots
- Unauthorized access to the `ProjectCreate` and `ProjectCreated` views.
- The `except Org.DoesNotExist` branch in `ProjectCreate.get_initial()`

Refactoring:
- Introduced a `ProjectDataFactory` for generating form submission payloads
- Consolidated and parametrised form unit tests
- Removed “happy path” view unit tests (covered by `test_projectcreate_post_success`)
- Removed authorisation integration tests (authorised access covered by the happy path integration test; unauthorised access covered by unit tests)
- Improved comments and docstrings for clarity


Note: future work is planned (#5510) to address client and server-side form validation, including the project number.