### PR TITLE
Fix typo: #co-pilot-support link text repeated.

### DIFF
--- a/templates/staff/project/created.html
+++ b/templates/staff/project/created.html
@@ -29,7 +29,7 @@
         <li><a href={{project.get_staff_url}}>View project in the Staff Area</a></li>
       </ul>
       <p>You can now add users to the project.</p>
-      <p>We sent a notification about the new project to the #co-pilot-support <a href="https://bennettoxford.slack.com/archives/C028EJH752A" target="_blank" class="whitespace-nowrap">#co-pilot-support</a> Slack channel so they can begin the project setup process.</p>
+      <p>We sent a notification about the new project to the <a href="https://bennettoxford.slack.com/archives/C028EJH752A" target="_blank" class="whitespace-nowrap">#co-pilot-support</a> Slack channel so they can begin the project setup process.</p>
     </div>
     {% url "staff:project-add-member" slug=project.slug as staff_project_add_member_url %}
     {% #button type="link" href=staff_project_add_member_url variant="success" %}Add members to project &rarr;{% /button %}


### PR DESCRIPTION
Fixes #5675.

On the project created page, recently added there is a typo with some text from a link repeated in the main text.

Eg http://localhost:8000/staff/projects/oeoeo/created/ (after http://localhost:8000/staff/projects/create/).

Before:

<img width="602" height="346" alt="image" src="https://github.com/user-attachments/assets/26fe0eae-091a-48a1-9a26-fd0fb276161b" />

After:

<img width="602" height="346" alt="image" src="https://github.com/user-attachments/assets/10f6d3b3-15e0-4aea-b03c-bc9e96bfdcca" />