### PR TITLE
Remove duplicated copilot text on ProjectCreated page

### DIFF
--- a/templates/staff/project/created.html
+++ b/templates/staff/project/created.html
@@ -29,7 +29,7 @@
         <li><a href={{project.get_staff_url}}>View project in the Staff Area</a></li>
       </ul>
       <p>You can now add users to the project.</p>
-      <p>We sent a notification about the new project to the #co-pilot-support <a href="https://bennettoxford.slack.com/archives/C028EJH752A" target="_blank" class="whitespace-nowrap">#co-pilot-support</a> Slack channel so they can begin the project setup process.</p>
+      <p>We sent a notification about the new project to the <a href="https://bennettoxford.slack.com/archives/C028EJH752A" target="_blank" class="whitespace-nowrap">#co-pilot-support</a> Slack channel so they can begin the project setup process.</p>
     </div>
     {% url "staff:project-add-member" slug=project.slug as staff_project_add_member_url %}
     {% #button type="link" href=staff_project_add_member_url variant="success" %}Add members to project &rarr;{% /button %}


### PR DESCRIPTION
Fixes #5675

The text `#co-pilot-support` was duplicated, as text before the link to the Slack channel, then as part of the link to the Slack channel.

This fix retains the link text only.

### Before

<img width="732" height="924" alt="image" src="https://github.com/user-attachments/assets/ce540454-4e8f-47bf-815c-428abbfc9c0e" />

### After
<img width="1119" height="664" alt="Screenshot from 2026-03-10 08-11-53" src="https://github.com/user-attachments/assets/868b7b1f-9dae-42f3-9e74-329602336e5c" />
