### PR TITLE
Add COVID project to permissions

### DIFF
--- a/jobserver/permissions/dataset_permissions/datasets.py
+++ b/jobserver/permissions/dataset_permissions/datasets.py
@@ -59,6 +59,11 @@ PROJECTS_WITH_PERMISSION = {
         "sgss_covid_all_tests",
         "occupation_on_covid_vaccine_record",
     ],
+    # https://jobs.opensafely.org/echo-evaluation-of-covid-19-vaccine-histories-using-opensafely/
+    "174": [
+        "sgss_covid_all_tests",
+        "occupation_on_covid_vaccine_record",
+    ],
     # https://jobs.opensafely.org/implications-of-metformin-for-long-covid/
     "175": [
         "appointments",


### PR DESCRIPTION
Following the changes implemented in https://github.com/opensafely-core/job-runner/issues/1206, this [existing project which had a job run for the first time in over a year](https://jobs.opensafely.org/echo-evaluation-of-covid-19-vaccine-histories-using-opensafely/) encountered an error because it was not yet on the list of permitted COVID projects.

[Confirmation for COVID project to access dataset](https://bennettoxford.slack.com/archives/C090LJWDGLE/p1770375308821009?thread_ts=1768565084.373159&cid=C090LJWDGLE)