### PR TITLE
Bump pipeline version and ignore warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
 
     # A specific version of the OpenSAFELY Pipeline for health data analysis.
     # Search 'pipeline' in jobserver/
-    "opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.01.26.163426.zip",
+    "opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.03.12.140752.zip",
 
     # OpenTelemetry exporter for sending traces/metrics via OTLP over HTTP.
     "opentelemetry-exporter-otlp-proto-http",
@@ -189,6 +189,9 @@ filterwarnings = [
     # See the FORMS_URLFIELD_ASSUME_HTTPS setting in jobserver/settings.py
     # for more information.
     "ignore:The FORMS_URLFIELD_ASSUME_HTTPS transitional setting is deprecated.:django.utils.deprecation.RemovedInDjango60Warning:",
+    # Ignore project.yaml end-user warnings from the opensafely-pipeline library
+    "ignore:ProjectWarning:UserWarning:pipeline.*:",
+    "ignore:ProjectWarning:UserWarning:tests.*:",
 ]
 markers = [
   "slow_test: mark test as being slow running",

--- a/uv.lock
+++ b/uv.lock
@@ -828,7 +828,7 @@ requires-dist = [
     { name = "gunicorn" },
     { name = "markdown" },
     { name = "nh3" },
-    { name = "opensafely-pipeline", url = "https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.01.26.163426.zip" },
+    { name = "opensafely-pipeline", url = "https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.03.12.140752.zip" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-django" },
     { name = "opentelemetry-instrumentation-psycopg2" },
@@ -933,12 +933,12 @@ wheels = [
 
 [[package]]
 name = "opensafely-pipeline"
-version = "2026.1.26.163426"
-source = { url = "https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.01.26.163426.zip" }
+version = "2026.3.12.140752"
+source = { url = "https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.03.12.140752.zip" }
 dependencies = [
     { name = "ruyaml" },
 ]
-sdist = { hash = "sha256:6414e6890ac9e982b03bade3daca8290221382dc57319f6448a1ea6bf1889a1a" }
+sdist = { hash = "sha256:e6e45b5b17f884af263a4c01ead72347d0e63899a0eb1811d7c3d0d5e802401b" }
 
 [package.metadata]
 requires-dist = [


### PR DESCRIPTION
Bump pipeline version and add pytest config to ignore warnings from the pipeline library in tests.

The latest pipeline version introduces some warnings if a project.yaml is not using the latest version, or if it contains and action with the reserved "run_all" action name.
See https://github.com/opensafely-core/pipeline/pull/455