### PR TITLE
Add `TechSupport` role.

### DIFF
--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -6,7 +6,9 @@ class StaffAreaAdministrator:
     description = """Access the Staff Area.
     View and edit applications, backends, organisations, project, repos, users, and workspaces.
     View dashboards.
-    See Staff Area Administrator Log for the list of individuals who are approved for this role."""
+    Tech team members must be listed as a Platform Developer in the Developer
+    Permissions Log to have this role.
+    Others must be on the the Staff Area Administrator Log."""
     models = [
         "jobserver.models.user.User",
     ]
@@ -23,6 +25,7 @@ class StaffAreaAdministrator:
 class TechSupport:
     display_name = "Tech Support"
     description = """Access pages required for the Tech team to provide technical suppport.
+    One must be listed as a Platform Developer in the Developer Permissions Log to have this role.
     Tech supporters also require the Staff Area Administrator role.
     Assign users to projects and project roles."""
     models = [


### PR DESCRIPTION
Part fixes https://github.com/opensafely-core/job-server/issues/5665. Release file view and team manual updates will be in other PRs.
https://github.com/ebmdatalab/team-manual/pull/1276

Tech support require access to some pages with restricted access in order to perform their job role. Let's create a Job Server role for them with the required access. This is part of an effort to make staff area access more fine-grained.

We plan to remove `Permission.USER_EDIT_PROJECT_ROLES` from `StaffAreaAdministrator` as  `ServiceAdministrator` has that role for most project role assignment activity. However tech support also sometimes need to assign project roles. Let's grant them the required role.

Example playbook where that access is required, adding Dataset Developers to a
project. This is tech-managed as it has no IG implications.
https://bennett.wiki/tech-group/tech-support/playbook/#grantingrevoking-access-for-dataset-developers