### PR TITLE
Grant project 202 access to the appointments dataset

### DIFF
--- a/jobserver/permissions/dataset_permissions/datasets.py
+++ b/jobserver/permissions/dataset_permissions/datasets.py
@@ -2,21 +2,27 @@
 #   IMPORTANT NOTE  *
 # *******************
 #
-# This file lists project numbers for projects permitted to access restricted (non-core) datasets.
+# This file lists project numbers for projects permitted to access restricted
+# (non-core) datasets.
 #
-# Permission must be requested from the OS service team in order to change the file
-# TODO: Document the process required, when confirmed.
+# Permission must be requested from the OS service team in order to change the
+# file TODO: Document the process required, when confirmed.
 #
-# Note also that this file is linked to in the documentation. If you move or restructure
-# this file you should ensure the documentation is updated appropriately.
+# Note also that this file is linked to in the documentation. If you move or
+# restructure this file you should ensure the documentation is updated
+# appropriately.
 # https://github.com/opensafely/documentation/blob/b070dd45d109314fa1bf119237937b9cadfc79df/docs/data-sources/index.md
 #
-# Historically (prior to Non-COVID opening), most table permissions were governed by IG, and can be found in the project spreadsheet:
+# Historically (prior to Non-COVID opening), most table permissions were
+# governed by IG, and can be found in the project spreadsheet:
 # https://docs.google.com/spreadsheets/d/1odgWEwFrkmCr3-7leE2amwVA3b55UCOzbXQOiNgyb1w/edit
 #
-# However, appointments and wl_* (waiting_list) table permissions are restricted for non-IG reasons, in that
-# their data need handling with due attention. Appointments is access managed by Alex, and
-# waiting_list table access is TBC. If they have approved access to those datasets, that permission can be added to that project in this file without requesting permission from the OS service team.
+# However, appointments and wl_* (waiting_list) table permissions are
+# restricted for non-IG reasons, in that their data need handling with due
+# attention. Appointments is access managed by Alex, and waiting_list table
+# access is TBC. If they have approved access to those datasets, that
+# permission can be added to that project in this file without requesting
+# permission from the OS service team.
 
 
 PROJECTS_WITH_PERMISSION = {


### PR DESCRIPTION
Fixes https://github.com/opensafely-core/job-server/issues/5680.

Not IG-restricted. Approved per:

https://bennett.wiki/tech-group/tech-support/playbook/#requests-about-accessing-the-appointments-table-in-ehrql
https://bennett.wiki/tech-group/tech-support/routing-table/
https://bennettoxford.slack.com/archives/C63UXGB8E/p1773241131595299

Also clarified the comments a little per https://bennettoxford.slack.com/archives/C069SADHP1Q/p1773651546163989 as we should be cautious about restricted datasets and good to be very clear about the difference between IG-related datasets and others.