### PR TITLE
Add note to dataset permissions docs re waiting list tables

### DIFF
--- a/jobserver/permissions/dataset_permissions/datasets.py
+++ b/jobserver/permissions/dataset_permissions/datasets.py
@@ -16,13 +16,15 @@
 # Historically (prior to Non-COVID opening), most table permissions were
 # governed by IG, and can be found in the project spreadsheet:
 # https://docs.google.com/spreadsheets/d/1odgWEwFrkmCr3-7leE2amwVA3b55UCOzbXQOiNgyb1w/edit
+
+# `appointments` table permissions are restricted for non_IG reasons, in that
+# their data need handling with due attention. Appointments is access managed by Alex Walker.
+# If Alex has approved access to the `appointments` dataset, that permission can be added to that
+# project in this file without requesting permission from the OS service team.
 #
-# However, appointments and wl_* (waiting_list) table permissions are
-# restricted for non-IG reasons, in that their data need handling with due
-# attention. Appointments is access managed by Alex, and waiting_list table
-# access is TBC. If they have approved access to those datasets, that
-# permission can be added to that project in this file without requesting
-# permission from the OS service team.
+# `wl_*` (waiting_list) datasets are restricted for non-COVID projects. For COVID projects, they are
+# ALSO restricted for data handling reasons, similarly to appointments. In both cases, contact the
+# OS service team for permission.
 
 
 PROJECTS_WITH_PERMISSION = {


### PR DESCRIPTION
Also add a note about waiting list data which is both restricted (for non-covid) and access-controlled (for covid). 
See also https://bennettoxford.slack.com/archives/C02HJTL065A/p1773652754016669