### PR TITLE
Add `RELEASE_FILE_VIEW` permission to `TechSupport`.

### DIFF
--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -27,11 +27,13 @@ class TechSupport:
     description = """Access pages required for the Tech team to provide technical suppport.
     One must be listed as a Platform Developer in the Developer Permissions Log to have this role.
     Tech supporters also require the Staff Area Administrator role.
-    Assign users to projects and project roles."""
+    Assign users to projects and project roles.
+    View outputs that have been released to Job Server."""
     models = [
         "jobserver.models.user.User",
     ]
     permissions = [
+        Permission.RELEASE_FILE_VIEW,
         Permission.USER_EDIT_PROJECT_ROLES,
     ]
 


### PR DESCRIPTION
Part fixes #5692.

Currently, people on tech support need to help with publishing files from Job Server (i.e removing files from a publish request or publishing only one file), they also need to be able to answer queries from researchers about files. It's preferable for them to be able to verify things through the staff area rather than looking in the database. Giving them the `RELEASE_FILE_VIEW` doesn't give them access to more data in practice (because they have access to the database.

Slack thread discussion:

https://bennettoxford.slack.com/archives/C069SADHP1Q/p1773655678750019?thread_ts=1771935827.964339&cid=C069SADHP1Q

Playbooks that need this (other PR to update these):

- https://bennett.wiki/tech-group/tech-support/playbook/#publishing-an-output-from-a-set-of-released-outputs
- https://bennett.wiki/tech-group/tech-support/playbook/#removing-files-from-a-draft-publication