### PR TITLE
Remove `|first` from `orgs` `form_select`

### DIFF
--- a/templates/staff/project/create.html
+++ b/templates/staff/project/create.html
@@ -84,7 +84,7 @@
             </p>
           {% endif %}
         {% endfragment %}
-        {% form_select field=form.orgs choices=form.fields.orgs.choices selected=form.orgs.value|default_if_none:''|first hint_text=select_hint_text hint_extra_class="max-w-full" %}
+        {% form_select field=form.orgs choices=form.fields.orgs.choices selected=form.orgs.value|default_if_none:'' hint_text=select_hint_text hint_extra_class="max-w-full" %}
       {% /form_fieldset %}
     {% /card %}
 


### PR DESCRIPTION
This field is a `ModelChoiceField` in the backend so we should not apply `|first`. This takes the first digit of the org PK, leading to inconsistent results when reloading the form. The wrong org might be selected.

See https://bennettoxford.slack.com/archives/C069SADHP1Q/p1773834256070059?thread_ts=1773827895.964339&cid=C069SADHP1Q for investigation.

This was a leftover from when https://github.com/opensafely-core/job-server/pull/5690 changed the field type in the backend. Before it was doing a valid select from an iterable.

This would be best caught by end-to-end testing (Playwright) so not adding for now. https://github.com/opensafely-core/job-server/issues/5621 may catch similar issues.