### PR TITLE
Temporarily remove include_gp_unactivated permission for OS Internal project

### DIFF
--- a/jobserver/permissions/population_permissions/gp_activations.py
+++ b/jobserver/permissions/population_permissions/gp_activations.py
@@ -26,7 +26,9 @@ ANALYSIS_SCOPE_KEY = "include_gp_unactivated"
 
 PROJECTS_WITH_GP_ACTIVATIONS_PERMISSION = {
     # Projects identified by slug (no project number)
-    "opensafely-internal",  # https://jobs.opensafely.org/opensafely-internal
+    # TODO: 2026-03-18: permission for the opensafely-internal project is temporarily removed for
+    # testing purposes and will be reinstated later
+    # "opensafely-internal",  # https://jobs.opensafely.org/opensafely-internal
     "156",  # https://jobs.opensafely.org/investigating-events-following-sars-cov-2-infection-project-continuation-of-approved-project-no-12/
     "157",  # https://jobs.opensafely.org/investigating-the-effectiveness-of-the-covid-19-vaccination-programme-in-the-uk-project-continuation-of-approved-project-no-22/
     "158",  # https://jobs.opensafely.org/the-effect-of-covid-19-on-pancreatic-cancer-diagnosis-and-care-project-continuation-of-approved-project-no-27/


### PR DESCRIPTION
TPP have now made the DB changes for GP activation filtering, and ehrql has been updated accordingly.

In order to test the ehrql filtering for real, we are temporarily removing the permission for the Internal project to access data for unactivated gp practices, so we can run jobs in this project with GP activation filtering applied.

Note: This [job request](https://jobs.opensafely.org/opensafely-internal/tpp-patient-population/25851/) has been run prior to this change, so we can compare on the same db build.