### PR TITLE
Remove outdated text.

### DIFF
--- a/templates/staff/index.html
+++ b/templates/staff/index.html
@@ -11,7 +11,6 @@
 {% block hero %}
   {% fragment as hero_text %}
     <p>The staff area is a tailored, staff-only interface.</p>
-    <p>It requires authentication but assumes all users are both equal and have full rights.</p>
   {% endfragment %}
   {% staff_hero title="Staff area" text=hero_text %}
 {% endblock hero %}


### PR DESCRIPTION
This is not true now that we have the tech support role assigned to people. And, soon, the service administrator role.  It's outdated and confusing. Let's just remove it. Maybe at one point this needed explaining like that, but not now.

Maybe later when we do more work on the staff area we can come up with some better overall guidance.

https://bennettoxford.slack.com/archives/C069SADHP1Q/p1773826272029459 brief discussion