### PR TITLE
Point viewers of `permissions/` to dev notes

### DIFF
--- a/jobserver/permissions/README.md
+++ b/jobserver/permissions/README.md
@@ -1,0 +1,4 @@
+# `permissions` package
+
+Please refer to information in [`DEVELOPERS.md`](../../DEVELOPERS.md#permissions)
+if you need to modify or add modules in this package.


### PR DESCRIPTION
Flag that editors of the package should be aware of how to edit it.