### PR TITLE
Fixes for form input component

### DIFF
--- a/templates/_components/form/input.html
+++ b/templates/_components/form/input.html
@@ -40,9 +40,9 @@
       {% attrs autocapitalize autocomplete autocorrect inputmode name=input_name placeholder required value=input_value|default_if_none:""|escape %}
       class="
              mt-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm placeholder:text-slate-400
+             user-invalid:border-bn-ribbon-600 user-invalid:ring-1 user-invalid:ring-bn-ribbon-600
              focus:border-oxford-500 focus:ring-oxford-500
              sm:text-sm
-             [&:user-invalid]:border-bn-ribbon-600 [&:user-invalid]:ring-bn-ribbon-600 [&:user-invalid]:ring-1
              {{ input_class }}
             "
       id="{{ input_id }}"


### PR DESCRIPTION
This PR fixes the issue where:

- If a user entered a closing quote and HTML tag (`" >`) on the create project form, it would close the tag on re-validation (assuming the form had errors)
- The Tailwind classes were using the pre-v4 naming structure for user-invalid tags

This does not fix the follow up issue of a project title which `slugify` turns in to a empty string do not save (causing a 500 error).

<img width="1588" height="864" alt="An on page error showing the class names for the HTML of a form input" src="https://github.com/user-attachments/assets/397bf733-f939-4c72-bbae-66eac5aa9d24" />
