### PR TITLE
Apply hotfix for HTML escaping issue in the `slippers` library

### DIFF
--- a/jobserver/patch_slippers.py
+++ b/jobserver/patch_slippers.py
@@ -1,0 +1,16 @@
+# Hotfix for HTML escaping issue in `slippers` library
+import slippers.templatetags.slippers
+from django.utils.html import format_html
+
+
+def safe_attr_string(key, value):
+    key = key.replace("_", "-")
+
+    if isinstance(value, bool):
+        return key if value else ""
+
+    return format_html('{}="{}"', key, value)
+
+
+def apply_patch():
+    slippers.templatetags.slippers.attr_string = safe_attr_string

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -19,8 +19,13 @@ from csp.constants import NONCE, NONE, SELF, UNSAFE_INLINE
 from django.contrib.messages import constants as messages
 from django.urls import reverse_lazy
 
+from jobserver import patch_slippers
 from services.logging import logging_config_dict
 from services.sentry import initialise_sentry
+
+
+# Hotfix for HTML escaping issue in `slippers` library
+patch_slippers.apply_patch()
 
 
 _missing_env_var_hint = """\

--- a/tests/unit/jobserver/test_slippers_attrs.py
+++ b/tests/unit/jobserver/test_slippers_attrs.py
@@ -1,0 +1,15 @@
+from django.template import Context, Template
+
+
+# Tests that our hotfix has been correctly applied
+def test_slippers_attrs_escapes_html():
+    template = Template("<input {% attrs my-attr=some_value %}>")
+    context = Context({"some_value": '">'})
+    assert template.render(context) == '<input my-attr="&quot;&gt;">'
+
+
+# Tests for coverage
+def test_slippers_attrs_handles_booleans():
+    template = Template("<input {% attrs bool-1=bool1 bool-2=bool2 %}>")
+    context = Context({"bool1": True, "bool2": False})
+    assert template.render(context) == "<input bool-1>"


### PR DESCRIPTION
Hopefully we will have an upstream fix soon and we can revert this.

Fortunately our CSP config prevents this being exploitable, but we should address the issue now that we know about it.