### PR TITLE
Fix migration conflict.

### DIFF
--- a/jobserver/migrations/0027_alter_project_number.py
+++ b/jobserver/migrations/0027_alter_project_number.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("jobserver", "0025_alter_project_copilot_support_ends_at"),
+        ("jobserver", "0026_alter_project_unique_number_ignore_null"),
     ]
 
     operations = [


### PR DESCRIPTION
Two non-conflicting migrations pointing to the same parent were merged, so the migration graph cannot be resolved and `main` cannot be deployed. Make the one that has not been applied in production yet the new final leaf (0027_alter_project_number) and point it at the one already applied (0026_alter_project_unique_number_ignore_null).

32db3e1d5843004cda1a814374dfda39bfe6ab72 passed CI 3 days ago but was merged today that is 0026_alter_project_number.

ba4edfaa90fe2a812c61098bbb0b5f11328f05f3 passed CI 2 days ago and was merged then. It has already been applied in production. That is 0026_alter_project_unique_number_ignore_null.