### PR TITLE
Show users with `STAFF_AREA_ACCESS` as `copilot` choices.

### DIFF
--- a/jobserver/authorization/__init__.py
+++ b/jobserver/authorization/__init__.py
@@ -5,7 +5,13 @@ from .roles import (
     ProjectDeveloper,
     StaffAreaAdministrator,
 )
-from .utils import has_permission, has_role, roles_for, strings_to_roles
+from .utils import (
+    has_permission,
+    has_role,
+    roles_for,
+    roles_with_permission,
+    strings_to_roles,
+)
 
 
 __all__ = [
@@ -17,5 +23,6 @@ __all__ = [
     "has_permission",
     "has_role",
     "roles_for",
+    "roles_with_permission",
     "strings_to_roles",
 ]

--- a/jobserver/authorization/global_roles.py
+++ b/jobserver/authorization/global_roles.py
@@ -1,10 +1,14 @@
-from ..models import User
+from ..models import ProjectMembership, User
 from .utils import roles_for
 
+
+# Not included in __init__ to avoid circular import problems.
 
 # A global role can be assigned to a User independently of ProjectMembership.
 # It either does not relate to Projects or grants permissions across ALL projects.
 
 GLOBAL_ROLES = roles_for(User)
-
 GLOBAL_ROLE_NAMES = [role.__name__ for role in GLOBAL_ROLES]
+
+PROJECT_ROLES = roles_for(ProjectMembership)
+ALL_ROLES = set(GLOBAL_ROLES).union(set(PROJECT_ROLES))

--- a/jobserver/authorization/utils.py
+++ b/jobserver/authorization/utils.py
@@ -132,6 +132,20 @@ def roles_for(model):
     return [r for r in available_roles if path in r.models]
 
 
+def roles_with_permission(permission):
+    """Get set of Roles with a specific permission.
+
+    That can be useful when querying objects with role fields, the permissions
+    cannot be queried directly as they are not represented in the database.
+    Instead, you can query on something like roles__overlap(permission).
+    """
+
+    # import here to avoid circular imports
+    from jobserver.authorization.global_roles import ALL_ROLES
+
+    return {role for role in ALL_ROLES if permission in role.permissions}
+
+
 def strings_to_roles(strings):
     """
     Convert Role names to Class objects

--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -31,8 +31,13 @@ class UserQuerySet(models.QuerySet):
 
     def potential_copilots(self, copilot_permission=Permission.STAFF_AREA_ACCESS):
         """
-        There is no copilot role, so we use staff area access as a proxy.
-        Copilots need access to view the copilot dashboard.
+        Return a QuerySet of User that could be a copilot.
+
+        There is no copilot role, so we use staff area access as a proxy. If we
+        add a more specific permission later we could use that instead.
+
+        Copilots need access to view the copilot dashboard, and may be assigned
+        to Project.copilot.
         """
         return self.with_permission(copilot_permission)
 

--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -15,11 +15,26 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from sentry_sdk import capture_message
 
+from jobserver.authorization.permissions import Permission
+from jobserver.authorization.utils import roles_with_permission
+
 from ..authorization.fields import RolesArrayField
 from ..hash_utils import hash_user_pat
 
 
 logger = structlog.get_logger(__name__)
+
+
+class UserQuerySet(models.QuerySet):
+    def with_permission(self, permission):
+        return self.filter(roles__overlap=roles_with_permission(permission))
+
+    def potential_copilots(self, copilot_permission=Permission.STAFF_AREA_ACCESS):
+        """
+        There is no copilot role, so we use staff area access as a proxy.
+        Copilots need access to view the copilot dashboard.
+        """
+        return self.with_permission(copilot_permission)
 
 
 class UserManager(models.Manager):
@@ -45,6 +60,15 @@ class UserManager(models.Manager):
             kwargs["password"] = make_password(password)
 
         return super().create(**kwargs)
+
+    def get_queryset(self):
+        return UserQuerySet(self.model, using=self._db)
+
+    def with_permission(self, permission):
+        return self.get_queryset().with_permission(permission)
+
+    def potential_copilots(self, copilot_permission=Permission.STAFF_AREA_ACCESS):
+        return self.get_queryset().potential_copilots(copilot_permission)
 
 
 class User(AbstractBaseUser):

--- a/staff/forms.py
+++ b/staff/forms.py
@@ -6,7 +6,7 @@ from applications.forms import YesNoField
 from applications.models import Application, ResearcherRegistration
 from jobserver.authorization.forms import RolesForm
 from jobserver.backends import backends_to_choices
-from jobserver.models import Backend, Org, Project, SiteAlert, Workspace
+from jobserver.models import Backend, Org, Project, SiteAlert, User, Workspace
 from jobserver.models.project import NUMBER_REGEX
 
 
@@ -143,6 +143,7 @@ class ProjectCreateForm(forms.ModelForm, UniqueProjectNumberMixin):
         super().__init__(*args, **kwargs)
 
         self.fields["orgs"].queryset = Org.objects.order_by(Lower("name"))
+        self.fields["copilot"].queryset = User.objects.potential_copilots()
 
     def clean_name(self):
         _validate_slug(self.cleaned_data["name"])
@@ -172,6 +173,7 @@ class ProjectEditForm(forms.ModelForm, UniqueProjectNumberMixin):
 
         self.fields["orgs"].queryset = Org.objects.order_by(Lower("name"))
         self.fields["copilot"].required = False
+        self.fields["copilot"].queryset = User.objects.potential_copilots()
 
 
 class ProjectLinkApplicationForm(forms.Form):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,21 +72,6 @@ def api_rf():
     return APIRequestFactory()
 
 
-@pytest.fixture
-def staff_area_administrator():
-    return UserFactory(roles=[StaffAreaAdministrator])
-
-
-@pytest.fixture
-def service_administrator():
-    return UserFactory(roles=[ServiceAdministrator])
-
-
-@pytest.fixture
-def tech_support():
-    return UserFactory(roles=[TechSupport])
-
-
 @pytest.fixture(name="log_output")
 def fixture_log_output():
     yield LogCapture()
@@ -443,6 +428,21 @@ def user_with_fake_role_factory(role_factory):
         return UserFactory(roles=[role_factory(permission=list(permission))])
 
     return _role_factory
+
+
+@pytest.fixture
+def staff_area_administrator():
+    return UserFactory(roles=[StaffAreaAdministrator])
+
+
+@pytest.fixture
+def service_administrator():
+    return UserFactory(roles=[ServiceAdministrator])
+
+
+@pytest.fixture
+def tech_support():
+    return UserFactory(roles=[TechSupport])
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -404,7 +404,11 @@ def role_factory():
         # them using their dotted path. To accommodate the check and the import, we move
         # this role class into place with __module__ and setattr.
 
-        name = f"Role_{permission}"
+        # Allow either single permission or iterable argument
+        if isinstance(permission, str):
+            permission = [permission]
+
+        name = f"Role_{'_'.join(permission)}"
         assert name.isidentifier(), f"{name} is not a valid Python identifier"
 
         Role = getattr(jobserver.authorization.roles, name, None)
@@ -415,7 +419,7 @@ def role_factory():
                 {
                     "__module__": jobserver.authorization.roles.__name__,
                     "models": [],
-                    "permissions": [permission],
+                    "permissions": list(permission),
                 },
             )
             setattr(jobserver.authorization.roles, name, Role)
@@ -433,7 +437,10 @@ def user_with_fake_role_factory(role_factory):
     """A fixture for dynamically creating a role with a given permission."""
 
     def _role_factory(*, permission):
-        return UserFactory(roles=[role_factory(permission=permission)])
+        # Allow either single permission or iterable argument
+        if isinstance(permission, str):
+            permission = [permission]
+        return UserFactory(roles=[role_factory(permission=list(permission))])
 
     return _role_factory
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ import jobserver.authorization.roles
 import services.slack
 from applications.form_specs import form_specs
 from jobserver.actions import project_members
+from jobserver.authorization.permissions import Permission
 from jobserver.authorization.roles import (
     ServiceAdministrator,
     StaffAreaAdministrator,
@@ -443,6 +444,15 @@ def service_administrator():
 @pytest.fixture
 def tech_support():
     return UserFactory(roles=[TechSupport])
+
+
+@pytest.fixture
+def user_USER_EDIT_PROJECT_ROLES(user_with_fake_role_factory):
+    return user_with_fake_role_factory(
+        permission=[
+            Permission.USER_EDIT_PROJECT_ROLES,
+        ]
+    )
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from structlog.testing import LogCapture
 
+import jobserver.authorization.global_roles
 import jobserver.authorization.roles
 import services.slack
 from applications.form_specs import form_specs
@@ -28,7 +29,7 @@ from jobserver.authorization.roles import (
     StaffAreaAdministrator,
     TechSupport,
 )
-from jobserver.models import SiteAlert
+from jobserver.models import SiteAlert, User
 from services.logging import base_processors
 from services.tracing import add_exporter, get_provider
 
@@ -419,9 +420,44 @@ def role_factory():
             )
             setattr(jobserver.authorization.roles, name, Role)
 
+        all_roles = getattr(jobserver.authorization.global_roles, "ALL_ROLES")
+        all_roles.add(Role)
+
         return Role
 
     return _role_factory
+
+
+@pytest.fixture
+def user_with_fake_role_factory(role_factory):
+    """A fixture for dynamically creating a role with a given permission."""
+
+    def _role_factory(*, permission):
+        return UserFactory(roles=[role_factory(permission=permission)])
+
+    return _role_factory
+
+
+@pytest.fixture()
+def potential_copilots(monkeypatch, user_with_fake_role_factory):
+    """
+    Fixture for patching User.objects.potential_copilots.
+
+    Decouple tests from real role/permission definitions.
+    Patch the copilot queryset to return two fake users with distinct fake
+    roles with a fake permission used to identify them.
+    """
+    fake_permission = "copilot_test_permission"
+    copilot0 = user_with_fake_role_factory(permission=fake_permission)
+    copilot1 = user_with_fake_role_factory(permission=fake_permission)
+    queryset = User.objects.filter(pk__in=[copilot0.pk, copilot1.pk])
+
+    monkeypatch.setattr(
+        "staff.forms.User.objects.potential_copilots",
+        # Return an actual QuerySet for chaining etc.
+        lambda: queryset,
+    )
+    return queryset
 
 
 @pytest.fixture

--- a/tests/functional/test_project_creation.py
+++ b/tests/functional/test_project_creation.py
@@ -12,7 +12,14 @@ pytestmark = pytest.mark.functional
 
 
 def test_can_create_a_project(
-    context, client, page, live_server, slack_messages, role_factory, freezer
+    context,
+    client,
+    page,
+    live_server,
+    slack_messages,
+    role_factory,
+    freezer,
+    potential_copilots,
 ):
     """
     Test that a user with the necessary permissions can successfully create a new project by interacting with the UI through their browser.
@@ -33,7 +40,7 @@ def test_can_create_a_project(
 
     # Create the form input data before we load the page, so the copilot User instance
     # exists in the db, and can be used in the copilot select form field later in the test
-    form_data = CreateProjectFormDataFactory()
+    form_data = CreateProjectFormDataFactory(copilot=str(potential_copilots.first().pk))
 
     # Go to the Staff Area Projects page
     page.goto(f"{live_server.url}{reverse('staff:project-list')}")

--- a/tests/integration/staff/views/test_projects.py
+++ b/tests/integration/staff/views/test_projects.py
@@ -2,32 +2,24 @@ import pytest
 from django.urls import reverse
 
 from jobserver.authorization.permissions import Permission
-from jobserver.authorization.roles import (
-    ServiceAdministrator,
-    StaffAreaAdministrator,
-    TechSupport,
-)
 from jobserver.models import AuditableEvent, Project
 from jobserver.utils import set_from_qs
 from tests.factories import (
     CreateProjectFormDataFactory,
     OrgFactory,
     ProjectFactory,
-    UserFactory,
 )
 
 
 class TestProjectListCreateProjectButton:
     """Tests of the Create a Project button on the Staff Area Projects page."""
 
-    @pytest.mark.parametrize(
-        "additional_role",
-        [ServiceAdministrator, TechSupport],
-    )
     def test_create_project_button_in_rendered_template_for_authorised_user(
-        self, client, additional_role
+        self, client, user_with_fake_role_factory
     ):
-        user = UserFactory(roles=[StaffAreaAdministrator, additional_role])
+        user = user_with_fake_role_factory(
+            permission=[Permission.STAFF_AREA_ACCESS, Permission.PROJECT_CREATE]
+        )
 
         client.force_login(user)
 
@@ -37,9 +29,9 @@ class TestProjectListCreateProjectButton:
         assert "Create a project" in response.text
 
     def test_create_project_button_not_in_rendered_template_for_unauthorised_user(
-        self, client, staff_area_administrator
+        self, client, user_with_fake_role_factory
     ):
-        user = staff_area_administrator
+        user = user_with_fake_role_factory(permission=[Permission.STAFF_AREA_ACCESS])
 
         client.force_login(user)
 
@@ -52,8 +44,8 @@ class TestProjectListCreateProjectButton:
 class TestProjectCreation:
     """Tests of the project creation user flow."""
 
-    def test_projectcreate_unauthorised(self, client, staff_area_administrator):
-        user = staff_area_administrator
+    def test_projectcreate_unauthorised(self, client, user_with_fake_role_factory):
+        user = user_with_fake_role_factory(permission=[Permission.STAFF_AREA_ACCESS])
 
         client.force_login(user)
 
@@ -173,8 +165,8 @@ class TestProjectCreation:
 
         assert len(slack_messages) == 0
 
-    def test_projectcreated_unauthorised(self, client, staff_area_administrator):
-        user = staff_area_administrator
+    def test_projectcreated_unauthorised(self, client, user_with_fake_role_factory):
+        user = user_with_fake_role_factory(permission=[Permission.STAFF_AREA_ACCESS])
 
         client.force_login(user)
 
@@ -191,19 +183,21 @@ class TestProjectDetail:
         "user_has_create_project",
         [True, False],
     )
-    def test_projectdetail_authorized(self, client, user_has_create_project):
+    def test_projectdetail_authorized(
+        self, client, user_with_fake_role_factory, user_has_create_project
+    ):
         """
         Test that a user with permission can access the ProjectDetail view.
 
         Parametrised to test that the Link Application content is only shown
-        to ServiceAdministrators.
+        to users that can manage applications.
         """
-        roles = (
-            [StaffAreaAdministrator, ServiceAdministrator]
+        permissions = (
+            [Permission.STAFF_AREA_ACCESS, Permission.PROJECT_LINK_TO_APPLICATION]
             if user_has_create_project
-            else [StaffAreaAdministrator]
+            else [Permission.STAFF_AREA_ACCESS]
         )
-        user = UserFactory(roles=roles)
+        user = user_with_fake_role_factory(permission=permissions)
         project = ProjectFactory()
 
         client.force_login(user)
@@ -215,7 +209,7 @@ class TestProjectDetail:
         # This class exists only to help automated testing that the content is as expected.
         assert "test-project-information-card" in response.text
         # This class exists only to help automated testing that the content is as expected.
-        # It should only be appear if the user can create projects.
+        # It should only be appear if the user can manage applications.
         assert ("test-link-application" in response.text) == user_has_create_project
 
     def test_projectdetail_unauthorized(self, client):

--- a/tests/integration/staff/views/test_projects.py
+++ b/tests/integration/staff/views/test_projects.py
@@ -1,6 +1,7 @@
 import pytest
 from django.urls import reverse
 
+from jobserver.authorization.permissions import Permission
 from jobserver.authorization.roles import (
     ServiceAdministrator,
     StaffAreaAdministrator,
@@ -81,13 +82,9 @@ class TestProjectCreation:
         selected_orgs = response.context_data["form"]["orgs"].value()
         assert selected_orgs == bennett_org.pk
 
-    @pytest.mark.parametrize(
-        "role_fixture_name",
-        ["service_administrator", "tech_support"],
-    )
     @pytest.mark.django_db(transaction=True)
     def test_projectcreate_post_success(
-        self, client, request, slack_messages, role_fixture_name
+        self, client, request, slack_messages, user_with_fake_role_factory
     ):
         """
         Test a successful POST to the ProjectCreate view.
@@ -102,18 +99,17 @@ class TestProjectCreation:
             * An AuditableEvent is created for the new project instance.
             * A Slack message is sent to the copilot support channel.
         """
-        role_fixture = request.getfixturevalue(role_fixture_name)
-        user = role_fixture
-        data = CreateProjectFormDataFactory()
+        user = user_with_fake_role_factory(permission=Permission.PROJECT_CREATE)
+        copilot = user_with_fake_role_factory(permission=Permission.STAFF_AREA_ACCESS)
+        data = CreateProjectFormDataFactory(copilot=copilot.pk)
 
         client.force_login(user)
 
         response = client.post(reverse("staff:project-create"), data, follow=True)
+        assert response.status_code == 200
 
         new_project = Project.objects.first()
         url = reverse("staff:project-created", kwargs={"slug": new_project.slug})
-
-        assert response.status_code == 200
         assert response.redirect_chain == [(url, 302)]
 
         assert new_project.copilot.pk == int(data["copilot"])

--- a/tests/integration/staff/views/test_projects.py
+++ b/tests/integration/staff/views/test_projects.py
@@ -60,14 +60,10 @@ class TestProjectCreation:
         response = client.post(reverse("staff:project-create"))
         assert response.status_code == 403
 
-    @pytest.mark.parametrize(
-        "role",
-        [ServiceAdministrator, TechSupport],
-    )
     def test_projectcreate_selects_org_from_url_when_multiple_orgs_exist(
-        self, client, role
+        self, client, user_with_fake_role_factory
     ):
-        user = UserFactory(roles=[role])
+        user = user_with_fake_role_factory(permission=Permission.PROJECT_CREATE)
         bennett_org = OrgFactory(slug="bennett-institute")
         OrgFactory(slug="university-of-oxford")
         OrgFactory(slug="phc-university-of-oxford")
@@ -125,16 +121,18 @@ class TestProjectCreation:
         message, channel = slack_messages[0]
         assert channel == "co-pilot-support"
 
-    @pytest.mark.parametrize(
-        "role_fixture_name",
-        ["service_administrator", "tech_support"],
-    )
     # parametrisation covers both empty and omitted values for each
     # required field when POSTing to the ProjectCreateForm.
     @pytest.mark.parametrize("field", ["name", "orgs", "copilot"])
     @pytest.mark.parametrize("missing_data", ["empty", "omitted"])
     def test_projectcreate_post_with_missing_data(
-        self, client, request, slack_messages, role_fixture_name, field, missing_data
+        self,
+        client,
+        request,
+        user_with_fake_role_factory,
+        slack_messages,
+        field,
+        missing_data,
     ):
         """
         Test an unsuccessful POST to the ProjectCreate view with missing data.
@@ -146,8 +144,7 @@ class TestProjectCreation:
             * A new AuditableEvent is not created
             * A Slack message is not sent to the copilot support channel.
         """
-        role_fixture = request.getfixturevalue(role_fixture_name)
-        user = role_fixture
+        user = user_with_fake_role_factory(permission=Permission.PROJECT_CREATE)
         projects_count = Project.objects.count()
         aes_count = AuditableEvent.objects.count()
 
@@ -191,10 +188,10 @@ class TestProjectDetail:
     """Tests of the project detail view."""
 
     @pytest.mark.parametrize(
-        "user_is_service_administrator",
+        "user_has_create_project",
         [True, False],
     )
-    def test_projectdetail_authorized(self, client, user_is_service_administrator):
+    def test_projectdetail_authorized(self, client, user_has_create_project):
         """
         Test that a user with permission can access the ProjectDetail view.
 
@@ -203,7 +200,7 @@ class TestProjectDetail:
         """
         roles = (
             [StaffAreaAdministrator, ServiceAdministrator]
-            if user_is_service_administrator
+            if user_has_create_project
             else [StaffAreaAdministrator]
         )
         user = UserFactory(roles=roles)
@@ -218,10 +215,8 @@ class TestProjectDetail:
         # This class exists only to help automated testing that the content is as expected.
         assert "test-project-information-card" in response.text
         # This class exists only to help automated testing that the content is as expected.
-        # It should only be appear if the user is a ServiceAdministrator.
-        assert (
-            "test-link-application" in response.text
-        ) == user_is_service_administrator
+        # It should only be appear if the user can create projects.
+        assert ("test-link-application" in response.text) == user_has_create_project
 
     def test_projectdetail_unauthorized(self, client):
         """

--- a/tests/unit/jobserver/authorization/test_global_roles.py
+++ b/tests/unit/jobserver/authorization/test_global_roles.py
@@ -1,14 +1,68 @@
-from jobserver.authorization.global_roles import GLOBAL_ROLE_NAMES
+import jobserver.authorization.roles as roles_module
+from jobserver.authorization.global_roles import (
+    ALL_ROLES,
+    GLOBAL_ROLE_NAMES,
+    GLOBAL_ROLES,
+    PROJECT_ROLES,
+)
+from jobserver.authorization.roles import (
+    DeploymentAdministrator,
+    OutputChecker,
+    OutputPublisher,
+    ProjectCollaborator,
+    ProjectDeveloper,
+    ServiceAdministrator,
+    SignOffRepoWithOutputs,
+    StaffAreaAdministrator,
+    TechSupport,
+)
 
 
 def test_global_role_names():
-    assert set(GLOBAL_ROLE_NAMES) & set(
+    assert set(GLOBAL_ROLE_NAMES) == set(
         [
-            "DeploymentAdministrator",
+            "StaffAreaAdministrator",
+            "TechSupport",
+            "ServiceAdministrator",
             "OutputChecker",
             "OutputPublisher",
             "ProjectCollaborator",
             "SignOffRepoWithOutputs",
-            "StaffAreaAdministrator",
+            "DeploymentAdministrator",
         ]
     )
+
+
+def test_global_roles():
+    assert set(GLOBAL_ROLES) == set(
+        [
+            StaffAreaAdministrator,
+            TechSupport,
+            ServiceAdministrator,
+            OutputChecker,
+            OutputPublisher,
+            ProjectCollaborator,
+            SignOffRepoWithOutputs,
+            DeploymentAdministrator,
+        ]
+    )
+
+
+def test_project_roles():
+    assert set(PROJECT_ROLES) == set(
+        [
+            ProjectDeveloper,
+            ProjectCollaborator,
+        ]
+    )
+
+
+def test_all_roles():
+    """Test that ALL_ROLES has all the roles from the roles module."""
+    role_names_in_module = {
+        role_name
+        for role_name in dir(roles_module)
+        # Exclude private attributes and the imported Permission class.
+        if not role_name.startswith("_") and not role_name.startswith("Perm")
+    }
+    assert {role.__name__ for role in ALL_ROLES} == role_names_in_module

--- a/tests/unit/jobserver/authorization/test_utils.py
+++ b/tests/unit/jobserver/authorization/test_utils.py
@@ -8,6 +8,7 @@ from jobserver.authorization import (
     has_permission,
     has_role,
     roles_for,
+    roles_with_permission,
     strings_to_roles,
 )
 from jobserver.models import ProjectMembership
@@ -101,3 +102,12 @@ def test_strings_to_roles_with_unknown_roles():
     msg = "Unknown Roles:\n - DummyRole\nAvailable Roles are:.*"
     with pytest.raises(Exception, match=msg):
         strings_to_roles(["DummyRole"])
+
+
+def test_roles_with_permission(role_factory):
+    fake_permission = "foo"
+    role_with_permission0 = role_factory(permission=fake_permission)
+    role_with_permission1 = role_factory(permission=fake_permission)
+
+    role_with_permission = roles_with_permission(permission=fake_permission)
+    assert set(role_with_permission) == {role_with_permission0, role_with_permission1}

--- a/tests/unit/jobserver/models/test_user.py
+++ b/tests/unit/jobserver/models/test_user.py
@@ -327,3 +327,25 @@ def test_user_fullname_non_blank():
     with pytest.raises(IntegrityError):
         u = User(username="foo", email="foo@bar.com", fullname="")
         u.save()
+
+
+def test_queryset_with_permission(user_with_fake_role_factory):
+    """Test that User.objects.with_permission returns right users."""
+    fake_permission = "foo"
+    user_with_permission0 = user_with_fake_role_factory(permission=fake_permission)
+    user_with_permission1 = user_with_fake_role_factory(permission=fake_permission)
+    UserFactory.create_batch(3)
+
+    copilots = User.objects.with_permission(permission=fake_permission)
+    assert set(copilots) == {user_with_permission0, user_with_permission1}
+
+
+def test_potential_copilots(user_with_fake_role_factory):
+    """Test that User.objects.potential_copilots returns right users."""
+    fake_permission = "copilot_test_permission"
+    copilot0 = user_with_fake_role_factory(permission=fake_permission)
+    copilot1 = user_with_fake_role_factory(permission=fake_permission)
+    UserFactory.create_batch(3)
+
+    copilots = User.objects.potential_copilots(copilot_permission=fake_permission)
+    assert set(copilots) == {copilot0, copilot1}

--- a/tests/unit/staff/test_forms.py
+++ b/tests/unit/staff/test_forms.py
@@ -150,13 +150,14 @@ def test_applicationapproveform_rejects_leading_zero_numeric_project_number():
     assert "project_number" in form.errors
 
 
-def test_projectcreateform_unbound():
+def test_projectcreateform_unbound(potential_copilots):
     """
     Test unbound state for ProjectCreate form.
 
     When the form is instantiated then:
         * The form is unbound.
         * name and number fields do not have initial values.
+        * The copilot field has the expected queryset.
     """
 
     form = ProjectCreateForm()
@@ -164,9 +165,10 @@ def test_projectcreateform_unbound():
     assert not form.is_bound
     assert form.fields["name"].initial is None
     assert form.fields["number"].initial is None
+    assert set(form.fields["copilot"].queryset) == set(potential_copilots)
 
 
-def test_projectcreateform_success():
+def test_projectcreateform_success(potential_copilots):
     """
     Test is_valid() success for ProjectCreate form.
 
@@ -174,7 +176,8 @@ def test_projectcreateform_success():
         * The form is bound with copilot, orgs, name, and number data input by the user.
         * Validation succeeds.
     """
-    data = CreateProjectFormDataFactory()
+
+    data = CreateProjectFormDataFactory(copilot=potential_copilots.first())
 
     form = ProjectCreateForm(data=data)
 
@@ -221,14 +224,16 @@ def test_projectcreateform_empty_slug():
 
 
 @pytest.mark.parametrize(
-    "invalid_data_type,data,field",
+    "invalid_data_type,invalid_data,field",
     [
         ("duplicate_name", {}, "name"),
         ("unknown_org", {"orgs": ["99999"]}, "orgs"),
         ("unknown_copilot", {"copilot": "99999"}, "copilot"),
     ],
 )
-def test_projectcreateform_invalid_data(invalid_data_type, data, field):
+def test_projectcreateform_invalid_data(
+    invalid_data_type, invalid_data, field, potential_copilots
+):
     """
     Test invalid data submission to ProjectCreateForm
 
@@ -241,7 +246,8 @@ def test_projectcreateform_invalid_data(invalid_data_type, data, field):
 
     existing_project = ProjectFactory()
 
-    invalid_data = CreateProjectFormDataFactory(**data)
+    valid_data = CreateProjectFormDataFactory(copilot=potential_copilots.first())
+    invalid_data = valid_data | invalid_data
 
     if invalid_data_type == "duplicate_name":
         invalid_data["name"] = existing_project.name
@@ -253,7 +259,9 @@ def test_projectcreateform_invalid_data(invalid_data_type, data, field):
 
 @pytest.mark.parametrize("field", ["name", "orgs", "copilot"])
 @pytest.mark.parametrize("missing_type", ["empty", "omitted"])
-def test_projectcreateform_without_required_data(field, missing_type):
+def test_projectcreateform_without_required_data(
+    field, missing_type, potential_copilots
+):
     """
     Test submission of empty and omitted values for each required field in the ProjectCreateForm.
 
@@ -261,7 +269,7 @@ def test_projectcreateform_without_required_data(field, missing_type):
     - is_valid() fails
     - we get a form error for the expected field
     """
-    data = CreateProjectFormDataFactory()
+    data = CreateProjectFormDataFactory(copilot=potential_copilots.first())
 
     if missing_type == "empty":
         if field == "orgs":
@@ -275,6 +283,21 @@ def test_projectcreateform_without_required_data(field, missing_type):
 
     assert not form.is_valid()
     assert form.errors == {field: ["This field is required."]}
+
+
+def test_projecteditform_unbound(potential_copilots):
+    """
+    Test unbound state for ProjectEditForm.
+
+    When the form is instantiated then:
+        * The form is unbound.
+        * The copilot field has the expected queryset.
+    """
+
+    form = ProjectEditForm()
+
+    assert not form.is_bound
+    assert set(form.fields["copilot"].queryset) == set(potential_copilots)
 
 
 def test_projecteditform_number_is_not_required():

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -256,10 +256,9 @@ def test_projectdetail_sets_permission_flags_for_roles(
     assert response.context_data["user_can_edit_members"] == user_can_edit_members
 
 
-def test_projectedit_get_success(rf, staff_area_administrator):
+def test_projectedit_get_success(rf, staff_area_administrator, potential_copilots):
     project = ProjectFactory(orgs=[OrgFactory()])
-
-    UserFactory(username="beng", fullname="Ben Goldacre")
+    copilot = potential_copilots.first()
 
     request = rf.get("/")
     request.user = staff_area_administrator
@@ -267,7 +266,7 @@ def test_projectedit_get_success(rf, staff_area_administrator):
     response = ProjectEdit.as_view()(request, slug=project.slug)
 
     assert response.status_code == 200
-    assert "Ben Goldacre (beng)" in response.rendered_content
+    assert copilot.fullname in response.rendered_content
 
 
 def test_projectedit_get_unauthorized(rf):
@@ -280,11 +279,11 @@ def test_projectedit_get_unauthorized(rf):
         ProjectEdit.as_view()(request, slug=project.slug)
 
 
-def test_projectedit_post_success(rf, staff_area_administrator):
+def test_projectedit_post_success(rf, staff_area_administrator, potential_copilots):
     project = ProjectFactory(name="test", number=123, orgs=[OrgFactory()])
     old_project_url = project.get_absolute_url()
+    new_copilot = potential_copilots.first()
 
-    new_copilot = UserFactory()
     new_org = OrgFactory()
 
     data = {
@@ -316,11 +315,13 @@ def test_projectedit_post_success(rf, staff_area_administrator):
     assert project.redirects.first().old_url == old_project_url
 
 
-def test_projectedit_post_success_when_not_changing_slug(rf, staff_area_administrator):
+def test_projectedit_post_success_when_not_changing_slug(
+    rf, staff_area_administrator, potential_copilots
+):
     org = OrgFactory()
     project = ProjectFactory(name="Test", slug="test", number=123, orgs=[org])
 
-    new_copilot = UserFactory()
+    new_copilot = potential_copilots.first()
 
     data = {
         "name": "Test",

--- a/tests/unit/staff/views/test_projects.py
+++ b/tests/unit/staff/views/test_projects.py
@@ -35,29 +35,21 @@ from ....factories import (
 )
 
 
-@pytest.mark.parametrize(
-    "user_fixture",
-    ["tech_support", "service_administrator"],
-)
-def test_projectaddmember_get_success(request, rf, user_fixture):
+def test_projectaddmember_get_success(rf, user_USER_EDIT_PROJECT_ROLES):
     project = ProjectFactory()
     UserFactory(username="beng", fullname="Ben Goldacre")
 
-    req = rf.get("/")
-    req.user = request.getfixturevalue(user_fixture)
+    request = rf.get("/")
+    request.user = user_USER_EDIT_PROJECT_ROLES
 
-    response = ProjectAddMember.as_view()(req, slug=project.slug)
+    response = ProjectAddMember.as_view()(request, slug=project.slug)
 
     assert response.status_code == 200
     assert response.context_data["project"] == project
     assert "Ben Goldacre (beng)" in response.rendered_content
 
 
-@pytest.mark.parametrize(
-    "user_fixture",
-    ["tech_support", "service_administrator"],
-)
-def test_projectaddmember_post_success(request, rf, user_fixture):
+def test_projectaddmember_post_success(rf, user_USER_EDIT_PROJECT_ROLES):
     project = ProjectFactory()
     user1 = UserFactory()
     user2 = UserFactory()
@@ -66,10 +58,10 @@ def test_projectaddmember_post_success(request, rf, user_fixture):
         "roles": ["jobserver.authorization.roles.ProjectDeveloper"],
         "users": [user1.pk, user2.pk],
     }
-    req = rf.post("/", data)
-    req.user = request.getfixturevalue(user_fixture)
+    request = rf.post("/", data)
+    request.user = user_USER_EDIT_PROJECT_ROLES
 
-    response = ProjectAddMember.as_view()(req, slug=project.slug)
+    response = ProjectAddMember.as_view()(request, slug=project.slug)
 
     assert response.status_code == 302
     assert response.url == project.get_staff_url()
@@ -87,13 +79,9 @@ def test_projectaddmember_unauthorized(rf):
         ProjectAddMember.as_view()(request)
 
 
-@pytest.mark.parametrize(
-    "user_fixture",
-    ["tech_support", "service_administrator"],
-)
-def test_projectaddmember_unknown_project(request, rf, user_fixture):
+def test_projectaddmember_unknown_project(request, rf, user_USER_EDIT_PROJECT_ROLES):
     req = rf.post("/")
-    req.user = request.getfixturevalue(user_fixture)
+    req.user = user_USER_EDIT_PROJECT_ROLES
 
     with pytest.raises(Http404):
         ProjectAddMember.as_view()(req, slug="test")


### PR DESCRIPTION
Fixes https://github.com/opensafely-core/job-server/issues/5750.

The list of all users displayed for the `copilot` field in the `ProjectCreateForm` and `ProjectEditForm` is very long in production -- anyone with a GitHub account can log in. Shortening it to a shorter valid set makes it slightly easier to navigate. This also makes manual errors less likely.

Ideally we would use a copilot-specific permission or role but that does not exist (yet?). So let's use `STAFF_AREA_ACCESS` as in practice all copilots do currently have that access for accessing the copilot dashboards (and formerly the application process).

Adjust the form field QuerySet to reduce the set of choices to those with roles that have the required permission. A function that returns User QuerySet is a User manager method so put it there, and this means that `with_permission` can be used more widely.

`potential_copilots` has the permission as a parameter to help with testing.

Add `ALL_ROLES` and `roles_with_permission` utility for making the `QuerySet` without hardcoding in the `StaffAreaAdministrator` role. Ideally all application behaviour should be driven by permissions, not roles, to decouple changes to the roles from the specific views et cetera.

Add `user_with_fake_role_factory` test fixture to aid with making `User` with fake permissions, to help with decoupling tests from specific roles and permissions. I updated existing tests using this where needed due to the copilot field change to show how this can be used, and also applied it to the rest of the integration tests and the `ProjectAddMember` unit tests for illustrative purposes.

The form tests use a fixture to patch the `QuerySet` returned by the `User.objects.potential_copilots` so that the other tests can be decoupled from the specific permission.