### PR TITLE
Increase gunicorn timeout

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -20,7 +20,7 @@ port = 8000
 bind = "0.0.0.0"
 
 # request timeout - more than the default of 30 for slow API requests
-timeout = 40
+timeout = 50
 
 
 def post_fork(server, worker):


### PR DESCRIPTION
We're seeing timeouts for large project.yamls on the run jobs page. This includes an API call to GitHub as well as rendering the yaml file, which can take some time. Longer term we'd like to investigate some better solutions, but for now, we have a user who wants to run some jobs.