### PR TITLE
Revert form_input component value escape

### DIFF
--- a/templates/_components/form/input.html
+++ b/templates/_components/form/input.html
@@ -37,7 +37,7 @@
 
   <div class="relative">
     <input
-      {% attrs autocapitalize autocomplete autocorrect inputmode name=input_name placeholder pattern required value=input_value|default_if_none:""|escape %}
+      {% attrs autocapitalize autocomplete autocorrect inputmode name=input_name placeholder pattern required value=input_value %}
       class="
              mt-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm placeholder:text-slate-400
              user-invalid:border-bn-ribbon-600 user-invalid:ring-1 user-invalid:ring-bn-ribbon-600


### PR DESCRIPTION
Slipper v0.6.3 (#5742) means that we no longer need to set a default value, or to escape the output ourselves.

Original PR to fix this was: #5715