### PR TITLE
Restrict visibility of workspace statuses to users with roles, to reduce potential public confusion

### DIFF
--- a/jobserver/models/workspace.py
+++ b/jobserver/models/workspace.py
@@ -42,6 +42,9 @@ class Workspace(models.Model):
 
     name = models.TextField(unique=True)
     branch = models.TextField()
+
+    # We don't show this field publicly to anonymous users, or to users without roles,
+    # as it may cause confusion or be misleading to users without necessary context.
     is_archived = models.BooleanField(default=False)
     should_notify = models.BooleanField(default=False)
     purpose = models.TextField(default="")

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -41,8 +41,9 @@ class ProjectDetail(View):
             request.user, Permission.PROJECT_MANAGE, project=project
         )
 
-        # An AnonymousUser doesn't have the has_any_roles property, so we use getattr
-        can_view_workspace_statuses = getattr(request.user, "has_any_roles", False)
+        can_view_workspace_statuses = (
+            request.user.is_authenticated and request.user.has_any_roles
+        )
 
         memberships = project.memberships.select_related("user").order_by(
             Lower("user__fullname"), "user__username"

--- a/jobserver/views/projects.py
+++ b/jobserver/views/projects.py
@@ -41,6 +41,9 @@ class ProjectDetail(View):
             request.user, Permission.PROJECT_MANAGE, project=project
         )
 
+        # An AnonymousUser doesn't have the has_any_roles property, so we use getattr
+        can_view_workspace_statuses = getattr(request.user, "has_any_roles", False)
+
         memberships = project.memberships.select_related("user").order_by(
             Lower("user__fullname"), "user__username"
         )
@@ -84,6 +87,7 @@ class ProjectDetail(View):
         context = {
             "can_create_workspaces": can_create_workspaces,
             "can_manage_project": can_manage_project,
+            "can_view_workspace_statuses": can_view_workspace_statuses,
             "first_job_ran_at": first_job_ran_at,
             "memberships": memberships,
             "outputs": self.get_outputs(workspaces),

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -192,6 +192,10 @@ class WorkspaceDetail(View):
             Permission.WORKSPACE_TOGGLE_NOTIFICATIONS,
             project=workspace.project,
         )
+
+        # An AnonymousUser doesn't have the has_any_roles property, so we use getattr
+        can_view_workspace_statuses = getattr(request.user, "has_any_roles", False)
+
         has_backends = request.user.is_authenticated and request.user.backends.exists()
 
         # Should we show the admin section in the UI?
@@ -215,6 +219,7 @@ class WorkspaceDetail(View):
             "user_can_archive_workspace": can_archive_workspace,
             "user_can_run_jobs": can_run_jobs,
             "user_can_toggle_notifications": can_toggle_notifications,
+            "user_can_view_workspace_statuses": can_view_workspace_statuses,
             "user_has_backends": has_backends,
             "workspace": workspace,
         }
@@ -291,9 +296,13 @@ class WorkspaceEventLog(ListView):
             )
         ).order_by("name")
 
+        # An AnonymousUser doesn't have the has_any_roles property, so we use getattr
+        can_view_workspace_statuses = getattr(self.request.user, "has_any_roles", False)
+
         return super().get_context_data(**kwargs) | {
             "backends": backends,
             "workspace": self.workspace,
+            "user_can_view_workspace_statuses": can_view_workspace_statuses,
         }
 
     def get_queryset(self):

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -193,8 +193,9 @@ class WorkspaceDetail(View):
             project=workspace.project,
         )
 
-        # An AnonymousUser doesn't have the has_any_roles property, so we use getattr
-        can_view_workspace_statuses = getattr(request.user, "has_any_roles", False)
+        can_view_workspace_statuses = (
+            request.user.is_authenticated and request.user.has_any_roles
+        )
 
         has_backends = request.user.is_authenticated and request.user.backends.exists()
 
@@ -296,8 +297,9 @@ class WorkspaceEventLog(ListView):
             )
         ).order_by("name")
 
-        # An AnonymousUser doesn't have the has_any_roles property, so we use getattr
-        can_view_workspace_statuses = getattr(self.request.user, "has_any_roles", False)
+        can_view_workspace_statuses = (
+            self.request.user.is_authenticated and self.request.user.has_any_roles
+        )
 
         return super().get_context_data(**kwargs) | {
             "backends": backends,

--- a/templates/project/detail.html
+++ b/templates/project/detail.html
@@ -114,38 +114,40 @@
                     {{ workspace.name }}
                   </a>
                 </dd>
-                <dt class="sr-only">Status:</dt>
-                <dd class="ml-auto shrink-0">
-                  {% if workspace.is_archived %}
-                    <span class="relative group">
-                      {% pill variant="warning" text="Archived" %}
-                      {% tooltip position="-bottom-3" content="Creating new jobs is disabled" %}
-                    </span>
-                  {% else %}
-                    {% pill variant="primary" text="Active" %}
-                  {% endif %}
-                </dd>
-              </div>
-              <div class="flex flex-col gap-2 text-sm text-slate-600 sm:flex-row sm:gap-x-4">
-                <dt class="sr-only">GitHub repository:</dt>
-                <dd class="flex flex-row items-start overflow-hidden sm:max-w-[50%]">
-                  {% icon_github_outline class="mr-1.5 h-5 w-5 shrink-0 text-slate-400" %}
-                  <span class="truncate">{{ workspace.repo.name }}</span>
-                </dd>
-                <dt class="sr-only">Git branch:</dt>
-                <dd class="flex flex-row items-start overflow-hidden sm:max-w-[50%]">
-                  {% icon_branches_outline class="mr-1.5 h-5 w-5 shrink-0 text-slate-400" %}
-                  <span class="truncate">{{ workspace.branch }}</span>
-                </dd>
-                <dt class="sr-only">Created at:</dt>
-                <dd class="flex flex-row shrink-0 items-start sm:ml-auto">
-                  {% icon_calendar_outline class="mr-1.5 h-5 w-5 shrink-0 text-slate-400" %}
-                  <time datetime="{{ workspace.created_at|date:"Y-m-d H:i:sO" }}">
-                    {{ workspace.created_at|date:"d M Y" }}
-                  </time>
-                </dd>
-              </div>
-            </dl>
+                {% if can_view_workspace_statuses %}
+                  <dt class="sr-only">Status:</dt>
+                  <dd class="ml-auto shrink-0">
+                    {% if workspace.is_archived %}
+                      <span class="relative group">
+                        {% pill variant="warning" text="Archived" %}
+                        {% tooltip position="-bottom-3" content="Creating new jobs is disabled" %}
+                      </span>
+                    {% else %}
+                      {% pill variant="primary" text="Active" %}
+                    {% endif %}
+                {% endif %}
+              </dd>
+            </div>
+            <div class="flex flex-col gap-2 text-sm text-slate-600 sm:flex-row sm:gap-x-4">
+              <dt class="sr-only">GitHub repository:</dt>
+              <dd class="flex flex-row items-start overflow-hidden sm:max-w-[50%]">
+                {% icon_github_outline class="mr-1.5 h-5 w-5 shrink-0 text-slate-400" %}
+                <span class="truncate">{{ workspace.repo.name }}</span>
+              </dd>
+              <dt class="sr-only">Git branch:</dt>
+              <dd class="flex flex-row items-start overflow-hidden sm:max-w-[50%]">
+                {% icon_branches_outline class="mr-1.5 h-5 w-5 shrink-0 text-slate-400" %}
+                <span class="truncate">{{ workspace.branch }}</span>
+              </dd>
+              <dt class="sr-only">Created at:</dt>
+              <dd class="flex flex-row shrink-0 items-start sm:ml-auto">
+                {% icon_calendar_outline class="mr-1.5 h-5 w-5 shrink-0 text-slate-400" %}
+                <time datetime="{{ workspace.created_at|date:"Y-m-d H:i:sO" }}">
+                  {{ workspace.created_at|date:"d M Y" }}
+                </time>
+              </dd>
+            </div>
+          </dl>
           </li>
         {% empty %}
           {% list_group_empty icon=True title="No workspaces" description="This project does not have any associated workspaces" %}

--- a/templates/project/detail.html
+++ b/templates/project/detail.html
@@ -125,29 +125,29 @@
                     {% else %}
                       {% pill variant="primary" text="Active" %}
                     {% endif %}
+                  </dd>
                 {% endif %}
-              </dd>
-            </div>
-            <div class="flex flex-col gap-2 text-sm text-slate-600 sm:flex-row sm:gap-x-4">
-              <dt class="sr-only">GitHub repository:</dt>
-              <dd class="flex flex-row items-start overflow-hidden sm:max-w-[50%]">
-                {% icon_github_outline class="mr-1.5 h-5 w-5 shrink-0 text-slate-400" %}
-                <span class="truncate">{{ workspace.repo.name }}</span>
-              </dd>
-              <dt class="sr-only">Git branch:</dt>
-              <dd class="flex flex-row items-start overflow-hidden sm:max-w-[50%]">
-                {% icon_branches_outline class="mr-1.5 h-5 w-5 shrink-0 text-slate-400" %}
-                <span class="truncate">{{ workspace.branch }}</span>
-              </dd>
-              <dt class="sr-only">Created at:</dt>
-              <dd class="flex flex-row shrink-0 items-start sm:ml-auto">
-                {% icon_calendar_outline class="mr-1.5 h-5 w-5 shrink-0 text-slate-400" %}
-                <time datetime="{{ workspace.created_at|date:"Y-m-d H:i:sO" }}">
-                  {{ workspace.created_at|date:"d M Y" }}
-                </time>
-              </dd>
-            </div>
-          </dl>
+              </div>
+              <div class="flex flex-col gap-2 text-sm text-slate-600 sm:flex-row sm:gap-x-4">
+                <dt class="sr-only">GitHub repository:</dt>
+                <dd class="flex flex-row items-start overflow-hidden sm:max-w-[50%]">
+                  {% icon_github_outline class="mr-1.5 h-5 w-5 shrink-0 text-slate-400" %}
+                  <span class="truncate">{{ workspace.repo.name }}</span>
+                </dd>
+                <dt class="sr-only">Git branch:</dt>
+                <dd class="flex flex-row items-start overflow-hidden sm:max-w-[50%]">
+                  {% icon_branches_outline class="mr-1.5 h-5 w-5 shrink-0 text-slate-400" %}
+                  <span class="truncate">{{ workspace.branch }}</span>
+                </dd>
+                <dt class="sr-only">Created at:</dt>
+                <dd class="flex flex-row shrink-0 items-start sm:ml-auto">
+                  {% icon_calendar_outline class="mr-1.5 h-5 w-5 shrink-0 text-slate-400" %}
+                  <time datetime="{{ workspace.created_at|date:"Y-m-d H:i:sO" }}">
+                    {{ workspace.created_at|date:"d M Y" }}
+                  </time>
+                </dd>
+              </div>
+            </dl>
           </li>
         {% empty %}
           {% list_group_empty icon=True title="No workspaces" description="This project does not have any associated workspaces" %}

--- a/templates/workspace/detail.html
+++ b/templates/workspace/detail.html
@@ -21,22 +21,24 @@
 {% endblock breadcrumbs %}
 
 {% block content %}
-  {% if workspace.is_archived %}
-    {% #alert variant="warning" title="Archived Workspace" class="mb-6" %}
-      <p class="text-sm mb-2">
-        This workspace has been archived. Archiving marks this workspace inactive without deleting it. Logs remain available, but you cannot create new jobs until it is unarchived.
-      </p>
-      {% if user_can_archive_workspace %}
+  {% if user_can_view_workspace_statuses %}
+    {% if workspace.is_archived %}
+      {% #alert variant="warning" title="Archived Workspace" class="mb-6" %}
         <p class="text-sm mb-2">
-          Use the <span class="font-semibold">Unarchive workspace</span> button in the workspace admin section below to unarchive this workspace.
+          This workspace has been archived. Archiving marks this workspace inactive without deleting it. Logs remain available, but you cannot create new jobs until it is unarchived.
         </p>
-      {% else %}
-        <p class="text-sm">
-          If you think this has been done in error,
-          {% link text="contact an admin" href="mailto:team@opensafely.org" append_after="." %}
-        </p>
-      {% endif %}
-    {% /alert %}
+        {% if user_can_archive_workspace %}
+          <p class="text-sm mb-2">
+            Use the <span class="font-semibold">Unarchive workspace</span> button in the workspace admin section below to unarchive this workspace.
+          </p>
+        {% else %}
+          <p class="text-sm">
+            If you think this has been done in error,
+            {% link text="contact an admin" href="mailto:team@opensafely.org" append_after="." %}
+          </p>
+        {% endif %}
+      {% /alert %}
+    {% endif %}
   {% endif %}
 
   {% if workspace.project.slug == "opensafely-internal" %}

--- a/templates/workspace/event_log.html
+++ b/templates/workspace/event_log.html
@@ -17,17 +17,19 @@
 {% endblock breadcrumbs %}
 
 {% block content %}
-  {% if workspace.is_archived %}
-    {% #alert variant="warning" title="Archived Workspace" class="mb-6" %}
-      <p class="text-sm mb-2">
-        This Workspace has been archived.
-        Logs are still available but new Jobs can no longer be requested.
-      </p>
-      <p class="text-sm">
-        If you think this has been done in error,
-        {% link text="contact an admin" href="mailto:team@opensafely.org" append_after="." %}
-      </p>
-    {% /alert %}
+  {% if user_can_view_workspace_statuses %}
+    {% if workspace.is_archived %}
+      {% #alert variant="warning" title="Archived Workspace" class="mb-6" %}
+        <p class="text-sm mb-2">
+          This Workspace has been archived.
+          Logs are still available but new Jobs can no longer be requested.
+        </p>
+        <p class="text-sm">
+          If you think this has been done in error,
+          {% link text="contact an admin" href="mailto:team@opensafely.org" append_after="." %}
+        </p>
+      {% /alert %}
+    {% endif %}
   {% endif %}
 
   {% fragment as intro_text %}


### PR DESCRIPTION
Closes #5647 

To find all pages where this info was used, I searched on `workspace.is_archived` across the repo, and then excluded all the pages (staff area, the 'yours' section, job requests & repo sign-off) where the necessary roles  to view workspace status would always be present by default.

The remaining pages which have now changed are:
- the project detail page; status pills for workspaces are only visible to logged-in role-having users. [http://localhost:8000/opensafely-internal/](http://localhost:8000/opensafely-internal/) demonstrates this
- the workspace detail page; the text at the top of the page denoting an archived workspace is only visible to logged-in role-having users. [http://localhost:8000/opensafely-internal/diamorphine-blank-dmd-check/](http://localhost:8000/opensafely-internal/diamorphine-blank-dmd-check/) demonstrates this
- the workspace logs page; the text at the top of the page denoting an archived workspace is only visible to logged-in role-having users. [http://localhost:8000/opensafely-internal/diamorphine-blank-dmd-check/logs/](http://localhost:8000/opensafely-internal/diamorphine-blank-dmd-check/logs/) demonstrates this.

I'm not 100% sold that the latter two changes are strictly necessary; in particular, the archived workspace note doesn't run the risk of someone mistakenly thinking that an 'active' workspace has a live link to sensitive data or so on. On the flip side, probably the only people who know and care about the distinction are strictly contained within the set of people to whom it's still visible anyway.

I don't believe there's documentation that needs updating; everywhere that the workspace status is referenced is already in sections that assume that the user has the roles that would get them visibility of it anyway.

The diff in the templates seems to be very inconsistent about whether or not it handles the extra `{% if user_can_view_workspace_statuses %}` checks nicely - all that's changed in the templates is surrounding the parts that deal with workspace status with the relevant context data check, even though some of the diffs look more involved.