### PR TITLE
Only require `copilot` field for `POS-` projects.

### DIFF
--- a/jobserver/actions/projects.py
+++ b/jobserver/actions/projects.py
@@ -45,9 +45,12 @@ def add(*, by, name, number, orgs, copilot=None):
             updated_by=by,
         )
 
-    # Send a Slack notificaton if and only if the entire transaction (including
-    # any outer transaction) commits successfully - if the database actually updates.
-    transaction.on_commit(partial(notify_copilots_project_added, project))
+    # Send Slack notificaton if the project has a copilot so they know to do
+    # rest of the process.
+    if copilot:
+        # Send if and only if the entire transaction (including any outer
+        # transaction) commits successfully - if the database actually updates.
+        transaction.on_commit(partial(notify_copilots_project_added, project))
 
     return project
 

--- a/jobserver/models/project.py
+++ b/jobserver/models/project.py
@@ -25,6 +25,7 @@ DIGITS_PATTERN = r"[1-9][0-9]*"
 # year, '-', followed by a string of digits, usually starting with 2001. Year
 # part must start '20'. Third part has no leading zero.
 POS_FORMAT_PATTERN = r"POS-20[0-9]{2}-[1-9][0-9]{3}"
+POS_FORMAT_REGEX = re.compile(POS_FORMAT_PATTERN)
 # Pattern for either format. This covers all valid values.
 NUMBER_PATTERN = rf"{DIGITS_PATTERN}|{POS_FORMAT_PATTERN}"
 NUMBER_REGEX = re.compile(NUMBER_PATTERN)

--- a/staff/forms.py
+++ b/staff/forms.py
@@ -7,7 +7,7 @@ from applications.models import Application, ResearcherRegistration
 from jobserver.authorization.forms import RolesForm
 from jobserver.backends import backends_to_choices
 from jobserver.models import Backend, Org, Project, SiteAlert, User, Workspace
-from jobserver.models.project import NUMBER_REGEX
+from jobserver.models.project import NUMBER_REGEX, POS_FORMAT_REGEX
 
 
 def user_label_from_instance(obj):
@@ -143,11 +143,27 @@ class ProjectCreateForm(forms.ModelForm, UniqueProjectNumberMixin):
         super().__init__(*args, **kwargs)
 
         self.fields["orgs"].queryset = Org.objects.order_by(Lower("name"))
+        self.fields["copilot"].required = False
         self.fields["copilot"].queryset = User.objects.potential_copilots()
 
     def clean_name(self):
         _validate_slug(self.cleaned_data["name"])
         return self.cleaned_data["name"]
+
+    def clean(self):
+        # Only require copilot be set for projects with a POS-format project number.
+        # TODO: When we implement project category, the second part of the
+        # condition could use that.
+        number = self.cleaned_data.get("number")
+        copilot = self.cleaned_data.get("copilot")
+        if not copilot and number and POS_FORMAT_REGEX.fullmatch(number):
+            self.add_error(
+                "copilot",
+                forms.ValidationError(
+                    "The copilot field is required for projects with a 'POS-' "
+                    "project number."
+                ),
+            )
 
 
 class ProjectEditForm(forms.ModelForm, UniqueProjectNumberMixin):

--- a/templates/staff/project/create.html
+++ b/templates/staff/project/create.html
@@ -90,7 +90,7 @@
     {% #card title="Co-pilot details" container=True %}
       {% #form_fieldset class="w-full items-stretch gap-y-6" %}
         {% form_legend text="Co-pilot details" class="sr-only" %}
-        {% form_select field=form.copilot choices=form.fields.copilot.choices selected=form.copilot.value required %}
+        {% form_select field=form.copilot choices=form.fields.copilot.choices selected=form.copilot.value %}
       {% /form_fieldset %}
     {% /card %}
     {% #button variant="success" type="submit" class="self-start" %}

--- a/tests/integration/staff/views/test_projects.py
+++ b/tests/integration/staff/views/test_projects.py
@@ -117,6 +117,7 @@ class TestProjectCreation:
     # required field when POSTing to the ProjectCreateForm.
     @pytest.mark.parametrize("field", ["name", "orgs", "copilot"])
     @pytest.mark.parametrize("missing_data", ["empty", "omitted"])
+    @pytest.mark.parametrize("project_number", ["123", "POS-2026-2001"])
     def test_projectcreate_post_with_missing_data(
         self,
         client,
@@ -125,6 +126,7 @@ class TestProjectCreation:
         slack_messages,
         field,
         missing_data,
+        project_number,
     ):
         """
         Test an unsuccessful POST to the ProjectCreate view with missing data.
@@ -135,12 +137,18 @@ class TestProjectCreation:
             * A new project is not created in the db
             * A new AuditableEvent is not created
             * A Slack message is not sent to the copilot support channel.
+        * Except if the missing field is copilot and the project number is not such
+        that the copilot field is required. In that case:
+            * The response is a redirect
+            * A new project is created in the db
+            * A new AuditableEvent is created
+            * A Slack message is not sent to the copilot support channel.
         """
         user = user_with_fake_role_factory(permission=Permission.PROJECT_CREATE)
         projects_count = Project.objects.count()
         aes_count = AuditableEvent.objects.count()
 
-        data = CreateProjectFormDataFactory()
+        data = CreateProjectFormDataFactory(number=project_number)
 
         if missing_data == "empty":
             if field == "orgs":
@@ -154,16 +162,35 @@ class TestProjectCreation:
 
         response = client.post(reverse("staff:project-create"), data)
 
-        assert response.status_code == 200
-        form = response.context_data["form"]
-        assert form.is_bound
-        assert field in form.errors
+        # Copilot is only required for POS- projects.
+        if project_number == "123" and field == "copilot":
+            assert response.status_code == 302
 
-        assert Project.objects.count() == projects_count
+            # This is actually a success case, so do similar checks as in
+            # test_projectcreate_post_success, except without a copilot or
+            # Slack message.
+            new_project = Project.objects.first()
+            assert new_project.copilot is None
+            assert new_project.created_by == user
+            assert new_project.name == data["name"]
+            assert new_project.number == data["number"]
+            assert set_from_qs(new_project.orgs.all()) == {int(data["orgs"])}
+            assert new_project.updated_by == user
 
-        assert AuditableEvent.objects.count() == aes_count
+            assert AuditableEvent.objects.filter(target_id=new_project.pk).count() == 1
 
-        assert len(slack_messages) == 0
+            assert len(slack_messages) == 0
+        else:
+            assert response.status_code == 200
+            form = response.context_data["form"]
+            assert form.is_bound
+            assert field in form.errors
+
+            assert Project.objects.count() == projects_count
+
+            assert AuditableEvent.objects.count() == aes_count
+
+            assert len(slack_messages) == 0
 
     def test_projectcreated_unauthorised(self, client, user_with_fake_role_factory):
         user = user_with_fake_role_factory(permission=[Permission.STAFF_AREA_ACCESS])

--- a/tests/unit/jobserver/actions/test_projects.py
+++ b/tests/unit/jobserver/actions/test_projects.py
@@ -121,7 +121,7 @@ def test_add_project_without_copilot(monkeypatch):
     assert event.parent_id == str(project.pk)
     assert event.created_by == actor.username
 
-    mock_notify.assert_called_once_with(project)
+    mock_notify.assert_not_called()
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/unit/staff/test_forms.py
+++ b/tests/unit/staff/test_forms.py
@@ -204,6 +204,25 @@ def test_projectcreateform_duplicate_slug():
     assert "name" in form.errors
 
 
+def test_projectcreateform_duplicate_number():
+    """Test that ProjectCreateForm does not validate when an already existing
+    number is submitted.
+
+    Given a project exists with a particular number.
+    When the form is populated with the same number:
+        * Validation fails.
+    """
+    number = "POS-2026-2001"
+    ProjectFactory(number=number)
+    data = CreateProjectFormDataFactory(number=number)
+
+    form = ProjectCreateForm(data=data)
+
+    assert form.is_bound
+    assert not form.is_valid()
+    assert "number" in form.errors
+
+
 def test_projectcreateform_empty_slug():
     """Test that ProjectCreateForm does not validate when an empty
     slug would be generated.
@@ -259,17 +278,23 @@ def test_projectcreateform_invalid_data(
 
 @pytest.mark.parametrize("field", ["name", "orgs", "copilot"])
 @pytest.mark.parametrize("missing_type", ["empty", "omitted"])
+@pytest.mark.parametrize("project_number", ["123", "POS-2026-2001"])
 def test_projectcreateform_without_required_data(
-    field, missing_type, potential_copilots
+    field, missing_type, project_number, potential_copilots
 ):
     """
     Test submission of empty and omitted values for each required field in the ProjectCreateForm.
 
     When empty or omitted values are submitted:
-    - is_valid() fails
+    - is_valid() is False
     - we get a form error for the expected field
+    Except if the missing field is copilot and the project number is not such
+    that the copilot field is required. In that case:
+    - is_valid() is True
     """
-    data = CreateProjectFormDataFactory(copilot=potential_copilots.first())
+    data = CreateProjectFormDataFactory(
+        number=project_number, copilot=potential_copilots.first()
+    )
 
     if missing_type == "empty":
         if field == "orgs":
@@ -281,8 +306,14 @@ def test_projectcreateform_without_required_data(
 
     form = ProjectCreateForm(data=data)
 
-    assert not form.is_valid()
-    assert form.errors == {field: ["This field is required."]}
+    # Copilot is only required for POS- projects.
+    if project_number == "123" and field == "copilot":
+        assert form.is_valid()
+    else:
+        assert not form.is_valid()
+        assert set(form.errors.keys()) == {field}
+        assert len(form.errors[field]) == 1
+        assert "is required" in form.errors[field][0]
 
 
 def test_projecteditform_unbound(potential_copilots):

--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -145,11 +145,10 @@ def test_applicationapprove_post_success(
     assert complete_application.project.created_by == staff_area_administrator
     assert complete_application.project.updated_by == staff_area_administrator
     assert complete_application.project.number == "42"
+    assert complete_application.project.copilot is None
 
-    # Then one Slack message gets sent. Don't test message details here.
-    assert len(slack_messages) == 1
-    message, channel = slack_messages[0]
-    assert channel == "co-pilot-support"
+    # Then no Slack message gets sent as we did not set a copilot.
+    assert len(slack_messages) == 0
 
 
 def test_applicationapprove_with_deleted_application(


### PR DESCRIPTION
Fixes https://github.com/opensafely-core/job-server/issues/5779. In the ProjectCreateForm we want to not require copilot for non-POS projects such as data development projects that do not have copilots, but still require one for POS- projects that do.

In the form `clean` method, do this check, using the regex for POS- projects. If we implement the project category attribute, we could use that instead, maybe.

In `actions.projects.add`, only send the copilots a Slack message if a copilot was set, as there is nothing for them to do for other project types.

Adapt existing tests with additional parameters or checks to validate the new behaviour.

http://localhost:8000/staff/projects/create/

<img width="739" height="101" alt="image" src="https://github.com/user-attachments/assets/86d24fcf-4037-44dc-b5d2-ab754e8931f3" />
