### PR TITLE
Always insert maintenance mode context variables

### DIFF
--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -86,15 +86,18 @@ def login_url(request):
 def db_maintenance_mode(request):
     """Add database maintenance banner flags to context for specific
     views."""
+    maintenance_statuses = Backend.objects.get_db_maintenance_mode_statuses()
 
     if (
         request.user.is_authenticated
         and request.resolver_match
         and request.resolver_match.url_name in BANNER_DISPLAY_URL_NAMES
     ):
-        maintenance_statuses = Backend.objects.get_db_maintenance_mode_statuses()
         return {
             f"{backend}_maintenance_banner": status
             for backend, status in maintenance_statuses.items()
         }
-    return {}
+    return {
+        f"{backend}_maintenance_banner": False
+        for backend, status in maintenance_statuses.items()
+    }

--- a/tests/unit/jobserver/test_context_processors.py
+++ b/tests/unit/jobserver/test_context_processors.py
@@ -12,7 +12,7 @@ from jobserver.context_processors import (
     site_alerts,
 )
 
-from ...factories import BackendFactory, JobFactory, JobRequestFactory, UserFactory
+from ...factories import JobFactory, JobRequestFactory, UserFactory
 
 
 class TestInProduction:
@@ -127,15 +127,9 @@ class TestSiteAlertContextProcessor:
 class TestDbMaintenanceModeContextProcessor:
     """Tests of the db_maintenance_mode context processor."""
 
-    def setup_method(self):
-        self.tpp = BackendFactory(slug="tpp", is_in_maintenance_mode=True)
-        self.emis = BackendFactory(slug="emis", is_in_maintenance_mode=False)
-        self.other = BackendFactory(slug="other", is_in_maintenance_mode=True)
-
     @pytest.mark.usefixtures("clear_cache", "enable_db_maintenance_context_processor")
     def test_expected_attribute_values_for_banner_display_url(self, rf):
         """Adds expected db maintenance status values for allowed backends on pre-specified banner display URLs."""
-
         user = UserFactory()
         job_request = JobRequestFactory(created_by=user)
         job = JobFactory(job_request=job_request)
@@ -171,7 +165,6 @@ class TestDbMaintenanceModeContextProcessor:
     @pytest.mark.usefixtures("enable_db_maintenance_context_processor")
     def test_attributes_false_for_non_banner_display_url(self, rf):
         """Test that each backend has a False flag for non-banner-display URLs."""
-
         request = rf.get(reverse("job-list"))
         request.user = UserFactory()
         request.resolver_match = resolve(request.path_info)
@@ -179,6 +172,10 @@ class TestDbMaintenanceModeContextProcessor:
         with (
             patch(
                 "jobserver.context_processors.BANNER_DISPLAY_URL_NAMES", ["job-detail"]
+            ),
+            patch(
+                "jobserver.context_processors.Backend.objects.get_db_maintenance_mode_statuses",
+                return_value={"tpp": True, "emis": False},
             ),
         ):
             context = db_maintenance_mode(request)
@@ -194,7 +191,18 @@ class TestDbMaintenanceModeContextProcessor:
         resolver_match attribute."""
         request = rf.get("/no-match-url/")
         request.user = UserFactory()
-        context = db_maintenance_mode(request)
+
+        with (
+            patch(
+                "jobserver.context_processors.BANNER_DISPLAY_URL_NAMES", ["job-detail"]
+            ),
+            patch(
+                "jobserver.context_processors.Backend.objects.get_db_maintenance_mode_statuses",
+                return_value={"tpp": True, "emis": False},
+            ),
+        ):
+            context = db_maintenance_mode(request)
+
         assert context == {
             "emis_maintenance_banner": False,
             "tpp_maintenance_banner": False,

--- a/tests/unit/jobserver/test_context_processors.py
+++ b/tests/unit/jobserver/test_context_processors.py
@@ -169,8 +169,8 @@ class TestDbMaintenanceModeContextProcessor:
         assert context["emis_maintenance_banner"] is False
 
     @pytest.mark.usefixtures("enable_db_maintenance_context_processor")
-    def test_attributes_not_added_for_non_banner_display_url(self, rf):
-        """Returns empty dict for non-banner-display URLs."""
+    def test_attributes_false_for_non_banner_display_url(self, rf):
+        """Test that each backend has a False flag for non-banner-display URLs."""
 
         request = rf.get(reverse("job-list"))
         request.user = UserFactory()
@@ -183,12 +183,19 @@ class TestDbMaintenanceModeContextProcessor:
         ):
             context = db_maintenance_mode(request)
 
-        assert context == {}
+        assert context == {
+            "emis_maintenance_banner": False,
+            "tpp_maintenance_banner": False,
+        }
 
     @pytest.mark.usefixtures("enable_db_maintenance_context_processor")
-    def test_attributes_not_added_for_no_resolver_match_url(self, rf):
-        """Returns empty dict if request has no resolver_match attribute."""
+    def test_attributes_false_for_no_resolver_match_url(self, rf):
+        """Test that each backend has a False flag if request has no
+        resolver_match attribute."""
         request = rf.get("/no-match-url/")
         request.user = UserFactory()
         context = db_maintenance_mode(request)
-        assert context == {}
+        assert context == {
+            "emis_maintenance_banner": False,
+            "tpp_maintenance_banner": False,
+        }

--- a/tests/unit/jobserver/test_context_processors.py
+++ b/tests/unit/jobserver/test_context_processors.py
@@ -127,6 +127,19 @@ class TestSiteAlertContextProcessor:
 class TestDbMaintenanceModeContextProcessor:
     """Tests of the db_maintenance_mode context processor."""
 
+    def _db_maintenance_mode(self, request):
+        """Call the function under test in isolation."""
+        with (
+            patch(
+                "jobserver.context_processors.BANNER_DISPLAY_URL_NAMES", ["job-detail"]
+            ),
+            patch(
+                "jobserver.context_processors.Backend.objects.get_db_maintenance_mode_statuses",
+                return_value={"tpp": True, "emis": False},
+            ),
+        ):
+            return db_maintenance_mode(request)
+
     @pytest.mark.usefixtures("clear_cache", "enable_db_maintenance_context_processor")
     def test_expected_attribute_values_for_banner_display_url(self, rf):
         """Adds expected db maintenance status values for allowed backends on pre-specified banner display URLs."""
@@ -143,21 +156,11 @@ class TestDbMaintenanceModeContextProcessor:
                 "identifier": job.identifier,
             },
         )
-
         request = rf.get(request_url)
         request.user = user
         request.resolver_match = resolve(request.path_info)
 
-        with (
-            patch(
-                "jobserver.context_processors.BANNER_DISPLAY_URL_NAMES", ["job-detail"]
-            ),
-            patch(
-                "jobserver.context_processors.Backend.objects.get_db_maintenance_mode_statuses",
-                return_value={"tpp": True, "emis": False},
-            ),
-        ):
-            context = db_maintenance_mode(request)
+        context = self._db_maintenance_mode(request)
 
         assert context["tpp_maintenance_banner"] is True
         assert context["emis_maintenance_banner"] is False
@@ -169,16 +172,7 @@ class TestDbMaintenanceModeContextProcessor:
         request.user = UserFactory()
         request.resolver_match = resolve(request.path_info)
 
-        with (
-            patch(
-                "jobserver.context_processors.BANNER_DISPLAY_URL_NAMES", ["job-detail"]
-            ),
-            patch(
-                "jobserver.context_processors.Backend.objects.get_db_maintenance_mode_statuses",
-                return_value={"tpp": True, "emis": False},
-            ),
-        ):
-            context = db_maintenance_mode(request)
+        context = self._db_maintenance_mode(request)
 
         assert context == {
             "emis_maintenance_banner": False,
@@ -192,16 +186,7 @@ class TestDbMaintenanceModeContextProcessor:
         request = rf.get("/no-match-url/")
         request.user = UserFactory()
 
-        with (
-            patch(
-                "jobserver.context_processors.BANNER_DISPLAY_URL_NAMES", ["job-detail"]
-            ),
-            patch(
-                "jobserver.context_processors.Backend.objects.get_db_maintenance_mode_statuses",
-                return_value={"tpp": True, "emis": False},
-            ),
-        ):
-            context = db_maintenance_mode(request)
+        context = self._db_maintenance_mode(request)
 
         assert context == {
             "emis_maintenance_banner": False,


### PR DESCRIPTION
Fixes https://github.com/opensafely-core/job-server/issues/5767.

We check the `tpp_maintenance_banner` variable in `base.html` on every page, so we should always set it. Without this we get warnings in console/logs, that could be confusing:

```
UserWarning: Exception while resolving variable 'tpp_maintenance_banner' in template [template_name]
```

To find the variable names we need to do the database query but doing this via
`get_db_maintenance_mode_statuses` is cheap (~1ms) and cached, so it does not
matter much that some pages get one more query sometimes. So we may as well do
the same code path but force the value to False when the banner should not be
shown.

Only unit tests need an update, the integration test does not check the context
values but is driven by what appears on the page.

<details>
<summary>Screenshots - click to expand</summary>

### Before

Visit a page while not logged in or without the banner -- eg http://localhost:8000/

<img width="936" height="235" alt="image" src="https://github.com/user-attachments/assets/a99136f9-65a0-458c-8ab9-1cbe7b0aaddb" />

Note the warning.

### After

Visit the same page -- no warning.

<img width="928" height="142" alt="image" src="https://github.com/user-attachments/assets/5f32620c-afa2-4945-928b-22181c911c46" />

Check that the banner is still displayed on the right pages when the mode is on:

```
~/job-server$ just manage shell
...
>>> tpp=Backend.objects.get(name='TPP')
>>> tpp.is_in_maintenance_mode
False
>>> tpp.is_in_maintenance_mode=True
>>> tpp.save ()
>>> Backend.objects.get(name='TPP').is_in_maintenance_mode
True
>>>
```

Then visit a page like the job request detail page http://localhost:8000/recording-of-additional-prescription-information-in-opensafely/raw_medicines_sdr/25899/ to check. Note that you may have to wait up to 60 seconds for the cache to expire.
</details> 