### PR TITLE
Mark more slow tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -81,6 +81,10 @@ few times and see if there is a consistent improvement. Remember that the very
 first seems to get punished by including the worker preparation time in its
 setup and call time, so that may appear much worse than it actually is.
 
+To benchmark the suite as a whole (or any shell command) you can use a tool
+like `hyperfine`: `hyperfine --warmup 1 'just test' --export-markdown
+hyperfine.md`.
+
 #### Database access
 
 All unit and integration tests have access to the database by default. You can

--- a/TESTING.md
+++ b/TESTING.md
@@ -70,7 +70,16 @@ This allows testing functionality of the entire running system, as a user would 
 
 We have a custom `@pytest.mark.slow_test` marker that should be used on test
 that take more than about 0.1s to run. These are excluded from `just test` to
-provide a quicker feedback loop.
+provide a quicker feedback loop. They can still be run with `just test-ci`.
+
+To check this against specific tests or as a suite-wide check, run `just test
+-n0 --durations=20 --durations-min=0.1`. We use `-n0` so there is only one
+worker to reduce some sources of variance. Run several times and observe if any
+tests consistently take longer than this. You can specify a module to reduce
+the overall runtime.  Also, try running with and without suspects marked up a
+few times and see if there is a consistent improvement. Remember that the very
+first seems to get punished by including the worker preparation time in its
+setup and call time, so that may appear much worse than it actually is.
 
 #### Database access
 

--- a/tests/integration/staff/views/test_projects.py
+++ b/tests/integration/staff/views/test_projects.py
@@ -71,6 +71,7 @@ class TestProjectCreation:
         assert selected_orgs == bennett_org.pk
 
     @pytest.mark.django_db(transaction=True)
+    @pytest.mark.slow_test
     def test_projectcreate_post_success(
         self, client, request, slack_messages, user_with_fake_role_factory
     ):
@@ -118,6 +119,7 @@ class TestProjectCreation:
     @pytest.mark.parametrize("field", ["name", "orgs", "copilot"])
     @pytest.mark.parametrize("missing_data", ["empty", "omitted"])
     @pytest.mark.parametrize("project_number", ["123", "POS-2026-2001"])
+    @pytest.mark.slow_test
     def test_projectcreate_post_with_missing_data(
         self,
         client,

--- a/tests/unit/airlock/test_issues.py
+++ b/tests/unit/airlock/test_issues.py
@@ -295,6 +295,7 @@ def test_update_output_checking_request_with_slack_notification(
     ]
 
 
+@pytest.mark.slow_test
 def test_update_output_checking_issue_retry_error_and_success():
     org = OrgFactory(pk=settings.BENNETT_ORG_PK)
     user = UserFactory()

--- a/tests/unit/airlock/test_views.py
+++ b/tests/unit/airlock/test_views.py
@@ -262,6 +262,7 @@ def test_api_post_release_request_default_org_and_repo(mock_create_issue, api_rf
     ],
 )
 @patch("airlock.views._get_github_api", FakeGitHubAPIWithErrors)
+@pytest.mark.slow_test
 def test_api_airlock_event_error(
     api_rf, slack_messages, event_type, updates, error, slack_notified
 ):
@@ -307,6 +308,7 @@ def test_api_airlock_event_error(
 
 @patch("airlock.views._get_github_api", FakeGitHubAPIWithErrors)
 @patch("airlock.emails.send_html_email")
+@pytest.mark.slow_test
 def test_api_airlock_event_multiple_errors(mock_send, api_rf, slack_messages):
     mock_send.side_effect = Exception("Error sending email")
     author = UserFactory()

--- a/tests/unit/applications/test_views.py
+++ b/tests/unit/applications/test_views.py
@@ -178,6 +178,7 @@ def test_applicationrestore_unknown_application(rf):
         ApplicationRestore.as_view()(request, pk_hash="")
 
 
+@pytest.mark.slow_test
 def test_confirmation_get_success(rf, incomplete_application):
     request = rf.get("/")
     request.user = incomplete_application.created_by

--- a/tests/unit/jobserver/actions/test_projects.py
+++ b/tests/unit/jobserver/actions/test_projects.py
@@ -16,6 +16,7 @@ from tests.factories import (
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.slow_test
 def test_add_project_with_copilot(monkeypatch):
     org0 = OrgFactory()
     org1 = OrgFactory()
@@ -74,6 +75,7 @@ def test_add_project_with_copilot(monkeypatch):
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.slow_test
 def test_add_project_without_copilot(monkeypatch):
     org0 = OrgFactory()
     org1 = OrgFactory()
@@ -125,6 +127,7 @@ def test_add_project_without_copilot(monkeypatch):
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.slow_test
 def test_add_project_transaction_rollback(monkeypatch):
     """Test that if a database error rolls back the whole transaction, the
     notify function is not called and no new database entries."""

--- a/tests/unit/jobserver/models/test_mutability.py
+++ b/tests/unit/jobserver/models/test_mutability.py
@@ -4,6 +4,10 @@ from django.apps import apps
 from jobserver.model_utils import ImmutableError, get_models
 
 
+# There are many tests in this module and we don't expect them to fail often so
+# it seems okay to bump them to CI testing.
+pytestmark = pytest.mark.slow_test
+
 MUTABLE_MODELS = [
     apps.get_model(x)
     for x in [

--- a/tests/unit/jobserver/views/test_index.py
+++ b/tests/unit/jobserver/views/test_index.py
@@ -1,3 +1,4 @@
+import pytest
 from django.contrib.auth.models import AnonymousUser
 
 from jobserver.views.index import Index
@@ -11,6 +12,7 @@ from ....factories import (
 )
 
 
+@pytest.mark.slow_test
 def test_index_authenticated(
     rf,
     django_assert_num_queries,
@@ -84,6 +86,7 @@ def test_index_authenticated_display_active_backend_job_requests(
         assert response.context_data["all_job_requests"][0].backend == active_backend
 
 
+@pytest.mark.slow_test
 def test_index_authenticated_client(client, django_assert_num_queries):
     user = UserFactory()
     JobRequestFactory.create_batch(10)
@@ -106,6 +109,7 @@ def test_index_unauthenticated(rf, django_assert_num_queries):
         assert len(response.context_data["all_job_requests"]) == 10
 
 
+@pytest.mark.slow_test
 def test_index_unauthenticated_client(client, django_assert_num_queries):
     JobRequestFactory.create_batch(10)
 

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -1422,6 +1422,7 @@ def test_jobrequestdetail_with_permission_with_completed_at(
     assert "Cancel" in response.rendered_content
 
 
+@pytest.mark.slow_test
 def test_jobrequestdetail_with_unauthenticated_user(rf):
     job_request = JobRequestFactory(project_definition="test")
 

--- a/tests/unit/jobserver/views/test_jobs.py
+++ b/tests/unit/jobserver/views/test_jobs.py
@@ -186,6 +186,7 @@ def test_jobdetail_with_permission(rf, project_membership, role_factory):
     assert "Honeycomb" not in response.rendered_content
 
 
+@pytest.mark.slow_test
 def test_jobdetail_with_staff_area_administrator(rf, freezer):
     freezer.move_to("2022-06-16 12:00")
 
@@ -230,6 +231,7 @@ def test_jobdetail_with_staff_area_administrator(rf, freezer):
     assert escape(honeycomb.status_link(job)) in response.rendered_content
 
 
+@pytest.mark.slow_test
 def test_jobdetail_with_staff_area_administrator_with_completed_at(rf, freezer):
     freezer.move_to("2022-06-15 13:00")
 

--- a/tests/unit/services/test_slack.py
+++ b/tests/unit/services/test_slack.py
@@ -1,8 +1,10 @@
+import pytest
 from slack_sdk.errors import SlackApiError
 
 from services import slack
 
 
+@pytest.mark.slow_test
 def test_post(mocker):
     mock = mocker.patch("services.slack.client", autospec=True)
 
@@ -11,6 +13,7 @@ def test_post(mocker):
     mock.chat_postMessage.assert_called_once_with(channel="channel", text="text")
 
 
+@pytest.mark.slow_test
 def test_post_error(mocker, log_output):
     mock = mocker.patch("services.slack.client", autospec=True)
 

--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -110,6 +110,7 @@ def test_applicationapprove_get_with_org_slug_and_unknown_org(
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.slow_test
 def test_applicationapprove_post_success(
     rf,
     django_assert_num_queries,
@@ -237,6 +238,7 @@ def test_applicationapprove_post_success_with_alphanumeric_project_number(
     assert complete_application.project.number == "POS-2025-2001"
 
 
+@pytest.mark.slow_test
 def test_applicationdetail_success_with_complete_application(
     rf, staff_area_administrator, complete_application
 ):
@@ -273,6 +275,7 @@ def test_applicationdetail_num_queries(
         response.render()
 
 
+@pytest.mark.slow_test
 def test_applicationdetail_success_with_incomplete_application(
     rf, staff_area_administrator, incomplete_application
 ):


### PR DESCRIPTION
TESTING.md says to mark slow tests that take more than about 0.1s to run. These
are excluded from `just test` to keep the feedback loop quick but are still run
in `just test-ci`.

There are a number of tests that consistently took longer than this. Most were
added in the last year and many use features like the test client, database
transactions, or are just long, so it makes sense that they are slow and not
obvious how to speed them up. Also, permutations of parametrised tests may add
up to a large amount if the individual tests are reasonably slow.

I used `hyperfine` for better profiling in main and this branch and got:

```
~/job-server$ hyperfine --warmup 1 'just test'
Benchmark 1: just test
  Time (mean ± σ):     27.267 s ±  3.372 s    [User: 95.866 s, System: 4.686 s]
  Range (min … max):   22.577 s … 32.413 s    10 runs
```

vs.

```
Benchmark 1: just test
  Time (mean ± σ):     19.746 s ±  2.771 s    [User: 81.794 s, System: 3.724 s]
  Range (min … max):   16.882 s … 23.891 s    10 runs

```

That shows about 8s improvement and lower variance.

Also added some explanation of work done to TESTING.md for future repeats.