### PR TITLE
Remove confusing and extraneous detail from the /status page

### DIFF
--- a/jobserver/views/status.py
+++ b/jobserver/views/status.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from django.views.generic import View
 
 from ..backends import show_warning
-from ..models import Backend, Job, JobRequestStatus
+from ..models import Backend, Job
 
 
 class DBAvailability(View):
@@ -51,22 +51,6 @@ class PerBackendStatus(View):
 class Status(View):
     def get(self, request, *args, **kwargs):
         def get_stats(backend):
-            acked = (
-                backend.job_requests.annotate(num_jobs=Count("jobs"))
-                .filter(num_jobs__gt=0)
-                .count()
-            )
-            unacked = (
-                backend.job_requests.annotate(num_jobs=Count("jobs"))
-                .filter(num_jobs=0)
-                .exclude(
-                    _status__in=[
-                        JobRequestStatus.NOTHING_TO_DO,
-                        JobRequestStatus.UNKNOWN_ERROR_CREATING_JOBS,
-                    ]
-                )
-                .count()
-            )
             counts_by_status = (
                 Job.objects.filter(
                     job_request__backend=backend,
@@ -89,8 +73,6 @@ class Status(View):
                 "alert_timeout": backend.alert_timeout,
                 "last_seen": last_seen,
                 "queue": {
-                    "acked": acked,
-                    "unacked": unacked,
                     "running": running,
                     "pending": pending,
                 },

--- a/templates/status.html
+++ b/templates/status.html
@@ -65,12 +65,6 @@
                   {% endif %}
                 </time>
               {% /description_item %}
-              {% #description_item title="Job requests not yet processed by "|add:backend.name|add:" backend" stacked=True %}
-                {{ backend.queue.unacked|floatformat:"-3g" }}
-              {% /description_item %}
-              {% #description_item title="Total job requests received by "|add:backend.name|add:" backend" stacked=True %}
-                {{ backend.queue.acked|floatformat:"-3g" }}
-              {% /description_item %}
             </div>
             {% #card_footer no_container class="border-t border-t-slate-200" %}
               <p class="text-sm font-medium text-slate-600">


### PR DESCRIPTION
Per #5782 we've learned that [the status page](https://jobs.opensafely.org/status) currently shows counts of jobs that are either now meaningless due to RAP API changes (unacked jobs) or are simply not useful and constitute noise (total jobs ever run on a given backend). This PR removes that information from view, and from the page queries.

Here's the page as it currently stands:
<img width="740" height="913" alt="image" src="https://github.com/user-attachments/assets/7c0f1953-4b28-47db-adb7-223bea315b6d" />

Here's how it looks (running locally and therefore not in maintenance mode) after these changes:
<img width="736" height="777" alt="image" src="https://github.com/user-attachments/assets/e27c7b3a-d300-40ae-8ddf-5d8c30fad9df" />
