### PR TITLE
Front-end improvements in the Create Project form 

### DIFF
--- a/templates/staff/project/create.html
+++ b/templates/staff/project/create.html
@@ -33,8 +33,8 @@
         </div>
 
         <div class="sm:pl-6">
-          <dt class="font-semibold">Status:</dt>
-          <dd>Ongoing</dd>
+          <dt class="font-semibold">Project status:</dt>
+          <dd>{% pill_project_status status="ongoing" text="Ongoing" %}</dd>
         </div>
       </dl>
     </div>

--- a/templates/staff/project/create.html
+++ b/templates/staff/project/create.html
@@ -29,7 +29,7 @@
 
         <div class="sm:px-6">
           <dt class="font-semibold">Created at:</dt>
-          <dd>{% now "d/m/Y" %}</dd>
+          <dd>{% now "d F Y" %}</dd>
         </div>
 
         <div class="sm:pl-6">

--- a/templates/staff/project/create.html
+++ b/templates/staff/project/create.html
@@ -16,21 +16,27 @@
 
 {% block hero %}
   {% #staff_hero title="Create a project" %}
-    {# show readonly metadata in the page header #}
     <div class="mt-2">
-      <p>
-        When created, this project will automatically be saved with the following data:
-      </p>
-      <p>
-        <strong>Created by:</strong>
-        {{ request.user.fullname }}
-        &nbsp;|&nbsp;
-        <strong>Created at:</strong>
-        {% now "d/m/Y" %}
-        &nbsp;|&nbsp;
-        <strong>Status:</strong>
-        Ongoing
-      </p>
+      <div class="prose prose-oxford">
+        <p>When created, this project will automatically be saved with the following data:</p>
+      </div>
+
+      <dl class="mt-6 grid sm:grid-cols-3 sm:divide-x sm:divide-bn-ribbon-300">
+        <div class="sm:pr-6">
+          <dt class="font-semibold">Created by:</dt>
+          <dd>{{ request.user.fullname }}</dd>
+        </div>
+
+        <div class="sm:px-6">
+          <dt class="font-semibold">Created at:</dt>
+          <dd>{% now "d/m/Y" %}</dd>
+        </div>
+
+        <div class="sm:pl-6">
+          <dt class="font-semibold">Status:</dt>
+          <dd>Ongoing</dd>
+        </div>
+      </dl>
     </div>
   {% /staff_hero %}
 {% endblock hero %}

--- a/templates/staff/project/create.html
+++ b/templates/staff/project/create.html
@@ -15,7 +15,24 @@
 {% endblock breadcrumbs %}
 
 {% block hero %}
-  {% staff_hero title="Create a project" %}
+  {% #staff_hero title="Create a project" %}
+    {# show readonly metadata in the page header #}
+    <div class="mt-2">
+      <p>
+        When created, this project will automatically be saved with the following data:
+      </p>
+      <p>
+        <strong>Created by:</strong>
+        {{ request.user.fullname }}
+        &nbsp;|&nbsp;
+        <strong>Created at:</strong>
+        {% now "d/m/Y" %}
+        &nbsp;|&nbsp;
+        <strong>Status:</strong>
+        Ongoing
+      </p>
+    </div>
+  {% /staff_hero %}
 {% endblock hero %}
 
 {% block content %}
@@ -43,23 +60,6 @@
       {% /alert %}
     {% endif %}
 
-    {# show readonly metadata above the form #}
-    <section class="mb-6">
-      <h3 class="sr-only">Project data</h3>
-      <p class="text-md">
-        When created, this project will automatically be saved with the following data:
-      </p>
-      <p>
-        <strong>Created by:</strong>
-        {{ request.user.fullname }}
-        &nbsp;|&nbsp;
-        <strong>Created at:</strong>
-        {% now "d/m/Y" %}
-        &nbsp;|&nbsp;
-        <strong>Status:</strong>
-        Ongoing
-      </p>
-    </section>
 
     {% #card title="Project information" container=True %}
       {% #form_fieldset class="w-full items-stretch gap-y-6" %}

--- a/tests/functional/test_project_creation.py
+++ b/tests/functional/test_project_creation.py
@@ -56,7 +56,7 @@ def test_can_create_a_project(
     )
     expect(metadata).to_contain_text(f"Created by: {user.fullname}")
     # We don't control the time/date in this test, so this assertion may fail if run close to midnight
-    expect(metadata).to_contain_text("Created at: 02/04/2026")
+    expect(metadata).to_contain_text("Created at: 02 April 2026")
     expect(metadata).to_contain_text("Project status: Ongoing")
 
     # See an empty form with a link to create a new org

--- a/tests/functional/test_project_creation.py
+++ b/tests/functional/test_project_creation.py
@@ -46,12 +46,12 @@ def test_can_create_a_project(
     page.goto(f"{live_server.url}{reverse('staff:project-list')}")
 
     # Click "Create a project" button (only visible to those with Permission.PROJECT_CREATE),
-    # go to ProjectCreate page and see correct meta data for new project in text above form
+    # go to ProjectCreate page and see correct meta data for new project in the page header
     expect(page.get_by_role("link", name="Create a project")).to_be_visible()
     page.get_by_role("link", name="Create a project").click()
 
     expect(page).to_have_url(f"{live_server.url}{reverse('staff:project-create')}")
-    metadata = page.locator("section").filter(
+    metadata = page.locator("header").filter(
         has_text="When created, this project will automatically be saved with the following data:"
     )
     expect(metadata).to_contain_text(f"Created by: {user.fullname}")

--- a/tests/functional/test_project_creation.py
+++ b/tests/functional/test_project_creation.py
@@ -57,7 +57,7 @@ def test_can_create_a_project(
     expect(metadata).to_contain_text(f"Created by: {user.fullname}")
     # We don't control the time/date in this test, so this assertion may fail if run close to midnight
     expect(metadata).to_contain_text("Created at: 02/04/2026")
-    expect(metadata).to_contain_text("Status: Ongoing")
+    expect(metadata).to_contain_text("Project status: Ongoing")
 
     # See an empty form with a link to create a new org
     form = page.locator("form")


### PR DESCRIPTION
Closes #5749 

Addressed the following suggestions:
1. move the project meta fields to the header
2. use `.prose` and` <dl>` for the meta info
3. use the project_pill component
4. update the date formatting to match how we list dates in other locations

Did not address:
_fix for the icon in the `<select>` fields which is floating weirdly_
because copilot is not required anymore because of [this](https://github.com/opensafely-core/job-server/commit/10ffc0d2549e0e8b7fa3c7f354548deaa9d773fb#diff-306fa855e999802fd16488f9bd804f192f15ede667d26b2c106cabb52fb5b95c) change for data development work.


<img width="1411" height="1359" alt="Screenshot from 2026-04-22 09-22-50" src="https://github.com/user-attachments/assets/90d2aade-7a85-411c-9b41-c86b31afaf22" />
