### PR TITLE
Fix select error icon alignment

### DIFF
--- a/templates/_components/form/select.html
+++ b/templates/_components/form/select.html
@@ -29,13 +29,13 @@
     {% endif %}
   </label>
 
-  <div class="relative">
-    {% if hint_text and not hint_below %}
-      <div class="mb-2 prose prose-sm prose-oxford {{ hint_extra_class }}">
-        {{ hint_text }}
-      </div>
-    {% endif %}
+  {% if hint_text and not hint_below %}
+    <div class="mb-2 prose prose-sm prose-oxford {{ hint_extra_class }}">
+      {{ hint_text }}
+    </div>
+  {% endif %}
 
+  <div class="relative">
     <select
       {% attrs id=select_id name=select_name required %}
       class="mt-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-xs focus:border-oxford-500 focus:ring-oxford-500 sm:text-sm [&:user-invalid]:border-bn-ribbon-600 [&:user-invalid]:ring-bn-ribbon-600 [&:user-invalid]:ring-1"
@@ -59,7 +59,7 @@
     {% endif %}
 
     {% if field.errors %}
-      <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+      <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-8">
         {% icon_exclamation_circle_mini class="h-4 w-4 text-red-500" %}
       </div>
     {% endif %}


### PR DESCRIPTION
Closes #5801 

Move the error icon positioning context so it is anchored to the select element instead of the full field wrapper. The icon was absolutely positioned inside a `relative` container that also included hint text, so its vertical centering was calculated against the whole block and it appeared too high.

This change makes the icon position relative to the select only, and adjusts the right padding to `pr-8` so it sits clear of the dropdown arrow.

<img width="1411" height="595" alt="Screenshot from 2026-04-24 13-26-04" src="https://github.com/user-attachments/assets/c7e68b69-f468-4f9d-8882-503d82956c05" />
