### PR TITLE
Set uv exclude-newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,7 @@ extend-ignore = [
 # See https://github.com/opensafely-core/repo-template/blob/main/DEVELOPERS.md for details.
 [tool.uv]
 required-version = ">=0.9"
+exclude-newer = "7 days"
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "argon2-cffi"
 version = "25.1.0"


### PR DESCRIPTION
We're now setting the equivalent of exclude-newer in Dependabot's config, but Dependabot isn't updating correctly. Setting it in the pyproject.toml might help, shouldn't do any harm and will make it easier to do manual updates.

See [docs](https://docs.astral.sh/uv/guides/integration/dependabot/#dependency-cooldown).