### PR TITLE
Ignore jobserver package for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,4 @@ updates:
     ignore:
       - dependency-name: "django"
         versions: [">=6.0.0"]
+      - dependency-name: "jobserver"


### PR DESCRIPTION
We build Job Server as a package, so that Airlock can use it to run e2e tests. However, it's being picked up by Dependabot as something that needs updating. This config change tells Dependabot to ignore the jobserver package when it comes to calculating package updates.