### PR TITLE
Remove accidental `Project` `name='kasdlkfj'`

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -85,6 +85,7 @@ INSTALLED_APPS = [
     "airlock",
     "applications",
     "jobserver",
+    "maintenance",
     "redirects",
     "staff",
     "anymail",

--- a/maintenance/__init__.py
+++ b/maintenance/__init__.py
@@ -1,0 +1,17 @@
+"""Maintenance migrations to fix up the production database.
+
+This app is for maintenance migrations to fix data issues in the production
+environment.  Doing these kinds of fix here rather than live in a Django shell
+via SSH makes such fixes auditable, reviewable, repeatable, testable, avoids
+the possibility of manual error, and fixes up development environment databases
+as well. It also avoids cluttering the feature apps and getting squashed.
+
+Make your migrations safe to apply in either production or developer
+environments without the problematic data, and safe to apply repeatedly.
+Probably if the fix is to remove or edit some instances, there may be no
+reverse operation that can be defined.
+
+At least manually test your migrations against a local copy of the production
+database, or similar synthetic data, to get some assurance that it has the
+intended effect.
+"""

--- a/maintenance/migrations/0001_delete_project_kasdlkfj.py
+++ b/maintenance/migrations/0001_delete_project_kasdlkfj.py
@@ -1,0 +1,45 @@
+# Delete a project created in error and associated instances.
+# See https://bennettoxford.slack.com/archives/C069SADHP1Q/p1777546132838079
+from django.db import migrations
+
+
+def delete_project_kasdlkfj(apps, schema_editor):
+    """Delete Project with name `kasdlkfj` and associated instances."""
+    Project = apps.get_model("jobserver", "Project")
+    AuditableEvent = apps.get_model("jobserver", "AuditableEvent")
+    ProjectCollaboration = apps.get_model("jobserver", "ProjectCollaboration")
+
+    try:
+        project = Project.objects.get(name="kasdlkfj")
+    except Project.DoesNotExist:
+        print("0001: No project `kasdlkfj`, nothing to do")
+        return
+    # Save this as will be updated to None after project delete.
+    project_id = project.id
+
+    deletions = []
+    # We have to delete ProjectCollaboration before Project as they have a
+    # protected relationship.
+    deletions.append(
+        ProjectCollaboration.objects.filter(project_id=project_id).delete()
+    )
+    # Also deletes ProjectMembership via CASCADE.
+    deletions.append(project.delete())
+    deletions.append(
+        AuditableEvent.objects.filter(
+            parent_model="jobserver.Project", parent_id=project_id
+        ).delete()
+    )
+
+    # Provide some feedback.
+    print(f"0001: Deleted {deletions}")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("jobserver", "0028_alter_project_name"),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_project_kasdlkfj, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
A Project was created in production by accident. Let's remove it.
See https://bennettoxford.slack.com/archives/C069SADHP1Q/p1777546132838079

We should also remove associated ProjectCollaboration, ProjectMembership, and
AuditableEvent instances.

Let's do this in a migration in a new maintenance app, so that the fix is
auditable, reviewable, repeatable, testable, avoids the possibility of manual
error, and fixes up development environment databases as well. This also
provides an example if we need to do this or other maintenance again. And it
avoids cluttering the feature apps and getting squashed.

See commit message for how this was testing locally.