### PR TITLE
Add AIRLOCK_READONLY_ACCESS permission for Level4AuthenticatedUser

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -725,23 +725,27 @@ Airlock refers to Job Server's permissions model to determine what users can
 do. The code it needs is in [jobserver/api/releases.py]. The endpoints it uses
 are `Level4TokenAuthenticationAPI` (`GET /releases/authenticate/`) and
 `Level4AuthorisationAPI` (`GET /releases/authorise/`). It receives the results
-of `build_level4_user` to determine whether a user is an [OutputChecker], and
-which workspaces they can access. (Current as of 2024-09.)
+of `build_level4_user` to determine whether a user is an [OutputChecker], whether
+they have [AIRLOCK_READONLY_ACCESS] permission for all workspaces and requests
+(currently a permission on the [DeploymentAdminstrator] role only), and which
+workspaces they can access. (Current as of 2026-05.)
 
 When releases are approved, Airlock triggers creation of a [Release] for the
 associated [Workspace] on Job Server through the [jobserver/api/releases.py]
 `ReleaseWorkspaceAPI` endpoint (`POST /releases/workspace/{workspace_name}`).
 Files are uploaded from Airlock to Job Server through the `ReleaseAPI`endpoint
-(`POST releases/release/{release_id}`). (Current as of 2024-09.)
+(`POST releases/release/{release_id}`). (Current as of 2026-05.)
 
 Notifications of events related to release requests are triggered through the
 [airlock_event_view] endpoint (`POST /airlock/events/`), which is currently the
 only responsibility of the [airlock app] within Job Server.  Depending on the
 event, users are notified by email, Slack or by creating/updating GitHub
-issues. (Current as of 2024-09.)
+issues. (Current as of 2026-05.)
 
 [Airlock]: https://github.com/opensafely-core/airlock
 [OutputChecker]: jobserver/authorization/roles.py
+[DeploymentAdministrator]: jobserver/authorization/roles.py
+[AIRLOCK_READONLY_ACCESSS]: jobserver/authorization/permissions.py
 [jobserver/api/releases.py]: jobserver/api/releases.py
 [Release]: jobserver/models/release.py
 [Workspace]: jobserver/models/workspace.py

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -588,6 +588,7 @@ def build_level4_user(user):
             # for.
             output_checker=has_role(user, OutputChecker),
             # This permission allows a user readonly access to all workspaces in Airlock
+            # (and consequently, all release requests related to any workspaces)
             readonly_access=has_permission(user, Permission.AIRLOCK_READONLY_ACCESS),
         )
     )

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -531,6 +531,7 @@ class Level4AuthenticatedUser(serializers.Serializer):
     workspaces = serializers.DictField(default={})
     copiloted_workspaces = serializers.DictField(default={})
     output_checker = serializers.BooleanField(default=False)
+    readonly_access = serializers.BooleanField(default=False)
 
 
 ONGOING_PROJECT_STATUSES = {
@@ -586,6 +587,8 @@ def build_level4_user(user):
             # list the explicit workspaces that the user has this permission
             # for.
             output_checker=has_role(user, OutputChecker),
+            # This permission allows a user readonly access to all workspaces in Airlock
+            readonly_access=has_permission(user, Permission.AIRLOCK_READONLY_ACCESS),
         )
     )
     assert level4_user.is_valid(), level4_user.errors

--- a/jobserver/authorization/permissions.py
+++ b/jobserver/authorization/permissions.py
@@ -11,6 +11,8 @@ class Permission(StrEnum):
         member names via `auto()`.
     """
 
+    AIRLOCK_READONLY_ACCESS = auto()
+
     APPLICATION_MANAGE = auto()
 
     BACKEND_MANAGE = auto()

--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -133,7 +133,9 @@ class SignOffRepoWithOutputs:
 
 class DeploymentAdministrator:
     display_name = "Deployment Administrator"
-    description = """Run and cancel jobs on any project, for development and maintenance purposes, including technical support for Approved Projects.
+    description = """
+    Run and cancel jobs on any project, for development and maintenance purposes, including technical support for Approved Projects.
+    View files, logs and release requests for any Airlock workspace, for those with Level 4 access.
     See Developer Permissions Log for the list of individuals who are approved for this role.
     """
     models = [

--- a/jobserver/authorization/roles.py
+++ b/jobserver/authorization/roles.py
@@ -142,4 +142,5 @@ class DeploymentAdministrator:
     permissions = [
         Permission.JOB_CANCEL,
         Permission.JOB_RUN,
+        Permission.AIRLOCK_READONLY_ACCESS,
     ]

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1657,6 +1657,7 @@ def test_level4tokenauthenticationapi_success(
         },
         "copiloted_workspaces": {},
         "output_checker": False,
+        "readonly_access": False,
     }
 
 
@@ -1711,6 +1712,38 @@ def test_level4tokenauthenticationapi_success_privileged(
         },  # should not include workspace3
         "copiloted_workspaces": {},
         "output_checker": True,
+        "readonly_access": False,
+    }
+
+
+def test_level4tokenauthenticationapi_success_readonly_permissions(
+    api_rf, token_login_user, role_factory
+):
+    # enable readonly privileges for user via permission
+    token_login_user.roles.append(
+        role_factory(permission=Permission.AIRLOCK_READONLY_ACCESS)
+    )
+    token_login_user.save()
+
+    token = generate_login_token(token_login_user)
+    backend = token_login_user.backends.first()
+    token_data = {"user": token_login_user.username, "token": token}
+    request = api_rf.post(
+        "/",
+        data=token_data,
+        headers={"authorization": backend.auth_token},
+        format="json",
+    )
+
+    response = Level4TokenAuthenticationAPI.as_view()(request)
+    assert response.status_code == 200
+    assert response.data == {
+        "username": token_login_user.username,
+        "fullname": token_login_user.fullname,
+        "workspaces": {},
+        "copiloted_workspaces": {},
+        "output_checker": False,
+        "readonly_access": True,
     }
 
 
@@ -1863,6 +1896,7 @@ def test_level4authorisationapi_success(
             },
         },
         "output_checker": False,
+        "readonly_access": False,
     }
 
 


### PR DESCRIPTION
This permission is passed to Airlock during authentication, and will allow certain users to view all workspaces (with readonly access) even if they do not have a role on the project.

The permission is currently attached to the DeploymentAdministrator role and will allow developers with L4 access to view files and logs for any workspace, which is useful when responding to tech support questions.

Airlock has already [been updated](https://github.com/opensafely-core/airlock/pull/1181) to accept and handle the new `readonly_access` field.

[Slack discussion](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1778061872689109)
Closes https://github.com/opensafely-core/airlock/issues/1176