### PR TITLE
Update components on the Run Jobs page

### DIFF
--- a/assets/src/scripts/job_request_create.js
+++ b/assets/src/scripts/job_request_create.js
@@ -34,40 +34,32 @@ async function getStatuses() {
  * @returns {void}
  */
 function setIcon(action, status) {
-  const parentEl = action.closest(`#jobActions`);
-  const loadingIcon = parentEl?.querySelector(`[data-action-status="loading"]`);
-  const successIcon = parentEl?.querySelector(
-    `[data-action-status="succeeded"]`,
-  );
-  const failedIcon = parentEl?.querySelector(`[data-action-status="failed"]`);
-  const noneIcon = parentEl?.querySelector(`[data-action-status="none"]`);
+  const parentEl = action.closest(`[data-action]`);
+  const pill = parentEl.querySelector("[data-action-status]");
+
+  pill.classList.remove("pill--success", "pill--failed", "pill--info");
 
   if (status === "succeeded") {
-    loadingIcon?.classList.add("hidden");
-    failedIcon?.classList.add("hidden");
-    return successIcon?.classList.remove("hidden");
+    pill.classList.add("pill--success");
+    return (pill.textContent = "Succeeded");
   }
 
   if (status === "failed") {
-    loadingIcon?.classList.add("hidden");
-    successIcon?.classList.add("hidden");
-    return failedIcon?.classList.remove("hidden");
+    pill.classList.add("pill--failed");
+    return (pill.textContent = "Failed");
   }
 
   if (status === "none") {
-    loadingIcon?.classList.add("hidden");
-    successIcon?.classList.add("hidden");
-    failedIcon?.classList.add("hidden");
-    return noneIcon?.classList.remove("hidden");
+    pill.classList.add("pill--info");
+    return (pill.textContent = "No status");
   }
 
-  failedIcon?.classList.add("hidden");
-  successIcon?.classList.add("hidden");
-  return loadingIcon?.classList.remove("hidden");
+  pill.classList.add("pill--info");
+  return (pill.textContent = "Loading");
 }
 
 async function setActionsStatuses() {
-  const actions = [...document.querySelectorAll(`#jobActions label`)];
+  const actions = [...document.querySelectorAll(`[data-action] label`)];
   actions.map((action) => setIcon(action, "loading"));
 
   const statuses = await getStatuses();

--- a/assets/src/styles/base.css
+++ b/assets/src/styles/base.css
@@ -226,3 +226,23 @@
     transition-duration: 0.15s;
   }
 }
+
+@utility link {
+  color: var(--color-blue-800);
+  cursor: pointer;
+  font-weight: 600;
+  text-decoration-line: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
+  transition-duration: 0.2s;
+  transition-property: color, text-decoration;
+  transition-timing-function: ease-in-out;
+
+  &:not(:is(:hover, :focus)) {
+    text-decoration-color: color-mix(in srgb, currentColor, transparent 75%);
+  }
+}
+
+.link {
+  @apply link;
+}

--- a/assets/src/styles/base.css
+++ b/assets/src/styles/base.css
@@ -246,3 +246,35 @@
 .link {
   @apply link;
 }
+
+.run-jobs__table {
+  @apply flex flex-col -my-3 -mx-3 md:-mx-6 py-2 text-sm w-[calc(100%+--spacing(6))] md:w-[calc(100%+--spacing(12))];
+}
+
+.run-jobs__row {
+  @apply bg-white gap-x-2 grid items-center w-full px-4 py-1 md:gap-x-4 md:px-8 grid-cols-[minmax(0,1fr)_min-content_--spacing(22)] transition-colors hover:bg-yellow-50;
+
+  label {
+    @apply flex flex-row items-start gap-2 w-fit max-w-full min-w-0 break-all leading-tight cursor-pointer hover:text-oxford-700;
+
+    input {
+      @apply cursor-pointer;
+    }
+
+    span {
+      @apply font-mono;
+    }
+  }
+
+  button {
+    @apply link inline-flex leading-0 h-fit;
+  }
+
+  ul {
+    @apply mb-2 ml-1.5 pl-3 border-l-4 border-l-oxford-200 order-4 font-mono;
+  }
+
+  .pill {
+    @apply h-fit whitespace-nowrap justify-center;
+  }
+}

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -121,6 +121,8 @@ class JobRequestCreate(CreateView):
     template_name = "job_request/create.html"
 
     def dispatch(self, request, *args, **kwargs):
+        self.actions_error = None
+
         try:
             self.workspace = Workspace.objects.get(
                 project__slug=self.kwargs["project_slug"],
@@ -175,9 +177,11 @@ class JobRequestCreate(CreateView):
             self.actions = []
             self.database_actions = []
             self.codelists_status = None
+            self.actions_error = str(e)
+
             # this is a bit nasty, need to mirror what get/post would set up for us
             self.object = None
-            context = self.get_context_data(actions_error=str(e))
+            context = self.get_context_data()
             return self.render_to_response(context=context)
 
         self.actions = list(get_actions(data))
@@ -261,6 +265,7 @@ class JobRequestCreate(CreateView):
             "actions": self.actions,
             "latest_job_request": self.get_latest_job_request(),
             "workspace": self.workspace,
+            "actions_error": self.actions_error,
         }
 
     def get_form_kwargs(self):

--- a/templates/job_request/create.html
+++ b/templates/job_request/create.html
@@ -209,67 +209,94 @@
       {% #card title="Latest Job Request" %}
         <dl class="border-t border-slate-200 sm:divide-y sm:divide-slate-200">
           {% #description_item title="Created at" %}
-            <time datetime="{{ latest_job_request.created_at|date:"Y-m-d H:i:sO" }}">
-              {{ latest_job_request.created_at|date:"d M Y H:i:s e" }}
+            <time datetime="{{ latest_job_request.created_at|date:"c" }}">
+              {{ latest_job_request.created_at|date:"j M Y" }} at {{ latest_job_request.created_at|date:"H:i e" }}
             </time>
           {% /description_item %}
 
           {% #description_item title="Total runtime" %}
-            {{ latest_job_request.runtime }}
+            {% if latest_job_request.runtime.hours > 0 %}
+              {{ latest_job_request.runtime.hours }} hour{{ latest_job_request.runtime.hours|pluralize }},
+            {% endif %}
+            {{ latest_job_request.runtime.minutes }} minute{{ latest_job_request.runtime.minutes|pluralize }}
+            and {{ latest_job_request.runtime.seconds }} second{{ latest_job_request.runtime.seconds|pluralize }}
+          {% /description_item %}
+
+          {% #description_item title="Status" %}
+            {% if latest_job_request.jobs_status == "succeeded" %}
+              <span class="pill pill--success">Succeeded</span>
+            {% elif latest_job_request.jobs_status == "pending" %}
+              <span class="pill pill--info">Pending</span>
+            {% elif latest_job_request.jobs_status == "running" %}
+              <span class="pill pill--primary">Running</span>
+            {% elif latest_job_request.jobs_status == "failed" %}
+              <span class="pill pill--danger">Failed</span>
+            {% endif %}
           {% /description_item %}
 
           {% #description_item title="Requested actions" %}
             {{ latest_job_request.requested_actions|join:", " }}
           {% /description_item %}
-        </dl>
 
-        <div class="px-4 py-3 md:px-6 border-t border-slate-200 overflow-x-auto">
-          <table class="min-w-full divide-y divide-slate-300">
-            <thead>
-              <tr>
-                <th class="whitespace-nowrap py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-slate-900 sm:pl-0">
-                  Status
-                </th>
-                <th class="whitespace-nowrap py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-slate-900 sm:pl-0">
-                  Action
-                </th>
-                <th class="whitespace-nowrap py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-slate-900 sm:pl-0">
-                  Runtime
-                </th>
-                <th class="whitespace-nowrap py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-slate-900 sm:pl-0">
-                  Status message
-                </th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-slate-200 bg-white text-sm">
-              {% for job in latest_job_request.jobs.all %}
-                <tr>
-                  <td class="py-2 pl-4 pr-3 text-sm text-slate-700 sm:pl-0">
-                    <span class="sr-only">{{ job_request.jobs_status|title }}</span>
-                    {% if job.status == "succeeded" %}
-                      {% icon_check_circle_solid class="h-6 w-6 text-green-700" %}
-                    {% elif job.status == "pending" %}
-                      {% icon_clock_outline class="h-6 w-6 text-slate-500 stroke-2" %}
-                    {% elif job.status == "running" %}
-                      {% icon_custom_spinner class="h-6 w-6 animate-spin stroke-oxford-600 stroke-2 text-oxford-300" %}
-                    {% elif job.status == "failed" %}
-                      {% icon_x_circle_solid class="h-6 w-6 text-bn-ribbon-700" %}
-                    {% endif %}
-                  </td>
-                  <td class="py-2 pl-4 pr-3 text-sm text-slate-700 sm:pl-0">
-                    {{ job.action }}
-                  </td>
-                  <td class="py-2 pl-4 pr-3 text-sm text-slate-700 sm:pl-0">
-                    {{ job.runtime }}
-                  </td>
-                  <td class="py-2 pl-4 pr-3 text-sm text-slate-700 sm:pl-0">
-                    {{ job.status_message|default:"-" }}
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
+          {% #description_item title="Individual actions" stacked=True title_class="sr-only" %}
+            <details class="group bg-oxford-50 border border-l-4 border-oxford-700/95 overflow-hidden rounded open:bg-white">
+              <summary class="cursor-pointer list-none p-4 py-2 transition-colors hover:bg-oxford-100 hover:text-oxford-900">
+                <span class="text-lg font-semibold text-oxford">
+                  <span class="group-open:hidden inline-flex">Show</span>
+                  <span class="group-open:inline-flex hidden">Hide</span>
+                  actions
+                </span>
+              </summary>
+
+              <div class="px-4 py-3 md:px-6 border-t border-slate-200 overflow-x-auto">
+                <table class="min-w-full divide-y divide-slate-300">
+                  <thead>
+                    <tr>
+                      <th class="whitespace-nowrap py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-slate-900 sm:pl-0">
+                        Status
+                      </th>
+                      <th class="whitespace-nowrap py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-slate-900 sm:pl-0">
+                        Action
+                      </th>
+                      <th class="whitespace-nowrap py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-slate-900 sm:pl-0">
+                        Runtime
+                      </th>
+                      <th class="whitespace-nowrap py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-slate-900 sm:pl-0">
+                        Status message
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-slate-200 bg-white text-sm">
+                    {% for job in latest_job_request.jobs.all %}
+                      <tr>
+                        <td class="py-2 pl-4 pr-3 text-sm text-slate-700 sm:pl-0">
+                          {% if job.status == "succeeded" %}
+                            <span class="pill pill--success whitespace-nowrap">Succeeded</span>
+                          {% elif job.status == "pending" %}
+                            <span class="pill pill--info whitespace-nowrap">Pending</span>
+                          {% elif job.status == "running" %}
+                            <span class="pill pill--primary whitespace-nowrap">Running</span>
+                          {% elif job.status == "failed" %}
+                            <span class="pill pill--danger whitespace-nowrap">Failed</span>
+                          {% endif %}
+                        </td>
+                        <td class="py-2 pl-4 pr-3 text-sm text-slate-700 sm:pl-0">
+                          {{ job.action }}
+                        </td>
+                        <td class="py-2 pl-4 pr-3 text-sm text-slate-700 sm:pl-0">
+                          {{ job.runtime }}
+                        </td>
+                        <td class="py-2 pl-4 pr-3 text-sm text-slate-700 sm:pl-0">
+                          {{ job.status_message|default:"-" }}
+                        </td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+          {% /description_item %}
+        </dl>
       {% /card %}
     {% endif %}
   </article>

--- a/templates/job_request/create.html
+++ b/templates/job_request/create.html
@@ -99,26 +99,25 @@
             </ul>
           {% endif %}
 
-          <ul class="flex flex-col -my-3 -mx-3 md:-mx-6 py-2 text-sm w-[calc(100%+--spacing(6))] md:w-[calc(100%+--spacing(12))]">
+          <ul class="run-jobs__table">
             {% for action in actions %}
-              <li class="bg-white gap-x-2 grid items-center w-full px-4 py-1 md:gap-x-4 md:px-8 grid-cols-[minmax(0,1fr)_min-content_min-content] transition-colors hover:bg-yellow-50" data-action>
-                <label for="checkbox-{{ action.name }}" class="flex flex-row items-start gap-2 w-fit max-w-full min-w-0 break-all leading-tight cursor-pointer hover:text-oxford-700">
+              <li class="run-jobs__row" data-action>
+                <label for="checkbox-{{ action.name }}">
                   <input
                     {% if action.name in form.requested_actions.value %}checked="true"{% endif %}
-                    class="cursor-pointer"
                     id="checkbox-{{ action.name }}"
                     name="requested_actions"
                     type="checkbox"
                     value="{{ action.name }}"
                   >
-                  <span class="font-mono">{{ action.name }}</span>
+                  <span>{{ action.name }}</span>
                 </label>
 
                 {% if action.needs %}
-                  <button class="link inline-flex leading-0 h-fit" data-expander-button={{ action.name }} type="button">
+                  <button data-expander-button={{ action.name }} type="button">
                     Needs
                   </button>
-                  <ul aria-expanded="false" class="hidden mb-2 ml-1.5 pl-3 border-l-4 border-l-oxford-200 order-4 font-mono" data-expander-list="{{ action.name }}">
+                  <ul aria-expanded="false" class="hidden" data-expander-list="{{ action.name }}">
                     {% for need in action.needs %}
                       <li>{{ need }}</li>
                     {% endfor %}
@@ -127,7 +126,7 @@
                   <span></span>
                 {% endif %}
 
-                <span class="pill h-fit w-[14ch] whitespace-nowrap justify-center" data-action-status>Loading</span>
+                <span class="pill" data-action-status>Loading</span>
               </li>
             {% endfor %}
           </ul>

--- a/templates/job_request/create.html
+++ b/templates/job_request/create.html
@@ -99,50 +99,38 @@
             </ul>
           {% endif %}
 
-          <div class="flex flex-col gap-y-2 max-w-full">
+          <ul class="flex flex-col -my-3 -mx-3 md:-mx-6 py-2 text-sm w-[calc(100%+--spacing(6))] md:w-[calc(100%+--spacing(12))]">
             {% for action in actions %}
-              <div class="flex flex-row gap-4" id="jobActions">
-                {% if action.name in form.requested_actions.value %}
-                  {% form_checkbox custom_field=True id="checkbox-"|add:action.name label=action.name name="requested_actions" value=action.name checked=False label_class="truncate py-0.5" span_class="font-mono text-base truncate" checked=True %}
-                {% else %}
-                  {% form_checkbox custom_field=True id="checkbox-"|add:action.name label=action.name name="requested_actions" value=action.name checked=False label_class="truncate py-0.5" span_class="font-mono text-base truncate" checked=False%}
-                {% endif %}
+              <li class="bg-white gap-x-2 grid items-center w-full px-4 py-1 md:gap-x-4 md:px-8 grid-cols-[minmax(0,1fr)_min-content_min-content] transition-colors hover:bg-yellow-50" data-action>
+                <label for="checkbox-{{ action.name }}" class="flex flex-row items-start gap-2 w-fit max-w-full min-w-0 break-all leading-tight cursor-pointer hover:text-oxford-700">
+                  <input
+                    {% if action.name in form.requested_actions.value %}checked="true"{% endif %}
+                    class="cursor-pointer"
+                    id="checkbox-{{ action.name }}"
+                    name="requested_actions"
+                    type="checkbox"
+                    value="{{ action.name }}"
+                  >
+                  <span class="font-mono">{{ action.name }}</span>
+                </label>
 
                 {% if action.needs %}
-                  {% #button class="min-w-fit ml-auto" variant="secondary-outline" small=True data-expander-button=action.name  %}
+                  <button class="link inline-flex leading-0 h-fit" data-expander-button={{ action.name }} type="button">
                     Needs
-                  {% /button %}
+                  </button>
+                  <ul aria-expanded="false" class="hidden mb-2 ml-1.5 pl-3 border-l-4 border-l-oxford-200 order-4 font-mono" data-expander-list="{{ action.name }}">
+                    {% for need in action.needs %}
+                      <li>{{ need }}</li>
+                    {% endfor %}
+                  </ul>
+                {% else %}
+                  <span></span>
                 {% endif %}
 
-                <span class="grid place-content-center {% if not action.needs %}ml-auto{% endif %}">
-                  <span class="relative grid place-content-center group hidden" data-action-status="loading">
-                    {% icon_custom_spinner class="h-5 w-5 mx-auto flex-1 animate-spin stroke-current stroke-2 text-oxford-600" %}
-                    {% tooltip position="-bottom-3" content="Loading" %}
-                  </span>
-                  <span class="relative grid place-content-center group hidden" data-action-status="succeeded">
-                    {% icon_check_circle_solid class="h-5 w-5 fill-green-700" %}
-                    {% tooltip position="-bottom-3" content="Successful" %}
-                  </span>
-                  <span class="relative grid place-content-center group hidden" data-action-status="failed">
-                    {% icon_x_circle_solid class="h-5 w-5 fill-red-700" %}
-                    {% tooltip position="-bottom-3" content="Failed" %}
-                  </span>
-                  <span class="relative block h-5 w-5 hidden" data-action-status="none"></span>
-                </span>
-              </div>
-              {% if action.needs %}
-                <ul
-                  aria-expanded="false"
-                  class="mt-0 mb-2 ml-2 pl-2 border-l-4 border-l-oxford-200 hidden list-none truncate"
-                  data-expander-list="{{ action.name }}"
-                >
-                  {% for need in action.needs %}
-                    <li class="text-sm font-mono truncate">{{ need }}</li>
-                  {% endfor %}
-                </ul>
-              {% endif %}
+                <span class="pill h-fit w-[14ch] whitespace-nowrap justify-center" data-action-status>Loading</span>
+              </li>
             {% endfor %}
-          </div>
+          </ul>
 
           <div class="mt-2 text-slate-700 grid grid-flow-row gap-y-2 max-w-3xl">
             <p>Selecting an Action will run it, regardless of its previous state or outputs.</p>


### PR DESCRIPTION
Closes #5789

## Update Latest Job Request card on Run Jobs page

* Show both the created at time, and the runtime in a more human-friendly format
* Show the overall job request status in a pill
* Put the list of actions inside a `<details>` component to hide long lists from initial page load
* Replace icons in each action with pills which show the status in text format

### Screenshots

<details><summary>Before</summary>

<img width="981" height="1116" alt="" src="https://github.com/user-attachments/assets/6812d545-96e4-4bac-a3a1-2e0c419e90d5" />
</details>

<details><summary>After</summary>

<img width="989" height="379" alt="" src="https://github.com/user-attachments/assets/07a74ea8-05d3-4e5a-ae02-418d9e180d38" />

<hr />

<img width="994" height="874" alt="" src="https://github.com/user-attachments/assets/b0a746ac-a431-4e40-9a72-dfb7cbbf0d53" />

</details>

---

## Style the actions list on Run Jobs page

* Use CSS Grid to make a set structure for the list and provide a table like structure
* Allow action names to overflow one line, rather than truncating
* Simplify the markup and JS, removing multiple duplicate IDs for each row
* Replace icons in each action with pills which show the status in text format
* Move the inline Tailwind CSS classes in to the stylesheet, to stop the repetition of the classes

### Screenshots

<details><summary>Before</summary>
<img width="2451" height="2235" alt="" src="https://github.com/user-attachments/assets/e86b0010-150a-432d-97bb-8f8b990af670" />

</details>

<details><summary>After</summary>

<img width="2429" height="2257" alt="" src="https://github.com/user-attachments/assets/8efcd6d4-c8eb-4347-877f-dbc069373a40" />
</details>

---

## Overall

When testing on [Run Jobs: post-covid-neurodegenerative-v3](http://localhost:8000/investigating-events-following-covid-19/post-covid-neurodegenerative-v3/run-jobs/) locally, these changes take the number of templates loaded from:

- Before: 11,531 rendered
- After: 59 rendered