### PR TITLE
Fix bug in remove files from publish requests command

### DIFF
--- a/jobserver/management/commands/remove_files_from_publish_request.py
+++ b/jobserver/management/commands/remove_files_from_publish_request.py
@@ -32,9 +32,7 @@ class Command(BaseCommand):
         release_files = []
         for path in paths:
             try:
-                release_file = ReleaseFile.objects.filter(
-                    workspace=snapshot.workspace
-                ).get(name=path)
+                release_file = snapshot.files.get(name=path)
                 release_files.append(release_file)
             except ReleaseFile.DoesNotExist:
                 raise CommandError(f"Unknown file path: {path}")

--- a/tests/unit/jobserver/management/commands/test_remove_files_from_publish_request.py
+++ b/tests/unit/jobserver/management/commands/test_remove_files_from_publish_request.py
@@ -26,6 +26,7 @@ def test_remove_files_from_publish_request_unknown_path():
     release_file = ReleaseFileFactory(
         workspace=snapshot.workspace, name="/release/test/file.csv"
     )
+    snapshot.files.add(release_file)
 
     with pytest.raises(CommandError, match="Unknown file path: /dummy/path"):
         call_command(
@@ -36,7 +37,7 @@ def test_remove_files_from_publish_request_unknown_path():
         )
 
 
-def test_remove_files_from_publish_request_path_to_file_in_wrong_workspace():
+def test_remove_files_from_publish_request_path_to_file_not_in_snapshot():
     snapshot = SnapshotFactory()
     release_file = ReleaseFileFactory(name="/release/test/file.csv")
 
@@ -118,3 +119,28 @@ def test_remove_files_from_publish_request(n_to_remove=2):
     )
 
     assert f"{n_to_remove} files removed from" in out.getvalue()
+
+
+def test_remove_files_from_publish_request_ignores_duplicate_path_outside_snapshot():
+    out = StringIO()
+    err = StringIO()
+
+    path = "/release/test/file.csv"
+    snapshot = SnapshotFactory()
+    release_file_to_remove = ReleaseFileFactory(workspace=snapshot.workspace, name=path)
+    duplicate_release_file = ReleaseFileFactory(workspace=snapshot.workspace, name=path)
+
+    snapshot.files.add(release_file_to_remove)
+
+    call_command(
+        "remove_files_from_publish_request",
+        snapshot.id,
+        path,
+        stdout=out,
+        stderr=err,
+    )
+
+    assert not err.getvalue()
+    assert release_file_to_remove not in snapshot.files.all()
+    assert duplicate_release_file not in snapshot.files.all()
+    assert "1 files removed from" in out.getvalue()


### PR DESCRIPTION
## Description
Fixes #5810 
The remove_files_from_publish_request command looked up files by workspace and path before removing them from a snapshot. ReleaseFile names are not unique within a workspace, so older releases or other files with the same path could make the lookup return multiple rows and raised the error `ReleaseFile.MultipleObjectsReturned`.

Look up files through `snapshot.files` instead, so the command only matches files that are actually part of the snapshot being edited.

Update the management command tests to cover the new lookup behavior and included test for case where another ReleaseFile in the same workspace has the same name but it is not attached to the snapshot.

## Testing
Tested it locally using the following command and it worked:
`python manage.py remove_files_from_publish_request <snapshot_id> <file>`