### PR TITLE
Update GitHub Actions with security and workflow improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
     cooldown:
       default-days: 7
 
@@ -43,3 +46,23 @@ updates:
       - dependency-name: "django"
         versions: [">=6.0.0"]
       - dependency-name: "jobserver"
+
+  - package-ecosystem: "docker"
+    directory: "docker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker-compose"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,13 +30,13 @@ jobs:
     if: github.ref == 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: "opensafely-core/setup-action@v1"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
 
       - name: Download docker image
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
             name: job-server-image
             path: /tmp/image

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Publish image
         run: |
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login "$REGISTRY" -u "${{ github.actor }}" --password-stdin
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login "$REGISTRY" -u "${GITHUB_ACTOR}" --password-stdin
             docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME:latest"
             docker push "$PUBLIC_IMAGE_NAME:latest"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 ---
 name: Deploy
 
+permissions:
+  contents: read
+
 env:
   IMAGE_NAME: job-server
   HOST: dokku4.ebmdatalab.net
@@ -17,6 +20,8 @@ concurrency: deploy-production
 jobs:
   test-and-build-docker-image:
     uses: ./.github/workflows/main.yml
+    permissions:
+      contents: read
 
   deploy:
     needs: [test-and-build-docker-image]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   check:
+    name: Python formatting check
     runs-on: ubuntu-22.04
 
     steps:
@@ -25,11 +26,13 @@ jobs:
           install-just: true
           install-uv: true
           cache: uv
-      - name: Check formatting, linting and import sorting
+      - name: Check formatting, linting, and import sorting
         run: just check
 
   test:
+    name: Python & JS tests
     runs-on: ubuntu-22.04
+    needs: check
 
     services:
       postgres:
@@ -105,7 +108,11 @@ jobs:
         if: ${{ failure() }}  # only upload when the previous step, run tests, fails
 
   test-functional:
+    name: Docker functional tests
     runs-on: ubuntu-22.04
+    needs:
+      - check
+      - lint-dockerfile
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -122,6 +129,7 @@ jobs:
           just docker-test-functional
 
   lint-dockerfile:
+    name: Dockerfile lint
     runs-on: ubuntu-22.04
 
     steps:
@@ -134,7 +142,11 @@ jobs:
           dockerfile: docker/Dockerfile
 
   docker-test:
+    name: Docker unit & smoke tests
     runs-on: ubuntu-22.04
+    needs:
+      - check
+      - lint-dockerfile
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,11 @@ jobs:
 
     services:
       postgres:
-        image: postgres@sha256:b994732fcf33f73776c65d3a5bf1f80c00120ba5007e8ab90307b1a743c1fc16 # v17
+        # When this updates, you need to also update:
+        # - docker/docker-compose.yaml:9
+        # - tests/test_repository.py:30
+        # to match this SHA
+        image: postgres@sha256:0027bef26712baaee437a4ea48fdf3d2d2e2bc5f0d81615374408ca320f3c7e3 # v17
         env:
           POSTGRES_USER: user
           POSTGRES_PASSWORD: password

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   check:
     name: Python formatting check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -35,7 +35,7 @@ jobs:
 
   test:
     name: Python & JS tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: check
 
     services:
@@ -113,7 +113,7 @@ jobs:
 
   test-functional:
     name: Docker functional tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - check
       - lint-dockerfile
@@ -134,7 +134,7 @@ jobs:
 
   lint-dockerfile:
     name: Dockerfile lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -147,7 +147,7 @@ jobs:
 
   docker-test:
     name: Docker unit & smoke tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - check
       - lint-dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17
+        image: postgres@sha256:b994732fcf33f73776c65d3a5bf1f80c00120ba5007e8ab90307b1a743c1fc16 # v17
         env:
           POSTGRES_USER: user
           POSTGRES_PASSWORD: password

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Python formatting check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: "opensafely-core/setup-action@v1"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           python-version: "3.12"
           install-just: true
@@ -44,8 +44,8 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: "opensafely-core/setup-action@v1"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           python-version: "3.12"
           install-just: true
@@ -53,7 +53,7 @@ jobs:
           cache: uv
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".node-version"
           cache: "npm"
@@ -88,7 +88,7 @@ jobs:
           just test-ci -n 4
 
       - name: Upload HTML coverage report if tests failed
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-coverage-report
           path: htmlcov
@@ -102,8 +102,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: opensafely-core/setup-action@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
 
@@ -116,8 +116,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: docker/Dockerfile
 
@@ -125,8 +125,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: "opensafely-core/setup-action@v1"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
           install-uv: true
@@ -155,7 +155,7 @@ jobs:
           docker save job-server | zstd --fast -o /tmp/job-server.tar.zst
 
       - name: Upload docker image
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
             name: job-server-image
             path: /tmp/job-server.tar.zst

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           python-version: "3.12"
@@ -45,6 +48,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           python-version: "3.12"
@@ -103,6 +109,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true
@@ -117,6 +126,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: docker/Dockerfile
@@ -126,6 +138,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           install-just: true

--- a/.github/workflows/verification-tests.yml
+++ b/.github/workflows/verification-tests.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: "opensafely-core/setup-action@v1"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           python-version: "3.12"
           install-just: true
@@ -33,7 +33,7 @@ jobs:
           just test-verification -n 4
 
       - name: Upload HTML coverage report if tests failed
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-coverage-report
           path: htmlcov

--- a/.github/workflows/verification-tests.yml
+++ b/.github/workflows/verification-tests.yml
@@ -1,6 +1,9 @@
 ---
 name: Verification Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/verification-tests.yml
+++ b/.github/workflows/verification-tests.yml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
           python-version: "3.12"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,7 +2,11 @@
 # configuring the production build
 services:
   db:
-    image: "postgres@sha256:b994732fcf33f73776c65d3a5bf1f80c00120ba5007e8ab90307b1a743c1fc16"
+    # When this updates, you need to also update:
+    # - .github/workflows/main.yml:47
+    # - tests/test_repository.py:30
+    # to match this SHA
+    image: postgres@sha256:0027bef26712baaee437a4ea48fdf3d2d2e2bc5f0d81615374408ca320f3c7e3 # v17
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,7 +2,7 @@
 # configuring the production build
 services:
   db:
-    image: "postgres:17"
+    image: "postgres@sha256:b994732fcf33f73776c65d3a5bf1f80c00120ba5007e8ab90307b1a743c1fc16"
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -24,4 +24,8 @@ def test_development_db_version_is_consistent(request):
         docker_yaml = yaml.safe_load(f)
         docker_postgres_version = docker_yaml["services"]["db"]["image"]
 
-    assert ci_postgres_version == docker_postgres_version == "postgres:17"
+    assert (
+        ci_postgres_version
+        == docker_postgres_version
+        == "postgres@sha256:b994732fcf33f73776c65d3a5bf1f80c00120ba5007e8ab90307b1a743c1fc16"
+    )

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -27,5 +27,5 @@ def test_development_db_version_is_consistent(request):
     assert (
         ci_postgres_version
         == docker_postgres_version
-        == "postgres@sha256:b994732fcf33f73776c65d3a5bf1f80c00120ba5007e8ab90307b1a743c1fc16"
+        == "postgres@sha256:0027bef26712baaee437a4ea48fdf3d2d2e2bc5f0d81615374408ca320f3c7e3"
     )


### PR DESCRIPTION
The majority of these changes have been spotted by [Zizmor](https://github.com/zizmorcore/zizmor).

- Pin GitHub Actions versions to specific hashes
    - [`unpinned-uses`](https://docs.zizmor.sh/audits/#unpinned-uses)
- Disable persist credentials in checkout action
    - [`artipacked`](https://docs.zizmor.sh/audits/#artipacked)
- Add `name` and `needs` to each step
    - [`anonymous-definition`](https://docs.zizmor.sh/audits/#anonymous-definition)
- Pin Postgres image using sha256
    - [`unpinned-images`](https://docs.zizmor.sh/audits/#unpinned-images)
    - And update the associated test
- Cancel running jobs when workflow is re-triggered
    - [`concurrency-limits`](https://docs.zizmor.sh/audits/#concurrency-limits)
- Update Ubuntu to version 24.04
    - As that's the version we're using on the server, and is the LTS
- Fix template injection for GitHub Actor
    - [`template-injection`](https://docs.zizmor.sh/audits/#template-injection)
- Fix excessive permissions
    - [`excessive-permissions`](https://docs.zizmor.sh/audits/#excessive-permissions)

## Before

<img width="328" height="372" alt="Screenshot of the GitHub Actions workflow before" src="https://github.com/user-attachments/assets/40474211-db55-4638-85d5-6b4680817685" />

## After

<img width="650" height="340" alt="Screenshot of the GitHub Actions workflow after" src="https://github.com/user-attachments/assets/03a28fd9-bf8d-4480-823f-4897e76c7951" />
