### PR TITLE
POC for scrubbing data via the ORM.

### DIFF
--- a/jobserver/management/commands/scrub_data.py
+++ b/jobserver/management/commands/scrub_data.py
@@ -1,0 +1,22 @@
+from django.apps import apps
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        for model in apps.get_app_config("jobserver").get_models():
+            scrub_fields = getattr(model, "scrub_fields", None)
+            if not scrub_fields:
+                continue
+
+            objs = list(model.objects.all())
+            for obj in objs:
+                for attr_name, fake_value in scrub_fields.items():
+                    value = fake_value() if callable(fake_value) else fake_value
+                    setattr(obj, attr_name, value)
+
+            field_names = scrub_fields.keys()
+            model.objects.bulk_update(objs, field_names)
+            self.stdout.write(
+                f"Scrubbed {len(objs)} {model.__name__} records from fields:{field_names}"
+            )

--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -13,6 +13,7 @@ from django.db.models.functions import Lower
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
+from faker import Faker
 from sentry_sdk import capture_message
 
 from jobserver.authorization.permissions import Permission
@@ -23,6 +24,8 @@ from ..hash_utils import hash_user_pat
 
 
 logger = structlog.get_logger(__name__)
+
+fake = Faker()
 
 
 class UserQuerySet(models.QuerySet):
@@ -142,6 +145,26 @@ class User(AbstractBaseUser):
     # Used by AbstractBaseUser machinery we possibly need.
     EMAIL_FIELD = "email"
     USERNAME_FIELD = "email"
+
+    scrub_fields = {
+        "email": fake.email,
+        "password": "",
+        "login_token": None,
+        "login_token_expires_at": None,
+        "pat_expires_at": None,
+        "pat_token": None,
+    }
+    scrub_allowed = frozenset(
+        {
+            "id",
+            "last_login",
+            "username",
+            "date_joined",
+            "fullname",
+            "created_by_id",
+            "roles",
+        }
+    )
 
     class Meta:
         constraints = [


### PR DESCRIPTION
We want to scrub some Django-managed model fields because they have personal data or secrets/tokens et cetera.

We can define in a model which fields require scrubbing and what they should be replaced with. Then a management command can do a bulk update on these fields via the ORM. Django can connect to a non-primary database in the cluster that has been loaded with a dump of the production database to run this command to scrub the data. Then it can be dumped out again without the sensitive data.

This POC just scrubs one table, User.

There are other tables not managed through Django models that contain data we might want to truncate as well, that is best done through raw SQL statements. That can also be done in a Django management command but is not shown here. Such tables include: `django_admin_log`, `django_session`, `auth_*`, and `social_auth_*`.

We could add some test that all models have both "scrub_fields" and "scrub_allowed" and that all fields on the model appear in exactly one of these.

Example invocation:

```
~/job-server$ just manage scrub_data
$BIN/python manage.py scrub_data
Scrubbed 408 User records from fields:dict_keys(['email', 'password', 'login_token', 'login_token_expires_at', 'pat_expires_at', 'pat_token'])
```

Then in a database shell:

```
jobserver=# select username, password, email, login_token from jobserver_user where username='mikerkelly';
  username  | password |         email         | login_token
------------+----------+-----------------------+-------------
 mikerkelly |          | whiteadam@example.net |
(1 row)
```

I can still use the site normally after logging back in to social auth.

<img width="523" height="337" alt="image" src="https://github.com/user-attachments/assets/4cbd9609-81a7-4812-972c-02f3a3d73998" />
