### PR TITLE
Add `created_by` to `select_related` in org and workspace `EventLog`

### DIFF
--- a/jobserver/views/orgs.py
+++ b/jobserver/views/orgs.py
@@ -44,7 +44,7 @@ class OrgEventLog(ListView):
         return (
             JobRequest.objects.with_started_at()
             .filter(workspace__project__orgs__in=[self.org])
-            .select_related("backend", "workspace", "workspace__project")
+            .select_related("backend", "created_by", "workspace", "workspace__project")
             .order_by("-pk")
         )
 

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -311,7 +311,7 @@ class WorkspaceEventLog(ListView):
         qs = (
             JobRequest.objects.with_started_at()
             .filter(workspace=self.workspace)
-            .select_related("backend", "workspace", "workspace__project")
+            .select_related("backend", "created_by", "workspace", "workspace__project")
             .order_by("-pk")
         )
 


### PR DESCRIPTION
These templates are doing database queries that can be avoided with a select_related. That makes it a bit easier to reason about the queries when looking at, for example, Django debug toolbar.  Only a slight (10s of ms) improvement to performance.

OrgEventLog and WorkspaceEventLog templates reference the JobRequest.created_by foreign key through `{{ group.created_by.fullname }}`. This leads to one SQL request per row in the table to look this up if the related User object has not been selected along with the request. This leads to up to 25 unneeded requests (or however many the pagination is set to in future).

We can include these with the JobRequest select so they are attached via inner joins, saving the queries. This was already done in the ProjectEventLog, we may as well do the same here.

This is not needed on the UserEventLog as that does not display information about the User in the table.

For testing this: suggest looking at the views before and after the change with Django debug toolbar and seeing the number of queries decrease.
Project, something like: http://localhost:8000/comparing-disparities-in-rsv-influenza-and-covid-19/logs/
Organisation, something like: http://localhost:8000/orgs/bennett-institute/logs/