### PR TITLE
Add a Job Statistics card to the job request detail page

### DIFF
--- a/jobserver/models/job.py
+++ b/jobserver/models/job.py
@@ -12,7 +12,11 @@ from ..runtime import Runtime
 
 logger = structlog.get_logger(__name__)
 
-COMPLETED_STATES = ["failed", "succeeded"]
+PENDING_STATES = ["pending"]
+RUNNING_STATES = ["running"]
+FAILED_STATES = ["failed", "Failed"]
+SUCCEEDED_STATES = ["succeeded", "Succeeded"]
+COMPLETED_STATES = ["failed", "succeeded", "Failed", "Succeeded", "0"]
 
 
 class JobManager(models.Manager):

--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -5,13 +5,30 @@ import sentry_sdk
 import structlog
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.db.models import Count, F, Min, Q, prefetch_related_objects
+from django.db.models import (
+    Case,
+    Count,
+    ExpressionWrapper,
+    F,
+    FloatField,
+    Min,
+    Q,
+    When,
+    prefetch_related_objects,
+)
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 from furl import furl
 
 from jobserver import rap_api
+from jobserver.models.job import (
+    COMPLETED_STATES,
+    FAILED_STATES,
+    PENDING_STATES,
+    RUNNING_STATES,
+    SUCCEEDED_STATES,
+)
 
 from ..runtime import Runtime
 
@@ -34,10 +51,40 @@ def new_id():
     return base64.b32encode(secrets.token_bytes(10)).decode("ascii").lower()
 
 
+def _pct(numerator):
+    return ExpressionWrapper(
+        Case(
+            When(total_jobs=0, then=0.0),
+            default=F(numerator) * 100.0 / F("total_jobs"),
+        ),
+        output_field=FloatField(),
+    )
+
+
 class JobRequestQuerySet(models.QuerySet):
     def with_started_at(self):
         return self.prefetch_related("jobs").annotate(
             started_at=Min("jobs__started_at")
+        )
+
+    def with_job_status_counts(self):
+        return self.annotate(
+            total_jobs=Count("jobs"),
+            num_pending_jobs=Count("jobs", filter=Q(jobs__status__in=PENDING_STATES)),
+            num_running_jobs=Count("jobs", filter=Q(jobs__status__in=RUNNING_STATES)),
+            num_succeeded_jobs=Count(
+                "jobs", filter=Q(jobs__status__in=SUCCEEDED_STATES)
+            ),
+            num_failed_jobs=Count("jobs", filter=Q(jobs__status__in=FAILED_STATES)),
+            num_completed_jobs=Count(
+                "jobs", filter=Q(jobs__status__in=COMPLETED_STATES)
+            ),
+        ).annotate(
+            percent_pending_jobs=_pct("num_pending_jobs"),
+            percent_running_jobs=_pct("num_running_jobs"),
+            percent_succeeded_jobs=_pct("num_succeeded_jobs"),
+            percent_failed_jobs=_pct("num_failed_jobs"),
+            percent_completed_jobs=_pct("num_completed_jobs"),
         )
 
 

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -302,6 +302,7 @@ class JobRequestDetail(View):
                 .annotate(
                     last_updated_at=Max("jobs__updated_at", default=timezone.now())
                 )
+                .with_job_status_counts()
                 .get(
                     workspace__project__slug=self.kwargs["project_slug"],
                     workspace__name=self.kwargs["workspace_slug"],

--- a/templates/job_request/detail.html
+++ b/templates/job_request/detail.html
@@ -250,6 +250,80 @@
     </div>
 
     <div class="gap-6 place-content-start lg:col-span-1 flex flex-col">
+      {% if job_request.total_jobs > 0 %}
+        {% #card class="text-sm test-marker-stats-table" header_class="border-b border-slate-200" title="Job statistics" %}
+          {% #table %}
+            {% #table_head %}
+              {% #table_header nowrap %}Status{% /table_header %}
+              {% #table_header nowrap class="text-right" %}Count{% /table_header %}
+              {% #table_header nowrap class="text-right" %}Percentage{% /table_header %}
+            {% /table_head %}
+            {% #table_body %}
+              {% #table_row %}
+                {% #table_cell %}
+                  {% pill variant="warning" class="whitespace-nowrap" text="Pending" %}
+                {% /table_cell %}
+                {% #table_cell class="tabular-nums text-right" %}
+                  {{ job_request.num_pending_jobs | floatformat:"g" }}
+                {% /table_cell %}
+                {% #table_cell class="tabular-nums text-right" %}
+                  {{ job_request.percent_pending_jobs | floatformat }}%
+                {% /table_cell %}
+              {% /table_row %}
+
+              {% #table_row %}
+                {% #table_cell %}
+                  {% pill variant="primary" class="whitespace-nowrap" text="Running" %}
+                {% /table_cell %}
+                {% #table_cell class="tabular-nums text-right" %}
+                  {{ job_request.num_running_jobs | floatformat:"g" }}
+                {% /table_cell %}
+                {% #table_cell class="tabular-nums text-right" %}
+                  {{ job_request.percent_running_jobs | floatformat }}%
+                {% /table_cell %}
+              {% /table_row %}
+
+              {% #table_row %}
+                {% #table_cell %}
+                  {% pill variant="success" class="whitespace-nowrap" text="Succeeded" %}
+                {% /table_cell %}
+                {% #table_cell class="tabular-nums text-right" %}
+                  {{ job_request.num_succeeded_jobs | floatformat:"g" }}
+                {% /table_cell %}
+                {% #table_cell class="tabular-nums text-right" %}
+                  {{ job_request.percent_succeeded_jobs | floatformat }}%
+                {% /table_cell %}
+              {% /table_row %}
+
+              {% #table_row %}
+                {% #table_cell %}
+                  {% pill variant="danger" class="whitespace-nowrap" text="Failed" %}
+                {% /table_cell %}
+                {% #table_cell class="tabular-nums text-right" %}
+                  {{ job_request.num_failed_jobs | floatformat:"g" }}
+                {% /table_cell %}
+                {% #table_cell class="tabular-nums text-right" %}
+                  {{ job_request.percent_failed_jobs | floatformat }}%
+                {% /table_cell %}
+              {% /table_row %}
+            {% /table_body %}
+          {% /table %}
+
+          {% #card_footer no_container=True %}
+            <p class="font-medium text-center">
+              {{ job_request.num_completed_jobs|intcomma }} /
+              {{ job_request.total_jobs|intcomma }}
+              ({{ job_request.percent_completed_jobs | floatformat }}%)
+              complete
+            </p>
+          {% /card_footer %}
+        {% /card %}
+      {% else %}
+        {% #card container=True title="Job statistics" class="test-marker-no-stats-table" %}
+          <p class="no-stats-message">No updates received from backend yet.</p>
+        {% /card %}
+      {% endif %}
+
       {% #card title="Timeline" container=True %}
         <ul class="flow-root">
           {% #timeline_item background="blue" title="Created:" time=job_request.created_at %}

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -924,3 +924,90 @@ def build_job_request():
         return JobRequestFactory(workspace=workspace)
 
     return _build_job_request
+
+
+class TestJobRequestJobStatusCounts:
+    """Tests of JobRequest.objects.with_job_status_counts."""
+
+    def test_no_jobs(self):
+        """Test that when a JobRequest has no associated jobs, all counts are
+        zero."""
+        request = JobRequestFactory()
+        stats = JobRequest.objects.filter(pk=request.pk).with_job_status_counts().last()
+        assert stats.total_jobs == 0
+        assert stats.num_pending_jobs == 0
+        assert stats.num_running_jobs == 0
+        assert stats.num_succeeded_jobs == 0
+        assert stats.num_failed_jobs == 0
+        assert stats.num_completed_jobs == 0
+        assert stats.percent_pending_jobs == 0
+        assert stats.percent_running_jobs == 0
+        assert stats.percent_succeeded_jobs == 0
+        assert stats.percent_failed_jobs == 0
+        assert stats.percent_completed_jobs == 0
+
+    @pytest.mark.parametrize(
+        "status,attr_count_one,attr_percent_one,completed",
+        [
+            ("pending", "num_pending_jobs", "percent_pending_jobs", False),
+            ("running", "num_running_jobs", "percent_running_jobs", False),
+            ("succeeded", "num_succeeded_jobs", "percent_succeeded_jobs", True),
+            ("failed", "num_failed_jobs", "percent_failed_jobs", True),
+            ("Succeeded", "num_succeeded_jobs", "percent_succeeded_jobs", True),
+            ("Failed", "num_failed_jobs", "percent_failed_jobs", True),
+            ("0", "no_count_", "no_percent", True),
+            ("invalid", "no_count", "no_percent", False),
+        ],
+    )
+    def test_single(self, status, attr_count_one, attr_percent_one, completed):
+        """Test that when a JobRequest has a single associated job with a
+        particular status, all counts are correct."""
+        request = JobRequestFactory()
+        JobFactory(job_request=request, status=status)
+        stats = JobRequest.objects.filter(pk=request.pk).with_job_status_counts().last()
+        assert stats.total_jobs == 1
+        assert stats.num_completed_jobs == (1 if completed else 0)
+        for attr_name in (
+            "num_pending_jobs",
+            "num_running_jobs",
+            "num_succeeded_jobs",
+            "num_failed_jobs",
+        ):
+            assert getattr(stats, attr_name) == (
+                1 if attr_name == attr_count_one else 0
+            )
+        for attr_name in (
+            "percent_pending_jobs",
+            "percent_running_jobs",
+            "percent_succeeded_jobs",
+            "percent_failed_jobs",
+        ):
+            assert getattr(stats, attr_name) == (
+                100.0 if attr_name == attr_percent_one else 0.0
+            )
+
+    def test_many(self):
+        """Test that when a JobRequest has many associated Jobs with
+        different statuses, all counts are correct."""
+        request = JobRequestFactory()
+
+        JobFactory.create_batch(6, status="pending", job_request=request)
+        JobFactory.create_batch(5, status="running", job_request=request)
+        JobFactory.create_batch(3, status="succeeded", job_request=request)
+        JobFactory.create_batch(4, status="failed", job_request=request)
+        JobFactory.create_batch(2, status="invalid", job_request=request)
+
+        stats = JobRequest.objects.filter(pk=request.pk).with_job_status_counts().last()
+        assert stats.total_jobs == 20
+
+        assert stats.num_pending_jobs == 6
+        assert stats.num_running_jobs == 5
+        assert stats.num_succeeded_jobs == 3
+        assert stats.num_failed_jobs == 4
+        assert stats.num_completed_jobs == 7
+
+        assert stats.percent_pending_jobs == 30.0
+        assert stats.percent_running_jobs == 25.0
+        assert stats.percent_succeeded_jobs == 15.0
+        assert stats.percent_failed_jobs == 20.0
+        assert stats.percent_completed_jobs == 35.0

--- a/tests/unit/jobserver/views/test_job_requests.py
+++ b/tests/unit/jobserver/views/test_job_requests.py
@@ -1232,6 +1232,10 @@ def test_jobrequestdetail_with_job_request_creator(rf):
     assert response.status_code == 200
     assert "Cancel" in response.rendered_content
 
+    # There are no jobs, so we should not see the stats table.
+    assert "test-marker-stats-table" not in response.rendered_content
+    assert "test-marker-no-stats-table" in response.rendered_content
+
 
 def test_jobrequestdetail_with_invalid_job_request(rf, django_assert_num_queries):
     job_request = JobRequestFactory()
@@ -1280,6 +1284,9 @@ def test_jobrequestdetail_with_permission(rf, project_membership, role_factory):
     assert not response.context_data["project_yaml"]["is_too_large"]
     assert not response.context_data["project_yaml"]["definition"]
     assert "Cancel" in response.rendered_content
+    # There are some jobs, so we should see the stats table.
+    assert "test-marker-stats-table" in response.rendered_content
+    assert "test-marker-no-stats-table" not in response.rendered_content
 
 
 def test_jobrequestdetail_with_permission_staff_area_administrator(rf, freezer):


### PR DESCRIPTION
Fixes https://github.com/opensafely-core/job-server/issues/5825. Not the event log part, I will make further PR and issue for that separately.

When a user has a job request with a large number of jobs, it can be very hard
for them to get an idea of the overall picture of what has run, succeeded,
failed, is pending or waiting. This adds a card in the right-hand column on the
job request detail page with counts and percentages of jobs by statuses and
overall.

Added to the top of the column. Arguably this is now the most interesting to
the main user of this view, the one running the jobs, as it helps them see
progress. And you can still see most of the detail from the timeline card like
this anyway.

Frontend parts co-authored with Thomas.

<details>
<summary>Screenshots - click to expand</summary>

### Full page 
<img width="732" height="694" alt="image" src="https://github.com/user-attachments/assets/8c6d49b1-1e41-4c75-aefe-1641c5080534" />


### Card with jobs
<img width="363" height="308" alt="image" src="https://github.com/user-attachments/assets/1841d990-a03f-4558-800c-a7d11af627f8" />


### Card with no jobs, for example a new job not acked by the RAP controller yet
<img width="468" height="498" alt="image" src="https://github.com/user-attachments/assets/569098f3-8df5-45bc-95ec-c9618b13a6f4" />


</details> 
