### PR TITLE
Use `int` path converter in `job-request-detail`.

### DIFF
--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -292,7 +292,7 @@ urlpatterns = [
     path("health-check/", HealthCheck.as_view(), name="health-check"),
     path("jobs/", RedirectView.as_view(query_string=True, pattern_name="job-list")),
     path(
-        "job-requests/<pk>/",
+        "job-requests/<int:pk>/",
         JobRequestDetailRedirect.as_view(),
         name="job-request-detail",
     ),


### PR DESCRIPTION
This URL pattern fails with a ValueError if passed a non-int value, as it performs a PK lookup which expects an int. That leads to a 500 error.  We should use a path converter in the URL pattern so that a 404 is raised and the bad "pk" never reaches the view code where it is mistreated.

Example unhappy URL before, now 404:
http://localhost:8000/job-requests/yijyztxck3ppxvfz/

Example happy URL:
http://localhost:8000/job-requests/1/

No unit test as our URL unit-testing only tests the positive cases (expected URLs reach expected views), not the vast infinitude of possible faulty URLs.