### PR TITLE
Link Job identifier to the short `/jobs/id` URL.

### DIFF
--- a/templates/job/detail.html
+++ b/templates/job/detail.html
@@ -150,9 +150,8 @@
           {% /description_item %}
 
           {% #description_item title="Job identifier" %}
-            <code class="font-mono font-semibold text-oxford-800 tracking-widest">
-              {{ job.identifier }}
-            </code>
+            {% url 'job-redirect' job.identifier as job_short_link_redirect %}
+            {% link href=job_short_link_redirect text=job.identifier %}
           {% /description_item %}
 
           {% #description_item title="Job request" %}


### PR DESCRIPTION
Make the job identifier on its own page a link to the short URL redirect, so that it is more discoverable.

This convenience URL was not known to some developers that could have benefited from it.

When debugging jobs in the RAP controller we often need to go from the job ID (e.g. gpgtmbjtbbxxjs56) to the full URL of the job: https://jobs.opensafely.org/migration-related-coding-in-english-primary-care-electronic-health-records/migration-short-data-report/26050/gpgtmbjtbbxxjs56/ shorter URL already existed at https://jobs.opensafely.org/jobs/gpgtmbjtbbxxjs56 but was not well known.