### PR TITLE
Configure `uv` to avoid Python `setup.py` scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,11 @@ extend-ignore = [
 [tool.uv]
 required-version = ">=0.9"
 exclude-newer = "7 days"
+no-build = true
+no-binary-package = [
+    "jobserver",
+    "opensafely-pipeline",
+]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Following lots of supply chain attacks, `npm` is moving to disabling setup scripts by default:

https://github.com/npm/rfcs/pull/868

It's perhaps less obvious, but Python packages that use source distributions may also run arbitrary scripts at install time, in addition to doing the more obvious thing of copying package files to the correct location.

It's also maybe less obvious that this feature can be disabled for `pip`:

https://pip.pypa.io/en/stable/topics/secure-installs/

> Disallow source distributions, by passing `--only-binary :all:`

https://pip.pypa.io/en/stable/cli/pip_download/#cmdoption-only-binary

> Do not use source packages. Can be supplied multiple times, and each
time adds to the existing value. Accepts either “:all:” to disable all source packages, “:none:” to empty the set, or one or more package names with commas between them. Packages without binary distributions will fail to install when this option is used on them.

We're using `uv` which has comparable options, albeit these options have different names:

* `no-build` sets a default of not allowing packages unless they are available as wheels
* `no-binary-package` forbids using binary wheels, and is necessary when packages are not available as wheels

See the `uv` documentation:

* https://docs.astral.sh/uv/reference/settings/#no-build
* https://docs.astral.sh/uv/reference/settings/#no-binary-package

The `no-binary-package` setting included here is necessary to get the application to run.