### PR TITLE
Dependabot ignore Postgres major version update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,3 +66,7 @@ updates:
       timezone: "Europe/London"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "postgres"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Linked to:

- https://github.com/opensafely-core/job-server/pull/5862
- https://github.com/opensafely-core/job-server/pull/5865