### PR TITLE
Remove old t1oo permissions code

### DIFF
--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -13,7 +13,6 @@ from furl import furl
 
 from jobserver import rap_api
 
-from ..permissions.population_permissions import t1oo
 from ..runtime import Runtime
 
 
@@ -484,10 +483,7 @@ class JobRequest(models.Model):
 
     @property
     def database_name(self):
-        if t1oo.project_has_permission(self.workspace.project):
-            return "include_t1oo"
-        else:
-            return "default"
+        return "default"
 
     @property
     def human_readable_status(self):

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -775,20 +775,13 @@ def test_jobrequestmanager_with_started_at():
     assert JobRequest.objects.with_started_at().filter(workspace=workspace).count() == 2
 
 
-def test_jobrequest_database_name_with_no_project_number(build_job_request):
+def test_jobrequest_database_name(build_job_request):
+    # Note: database_name used to pass a different string if the
+    # project had permission to access t1oo; that permission has now moved to
+    # the new permissions system and is passed via the rap_api module, so
+    # the databse_name is now always "default"
     job_request = build_job_request(project_number=None)
     assert job_request.database_name == "default"
-
-
-def test_jobrequest_database_name_without_t1oo_permission(build_job_request):
-    job_request = build_job_request(project_number=1)
-    assert job_request.database_name == "default"
-
-
-def test_jobrequest_database_name_with_t1oo_permission(build_job_request):
-    # This is one of the project numbers hardcoded into `permissions/population_permissions/t1oo.py`
-    job_request = build_job_request(project_number="2")
-    assert job_request.database_name == "include_t1oo"
 
 
 @patch("jobserver.rap_api.create")

--- a/tests/unit/jobserver/test_rap_api.py
+++ b/tests/unit/jobserver/test_rap_api.py
@@ -437,10 +437,6 @@ class TestCreate:
                 "include_gp_unactivated",
             ]
         }
-        # update request body with database name, as this project now has t1oo permission
-        # TODO: Note this is the current method of applying t1oo permission. When we have moved to using
-        # the new permissions via the analysis_scope RAP API, this should be updated.
-        expected_request_body["database_name"] = "include_t1oo"
 
         result = create(job_request)
         assert result == fake_json


### PR DESCRIPTION
t1oo permission now uses the new permissions system, and passes include_t1oo to the RAP API when a job request is created (if that job request's project has permission). We can now remove the old code that passed a different database name to indicate t1oo permission. We still pass the database name, as it's threaded through the RAP controller, but it's now always "default".

Part 3 of https://github.com/opensafely-core/ehrql/issues/2801

(Note: the new code was added in parallel already for backwards compatibility - somewhat redundantly, as no active projects have t1oo permission at the moment. But just to confirm, no currently running or pending job requests have t1oo permission that could be affected by this change)