### PR TITLE
Fix incorrect status showing on Job Request create template

### DIFF
--- a/assets/src/scripts/job_request_create.js
+++ b/assets/src/scripts/job_request_create.js
@@ -28,34 +28,47 @@ async function getStatuses() {
 }
 
 /**
+ * @typedef {"succeeded"|"failed"|"none"|"running"|"pending"|"loading"} StatusState
+ */
+
+/** @type {Record<StatusState, {className: string, label: string}>} */
+const STATUS_STATES = {
+  succeeded: {
+    className: "pill--success",
+    label: "Succeeded",
+  },
+  failed: {
+    className: "pill--failed",
+    label: "Failed",
+  },
+  none: {
+    className: "pill--info",
+    label: "No status",
+  },
+  loading: {
+    className: "pill--info",
+    label: "Loading",
+  },
+};
+
+/**
  * Set the visible icon based on the status returned from the API
  * @param {Element} action - label element for an action
- * @param {("succeeded"|"failed"|"loading")} status - status returned from the API
+ * @param {StatusState|string} status - status returned from the API
  * @returns {void}
  */
 function setIcon(action, status) {
   const parentEl = action.closest(`[data-action]`);
   const pill = parentEl.querySelector("[data-action-status]");
+  const state = STATUS_STATES[status] || STATUS_STATES.loading;
 
-  pill.classList.remove("pill--success", "pill--failed", "pill--info");
-
-  if (status === "succeeded") {
-    pill.classList.add("pill--success");
-    return (pill.textContent = "Succeeded");
-  }
-
-  if (status === "failed") {
-    pill.classList.add("pill--failed");
-    return (pill.textContent = "Failed");
-  }
-
-  if (status === "none") {
-    pill.classList.add("pill--info");
-    return (pill.textContent = "No status");
-  }
-
-  pill.classList.add("pill--info");
-  return (pill.textContent = "Loading");
+  pill.classList.remove(
+    ...[...pill.classList].filter((className) =>
+      className.startsWith("pill--"),
+    ),
+  );
+  pill.classList.add(state.className);
+  pill.textContent = state.label;
 }
 
 async function setActionsStatuses() {

--- a/assets/src/scripts/job_request_create.js
+++ b/assets/src/scripts/job_request_create.js
@@ -62,12 +62,12 @@ const STATUS_STATES = {
 };
 
 /**
- * Set the visible icon based on the status returned from the API
+ * Set the visible status based on the API
  * @param {Element} action - label element for an action
  * @param {StatusState|string} status - status returned from the API
  * @returns {void}
  */
-function setIcon(action, status) {
+function setActionStatus(action, status) {
   const parentEl = action.closest(`[data-action]`);
   const pill = parentEl.querySelector("[data-action-status]");
   const state = STATUS_STATES[status] || STATUS_STATES.loading;
@@ -83,14 +83,14 @@ function setIcon(action, status) {
 
 async function setActionsStatuses() {
   const actions = [...document.querySelectorAll(`[data-action] label`)];
-  actions.map((action) => setIcon(action, "loading"));
+  actions.map((action) => setActionStatus(action, "loading"));
 
   const statuses = await getStatuses();
 
   actions.map((action) => {
     const actionName = action?.textContent?.trim();
     const status = statuses?.[actionName] || "none";
-    return setIcon(action, status);
+    return setActionStatus(action, status);
   });
 }
 

--- a/assets/src/scripts/job_request_create.js
+++ b/assets/src/scripts/job_request_create.js
@@ -70,7 +70,7 @@ const STATUS_STATES = {
 function setActionStatus(action, status) {
   const parentEl = action.closest(`[data-action]`);
   const pill = parentEl.querySelector("[data-action-status]");
-  const state = STATUS_STATES[status] || STATUS_STATES.loading;
+  const state = STATUS_STATES[status] || STATUS_STATES.none;
 
   pill.classList.remove(
     ...[...pill.classList].filter((className) =>

--- a/assets/src/scripts/job_request_create.js
+++ b/assets/src/scripts/job_request_create.js
@@ -28,11 +28,21 @@ async function getStatuses() {
 }
 
 /**
- * @typedef {"succeeded"|"failed"|"none"|"running"|"pending"|"loading"} StatusState
+ * @typedef {"pending"|"running"|"succeeded"|"failed"|"loading"|"none"} StatusState
+ * These are taken from StatusCode which is defined in Job Runner. We add
+ * "loading" and "none" as states the UI may end up in.
  */
 
 /** @type {Record<StatusState, {className: string, label: string}>} */
 const STATUS_STATES = {
+  pending: {
+    className: "pill--pending",
+    label: "Pending",
+  },
+  running: {
+    className: "pill--running",
+    label: "Running",
+  },
   succeeded: {
     className: "pill--success",
     label: "Succeeded",
@@ -41,21 +51,13 @@ const STATUS_STATES = {
     className: "pill--failed",
     label: "Failed",
   },
-  none: {
-    className: "pill--info",
-    label: "No status",
-  },
-  running: {
-    className: "pill--running",
-    label: "Running",
-  },
-  pending: {
-    className: "pill--pending",
-    label: "Pending",
-  },
   loading: {
     className: "pill--info",
     label: "Loading",
+  },
+  none: {
+    className: "pill--info",
+    label: "No status",
   },
 };
 

--- a/assets/src/scripts/job_request_create.js
+++ b/assets/src/scripts/job_request_create.js
@@ -45,6 +45,14 @@ const STATUS_STATES = {
     className: "pill--info",
     label: "No status",
   },
+  running: {
+    className: "pill--running",
+    label: "Running",
+  },
+  pending: {
+    className: "pill--pending",
+    label: "Pending",
+  },
   loading: {
     className: "pill--info",
     label: "Loading",


### PR DESCRIPTION
Running and pending states were not accurately reflected on the page.

This PR also simplifies the code for updating the pill class and text content.