### PR TITLE
Return to `update-dependencies-action` for Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,27 +26,6 @@ updates:
     cooldown:
       default-days: 7
 
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
-      timezone: "Europe/London"
-    cooldown:
-      default-days: 7
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
-    allow:
-      - dependency-type: "all"
-    ignore:
-      - dependency-name: "django"
-        versions: [">=6.0.0"]
-      - dependency-name: "jobserver"
-
   - package-ecosystem: "docker"
     directory: "docker"
     schedule:

--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -1,0 +1,34 @@
+name: Update Python dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  "16 7 * * MON"
+
+permissions:
+  contents: read
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
+      with:
+        install-just: true
+        install-uv: true
+        cache: uv
+
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      id: generate-token
+      with:
+        app-id: 1031449  # opensafely-core Create PR app
+        private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+
+    - uses: bennettoxford/update-dependencies-action@b77a22bcfe1d06020d908e64c9828fe944da3a5e
+      id: update
+      with:
+        token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -20,7 +20,6 @@ jobs:
       with:
         install-just: true
         install-uv: true
-        cache: uv
 
     - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: generate-token

--- a/.github/workflows/uvmirror-check.yml
+++ b/.github/workflows/uvmirror-check.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           install-just: true
           install-uv: true
-          cache: uv
 
       - name: Ensure requirements.uvmirror.txt is consistent with uv.lock
         run: just uvmirror && git diff -s --exit-code

--- a/.github/workflows/uvmirror-check.yml
+++ b/.github/workflows/uvmirror-check.yml
@@ -1,0 +1,27 @@
+---
+name: Check uvmirror
+
+permissions:
+  contents: read
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  check-uvmirror:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
+        with:
+          install-just: true
+          install-uv: true
+          cache: uv
+
+      - name: Ensure requirements.uvmirror.txt is consistent with uv.lock
+        run: just uvmirror && git diff -s --exit-code

--- a/justfile
+++ b/justfile
@@ -74,7 +74,8 @@ install-precommit:
 upgrade-package package: && devenv
     uv lock --upgrade-package {{ package }}
 
-# The upgrade-all recipe is used for doing lockfileMaintenance via update-dependencies action, until min release age is respected fo uv
+# The upgrade-all recipe is used for doing lockfile
+# maintenance via update-dependencies action, until min release age is respected for uv.
 # Note that we run devenv with && to remove the timestamp written into the uv.lock file
 
 # upgrade all dependencies with specified cooldown

--- a/justfile
+++ b/justfile
@@ -74,12 +74,22 @@ install-precommit:
 upgrade-package package: && devenv
     uv lock --upgrade-package {{ package }}
 
+# The upgrade-all recipe is used for doing lockfileMaintenance via update-dependencies action, until min release age is respected fo uv
+# Note that we run devenv with && to remove the timestamp written into the uv.lock file
+
+# upgrade all dependencies with specified cooldown
+upgrade-all cooldown="7 days ago": && devenv
+    uv lock --upgrade --exclude-newer "{{ cooldown }}"
+
+# update the companion requirements formatted file
+uvmirror file="requirements.uvmirror":
+    rm -f {{ file }}
+    uv export --format requirements-txt --frozen --no-hashes --all-groups --all-extras > {{ file }}
 
 # Upgrade all packages to the latest version per pyproject.toml, then
 # update the local venv. NOTE: This does not upgrade the opensafely-pipeline;
 # to upgrade, run the upgrade-pipeline recipe
-update-dependencies: devenv
-    uv lock --upgrade
+update-dependencies: upgrade-all && uvmirror
 
 # upgrade our internal pipeline library
 upgrade-pipeline: && prodenv


### PR DESCRIPTION
Fixes #5812.

These changes see a return to using the `update-dependencies-action` for Python, with some slight changes. These are based on the current workflows in Airlock and job-runner.[^1]

This PR:

* Adds the `update-python-dependencies` workflow to run on schedule on Mondays, or manually.
* Uses `uv` but only adds `exclude-newer` at the command-line with `just upgrade-all`, instead of in `pyproject.toml`
  * *This should fix one of the previous issues with Dependabot security PRs, where Dependabot could not apply updates due to the enforced `exclude-newer`.*
* Adds a `just uvmirror` recipe that gets run on dependency update (which you'll also need to run if you change dependencies)…
  * …which updates the `requirements.uvmirror` file that can be used to review the changes more easily than `uv.lock`
  * *This cleaner diff was another thing missing from the previous use of `update-dependencies-action`.*
* Enables transitive dependency updates, *also missing with Dependabot*.

This PR **does not**:

* Add a workflow to update `requirements.uvmirror`
  * This would help with Dependabot security update PRs which will fail CI, and need intervention to fix them in a process like:
    1. Check out the Dependabot branch
    1. Run `just uvmirror`
    1. `git add requirements.uvmirror && git commit -m "Update requirements.uvmirror" && git push origin HEAD`
    1. Approve and merge the PR.
  * I think [something like in Airlock might work via workflow dispatch](https://github.com/opensafely-core/airlock/blob/1e29a5be23db7e8c8b693e369ac7214e03be8434/.github/workflows/uvmirror-update.yml). That's if we're happy with the current changes as deployed, *and* if we deem a workflow necessary.

This PR was used to generate the update in #5885 (now merged).

[^1]: See also [the discussion](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1779366369543479) where Becky gave me a better understanding of the current way that RAP update their dependencies with this action.