### PR TITLE
Basic job that acts as a skeleton for dump scrubbed db job

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,6 +28,8 @@ dokku config:set job-server SOCIAL_AUTH_GITHUB_KEY='xxx'
 dokku config:set job-server SOCIAL_AUTH_GITHUB_SECRET='xxx'
 dokku config:set job-server RAP_API_TOKEN='xxx'
 dokku config:set job-server RAP_API_BASE_URL=https://controller.opensafely.org/controller/v1/
+dokku config:set job-server JOBSERVER_READONLY_DATABASE_URL='xxxx'
+dokku config:set job-server JOBSERVER_SCRUBBED_DATABASE_URL='xxxx'
 
 # Disable zero-downtime deploys for the rapstatus process (which runs the rap_status_service
 # manangement command). We don't ever want two of these loops running simultaneously

--- a/app.json
+++ b/app.json
@@ -19,6 +19,10 @@
     {
       "command": "python manage.py runjobs monthly",
       "schedule": "@monthly"
+    },
+    {
+      "command": "python manage.py runjobs yearly",
+      "schedule": "0 15 10 6 *"
     }
   ],
   "healthchecks": {

--- a/app.json
+++ b/app.json
@@ -22,7 +22,7 @@
     },
     {
       "command": "python manage.py runjobs yearly",
-      "schedule": "0 15 10 6 *"
+      "schedule": "0 17 10 6 *"
     }
   ],
   "healthchecks": {

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,6 +1,8 @@
 # Note: this assumes docker dev db. You will need to change it if you want to
 # point another postgres
 DATABASE_URL=postgres://user:pass@localhost:6543/jobserver
+JOBSERVER_READONLY_DATABASE_URL=postgres://user:pass@localhost:6543/jobserver
+JOBSERVER_SCRUBBED_DATABASE_URL=postgres://user:pass@localhost:6543/jobserver
 
 # Turn on debug
 DEBUG=1

--- a/jobserver/jobs/yearly/dump_scrubbed_db.py
+++ b/jobserver/jobs/yearly/dump_scrubbed_db.py
@@ -1,0 +1,25 @@
+from urllib.parse import urlparse
+
+import structlog
+from django.conf import settings
+from django_extensions.management.jobs import YearlyJob
+
+
+logger = structlog.get_logger(__name__)
+
+
+class Job(YearlyJob):
+    help = "Scrubbed database dump job (in progress)"
+
+    def execute(self):
+        readonly_db_url = urlparse(settings.JOBSERVER_READONLY_DATABASE_URL)
+        scrubbed_db_url = urlparse(settings.JOBSERVER_SCRUBBED_DATABASE_URL)
+        logger.info("Scrubbed database dump job")
+        logger.info(
+            "Database path for readonly JobServer database",
+            database_path=readonly_db_url.path,
+        )
+        logger.info(
+            "Database path for scrubbed JobServer database",
+            database_path=scrubbed_db_url.path,
+        )

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -278,6 +278,12 @@ SOCIAL_AUTH_GITHUB_SECRET = get_env_var("SOCIAL_AUTH_GITHUB_SECRET")
 SOCIAL_AUTH_GITHUB_SCOPE = ["user:email"]
 RAP_API_BASE_URL = os.environ.get("RAP_API_BASE_URL", default="")
 RAP_API_TOKEN = os.environ.get("RAP_API_TOKEN", default="")
+JOBSERVER_READONLY_DATABASE_URL = os.environ.get(
+    "JOBSERVER_READONLY_DATABASE_URL", default=""
+)
+JOBSERVER_SCRUBBED_DATABASE_URL = os.environ.get(
+    "JOBSERVER_SCRUBBED_DATABASE_URL", default=""
+)
 
 
 # Passwords


### PR DESCRIPTION
Addresses https://github.com/opensafely-core/security/issues/52

- Instead of a daily job, created a yearly job so that it is easier to test it on dokku and it won't be triggered daily. After the job is created completely with sanitisation logic, we can shift it to a daily job.
- Created env variables for readonly jobserver database and jobserver_data_scrubbing database.
- Set the yearly job in app.json.

#### Note:
Need to create variables `JOBSERVER_READONLY_DATABASE_URL` and `JOBSERVER_SCRUBBED_DATABASE_URL` in dokku before merging this PR. I haven't created them now because I wanted a review of the names I have used.

#### Testing:
To test this locally:
1. Recreate `.env` from the updated `dotenv-sample` 
2. run the job `just manage runjob dump_scrubbed_db`