### PR TITLE
Add just command and documentation for scrubbing local Job Server data

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -177,9 +177,10 @@ After restoring a production database dump locally, run the data scrubbing comma
 just scrub-data
 ```
 
-This command removes or replaces sensitive data.
+This command removes or replaces sensitive data in your local database.
 
-Once the dump has been restored and scrubbed, the original downloaded dump file should be deleted, if present. This helps minimise the amount of raw production data stored outside production systems.
+As part of the scrubbing process, the local `jobserver.dump` file is automatically deleted. This helps minimise the amount of raw production data stored outside production system.
+If you have any additional copies of `jobserver.dump`, they should be deleted once they are no longer needed.
 
 
 #### Steps

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -179,7 +179,7 @@ just scrub-data
 
 This command removes or replaces sensitive data.
 
-Once the dump has been restored and scrubbed, the original downloaded dump file should be deleted. This helps minimise the amount of raw production data stored outside production systems.
+Once the dump has been restored and scrubbed, the original downloaded dump file should be deleted, if present. This helps minimise the amount of raw production data stored outside production systems.
 
 
 #### Steps

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -10,6 +10,7 @@
       - [Installing on Linux](#installing-on-linux)
       - [Creating a database](#creating-a-database)
     - [Restoring Backups](#restoring-backups)
+    - [Scrubbing jobserver database](#scrubbing-jobserver-database)
     - [Steps](#steps)
   - [Docker Compose](#docker-compose)
   - [Frontend development (CSS/JS)](#frontend-development-cssjs)
@@ -167,6 +168,18 @@ Note: `pg_restore` will throw errors in various scenarios, which can often be ig
 The important line to check for (typically at the very end) is `errors ignored on restore: N`.
 Where `N` should match the number of errors you got.
 
+
+#### Scrubbing jobserver database
+
+After restoring a production database dump locally, run the data scrubbing command before using the database for development or debugging:
+
+```bash
+just scrub-data
+```
+
+This command removes or replaces sensitive data.
+
+Once the dump has been restored and scrubbed, the original downloaded dump file should be deleted. This helps minimise the amount of raw production data stored outside production systems.
 
 
 #### Steps

--- a/justfile
+++ b/justfile
@@ -97,6 +97,7 @@ manage command *args:
 # scrub sensitive data from the database
 scrub-data: devenv
     $BIN/python manage.py scrub_data
+    rm -f jobserver.dump
 
 test-ci *args: assets
     #!/bin/bash

--- a/justfile
+++ b/justfile
@@ -94,6 +94,10 @@ run-telemetry: devenv
 manage command *args:
     $BIN/python manage.py {{command}} {{args}}
 
+# scrub sensitive data from the database
+scrub-data: devenv
+    $BIN/python manage.py scrub_data
+
 test-ci *args: assets
     #!/bin/bash
     export COVERAGE_PROCESS_START="pyproject.toml"


### PR DESCRIPTION
https://github.com/opensafely-core/security/issues/55

Related to the 3rd point in the ticket:

> Ask/automatically developers to run the latest version of that management command whenever they download the production dump. Maybe we can modify the just command so that it does this? Ask developers to delete after loading locally and delete that and any old copies. (Later scrubbing won't need to happen locally as it will be applied at source, but we can reduce the data lying outside production earlier this way, and we may still want to auto-delete the downloaded dump.)

Adding just command and doc before asking developers to use this command