### PR TITLE
Pin `pytest-socket` to v0.7.0 temporarily

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,7 +267,8 @@ dev = [
     "pytest-icdiff",
     "pytest-mock",
     "pytest-playwright",
-    "pytest-socket",
+    # Pin temporarily due to failures with v0.8.0.
+    "pytest-socket==0.7.0",
     "pytest-xdist[psutil]",
     "responses",
     "ruff",

--- a/uv.lock
+++ b/uv.lock
@@ -899,7 +899,7 @@ dev = [
     { name = "pytest-icdiff" },
     { name = "pytest-mock" },
     { name = "pytest-playwright" },
-    { name = "pytest-socket" },
+    { name = "pytest-socket", specifier = "==0.7.0" },
     { name = "pytest-xdist", extras = ["psutil"] },
     { name = "responses" },
     { name = "ruff" },


### PR DESCRIPTION
There's a new version for which nearly all our tests fails, due to database access.

`pytest-socket` changed to block DNS resolution in v0.8.0:

https://github.com/miketheman/pytest-socket/releases/tag/0.8.0

The fix is probably to change the options to be:

```
--disable-socket --allow-hosts=localhost
```

but that probably needs confirming (as to what the goal of using `pytest-socket` is), so for now it's easier to pin the known good version, until we decide that.