### PR TITLE
Make Run Jobs visible for DeploymentAdministrator

### DIFF
--- a/jobserver/models/workspace.py
+++ b/jobserver/models/workspace.py
@@ -6,6 +6,9 @@ from django.urls import reverse
 from django.utils import timezone
 from furl import furl
 
+from ..authorization import has_permission
+from ..authorization.permissions import Permission
+
 
 logger = structlog.get_logger(__name__)
 
@@ -145,6 +148,18 @@ class Workspace(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_run_jobs_disabled_reason(self, user):
+        if self.is_archived:
+            return "Jobs cannot be run on an archived workspace"
+
+        if not has_permission(user, Permission.JOB_RUN, project=self.project):
+            return "You do not have permission to run jobs on this workspace"
+
+        if not user.backends.exists():
+            return "You do not have permission to run jobs on any OpenSAFELY backends"
+
+        return None
 
     def get_absolute_url(self):
         return reverse(

--- a/jobserver/views/workspaces.py
+++ b/jobserver/views/workspaces.py
@@ -208,6 +208,8 @@ class WorkspaceDetail(View):
 
         outputs = self.get_output_permissions(workspace)
 
+        run_jobs_disabled_reason = workspace.get_run_jobs_disabled_reason(request.user)
+
         context = {
             "first_job": first_job,
             "honeycomb_can_view_links": honeycomb_can_view_links,
@@ -215,8 +217,10 @@ class WorkspaceDetail(View):
             "is_member": is_member,
             "outputs": outputs,
             "repo_is_private": repo_is_private,
+            "run_jobs_disabled_reason": run_jobs_disabled_reason,
             "show_admin": show_admin,
             "show_publish_repo_warning": show_publish_repo_warning,
+            "show_run_jobs_button": is_member or can_run_jobs,
             "user_can_archive_workspace": can_archive_workspace,
             "user_can_run_jobs": can_run_jobs,
             "user_can_toggle_notifications": can_toggle_notifications,

--- a/templates/workspace/detail.html
+++ b/templates/workspace/detail.html
@@ -81,32 +81,30 @@
     </div>
 
     <ul class="flex flex-row gap-2">
-      {% if is_member %}
-        {% if workspace.is_archived %}
-          <li>
-            {% #button type="button" variant="info" disabled=True tooltip="Jobs cannot be run on an archived workspace" %}
-              Run jobs
-            {% /button %}
-          </li>
-        {% elif not user_can_run_jobs %}
-          <li>
-            {% #button type="button" variant="info" disabled=True tooltip="You do not have permission to run jobs on this workspace" %}
-              Run jobs
-            {% /button %}
-          </li>
-        {% elif not user_has_backends %}
-          <li>
-            {% #button type="button" variant="info" disabled=True tooltip="You do not have permission to run jobs on any OpenSAFELY backends" %}
-              Run jobs
-            {% /button %}
-          </li>
-        {% else %}
-          <li>
-            {% #button class="plausible-event-name=Run+jobs+click" href=workspace.get_jobs_url type="link" variant="success" %}
-              Run jobs
-            {% /button %}
-          </li>
-        {% endif %}
+      {% if user_can_run_jobs and workspace.is_archived %}
+        <li>
+          {% #button type="button" variant="info" disabled=True tooltip="Jobs cannot be run on an archived workspace" %}
+            Run jobs
+          {% /button %}
+        </li>
+      {% elif is_member and not user_can_run_jobs %}
+        <li>
+          {% #button type="button" variant="info" disabled=True tooltip="You do not have permission to run jobs on this workspace" %}
+            Run jobs
+          {% /button %}
+        </li>
+      {% elif is_member and not user_has_backends %}
+        <li>
+          {% #button type="button" variant="info" disabled=True tooltip="You do not have permission to run jobs on any OpenSAFELY backends" %}
+            Run jobs
+          {% /button %}
+        </li>
+      {% elif user_can_run_jobs %}
+        <li>
+          {% #button class="plausible-event-name=Run+jobs+click" href=workspace.get_jobs_url type="link" variant="success" %}
+            Run jobs
+          {% /button %}
+        </li>
       {% endif %}
       <li>
         {% #button href=workspace.get_logs_url type="link" variant="primary" %}

--- a/templates/workspace/detail.html
+++ b/templates/workspace/detail.html
@@ -81,29 +81,17 @@
     </div>
 
     <ul class="flex flex-row gap-2">
-      {% if user_can_run_jobs and workspace.is_archived %}
+      {% if show_run_jobs_button %}
         <li>
-          {% #button type="button" variant="info" disabled=True tooltip="Jobs cannot be run on an archived workspace" %}
-            Run jobs
-          {% /button %}
-        </li>
-      {% elif is_member and not user_can_run_jobs %}
-        <li>
-          {% #button type="button" variant="info" disabled=True tooltip="You do not have permission to run jobs on this workspace" %}
-            Run jobs
-          {% /button %}
-        </li>
-      {% elif is_member and not user_has_backends %}
-        <li>
-          {% #button type="button" variant="info" disabled=True tooltip="You do not have permission to run jobs on any OpenSAFELY backends" %}
-            Run jobs
-          {% /button %}
-        </li>
-      {% elif user_can_run_jobs %}
-        <li>
-          {% #button class="plausible-event-name=Run+jobs+click" href=workspace.get_jobs_url type="link" variant="success" %}
-            Run jobs
-          {% /button %}
+          {% if run_jobs_disabled_reason %}
+            {% #button type="button" variant="info" disabled=True tooltip=run_jobs_disabled_reason %}
+              Run jobs
+            {% /button %}
+          {% else %}
+            {% #button class="plausible-event-name=Run+jobs+click" href=workspace.get_jobs_url type="link" variant="success" %}
+              Run jobs
+            {% /button %}
+          {% endif %}
         </li>
       {% endif %}
       <li>

--- a/tests/unit/jobserver/models/test_workspace.py
+++ b/tests/unit/jobserver/models/test_workspace.py
@@ -1,12 +1,15 @@
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError
 from django.urls import reverse
 from django.utils import timezone
 
+from jobserver.authorization.permissions import Permission
 from jobserver.models import Workspace
 
 from ....factories import (
     BackendFactory,
+    BackendMembershipFactory,
     JobFactory,
     JobRequestFactory,
     ProjectFactory,
@@ -120,6 +123,84 @@ def test_workspace_get_jobs_url():
             "project_slug": workspace.project.slug,
             "workspace_slug": workspace.name,
         },
+    )
+
+
+def test_workspace_get_reason_can_run_jobs(project_membership, role_factory):
+    workspace = WorkspaceFactory()
+    user = UserFactory()
+    backend = BackendFactory()
+
+    project_membership(
+        project=workspace.project,
+        user=user,
+        roles=[role_factory(permission=Permission.JOB_RUN)],
+    )
+    BackendMembershipFactory(backend=backend, user=user)
+
+    assert workspace.get_run_jobs_disabled_reason(user) is None
+
+
+def test_workspace_get_reason_can_run_jobs_global_permission(
+    user_with_fake_role_factory,
+):
+    workspace = WorkspaceFactory()
+    user = user_with_fake_role_factory(permission=Permission.JOB_RUN)
+    backend = BackendFactory()
+
+    BackendMembershipFactory(backend=backend, user=user)
+
+    assert workspace.get_run_jobs_disabled_reason(user) is None
+
+
+def test_workspace_get_run_jobs_disabled_reason_archived():
+    workspace = WorkspaceFactory(is_archived=True)
+    user = UserFactory()
+
+    assert (
+        workspace.get_run_jobs_disabled_reason(user)
+        == "Jobs cannot be run on an archived workspace"
+    )
+
+
+def test_workspace_get_run_jobs_disabled_reason_without_project_permission():
+    workspace = WorkspaceFactory()
+    user = UserFactory()
+    backend = BackendFactory()
+
+    BackendMembershipFactory(backend=backend, user=user)
+
+    assert (
+        workspace.get_run_jobs_disabled_reason(user)
+        == "You do not have permission to run jobs on this workspace"
+    )
+
+
+def test_workspace_get_run_jobs_disabled_reason_without_backend_access(
+    project_membership, role_factory
+):
+    workspace = WorkspaceFactory()
+    user = UserFactory()
+
+    project_membership(
+        project=workspace.project,
+        user=user,
+        roles=[role_factory(permission=Permission.JOB_RUN)],
+    )
+
+    assert (
+        workspace.get_run_jobs_disabled_reason(user)
+        == "You do not have permission to run jobs on any OpenSAFELY backends"
+    )
+
+
+def test_workspace_get_run_jobs_disabled_reason_anonymous_user():
+    workspace = WorkspaceFactory()
+    user = AnonymousUser()
+
+    assert (
+        workspace.get_run_jobs_disabled_reason(user)
+        == "You do not have permission to run jobs on this workspace"
     )
 
 

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -1,3 +1,4 @@
+import re
 import zipfile
 from datetime import timedelta
 
@@ -10,7 +11,6 @@ from django.utils import timezone
 
 from jobserver.authorization import StaffAreaAdministrator
 from jobserver.authorization.permissions import Permission
-from jobserver.authorization.roles import DeploymentAdministrator
 from jobserver.models import PublishRequest, Workspace
 from jobserver.views.workspaces import (
     WorkspaceArchiveToggle,
@@ -435,32 +435,6 @@ def test_workspacedetail_authorized_run_jobs(rf, project_membership, role_factor
     assert response.context_data["user_has_backends"]
 
 
-def test_workspacedetail_deployment_administrator_run_jobs(
-    rf, project_membership, role_factory
-):
-    workspace = WorkspaceFactory()
-    user = UserFactory(roles=[DeploymentAdministrator])
-    backend = BackendFactory()
-
-    BackendMembershipFactory(backend=backend, user=user)
-
-    request = rf.get("/")
-    request.user = user
-
-    response = WorkspaceDetail.as_view(get_github_api=FakeGitHubAPI)(
-        request,
-        project_slug=workspace.project.slug,
-        workspace_slug=workspace.name,
-    )
-
-    assert response.status_code == 200
-    assert response.context_data["user_can_run_jobs"]
-    assert response.context_data["user_has_backends"]
-
-    response.render()
-    assert b"Run jobs" in response.content
-
-
 def test_workspacedetail_authorized_run_jobs_no_backends(
     rf, project_membership, role_factory
 ):
@@ -485,6 +459,68 @@ def test_workspacedetail_authorized_run_jobs_no_backends(
     assert response.status_code == 200
     assert response.context_data["user_can_run_jobs"]
     assert not response.context_data["user_has_backends"]
+
+
+def test_workspacedetail_run_jobs_button_disabled(
+    rf, mocker, project_membership, role_factory
+):
+    workspace = WorkspaceFactory()
+    user = UserFactory()
+    backend = BackendFactory()
+    reason = "Jobs cannot be run on an archived workspace"
+    get_run_jobs_disabled_reason = mocker.patch.object(
+        Workspace,
+        "get_run_jobs_disabled_reason",
+        autospec=True,
+        return_value=reason,
+    )
+
+    project_membership(
+        project=workspace.project,
+        user=user,
+        roles=[role_factory(permission=Permission.JOB_RUN)],
+    )
+    BackendMembershipFactory(backend=backend, user=user)
+
+    request = rf.get("/")
+    request.user = user
+
+    response = WorkspaceDetail.as_view(get_github_api=FakeGitHubAPI)(
+        request,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+    assert response.context_data["run_jobs_disabled_reason"] == reason
+    get_run_jobs_disabled_reason.assert_called_once_with(workspace, user)
+
+    assert re.search(
+        r"<button\b(?=[^>]*\bdisabled\b)[^>]*>\s*Run jobs",
+        response.rendered_content,
+    )
+    assert workspace.get_jobs_url() not in response.rendered_content
+    assert reason in response.rendered_content
+
+
+def test_workspacedetail_run_jobs_button_hidden(rf, mocker):
+    workspace = WorkspaceFactory()
+    user = UserFactory()
+
+    request = rf.get("/")
+    request.user = user
+
+    response = WorkspaceDetail.as_view(get_github_api=FakeGitHubAPI)(
+        request,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+    assert not response.context_data["show_run_jobs_button"]
+
+    assert "Run jobs" not in response.rendered_content
+    assert workspace.get_jobs_url() not in response.rendered_content
 
 
 def test_workspacedetail_authorized_honeycomb(rf):

--- a/tests/unit/jobserver/views/test_workspaces.py
+++ b/tests/unit/jobserver/views/test_workspaces.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 
 from jobserver.authorization import StaffAreaAdministrator
 from jobserver.authorization.permissions import Permission
+from jobserver.authorization.roles import DeploymentAdministrator
 from jobserver.models import PublishRequest, Workspace
 from jobserver.views.workspaces import (
     WorkspaceArchiveToggle,
@@ -432,6 +433,32 @@ def test_workspacedetail_authorized_run_jobs(rf, project_membership, role_factor
     assert response.status_code == 200
     assert response.context_data["user_can_run_jobs"]
     assert response.context_data["user_has_backends"]
+
+
+def test_workspacedetail_deployment_administrator_run_jobs(
+    rf, project_membership, role_factory
+):
+    workspace = WorkspaceFactory()
+    user = UserFactory(roles=[DeploymentAdministrator])
+    backend = BackendFactory()
+
+    BackendMembershipFactory(backend=backend, user=user)
+
+    request = rf.get("/")
+    request.user = user
+
+    response = WorkspaceDetail.as_view(get_github_api=FakeGitHubAPI)(
+        request,
+        project_slug=workspace.project.slug,
+        workspace_slug=workspace.name,
+    )
+
+    assert response.status_code == 200
+    assert response.context_data["user_can_run_jobs"]
+    assert response.context_data["user_has_backends"]
+
+    response.render()
+    assert b"Run jobs" in response.content
 
 
 def test_workspacedetail_authorized_run_jobs_no_backends(


### PR DESCRIPTION
As they might not be a member of a project.

This includes a refactor for the nasty if/else statement moving that logic to the view, and adding tests around the existing behaviour.

Closes https://github.com/opensafely-core/job-server/issues/5892