### PR TITLE
Add ruff lint rule to ban direct settings imports

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -6,13 +6,8 @@ import structlog
 from django.conf import settings
 from furl import furl
 
-from jobserver.settings import get_env_var
-
 
 logger = structlog.getLogger(__name__)
-
-
-JOBSERVER_GITHUB_TOKEN = get_env_var("JOBSERVER_GITHUB_TOKEN")
 
 
 session = requests.Session()
@@ -657,4 +652,6 @@ class GitHubAPI:
 
 def _get_github_api():
     """Simple invocation wrapper of GitHubAPI"""
-    return GitHubAPI(_session=session, token=JOBSERVER_GITHUB_TOKEN)  # pragma: no cover
+    return GitHubAPI(
+        _session=session, token=settings.JOBSERVER_GITHUB_TOKEN
+    )  # pragma: no cover

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -508,3 +508,9 @@ UNIVERSITY_OF_BRISTOL_ORG_PK = 9
 # How long in seconds to wait between calls to the RAP API status endpoint to
 # fetch job updates
 RAP_API_POLL_INTERVAL = int(os.environ.get("RAP_API_POLL_INTERVAL", default=60))
+
+# GitHub token for interactions with the GitHub API.
+# See jobserver/github.py for how this is used.
+# See DEVELOPERS.md and TESTING.md for information on how it is used in
+# production, CI, and developer environments.
+JOBSERVER_GITHUB_TOKEN = os.environ.get("JOBSERVER_GITHUB_TOKEN", default=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,7 @@ extend-select = [
   "ISC",  # flake8-implicit-str-concat
   "UP",  # pyupgrade
   "W",  # pycodestyle warning
+  "TID251", # banned imports
 ]
 extend-ignore = [
   "A005", # ignore stdlib-module-shadowing. Would need to re-name services.logging.
@@ -246,6 +247,9 @@ extend-ignore = [
 "gunicorn.conf.py" = ["INP001"]
 "manage.py" = ["INP001"]
 "sitecustomize.py" = ["INP001"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"jobserver.settings".msg = "Use 'from django.conf import settings' instead"
 
 # Note: any `exclude-newer-package` timestamps should be removed if > 7 days old.
 # See https://github.com/opensafely-core/repo-template/blob/main/DEVELOPERS.md for details.


### PR DESCRIPTION
Inspired by https://github.com/opensafely-core/opencodelists/pull/3109

Settings should not be imported from the module where they are set but via the
Django settings object in the `django.conf` module:

https://docs.djangoproject.com/en/6.0/topics/settings/#using-settings-in-python-code

> In your Django apps, use settings by importing the object django.conf.settings.
> Note that django.conf.settings isn’t a module – it’s an object. So importing
> individual settings is not possible.
> Also note that your code should not import from either global_settings or your
> own settings file. django.conf.settings abstracts the concepts of default
> settings and site-specific settings; it presents a single interface. It also
> decouples the code that uses settings from the location of your settings.

So let's have a ruff linter rule to enforce this.

First commit fixes the one violation in our codebase first by moving a settings-like variable to settings to avoid importing related utility code.