### PR TITLE
Add `database` option to data scrubbing management command

### DIFF
--- a/data_scrubbing/management/commands/scrub_data.py
+++ b/data_scrubbing/management/commands/scrub_data.py
@@ -12,10 +12,18 @@ class Command(BaseCommand):
 
     help = "Scrub sensitive data from selected fields"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "database_alias",
+            help="Alias of database to scrub, should be in Django setting DATABASES",
+        )
+
     def handle(self, *args, **kwargs):
+        database_alias = kwargs["database_alias"]
+
         models = {model for model in apps.get_app_config("jobserver").get_models()}
         models |= {model for model in apps.get_app_config("applications").get_models()}
-        with transaction.atomic():
+        with transaction.atomic(using=database_alias):
             for model in models:
                 data_scrubbing = getattr(model, "DataScrubbing", None)
                 if data_scrubbing is None:
@@ -25,13 +33,13 @@ class Command(BaseCommand):
                     continue
                 field_names = scrub_fields.keys()
 
-                objs = model.objects.all().iterator()
+                objs = model.objects.using(database_alias).all().iterator()
                 count = 0
                 for obj in objs:
                     for attr_name, fake_value in scrub_fields.items():
                         value = fake_value() if callable(fake_value) else fake_value
                         setattr(obj, attr_name, value)
-                    obj.save(update_fields=field_names)
+                    obj.save(using=database_alias, update_fields=field_names)
                     count += 1
 
                 self.stdout.write(

--- a/data_scrubbing/management/commands/scrub_data.py
+++ b/data_scrubbing/management/commands/scrub_data.py
@@ -1,4 +1,5 @@
 from django.apps import apps
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from faker import Faker
@@ -13,9 +14,10 @@ class Command(BaseCommand):
     help = "Scrub sensitive data from selected fields"
 
     def add_arguments(self, parser):
+        options = list(settings.DATABASES.keys())
         parser.add_argument(
             "database_alias",
-            help="Alias of database to scrub, should be in Django setting DATABASES",
+            help=f"Alias of database to scrub, options: {options}",
         )
 
     def handle(self, *args, **kwargs):

--- a/data_scrubbing/management/commands/scrub_data.py
+++ b/data_scrubbing/management/commands/scrub_data.py
@@ -22,15 +22,17 @@ class Command(BaseCommand):
             scrub_fields = getattr(data_scrubbing, "fields_to_scrub", None)
             if not scrub_fields:
                 continue
+            field_names = scrub_fields.keys()
 
-            objs = list(model.objects.all())
+            objs = model.objects.all().iterator()
+            count = 0
             for obj in objs:
                 for attr_name, fake_value in scrub_fields.items():
                     value = fake_value() if callable(fake_value) else fake_value
                     setattr(obj, attr_name, value)
+                obj.save(update_fields=field_names)
+                count += 1
 
-            field_names = scrub_fields.keys()
-            model.objects.bulk_update(objs, field_names)
             self.stdout.write(
-                f"Scrubbed {len(objs)} {model.__name__} records from fields: {', '.join(field_names)}"
+                f"Scrubbed {count} {model.__name__} records from fields: {', '.join(field_names)}"
             )

--- a/data_scrubbing/management/commands/scrub_data.py
+++ b/data_scrubbing/management/commands/scrub_data.py
@@ -1,5 +1,6 @@
 from django.apps import apps
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from faker import Faker
 
 
@@ -14,25 +15,26 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         models = {model for model in apps.get_app_config("jobserver").get_models()}
         models |= {model for model in apps.get_app_config("applications").get_models()}
+        with transaction.atomic():
+            for model in models:
+                data_scrubbing = getattr(model, "DataScrubbing", None)
+                if data_scrubbing is None:
+                    continue
+                scrub_fields = getattr(data_scrubbing, "fields_to_scrub", None)
+                if not scrub_fields:
+                    continue
+                field_names = scrub_fields.keys()
 
-        for model in models:
-            data_scrubbing = getattr(model, "DataScrubbing", None)
-            if data_scrubbing is None:
-                continue
-            scrub_fields = getattr(data_scrubbing, "fields_to_scrub", None)
-            if not scrub_fields:
-                continue
-            field_names = scrub_fields.keys()
+                objs = model.objects.all().iterator()
+                count = 0
+                for obj in objs:
+                    for attr_name, fake_value in scrub_fields.items():
+                        value = fake_value() if callable(fake_value) else fake_value
+                        setattr(obj, attr_name, value)
+                    obj.save(update_fields=field_names)
+                    count += 1
 
-            objs = model.objects.all().iterator()
-            count = 0
-            for obj in objs:
-                for attr_name, fake_value in scrub_fields.items():
-                    value = fake_value() if callable(fake_value) else fake_value
-                    setattr(obj, attr_name, value)
-                obj.save(update_fields=field_names)
-                count += 1
-
-            self.stdout.write(
-                f"Scrubbed {count} {model.__name__} records from fields: {', '.join(field_names)}"
-            )
+                self.stdout.write(
+                    f"Scrubbed {count} {model.__name__} records from fields: {', '.join(field_names)}"
+                )
+        self.stdout.write("Committed scrubbing transaction")

--- a/data_scrubbing/management/commands/scrub_data.py
+++ b/data_scrubbing/management/commands/scrub_data.py
@@ -1,6 +1,6 @@
 from django.apps import apps
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from faker import Faker
 
@@ -19,9 +19,17 @@ class Command(BaseCommand):
             "database_alias",
             help=f"Alias of database to scrub, options: {options}",
         )
+        parser.add_argument(
+            "--i-am-sure",
+            action="store_true",
+            dest="i_am_sure",
+            help="Must be set to scrub the default database",
+        )
 
     def handle(self, *args, **kwargs):
         database_alias = kwargs["database_alias"]
+        if database_alias == "default" and not kwargs["i_am_sure"]:
+            raise CommandError("Use --i-am-sure flag to run against default database")
 
         models = {model for model in apps.get_app_config("jobserver").get_models()}
         models |= {model for model in apps.get_app_config("applications").get_models()}

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -169,6 +169,10 @@ DATABASES = {
         os.environ.get("DATABASE_URL", default="sqlite:///db.sqlite3")
     ),
 }
+DATA_SCRUBBING_DATABASE_URL = os.environ.get("JOBSERVER_SCRUBBED_DATABASE_URL")
+if DATA_SCRUBBING_DATABASE_URL:
+    DATABASES["data_scrubbing"] = dj_database_url.parse(DATA_SCRUBBING_DATABASE_URL)
+
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -13,6 +13,7 @@ from ..factories import (
 
 
 @pytest.mark.django_db
+@pytest.mark.slow_test
 def test_scrub_data_command_success():
     instances = [
         UserFactory(),

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core.management import call_command
+from django.core.management.base import CommandError
 
 from ..factories import (
     BackendFactory,
@@ -12,7 +13,7 @@ from ..factories import (
 
 
 @pytest.mark.django_db
-def test_scrub_data_command():
+def test_scrub_data_command_success():
     instances = [
         UserFactory(),
         BackendFactory(),
@@ -32,7 +33,7 @@ def test_scrub_data_command():
         for instance in instances
     }
 
-    call_command("scrub_data", "default")
+    call_command("scrub_data", "default", "--i-am-sure")
 
     # For each instance check that scrubbing was applied according
     # to the configuration in DataScrubbing. Manually specifying
@@ -65,3 +66,8 @@ def test_scrub_data_command():
             assert getattr(instance, field_name) == original_value, (
                 f"{model_class.__name__}.{field_name} should not have been touched by scrubbing"
             )
+
+
+def test_scrub_data_command_require_confirmation_on_default_database():
+    with pytest.raises(CommandError, match="Use --i-am-sure"):
+        call_command("scrub_data", "default")

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -32,7 +32,7 @@ def test_scrub_data_command():
         for instance in instances
     }
 
-    call_command("scrub_data")
+    call_command("scrub_data", "default")
 
     # For each instance check that scrubbing was applied according
     # to the configuration in DataScrubbing. Manually specifying


### PR DESCRIPTION
Partly fixes https://github.com/opensafely-core/security/issues/55. Adds a required `database` option to the database scrubbing management command to enable this to be useful in production where we intend to run it against a non-default database.

Also uses an iterator to reduce memory usage, adds transaction wrapping, adds a `data_scrubbing` database alias (overlapping with https://github.com/opensafely-core/job-server/pull/5904/), and a guard clause to reduce the risk of accidentally running this against the default database in production.

To test, suggest getting a separate database with data from the default database loaded into it following https://github.com/opensafely-core/job-server/pull/5904/, then running `just manage scrub_data data_scrubbing` and using `psql` to confirm that the target database changed and the default one did not (for example by checking a particular username and email in the default database before and after).