### PR TITLE
Categorise all of our model fields for scrubbing and test none missed

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -239,7 +239,6 @@ class ContactDetailsPage(AbstractPage):
     telephone = models.TextField(blank=True)
     job_title = models.TextField(blank=True)
     team_name = models.TextField(blank=True)
-    # TODO: how will we tie this to an existing org, especially with typos?
     organisation = models.TextField(blank=True)
 
     class DataScrubbing:

--- a/applications/models.py
+++ b/applications/models.py
@@ -65,6 +65,28 @@ class Application(models.Model):
     approved_at = models.DateTimeField(null=True)
     deleted_at = models.DateTimeField(null=True)
 
+    class DataScrubbing:
+        fields_to_scrub = {
+            "status_comment": "",
+            "has_agreed_to_terms": True,
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "project",
+                "status",
+                "created_at",
+                "created_by",
+                "submitted_at",
+                "submitted_by",
+                "approved_at",
+                "approved_by",
+                "completed_at",
+                "deleted_at",
+                "deleted_by",
+            ]
+        )
+
     class Meta:
         constraints = [
             models.CheckConstraint(
@@ -222,6 +244,7 @@ class ContactDetailsPage(AbstractPage):
 
     class DataScrubbing:
         fields_to_scrub = {
+            "notes": "",
             "full_name": fake.name,
             "email": fake.email,
             "telephone": "",
@@ -229,10 +252,38 @@ class ContactDetailsPage(AbstractPage):
             "team_name": "",
             "organisation": "",
         }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+            ]
+        )
 
 
 class CommercialInvolvementPage(AbstractPage):
     details = models.TextField(blank=True)
+
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+            "details": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+            ]
+        )
 
 
 class StudyInformationPage(AbstractPage):
@@ -241,6 +292,25 @@ class StudyInformationPage(AbstractPage):
     read_analytic_methods_policy = models.BooleanField(
         null=True, choices=YES_NO_CHOICES
     )
+
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+            "study_name": "",
+            "study_purpose": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+                "read_analytic_methods_policy",
+            ]
+        )
 
 
 class StudyPurposePage(AbstractPage):
@@ -257,14 +327,52 @@ class StudyPurposePage(AbstractPage):
 
     class DataScrubbing:
         fields_to_scrub = {
+            "notes": "",
             "author_name": fake.name,
             "author_email": fake.email,
+            "author_organisation": "",
+            "description": "",
         }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+                "is_covid_prevention",
+                "is_covid_vaccine_effectiveness_or_safety",
+                "is_covid_vaccine_eligibility_or_coverage",
+                "is_other_impacts_of_covid",
+                "is_post_covid_health_impacts",
+                "is_risk_from_covid",
+            ]
+        )
 
 
 class StudyDataPage(AbstractPage):
     data_meets_purpose = models.TextField(blank=True)
     need_record_level_data = models.BooleanField(null=True, choices=YES_NO_CHOICES)
+
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+            "data_meets_purpose": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+                "need_record_level_data",
+            ]
+        )
 
 
 class DatasetsPage(AbstractPage):
@@ -274,9 +382,47 @@ class DatasetsPage(AbstractPage):
     needs_phosp = models.BooleanField(default=False)
     needs_ukrr = models.BooleanField(default=False)
 
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+                "needs_icnarc",
+                "needs_isaric",
+                "needs_ons_cis",
+                "needs_phosp",
+                "needs_ukrr",
+            ]
+        )
+
 
 class RecordLevelDataPage(AbstractPage):
     record_level_data_reasons = models.TextField(blank=True)
+
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+            "record_level_data_reasons": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+            ]
+        )
 
 
 class TypeOfStudyPage(AbstractPage):
@@ -285,11 +431,50 @@ class TypeOfStudyPage(AbstractPage):
     is_study_audit = models.BooleanField(default=False)
     is_study_short_data_report = models.BooleanField(default=False)
 
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+                "is_study_audit",
+                "is_study_research",
+                "is_study_service_evaluation",
+                "is_study_short_data_report",
+            ]
+        )
+
 
 class ReferencesPage(AbstractPage):
     hra_ires_id = models.TextField(blank=True)
     hra_rec_reference = models.TextField(blank=True)
     institutional_rec_reference = models.TextField(blank=True)
+
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+            "hra_ires_id": "",
+            "hra_rec_reference": "",
+            "institutional_rec_reference": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+            ]
+        )
 
 
 class SponsorDetailsPage(AbstractPage):
@@ -301,36 +486,149 @@ class SponsorDetailsPage(AbstractPage):
 
     class DataScrubbing:
         fields_to_scrub = {
+            "notes": "",
             "sponsor_name": fake.name,
             "sponsor_email": fake.email,
             "sponsor_job_role": "",
             "institutional_rec_reference": "",
+            "is_member_of_bennett_or_lshtm": False,
         }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+            ]
+        )
 
 
 class ShortDataReportPage(AbstractPage):
-    pass
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+            ]
+        )
 
 
 class CmoPriorityListPage(AbstractPage):
     is_on_cmo_priority_list = models.BooleanField(null=True, choices=YES_NO_CHOICES)
+
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+                "is_on_cmo_priority_list",
+            ]
+        )
 
 
 class LegalBasisPage(AbstractPage):
     legal_basis_for_accessing_data_under_dpa = models.TextField(blank=True)
     how_is_duty_of_confidentiality_satisfied = models.TextField(blank=True)
 
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+            "how_is_duty_of_confidentiality_satisfied": "",
+            "legal_basis_for_accessing_data_under_dpa": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+            ]
+        )
+
 
 class StudyFundingPage(AbstractPage):
     funding_details = models.TextField(blank=True)
+
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+            "funding_details": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+            ]
+        )
 
 
 class TeamDetailsPage(AbstractPage):
     team_details = models.TextField(blank=True)
 
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+            "team_details": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+            ]
+        )
+
 
 class PreviousEhrExperiencePage(AbstractPage):
     previous_experience_with_ehr = models.TextField(blank=True)
+
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+            "previous_experience_with_ehr": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+            ]
+        )
 
 
 class SoftwareDevelopmentExperiencePage(AbstractPage):
@@ -339,13 +637,62 @@ class SoftwareDevelopmentExperiencePage(AbstractPage):
         null=True, choices=YES_NO_CHOICES
     )
 
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+            "evidence_of_coding": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+                "all_applicants_completed_getting_started",
+            ]
+        )
+
 
 class SharingCodePage(AbstractPage):
     evidence_of_sharing_in_public_domain_before = models.TextField(blank=True)
 
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+            "evidence_of_sharing_in_public_domain_before": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+            ]
+        )
+
 
 class ResearcherDetailsPage(AbstractPage):
-    pass
+    class DataScrubbing:
+        fields_to_scrub = {
+            "notes": "",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "reviewed_by",
+                "is_approved",
+                "last_reviewed_at",
+                "created_at",
+                "updated_at",
+            ]
+        )
 
 
 class ResearcherRegistration(models.Model):
@@ -407,7 +754,17 @@ class ResearcherRegistration(models.Model):
             "daa": None,
             "training_with_org": "",
             "training_passed_at": None,
+            "user": None,
+            "has_taken_safe_researcher_training": True,
         }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "application",
+                "created_at",
+                "does_researcher_need_server_access",
+            ]
+        )
 
     def __str__(self):
         return self.name

--- a/data_scrubbing/management/commands/scrub_data.py
+++ b/data_scrubbing/management/commands/scrub_data.py
@@ -14,6 +14,16 @@ SCRUBBED_APPLICATIONS = {
 """Names of Django applications with models to be scrubbed."""
 
 
+def get_scrubbed_models():
+    "Accumulate set of Django model classes to be scrubbed."
+    scrubbed_models = set()
+    for application in SCRUBBED_APPLICATIONS:
+        scrubbed_models |= {
+            model for model in apps.get_app_config(application).get_models()
+        }
+    return scrubbed_models
+
+
 class Command(BaseCommand):
     """Management command to scrub sensitive fields"""
 
@@ -37,13 +47,8 @@ class Command(BaseCommand):
         if database_alias == "default" and not kwargs["i_am_sure"]:
             raise CommandError("Use --i-am-sure flag to run against default database")
 
-        # Accumulate models from the in-scope applications.
-        models = {}
-        for application in SCRUBBED_APPLICATIONS:
-            models |= {model for model in apps.get_app_config(application).get_models()}
-
         with transaction.atomic(using=database_alias):
-            for model in models:
+            for model in get_scrubbed_models():
                 # Find fields to scrub, if any.
                 data_scrubbing = getattr(model, "DataScrubbing", None)
                 if data_scrubbing is None:

--- a/data_scrubbing/management/commands/scrub_data.py
+++ b/data_scrubbing/management/commands/scrub_data.py
@@ -7,6 +7,12 @@ from faker import Faker
 
 fake = Faker()
 
+SCRUBBED_APPLICATIONS = {
+    "applications",
+    "jobserver",
+}
+"Names of Django applications with models to be scrubbed."
+
 
 class Command(BaseCommand):
     """Management command to scrub sensitive fields"""
@@ -31,8 +37,10 @@ class Command(BaseCommand):
         if database_alias == "default" and not kwargs["i_am_sure"]:
             raise CommandError("Use --i-am-sure flag to run against default database")
 
-        models = {model for model in apps.get_app_config("jobserver").get_models()}
-        models |= {model for model in apps.get_app_config("applications").get_models()}
+        models = {}
+        for application in SCRUBBED_APPLICATIONS:
+            models |= {model for model in apps.get_app_config(application).get_models()}
+
         with transaction.atomic(using=database_alias):
             for model in models:
                 data_scrubbing = getattr(model, "DataScrubbing", None)

--- a/data_scrubbing/management/commands/scrub_data.py
+++ b/data_scrubbing/management/commands/scrub_data.py
@@ -11,7 +11,7 @@ SCRUBBED_APPLICATIONS = {
     "applications",
     "jobserver",
 }
-"Names of Django applications with models to be scrubbed."
+"""Names of Django applications with models to be scrubbed."""
 
 
 class Command(BaseCommand):
@@ -37,12 +37,14 @@ class Command(BaseCommand):
         if database_alias == "default" and not kwargs["i_am_sure"]:
             raise CommandError("Use --i-am-sure flag to run against default database")
 
+        # Accumulate models from the in-scope applications.
         models = {}
         for application in SCRUBBED_APPLICATIONS:
             models |= {model for model in apps.get_app_config(application).get_models()}
 
         with transaction.atomic(using=database_alias):
             for model in models:
+                # Find fields to scrub, if any.
                 data_scrubbing = getattr(model, "DataScrubbing", None)
                 if data_scrubbing is None:
                     continue
@@ -51,6 +53,9 @@ class Command(BaseCommand):
                     continue
                 field_names = scrub_fields.keys()
 
+                # Iterate per-object updating and saving scrubbed fields.
+                # Many small queries in the transaction but avoids either holding
+                # whole tables in memory or chunking bulk updates.
                 objs = model.objects.using(database_alias).all().iterator()
                 count = 0
                 for obj in objs:

--- a/data_scrubbing/management/commands/scrub_data.py
+++ b/data_scrubbing/management/commands/scrub_data.py
@@ -10,6 +10,7 @@ fake = Faker()
 SCRUBBED_APPLICATIONS = {
     "applications",
     "jobserver",
+    "redirects",
 }
 """Names of Django applications with models to be scrubbed."""
 

--- a/jobserver/models/auditable_event.py
+++ b/jobserver/models/auditable_event.py
@@ -47,6 +47,26 @@ class AuditableEvent(models.Model):
     created_at = models.DateTimeField(default=timezone.now)
     created_by = models.TextField()
 
+    class DataScrubbing:
+        fields_to_scrub = {
+            "new": "fake new audit value",
+            "old": "fake old audit value",
+            "created_by": "fake audit created_by",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "created_at",
+                "parent_id",
+                "parent_model",
+                "target_field",
+                "target_id",
+                "target_model",
+                "target_user",
+                "type",
+            ]
+        )
+
     def __str__(self):
         return f"pk={self.pk} type={self.type}"
 

--- a/jobserver/models/backend.py
+++ b/jobserver/models/backend.py
@@ -89,6 +89,21 @@ class Backend(models.Model):
         fields_to_scrub = {
             "auth_token": generate_token,
         }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "alert_timeout",
+                "created_at",
+                "is_active",
+                "is_in_maintenance_mode",
+                "last_seen_at",
+                "last_seen_maintenance_mode",
+                "name",
+                "rap_api_state",
+                "slug",
+                "updated_at",
+            ]
+        )
 
     def __str__(self):
         return self.slug

--- a/jobserver/models/backend_membership.py
+++ b/jobserver/models/backend_membership.py
@@ -28,6 +28,18 @@ class BackendMembership(models.Model):
 
     created_at = models.DateTimeField(default=timezone.now)
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "backend",
+                "created_at",
+                "created_by",
+                "user",
+            ]
+        )
+
     class Meta:
         unique_together = ["backend", "user"]
 

--- a/jobserver/models/job.py
+++ b/jobserver/models/job.py
@@ -73,6 +73,27 @@ class Job(models.Model):
 
     metrics = models.JSONField(null=True)
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "action",
+                "completed_at",
+                "created_at",
+                "identifier",
+                "job_request",
+                "metrics",
+                "run_command",
+                "started_at",
+                "status",
+                "status_code",
+                "status_message",
+                "trace_context",
+                "updated_at",
+            ]
+        )
+
     class Meta:
         ordering = ["pk"]
 

--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -180,6 +180,28 @@ class JobRequest(models.Model):
 
     objects = JobRequestManager()
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "_status",
+                "backend",
+                "cancelled_actions",
+                "codelists_ok",
+                "created_at",
+                "created_by",
+                "force_run_dependencies",
+                "identifier",
+                "project_definition",
+                "requested_actions",
+                "sha",
+                "status_message",
+                "will_notify",
+                "workspace",
+            ]
+        )
+
     class Meta:
         constraints = [
             models.CheckConstraint(

--- a/jobserver/models/org.py
+++ b/jobserver/models/org.py
@@ -34,6 +34,23 @@ class Org(models.Model):
 
     created_at = models.DateTimeField(default=timezone.now)
 
+    class DataScrubbing:
+        fields_to_scrub = {
+            "description": "fake org description",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "created_at",
+                "created_by",
+                "github_orgs",
+                "logo",
+                "logo_file",
+                "name",
+                "slug",
+            ]
+        )
+
     class Meta:
         verbose_name = "Organisation"
 

--- a/jobserver/models/org_membership.py
+++ b/jobserver/models/org_membership.py
@@ -28,6 +28,18 @@ class OrgMembership(models.Model):
 
     created_at = models.DateTimeField(default=timezone.now)
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "created_at",
+                "created_by",
+                "org",
+                "user",
+            ]
+        )
+
     class Meta:
         unique_together = ["org", "user"]
 

--- a/jobserver/models/project.py
+++ b/jobserver/models/project.py
@@ -155,6 +155,27 @@ class Project(models.Model):
 
     objects = ProjectQuerySet.as_manager()
 
+    class DataScrubbing:
+        fields_to_scrub = {
+            "copilot_notes": "fake copilot notes",
+            "status_description": "fake status description",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "copilot",
+                "copilot_support_ends_at",
+                "created_at",
+                "created_by",
+                "name",
+                "number",
+                "slug",
+                "status",
+                "updated_at",
+                "updated_by",
+            ]
+        )
+
     class Meta:
         constraints = [
             models.CheckConstraint(

--- a/jobserver/models/project_collaboration.py
+++ b/jobserver/models/project_collaboration.py
@@ -34,6 +34,21 @@ class ProjectCollaboration(models.Model):
         suffix = " (lead)" if self.is_lead else ""
         return f"{self.org.name} <-> {self.project.name}{suffix}"
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "created_at",
+                "created_by",
+                "is_lead",
+                "org",
+                "project",
+                "updated_at",
+                "updated_by",
+            ]
+        )
+
     class Meta:
         constraints = [
             models.UniqueConstraint(

--- a/jobserver/models/project_membership.py
+++ b/jobserver/models/project_membership.py
@@ -41,6 +41,19 @@ class ProjectMembership(ImmutableModelMixin, models.Model):
 
     objects = ImmutableManager()
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "created_at",
+                "created_by",
+                "project",
+                "roles",
+                "user",
+            ]
+        )
+
     class Meta:
         unique_together = ["project", "user"]
 

--- a/jobserver/models/publish_request.py
+++ b/jobserver/models/publish_request.py
@@ -48,6 +48,23 @@ class PublishRequest(models.Model):
         related_name="snapshot_requests_updated",
     )
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "created_at",
+                "created_by",
+                "decision",
+                "decision_at",
+                "decision_by",
+                "snapshot",
+                "updated_at",
+                "updated_by",
+                "workspace",
+            ]
+        )
+
     class Meta:
         constraints = [
             models.CheckConstraint(

--- a/jobserver/models/release.py
+++ b/jobserver/models/release.py
@@ -53,6 +53,22 @@ class Release(models.Model):
         related_name="releases",
     )
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "backend",
+                "created_at",
+                "created_by",
+                "metadata",
+                "requested_files",
+                "review",
+                "status",
+                "workspace",
+            ]
+        )
+
     class Meta:
         constraints = [
             models.CheckConstraint(

--- a/jobserver/models/release_file.py
+++ b/jobserver/models/release_file.py
@@ -72,6 +72,27 @@ class ReleaseFile(models.Model):
 
     uploaded_at = models.DateTimeField(null=True)
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "created_at",
+                "created_by",
+                "deleted_at",
+                "deleted_by",
+                "filehash",
+                "metadata",
+                "mtime",
+                "name",
+                "path",
+                "release",
+                "size",
+                "uploaded_at",
+                "workspace",
+            ]
+        )
+
     class Meta:
         constraints = [
             models.CheckConstraint(

--- a/jobserver/models/release_file_review.py
+++ b/jobserver/models/release_file_review.py
@@ -29,6 +29,19 @@ class ReleaseFileReview(models.Model):
         related_name="release_file_reviews",
     )
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "comments",
+                "created_at",
+                "created_by",
+                "release_file",
+                "status",
+            ]
+        )
+
     class Meta:
         constraints = [
             models.CheckConstraint(

--- a/jobserver/models/repo.py
+++ b/jobserver/models/repo.py
@@ -30,6 +30,20 @@ class Repo(models.Model):
         related_name="repos_signed_off_by_researcher",
     )
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "has_github_outputs",
+                "internal_signed_off_at",
+                "internal_signed_off_by",
+                "researcher_signed_off_at",
+                "researcher_signed_off_by",
+                "url",
+            ]
+        )
+
     class Meta:
         constraints = [
             models.CheckConstraint(

--- a/jobserver/models/site_alert.py
+++ b/jobserver/models/site_alert.py
@@ -57,6 +57,22 @@ class SiteAlert(models.Model):
     def __repr__(self):
         return f"<SiteAlert title: '{self.title}' message: '{self.message}' level: {self.level}>"
 
+    class DataScrubbing:
+        fields_to_scrub = {
+            "message": "fake site alert message",
+            "title": "fake site alert title",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "created_at",
+                "created_by",
+                "level",
+                "updated_at",
+                "updated_by",
+            ]
+        )
+
     class Meta:
         ordering = ["-created_at"]
 

--- a/jobserver/models/snapshot.py
+++ b/jobserver/models/snapshot.py
@@ -34,6 +34,17 @@ class Snapshot(models.Model):
         related_name="snapshots",
     )
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "created_at",
+                "created_by",
+                "workspace",
+            ]
+        )
+
     class Meta:
         constraints = [
             models.CheckConstraint(

--- a/jobserver/models/stats.py
+++ b/jobserver/models/stats.py
@@ -11,6 +11,17 @@ class Stats(models.Model):
     api_last_seen = models.DateTimeField(null=True, blank=True)
     url = models.TextField()
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "api_last_seen",
+                "backend",
+                "url",
+            ]
+        )
+
     class Meta:
         unique_together = ["backend", "url"]
 

--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -147,12 +147,29 @@ class User(AbstractBaseUser):
     class DataScrubbing:
         fields_to_scrub = {
             "email": fake.unique.email,
+            "fullname": "Fake user name",
             "password": "",
             "login_token": None,
             "login_token_expires_at": None,
             "pat_expires_at": None,
             "pat_token": None,
         }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "created_by",
+                "date_joined",
+                "last_login",
+                "roles",
+                # GitHub usernames OAuth. Developers sometimes need this
+                # locally and it is convenient. These are online identifiers
+                # publicly visible on the GitHub and Job Server websites. Their
+                # public nature and the removal of other related personal data
+                # (such as fullname and email) reduces the severity of any
+                # accidental disclosure.
+                "username",
+            ]
+        )
 
     class Meta:
         constraints = [

--- a/jobserver/models/workspace.py
+++ b/jobserver/models/workspace.py
@@ -77,6 +77,29 @@ class Workspace(models.Model):
 
     objects = WorkspaceQuerySet.as_manager()
 
+    class DataScrubbing:
+        fields_to_scrub = {
+            "purpose": "fake workspace purpose",
+        }
+        allowed_fields = frozenset(
+            [
+                "id",
+                "branch",
+                "created_at",
+                "created_by",
+                "is_archived",
+                "name",
+                "project",
+                "repo",
+                "should_notify",
+                "signed_off_at",
+                "signed_off_by",
+                "updated_at",
+                "updated_by",
+                "uses_new_release_flow",
+            ]
+        )
+
     class Meta:
         constraints = [
             # mirror Django's validate_slug validator into the database

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,7 @@ markers = [
   "verification: tests that verify fakes",
   "functional: tests that use Playwright in functional tests",
 ]
+xfail_strict=true
 
 [tool.ruff]
 line-length = 88

--- a/redirects/models.py
+++ b/redirects/models.py
@@ -50,6 +50,24 @@ class Redirect(models.Model):
         related_name="redirect_deleted",
     )
 
+    class DataScrubbing:
+        fields_to_scrub = {}
+        allowed_fields = frozenset(
+            [
+                "id",
+                "created_at",
+                "created_by",
+                "deleted_at",
+                "deleted_by",
+                "expires_at",
+                "old_url",
+                "org",
+                "project",
+                "updated_at",
+                "workspace",
+            ]
+        )
+
     class Meta:
         constraints = [
             models.CheckConstraint(

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -75,11 +75,21 @@ def test_scrub_data_command_require_confirmation_on_default_database():
         call_command("scrub_data", "default")
 
 
+def _details_str(model_dict):
+    return "\n".join(
+        f"  - {name}:\n"
+        + "\n".join(f'{" " * 16}"{field}",' for field in sorted(fields))
+        for name, fields in sorted(model_dict.items())
+    )
+
+
 def test_all_applications_fields_categorised():
     models = {model for model in apps.get_app_config("applications").get_models()}
 
     models_with_no_configuration = set()
     fields_not_categorised = {}
+    extra_fields = {}
+    duplicated_fields = {}
 
     for model in models:
         dotted_path = f"{model.__module__}.{model.__name__}"
@@ -88,14 +98,23 @@ def test_all_applications_fields_categorised():
         if data_scrubbing is None:
             models_with_no_configuration.add(dotted_path)
             continue
+
         fields_to_scrub_dict = getattr(data_scrubbing, "fields_to_scrub", {})
         fields_to_scrub = set(fields_to_scrub_dict.keys())
         allowed_fields = getattr(data_scrubbing, "allowed_fields", set())
-
         all_model_fields = {f.name for f in model._meta.fields}
+
         uncategorised_fields = all_model_fields - fields_to_scrub - allowed_fields
         if uncategorised_fields:
             fields_not_categorised[dotted_path] = uncategorised_fields
+
+        extras = (fields_to_scrub | allowed_fields) - all_model_fields
+        if extras:
+            extra_fields[dotted_path] = extras
+
+        duplicates = fields_to_scrub & allowed_fields
+        if duplicates:
+            duplicated_fields[dotted_path] = duplicates
 
     hint = (
         "Each model must define a `DataScrubbing` inner class specifying "
@@ -117,14 +136,23 @@ def test_all_applications_fields_categorised():
         )
 
     if fields_not_categorised:
-        details = "\n".join(
-            f"  - {name}:\n"
-            + "\n".join(f'{" " * 16}"{field}",' for field in sorted(fields))
-            for name, fields in sorted(fields_not_categorised.items())
-        )
+        details = _details_str(fields_not_categorised)
         pytest.fail(
             f"{len(fields_not_categorised)} model(s) have fields not included in "
-            f"their `DataScrubbing` inner class:\n"
-            f"{details}\n\n"
-            f"{hint}"
+            f"their `DataScrubbing` inner class:\n{details}\n\n{hint}"
+        )
+
+    if extra_fields:
+        details = _details_str(extra_fields)
+        pytest.fail(
+            f"{len(extra_fields)} model(s) have extra fields included in "
+            f"their `DataScrubbing` inner class:\n{details}\n\n{hint}"
+        )
+
+    if duplicated_fields:
+        details = _details_str(duplicated_fields)
+        pytest.fail(
+            f"{len(duplicated_fields)} model(s) have fields included in both "
+            f"`fields_to_scrub` and in `allowed_fields` in "
+            f"their `DataScrubbing` inner class:\n{details}\n\n{hint}"
         )

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -1,4 +1,5 @@
 import pytest
+from django.apps import apps
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
@@ -72,3 +73,59 @@ def test_scrub_data_command_success():
 def test_scrub_data_command_require_confirmation_on_default_database():
     with pytest.raises(CommandError, match="Use --i-am-sure"):
         call_command("scrub_data", "default")
+
+
+@pytest.mark.xfail(reason="Not finished initial categorisation yet")
+def test_all_applications_fields_categorised():
+    models = {model for model in apps.get_app_config("applications").get_models()}
+
+    models_with_no_configuration = set()
+    fields_not_categorised = {}
+
+    for model in models:
+        dotted_path = f"{model.__module__}.{model.__name__}"
+        data_scrubbing = getattr(model, "DataScrubbing", None)
+
+        if data_scrubbing is None:
+            models_with_no_configuration.add(dotted_path)
+            continue
+        fields_to_scrub_dict = getattr(data_scrubbing, "fields_to_scrub", {})
+        fields_to_scrub = set(fields_to_scrub_dict.keys())
+        allowed_fields = getattr(data_scrubbing, "allowed_fields", set())
+
+        all_model_fields = {f.name for f in model._meta.fields}
+        uncategorised_fields = all_model_fields - fields_to_scrub - allowed_fields
+        if uncategorised_fields:
+            fields_not_categorised[dotted_path] = uncategorised_fields
+
+    hint = (
+        "Each model must define a `DataScrubbing` inner class specifying "
+        "`fields_to_scrub` (a dict of field name -> scrubbing strategy) and/or "
+        "`allowed_fields` (a set of field names that don't need scrubbing) "
+        "so that every field is explicitly categorised. They must not overlap.\n"
+        "Refer to the documentation of the data_scrubbing module."
+    )
+
+    if models_with_no_configuration:
+        missing_list = "\n".join(
+            f"  - {name}" for name in sorted(models_with_no_configuration)
+        )
+        pytest.fail(
+            f"{len(models_with_no_configuration)} model(s) are missing a "
+            f"`DataScrubbing` inner class entirely:\n"
+            f"{missing_list}\n\n"
+            f"{hint}"
+        )
+
+    if fields_not_categorised:
+        details = "\n".join(
+            f"  - {name}:\n"
+            + "\n".join(f'{" " * 16}"{field}",' for field in sorted(fields))
+            for name, fields in sorted(fields_not_categorised.items())
+        )
+        pytest.fail(
+            f"{len(fields_not_categorised)} model(s) have fields not included in "
+            f"their `DataScrubbing` inner class:\n"
+            f"{details}\n\n"
+            f"{hint}"
+        )

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -16,6 +16,10 @@ from ..factories import (
 @pytest.mark.django_db
 @pytest.mark.slow_test
 def test_scrub_data_command_success():
+    """Test that the scrub_data command does replace senstive fields according
+    to its configuration.
+
+    See the data_scrubbing package to better understand this functionality."""
     instances = [
         UserFactory(),
         BackendFactory(),
@@ -84,14 +88,27 @@ def _details_str(model_dict):
 
 
 def test_all_applications_fields_categorised():
+    """Test that each model has an exhaustive DataScrubbing class.
+
+    Each model must define a `DataScrubbing` inner class specifying
+    `fields_to_scrub` (a dict of field name -> scrubbing strategy) and/or
+    `allowed_fields` (a set of field names that don't need scrubbing) so that
+    every field is explicitly categorised. They must not overlap.
+
+    Refer to the documentation of the data_scrubbing module."""
     models = {model for model in apps.get_app_config("applications").get_models()}
 
     models_with_no_configuration = set()
+    """Set of model dotted paths that have on DataScrubbing configuration."""
     fields_not_categorised = {}
+    """Dict mapping model dotted paths to list of fields missing from DataScrubbing."""
     extra_fields = {}
+    """Dict mapping model dotted paths to list of extra fields in DataScrubbing."""
     duplicated_fields = {}
+    """Dict mapping model dotted paths to list of fields duplicated in DataScrubbing."""
 
     for model in models:
+        # Check that the model has DataScrubbing configuration.
         dotted_path = f"{model.__module__}.{model.__name__}"
         data_scrubbing = getattr(model, "DataScrubbing", None)
 
@@ -99,6 +116,7 @@ def test_all_applications_fields_categorised():
             models_with_no_configuration.add(dotted_path)
             continue
 
+        # Check for uncategorised, extra and duplicated fields with set operations.
         fields_to_scrub_dict = getattr(data_scrubbing, "fields_to_scrub", {})
         fields_to_scrub = set(fields_to_scrub_dict.keys())
         allowed_fields = getattr(data_scrubbing, "allowed_fields", set())
@@ -116,6 +134,7 @@ def test_all_applications_fields_categorised():
         if duplicates:
             duplicated_fields[dotted_path] = duplicates
 
+    # Assertions on the results of the above.
     hint = (
         "Each model must define a `DataScrubbing` inner class specifying "
         "`fields_to_scrub` (a dict of field name -> scrubbing strategy) and/or "

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -75,7 +75,6 @@ def test_scrub_data_command_require_confirmation_on_default_database():
         call_command("scrub_data", "default")
 
 
-@pytest.mark.xfail(reason="Not finished initial categorisation yet")
 def test_all_applications_fields_categorised():
     models = {model for model in apps.get_app_config("applications").get_models()}
 

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -1,7 +1,8 @@
 import pytest
-from django.apps import apps
 from django.core.management import call_command
 from django.core.management.base import CommandError
+
+from data_scrubbing.management.commands.scrub_data import get_scrubbed_models
 
 from ..factories import (
     BackendFactory,
@@ -104,17 +105,17 @@ def test_details_str_formats_model_dict():
     )
 
 
-def test_all_applications_fields_categorised():
-    """Test that each model has an exhaustive DataScrubbing class.
+@pytest.mark.xfail(reason="Not categorised jobserver models yet")
+def test_all_scrubbed_model_fields_categorised():
+    """Test that each model in `get_scrubbed_models` has a DataScrubbing class
+    that includes all its concrete fields.
 
     Each model must define a `DataScrubbing` inner class specifying
     `fields_to_scrub` (a dict of field name -> scrubbing strategy) and/or
     `allowed_fields` (a set of field names that don't need scrubbing) so that
-    every field is explicitly categorised. They must not overlap.
+    every concrete field is explicitly categorised. They must not overlap.
 
     Refer to the documentation of the data_scrubbing module."""
-    models = {model for model in apps.get_app_config("applications").get_models()}
-
     models_with_no_configuration = set()
     """Set of model dotted paths that have on DataScrubbing configuration."""
     fields_not_categorised = {}
@@ -124,7 +125,7 @@ def test_all_applications_fields_categorised():
     duplicated_fields = {}
     """Dict mapping model dotted paths to list of fields duplicated in DataScrubbing."""
 
-    for model in models:
+    for model in get_scrubbed_models():
         # Check that the model has DataScrubbing configuration.
         dotted_path = f"{model.__module__}.{model.__name__}"
         data_scrubbing = getattr(model, "DataScrubbing", None)

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -76,6 +76,8 @@ def test_scrub_data_command_success():
 
 
 def test_scrub_data_command_require_confirmation_on_default_database():
+    """Test that the scrub_data command requires confirmation through an extra
+    flag when running against the default database."""
     with pytest.raises(CommandError, match="Use --i-am-sure"):
         call_command("scrub_data", "default")
 
@@ -157,7 +159,7 @@ def test_all_scrubbed_model_fields_categorised():
         "`fields_to_scrub` (a dict of field name -> scrubbing strategy) and/or "
         "`allowed_fields` (a set of field names that don't need scrubbing) "
         "so that every field is explicitly categorised. They must not overlap.\n"
-        "Refer to the documentation of the data_scrubbing module."
+        "See the `data_scrubbing` package to better understand this functionality."
     )
 
     if models_with_no_configuration:  # pragma: no cover

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -17,7 +17,7 @@ from ..factories import (
 @pytest.mark.django_db
 @pytest.mark.slow_test
 def test_scrub_data_command_success():
-    """Test that the scrub_data command does replace senstive fields according
+    """Test that the scrub_data command does replace sensitive fields according
     to its configuration.
 
     See the data_scrubbing package to better understand this functionality."""

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -80,10 +80,27 @@ def test_scrub_data_command_require_confirmation_on_default_database():
 
 
 def _details_str(model_dict):
+    """String listing apps and fields in model_dict formatted nicely."""
     return "\n".join(
         f"  - {name}:\n"
         + "\n".join(f'{" " * 16}"{field}",' for field in sorted(fields))
         for name, fields in sorted(model_dict.items())
+    )
+
+
+def test_details_str_formats_model_dict():
+    """Test that _details_str can format a model dict."""
+    model_dict = {
+        "app.models.Foo": {"alpha", "beta"},
+        "app.models.Bar": {"gamma"},
+    }
+    result = _details_str(model_dict)
+    assert result == (
+        "  - app.models.Bar:\n"
+        '                "gamma",\n'
+        "  - app.models.Foo:\n"
+        '                "alpha",\n'
+        '                "beta",'
     )
 
 
@@ -112,7 +129,7 @@ def test_all_applications_fields_categorised():
         dotted_path = f"{model.__module__}.{model.__name__}"
         data_scrubbing = getattr(model, "DataScrubbing", None)
 
-        if data_scrubbing is None:
+        if data_scrubbing is None:  # pragma: no cover
             models_with_no_configuration.add(dotted_path)
             continue
 
@@ -123,15 +140,15 @@ def test_all_applications_fields_categorised():
         all_model_fields = {f.name for f in model._meta.fields}
 
         uncategorised_fields = all_model_fields - fields_to_scrub - allowed_fields
-        if uncategorised_fields:
+        if uncategorised_fields:  # pragma: no cover
             fields_not_categorised[dotted_path] = uncategorised_fields
 
         extras = (fields_to_scrub | allowed_fields) - all_model_fields
-        if extras:
+        if extras:  # pragma: no cover
             extra_fields[dotted_path] = extras
 
         duplicates = fields_to_scrub & allowed_fields
-        if duplicates:
+        if duplicates:  # pragma: no cover
             duplicated_fields[dotted_path] = duplicates
 
     # Assertions on the results of the above.
@@ -143,7 +160,7 @@ def test_all_applications_fields_categorised():
         "Refer to the documentation of the data_scrubbing module."
     )
 
-    if models_with_no_configuration:
+    if models_with_no_configuration:  # pragma: no cover
         missing_list = "\n".join(
             f"  - {name}" for name in sorted(models_with_no_configuration)
         )
@@ -154,21 +171,21 @@ def test_all_applications_fields_categorised():
             f"{hint}"
         )
 
-    if fields_not_categorised:
+    if fields_not_categorised:  # pragma: no cover
         details = _details_str(fields_not_categorised)
         pytest.fail(
             f"{len(fields_not_categorised)} model(s) have fields not included in "
             f"their `DataScrubbing` inner class:\n{details}\n\n{hint}"
         )
 
-    if extra_fields:
+    if extra_fields:  # pragma: no cover
         details = _details_str(extra_fields)
         pytest.fail(
             f"{len(extra_fields)} model(s) have extra fields included in "
             f"their `DataScrubbing` inner class:\n{details}\n\n{hint}"
         )
 
-    if duplicated_fields:
+    if duplicated_fields:  # pragma: no cover
         details = _details_str(duplicated_fields)
         pytest.fail(
             f"{len(duplicated_fields)} model(s) have fields included in both "

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -105,7 +105,6 @@ def test_details_str_formats_model_dict():
     )
 
 
-@pytest.mark.xfail(reason="Not categorised jobserver models yet")
 def test_all_scrubbed_model_fields_categorised():
     """Test that each model in `get_scrubbed_models` has a DataScrubbing class
     that includes all its concrete fields.


### PR DESCRIPTION
Part fixes https://github.com/opensafely-core/security/issues/55.

Previous commits f6514057c0b9fa92f4aeab76c33e55344f5bf44d and 90bb4d5415f4ef902053caa064ca7062f160f1c8 added some scrubbing to the User and Backend model. Previous commit d25d964 identified some of the more sensitive `applications` fields. With this PR, this is now exhaustive across `applications`, `jobserver`, and `redirects` (as tested with
`test_all_scrubbed_model_fields_categorised`). Examining the tables in more detail showed that many freetext fields included information about people so could be classed as personal data. Let's be prudent and drop it, as it is probably almost never needed for development. See commit messages and some comments for more detailed rationales.

Also relevant: We did not scrub the `User.username field`. See the [personal data copying policy](https://bennett.wiki/tech-group/policies/personal-data-copying-policy/)
and [exceptions to this policy](https://docs.google.com/document/d/1dEo2fiGOgkyBw1Gk-9RrobRKL-i44jQa-BQcWOeBBbI/edit?usp=sharing) for more discussion (internal). Some explanation
is reproduced in commit messages and code comments.


Have replaced all freetext fields with an empty string. Replaced booleans where it is about an individual. ForeignKeys are mostly fine.

Add `allowed_fields` across applications and test scrubbed+allowed covers the whole set of fields in all models to force developers to think about this in future. With hopefully useful messages. Examples (shortened) below.

<details>
You could edit the configuration and run the test to see similar messages.

<summary>Examples for different types of failure</summary>

### Missing DataScrubbing

```
Failed: 3 model(s) are missing a `DataScrubbing` inner class entirely:
  - applications.models.Application
  - applications.models.CmoPriorityListPage
  - applications.models.CommercialInvolvementPage

Each model must define a `DataScrubbing` inner class specifying `fields_to_scrub` (a dict of field name -> scrubbing strategy) and/or `allowed_fields` (a set of field names that don't need scrubbing) so that every field is explicitly categorised. They must not overlap.
Refer to the documentation of the data_scrubbing module.
================================== short test summary info ===================================
FAILED tests/integration/test_data_scrubbing.py::test_all_scrubbed_model_fields_categorised - Failed: 3 model(s) are missing a `DataScrubbing` inner class entirely:
```

### Some fields not included

```
Failed: 
2 model(s) have fields not included in their `DataScrubbing` inner class:
  - applications.models.ContactDetailsPage:
      "application",
      "created_at",
      "id",
      "is_approved",
      "last_reviewed_at",
      "notes",
      "reviewed_by",
      "updated_at",
  - applications.models.ResearcherRegistration:
      "application",
      "created_at",
      "does_researcher_need_server_access",
      "has_taken_safe_researcher_training",
      "id",
      "user",
================================== short test summary info ===================================
FAILED tests/integration/test_data_scrubbing.py::test_all_scrubbed_model_fields_categorised - Failed: 2 model(s) have fields not included in their `DataScrubbing` inner class:
```


### Extra non-recognised fields included

```
Failed: 1 model(s) have fields included in both `fields_to_scrub` and in `allowed_fields` in their `DataScrubbing` inner class:
  - applications.models.Application:
                "created_at",
================================== short test summary info ===================================
FAILED tests/integration/test_data_scrubbing.py::test_all_scrubbed_model_fields_categorised - Failed: 1 model(s) have fields included in both `fields_to_scrub` and in `allowed_fields`...
```

### Fields included in both sets

```
Failed: 1 model(s) have fields included in both `fields_to_scrub` and in `allowed_fields` in their `DataScrubbing` inner class:
  - applications.models.Application:
                "id",
================================== short test summary info ===================================
FAILED tests/integration/test_data_scrubbing.py::test_all_scrubbed_model_fields_categorised - Failed: 1 model(s) have fields included in both `fields_to_scrub` and in `allowed_fields`...

```

</details>