### PR TITLE
Update `scrub-data` just recipe to specify database.

### DIFF
--- a/justfile
+++ b/justfile
@@ -107,7 +107,7 @@ manage command *args:
 
 # scrub sensitive data from the database
 scrub-data: devenv
-    $BIN/python manage.py scrub_data
+    $BIN/python manage.py scrub_data default --i-am-sure
     rm -f jobserver.dump
 
 test-ci *args: assets


### PR DESCRIPTION
Commit 3f244ddf33f0f860f750fde4d427a8491551f92f added `database_alias` argument.

This changes which database the database operations are performed against, which is needed so this can be used in a script to run in production.  However, the justfile recipe did not get a corresponding update. This commit adds it now.