### PR TITLE
Add NDOO step to project creation next steps

### DIFF
--- a/templates/staff/project/created.html
+++ b/templates/staff/project/created.html
@@ -29,6 +29,7 @@
         <li><a href={{project.get_staff_url}}>View project in the Staff Area</a></li>
       </ul>
       <p>You can now add users to the project.</p>
+      <p>If the project will <em>not</em> be applying NDOO, create a <a href="https://github.com/opensafely-core/job-server/issues/new?template=0040_ndoo_request.md">National Data Opt-Out request issue</a> and share it with tech-support on Slack so they can update the permissions.</p>
       <p>We sent a notification about the new project to the <a href="https://bennettoxford.slack.com/archives/C028EJH752A" target="_blank" class="whitespace-nowrap">#co-pilot-support</a> Slack channel so they can begin the project setup process.</p>
     </div>
     {% url "staff:project-add-member" slug=project.slug as staff_project_add_member_url %}


### PR DESCRIPTION
Remind a user who has just created a project that they need to ask tech-support to update the National Data Opt-Out permissions if the new project will not be applying NDOO.

tech-support will follow the instructions in the Playbook: https://bennett.wiki/tech-group/tech-support/playbook/#requests-for-national-data-opt-out-ndoo-permissions

See Slack discussion:
https://bennettoxford.slack.com/archives/C069SADHP1Q/p1781712045025139

This is just my suggested wording and layout. Happy to update it!

I've added it as a simple reminder for now. We've also talked about making this an [auto-generated Slack message](https://bennettoxford.slack.com/archives/C069SADHP1Q/p1781716869572039?thread_ts=1781712045.025139&cid=C069SADHP1Q) (though it's only needed for some projects) and ultimately [moving the permissions](https://docs.google.com/document/d/1h0e4eyLpBVivdZmztC8T6yFrIk8KNfg4WCz3rmSnulk/edit?tab=t.0#heading=h.bvo0507err9) from the [config file](https://github.com/opensafely-core/job-server/blob/main/jobserver/permissions/population_permissions/ndoo.py) to the Job Server DB.