### PR TITLE
Update 403 and 404 page messages for users

### DIFF
--- a/jobserver/views/errors.py
+++ b/jobserver/views/errors.py
@@ -41,6 +41,12 @@ def csrf_failure(request, reason=""):
 
 
 def page_not_found(request, exception=None):
+
+    if not request.user.is_authenticated:
+        error_message = "We could not find the page you are looking for. The link may be incorrect, the page may have moved, or you may need to log in to access it. Please check the URL, try logging in, or contact us if you need further help."
+    else:
+        error_message = "We could not find the page you are looking for. The link may be incorrect or the page may have moved. Please check the URL or contact us if you need further help."
+
     return TemplateResponse(
         request,
         "error.html",
@@ -48,12 +54,18 @@ def page_not_found(request, exception=None):
         context={
             "error_code": "404",
             "error_name": "Page not found",
-            "error_message": "Please check the URL in the address bar.",
+            "error_message": error_message,
         },
     )
 
 
 def permission_denied(request, exception=None):
+
+    if not request.user.is_authenticated:
+        error_message = "You do not have permission to access this page. You may need to log in, or your account may not have the required permissions. Try logging in, or if you need to discuss permissions please contact us."
+    else:
+        error_message = "You do not have permission to access this page. Please contact us if you have a query about your permissions or require further support."
+
     return TemplateResponse(
         request,
         "error.html",
@@ -61,7 +73,7 @@ def permission_denied(request, exception=None):
         context={
             "error_code": "403",
             "error_name": "Permission denied",
-            "error_message": "You do not have permission to access this page.",
+            "error_message": error_message,
         },
     )
 

--- a/templates/error.html
+++ b/templates/error.html
@@ -26,6 +26,11 @@
           {% #button href="mailto:tech@opensafely.org" type="link" variant="secondary" %}
             Contact support
           {% /button %}
+          {% if not user.is_authenticated %}
+            {% #button id="error-page-login-button" href=login_url type="link" variant="success" %}
+              Login
+            {% /button %}
+          {% endif %}
         </div>
       </div>
     </div>

--- a/tests/unit/jobserver/views/test_errors.py
+++ b/tests/unit/jobserver/views/test_errors.py
@@ -9,6 +9,8 @@ from jobserver.views.errors import (
     server_error,
 )
 
+from ....factories import UserFactory
+
 
 def test_bad_request(rf):
     request = rf.get("/")
@@ -46,28 +48,52 @@ def test_csrf_failure(rf):
     assert "The form was not able to submit." in response.rendered_content
 
 
-def test_permission_denied(rf):
-    request = rf.get("/")
+def test_permission_denied_for_anonymous_user(rf):
+    request = rf.get("/test/")
     request.user = AnonymousUser()
 
     response = permission_denied(request)
 
     assert response.status_code == 403
     assert "Permission denied" in response.rendered_content
-    assert (
-        "You do not have permission to access this page." in response.rendered_content
-    )
+    assert "you may need to log in" in response.rendered_content.lower()
+    assert 'id="error-page-login-button"' in response.rendered_content
 
 
-def test_page_not_found(rf):
-    request = rf.get("/")
+def test_permission_denied_for_authenticated_user(rf):
+    request = rf.get("/test/")
+    request.user = UserFactory()
+
+    response = permission_denied(request)
+
+    assert response.status_code == 403
+    assert "Permission denied" in response.rendered_content
+    assert "you may need to log in" not in response.rendered_content.lower()
+    assert 'id="error-page-login-button"' not in response.rendered_content
+
+
+def test_page_not_found_for_anonymous_user(rf):
+    request = rf.get("/test/")
     request.user = AnonymousUser()
 
     response = page_not_found(request)
 
     assert response.status_code == 404
     assert "Page not found" in response.rendered_content
-    assert "Please check the URL in the address bar." in response.rendered_content
+    assert "you may need to log in" in response.rendered_content.lower()
+    assert 'id="error-page-login-button"' in response.rendered_content
+
+
+def test_page_not_found_for_authenticated_user(rf):
+    request = rf.get("/test/")
+    request.user = UserFactory()
+
+    response = page_not_found(request)
+
+    assert response.status_code == 404
+    assert "Page not found" in response.rendered_content
+    assert "you may need to log in" not in response.rendered_content.lower()
+    assert 'id="error-page-login-button"' not in response.rendered_content
 
 
 def test_server_error(rf):


### PR DESCRIPTION
Part fixes #5909

Summary of work in this PR:
- [x] Improve the messages on the 403 and 404 pages so that the possible causes for these are clearer to users.
- [x] Add some extra hints to the 403 and 404 pages if not `user.is_authenticated` to remind users that they may have been logged out and linking to the login page in a button.

Testing:
- Updating the unit tests for the permission_denied and page_not_found_views
- Tested manually with a local dev site (`just run` and debug set to false, so I could see the error pages)
  - As a logged-out user, I navigated to http://localhost:8000/test/ (404), and http://localhost:8000/staff/ (403)
  - As a logged-in user, I navigated to http://localhost:8000/test/ (404), and http://localhost:8000/staff/projects/create/ (403, because I don't have `ServiceAdministrator` role and associated permissions required to access the `ProjectCreate` view)

<details>
  <summary>Screenshots from running a local site</summary>
  
**Error pages for a logged in user**
<img width="1235" height="1010" alt="Screenshot from 2026-06-24 12-42-10" src="https://github.com/user-attachments/assets/65e6809b-bc5e-45d2-98c6-d9764b41692b" />
<img width="1235" height="1010" alt="Screenshot from 2026-06-24 12-48-37" src="https://github.com/user-attachments/assets/ca62949c-fb9c-4aa7-8512-7ab5ff520528" />


  **Error pages for a user who isn't logged in**
<img width="1235" height="1010" alt="Screenshot from 2026-06-24 12-37-08" src="https://github.com/user-attachments/assets/0fdc036d-2d95-4572-8000-6091030cb855" />
<img width="1235" height="1010" alt="Screenshot from 2026-06-24 12-42-26" src="https://github.com/user-attachments/assets/cec67bf3-e9c8-44fa-a2c3-46b4dc3077df" />


</details>