### PR TITLE
Fix error in scrubbing job encountered while testing in production

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -185,16 +185,19 @@ Follow the steps below to create the database, user, and set required permission
    GRANT USAGE ON SCHEMA public TO  jobserver_data_scrubbing;
    ```
 
-7. Grant read access to existing tables
+7. Grant read access to existing tables and sequences
 
    ```sql
    GRANT SELECT ON ALL TABLES IN SCHEMA public TO jobserver_data_scrubbing;
+   GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO jobserver_data_scrubbing;
    ```
 
-8. Grant read access to future tables
+8. Grant read access to future tables and sequences
 
    ```sql
    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO jobserver_data_scrubbing;
+   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON SEQUENCES TO jobserver_data_scrubbing;
+
    ```
 
 9. Re-run the query from step 4 and verify that the expected permissions have been granted.

--- a/jobserver/jobs/yearly/dump_scrubbed_db.py
+++ b/jobserver/jobs/yearly/dump_scrubbed_db.py
@@ -61,7 +61,7 @@ def run_database_command(command, database_config):
     try:
         subprocess.run(
             command,
-            env={**os.environ, "PGPASSWORD": database_config["PASSWORD"]},
+            env={"PATH": os.environ["PATH"], "PGPASSWORD": database_config["PASSWORD"]},
             capture_output=True,
             text=True,
             check=True,

--- a/jobserver/jobs/yearly/dump_scrubbed_db.py
+++ b/jobserver/jobs/yearly/dump_scrubbed_db.py
@@ -56,15 +56,23 @@ def database_connection_args(database_config):
 
 
 def run_database_command(command, database_config):
-    result = subprocess.run(
-        command,
-        env={**os.environ, "PGPASSWORD": database_config["PASSWORD"]},
-        capture_output=True,
-        text=True,
-    )
+    logger.info("Running database command", command=command)
 
-    if result.returncode != 0:
-        raise JobError(f"{command[0]} failed: stderr={result.stderr}")
+    try:
+        subprocess.run(
+            command,
+            env={**os.environ, "PGPASSWORD": database_config["PASSWORD"]},
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as error:
+        raise JobError(
+            f"{command[0]} failed\n"
+            f"returncode={error.returncode}\n"
+            f"stdout={error.stdout}\n"
+            f"stderr={error.stderr}"
+        ) from error
 
 
 def dump_database(database_config, output):

--- a/jobserver/jobs/yearly/dump_scrubbed_db.py
+++ b/jobserver/jobs/yearly/dump_scrubbed_db.py
@@ -55,8 +55,20 @@ def database_connection_args(database_config):
     ]
 
 
+def run_database_command(command, database_config):
+    result = subprocess.run(
+        command,
+        env={**os.environ, "PGPASSWORD": database_config["PASSWORD"]},
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        raise JobError(f"{command[0]} failed: stderr={result.stderr}")
+
+
 def dump_database(database_config, output):
-    subprocess.run(
+    run_database_command(
         [
             "pg_dump",
             "--format=c",
@@ -65,13 +77,12 @@ def dump_database(database_config, output):
             f"--file={output}",
             *database_connection_args(database_config),
         ],
-        env={**os.environ, "PGPASSWORD": database_config["PASSWORD"]},
-        check=True,
+        database_config,
     )
 
 
 def restore_database(database_config, input_dump):
-    subprocess.run(
+    run_database_command(
         [
             "pg_restore",
             "--clean",
@@ -81,19 +92,17 @@ def restore_database(database_config, input_dump):
             *database_connection_args(database_config),
             input_dump,
         ],
-        env={**os.environ, "PGPASSWORD": database_config["PASSWORD"]},
-        check=True,
+        database_config,
     )
 
 
 def clear_database(database_config):
-    subprocess.run(
+    run_database_command(
         [
             "psql",
             *database_connection_args(database_config),
             "--command",
             "DROP SCHEMA public CASCADE; CREATE SCHEMA public;",
         ],
-        env={**os.environ, "PGPASSWORD": database_config["PASSWORD"]},
-        check=True,
+        database_config,
     )

--- a/services/sentry.py
+++ b/services/sentry.py
@@ -91,6 +91,8 @@ def parse(data):
         "SOCIAL_AUTH_GITHUB_SECRET",
         "JOBSERVER_SCRUBBING_DATABASE_URL",
         "JOBSERVER_READONLY_DATABASE_URL",
+        "PASSWORD",
+        "PGPASSWORD",
     ]
 
     for token in tokens:

--- a/services/sentry.py
+++ b/services/sentry.py
@@ -89,6 +89,8 @@ def parse(data):
         "SENTRY_DSN",
         "SOCIAL_AUTH_GITHUB_KEY",
         "SOCIAL_AUTH_GITHUB_SECRET",
+        "JOBSERVER_SCRUBBING_DATABASE_URL",
+        "JOBSERVER_READONLY_DATABASE_URL",
     ]
 
     for token in tokens:


### PR DESCRIPTION
While testing the job in production after merging [this](https://github.com/opensafely-core/job-server/pull/5904) PR, I encountered an error and related [Sentry alert](https://ebm-datalab.sentry.io/issues/7570238993/?alert_rule_id=15682564&alert_type=issue&notification_uuid=d237a5c8-86ca-45ac-bad2-deb2f41fd179&project=5443358).

This PR fixes that error and add related error handling:
- Give the `jobserver_data_scrubbing` user `SELECT` permissions on sequences in the jobserver database, in addition to table `SELECT` permissions.
- Strip scrubbing database URLs from Sentry events. Add the `JOBSERVER_SCRUBBING_DATABASE_URL` and
`JOBSERVER_READONLY_DATABASE_URL` environment variables to the Sentry token scrub list so their full values are replaced before events are sent to Sentry.
- Handle error when database commands fail. Run `pg_dump`, `pg_restore` and `psql` through a helper that captures stderr output and raises `JobError` when the command fails. This makes failures visible in Sentry and helps to debug any issues.

## Testing
- The job ran successfully in production once when correct permissions were granted.
Related [slack](https://bennettoxford.slack.com/archives/C03D1G814BA/p1782222341533529) thread.
- Tested manually that JobError was thrown when the command failed.