### PR TITLE
Update uv tooling config in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 
 ## These build args are used in FROM lines, so need to be declared globally and have defaults set.
 ARG NODE_VERSION
-ARG UV_VERSION=0.9
+ARG UV_VERSION=0.11
 
 #################################################
 #
@@ -34,8 +34,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
 ENV UV_LINK_MODE=copy
 # compile at installation time, not import time
 ENV UV_COMPILE_BYTECODE=1
-# we are providing python via deadsnakes ppa
-# (as we require dynamic linking of openssl for security reasons)
+# we are using the ubuntu 24.04 system default python (3.12)
 ENV UV_PYTHON_DOWNLOADS=never
 # set the directory for the venv
 ENV UV_PROJECT_ENVIRONMENT="/opt/venv"


### PR DESCRIPTION
Closes #5854 

Work done:
- [x] update jobserver Dockerfile:
   - [x] update old comments, as we're not using deadsnakes ppa to install python (#5824)
   - [x] update `UV_VERSION` to 0.11 (from 0.9), to match what we use in other services e.g. [opencodelists](https://github.com/opensafely-core/opencodelists/blob/69005f45b8903bd263df0591057c23e61aaf4048/docker/Dockerfile#L5)
- [x] update jobserver [GHA workflows](https://github.com/opensafely-core/job-server/tree/main/.github/workflows)
  - [x] check if we can remove `uv` from the host runner set up (`install: uv` and `cache: uv`)
    - the workflow steps that install `uv` on the host runner do need `uv`, as they execute `just` recipes that call `uv` commands, so the current config remains unchanged.

Testing:

- Ran `just docker-build` locally; ran successfully to completion
- Ran `just docker-serve` with the newly-build image; successfully ran a local dev site
- For the verification workflow, I went to our [Verification tests workflow page](https://github.com/opensafely-core/job-server/actions/workflows/verification-tests.yml) and ran the workflow on my branch; it succeeded.