### PR TITLE
Address pytest parametrize deprecation notice

### DIFF
--- a/tests/paired_fields_utils.py
+++ b/tests/paired_fields_utils.py
@@ -54,16 +54,26 @@ def get_all_paired_fields(lsuffix, rsuffix, *, exclude=None):
         else:
             models.pop(model)
 
+    paired_fields = []
     for model, field_names in models.items():
         factory = get_factory(model)
         for lname, rname in get_paired_fields(model, lsuffix, rsuffix, field_names):
-            yield factory, lname, rname
+            paired_fields.append(
+                (factory, lname, rname),
+            )
+
+    return paired_fields
 
 
 def get_optional_paired_fields(*args, **kwargs):
+    paired_fields = []
     for factory, lname, rname in get_all_paired_fields(*args, **kwargs):
         model = factory._meta.model
         lfield = model._meta.get_field(lname)
         rfield = model._meta.get_field(rname)
         if lfield.null and rfield.null:
-            yield factory, lname, rname
+            paired_fields.append(
+                (factory, lname, rname),
+            )
+
+    return paired_fields

--- a/tests/unit/jobserver/api/test_releases.py
+++ b/tests/unit/jobserver/api/test_releases.py
@@ -1798,25 +1798,22 @@ def test_level4tokenauthenticationapi_fails_invalid_token(
     )
 
 
-def invalid_users():
-    def nonsocial_user():
-        user = UserFactory()
-        return user, f"User {user.username} is not a github user"
-
-    def social_user():
-        # github user but no backends
-        social_user = UserFactory()
-        UserSocialAuthFactory(user=social_user)
-        return (
-            social_user,
-            f"User {social_user.username} does not have access to any backends",
-        )
-
-    yield nonsocial_user
-    yield social_user
+def nonsocial_user():
+    user = UserFactory()
+    return user, f"User {user.username} is not a github user"
 
 
-@pytest.mark.parametrize("user_function", invalid_users())
+def social_user():
+    # github user but no backends
+    social_user = UserFactory()
+    UserSocialAuthFactory(user=social_user)
+    return (
+        social_user,
+        f"User {social_user.username} does not have access to any backends",
+    )
+
+
+@pytest.mark.parametrize("user_function", [nonsocial_user, social_user])
 def test_level4tokenauthenticationapi_fails_invalid_user(
     api_rf, project_membership, user_function, role_factory
 ):


### PR DESCRIPTION
In the latest version of pytest (v9.1.0) a deprecation warning is added for the use of non-Collection iterables in `@pytest.mark.parametrize`, as this can cause unexpected issues when the iterables are exhausted after the first iteration. This change replaces all uses with a list instead.

This will allow us to apply the latest dependency updates from #5922.