### PR TITLE
Add more sensitive tokens to Sentry scrubbing

### DIFF
--- a/services/sentry.py
+++ b/services/sentry.py
@@ -82,17 +82,22 @@ def parse(data):
 
     # tokens with values we want to strip
     tokens = [
+        "DATABASES",
+        "DATABASE_URL",
+        "CSP_REPORT_URI",
         "GITHUB_TOKEN_TESTING",
         "JOBSERVER_GITHUB_TOKEN",
+        "JOBSERVER_SCRUBBING_DATABASE_URL",
+        "JOBSERVER_READONLY_DATABASE_URL",
+        "MAILGUN_API_KEYPASSWORD",
+        "PASSWORD",
+        "PGPASSWORD",
         "RAP_API_TOKEN",
         "SECRET_KEY",
         "SENTRY_DSN",
+        "SLACK_BOT_TOKEN",
         "SOCIAL_AUTH_GITHUB_KEY",
         "SOCIAL_AUTH_GITHUB_SECRET",
-        "JOBSERVER_SCRUBBING_DATABASE_URL",
-        "JOBSERVER_READONLY_DATABASE_URL",
-        "PASSWORD",
-        "PGPASSWORD",
     ]
 
     for token in tokens:


### PR DESCRIPTION
Part fixes https://github.com/opensafely-core/job-server/issues/4219.

These contain or could contain secrets so it seems better security to never send them to Sentry at all rather than rely on Sentry-side scrubbing to avoid these leaking.

Found by looking at the environment variables in Job Server production and looking for things that might be sensitive. Except PASSWORD and PGPASSWORD which are likely risks in either subprocesses or as part of the DATABASES setting.

We should do a more thorough check later.

https://github.com/opensafely-core/job-server/issues/4219 also suggests changing our approach to the one Sentry reccomends. We should do that later. https://docs.sentry.io/platforms/python/data-management/sensitive-data/#scrubbing-data