### PR TITLE
Data scrubbing: Truncate `django_session` and `social_auth` tables

### DIFF
--- a/data_scrubbing/management/commands/scrub_data.py
+++ b/data_scrubbing/management/commands/scrub_data.py
@@ -1,24 +1,39 @@
 from django.apps import apps
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
+from django.core.management.color import no_style
+from django.db import connections, transaction
 from faker import Faker
 
 
 fake = Faker()
 
-SCRUBBED_APPLICATIONS = {
+APPLICATIONS_TO_SCRUB = {
     "applications",
     "jobserver",
     "redirects",
 }
 """Names of Django applications with models to be scrubbed."""
 
+TABLES_TO_TRUNCATE = [
+    # Session tokens should be kept secret and are not needed for local development.
+    # They are also arguably personal data.
+    "django_session",
+    # All the social auth tables may contain tokens or personal data and they
+    # are not needed for local development.
+    "social_auth_association",
+    "social_auth_code",
+    "social_auth_partial",
+    "social_auth_nonce",
+    "social_auth_usersocialauth",
+]
+"""Names of Database tables to be truncated entirely."""
+
 
 def get_scrubbed_models():
     "Accumulate set of Django model classes to be scrubbed."
     scrubbed_models = set()
-    for application in SCRUBBED_APPLICATIONS:
+    for application in APPLICATIONS_TO_SCRUB:
         scrubbed_models |= {
             model for model in apps.get_app_config(application).get_models()
         }
@@ -42,6 +57,19 @@ class Command(BaseCommand):
             dest="i_am_sure",
             help="Must be set to scrub the default database",
         )
+
+    def _truncate_tables(self, database_alias):
+        connection = connections[database_alias]
+        sql_list = connection.ops.sql_flush(
+            no_style(), TABLES_TO_TRUNCATE, allow_cascade=False
+        )
+
+        self.stdout.write("Truncating tables")
+        with connection.cursor() as cursor:
+            for sql_query in sql_list:
+                self.stdout.write(sql_query)
+                cursor.execute(sql_query)
+        self.stdout.write("Truncating tables complete")
 
     def handle(self, *args, **kwargs):
         database_alias = kwargs["database_alias"]
@@ -74,4 +102,7 @@ class Command(BaseCommand):
                 self.stdout.write(
                     f"Scrubbed {count} {model.__name__} records from fields: {', '.join(field_names)}"
                 )
-        self.stdout.write("Committed scrubbing transaction")
+
+            self._truncate_tables(database_alias)
+
+        self.stdout.write("Committed transaction")


### PR DESCRIPTION
These Django-defined and extension-defined tables may contain sensitive personal data or tokens. Let's just truncate these tables in full, as none of them seem to have necessary production data for the development site to work coherently. 

Use `sql_flush` so Django can write a backend-agnostic query list for us and handle escaping et cetera. Use `allow_cascade=False` to force listing all affected tables explicitly.

https://github.com/django/django/blob/61e078ecab9a9e8de9d283adf9fa554b6a145ce8/django/db/backends/base/operations.py#L465

So far I have only tested manually by getting a production-like database, running the command, reading the query logged, and seeing that the tables that were populated are empty after. We could try to populate them in the test database in the integration test perhaps.

Part addresses https://github.com/opensafely-core/security/issues/55.

These Django-defined and extension-defined tables may contain sensitive personal data or tokens. Let's just truncate these tables in full, as none of them seem to be necessary for the development site to work.

Use `sql_flush` so Django can write a backend-agnostic query list for us and
handle escaping et cetera. Use `allow_cascade=False` to force listing all
affected tables explicitly.

Some very old Django auth and admin tables are not present in the test database because we don't use them at all. So the integration test fails if you try to unconditionally truncate them. So they are not included. Probably the best option is to make a maintenance migration to drop these very old unused tables in production, so that it aligns with the tables that we actually use in the code, then we don't have to worry about scrubbing them or reintroduce them in the tests.

```
    # Default Django User tables. Different to jobserver_user.
    # Guard against future use or old production data that may have personal data.
    "auth_user",
    "auth_user_groups",
    "auth_user_user_permissions",
    # Can contain references to many other models including personal data.
    # Guard against future use or old production data that may have personal data.
    "django_admin_log",
```