### PR TITLE
Update NDOO issue template to support multiple projects

### DIFF
--- a/.github/ISSUE_TEMPLATE/0040_ndoo_request.md
+++ b/.github/ISSUE_TEMPLATE/0040_ndoo_request.md
@@ -1,22 +1,22 @@
 ---
 name: National Data Opt-Out request
-about: Request from the service team to allow a project to query patients who have opted out under NDOO
-title: Add project [PROJECT NUMBER] to NDOO permissions list
+about: Request from the service team to allow projects to query patients who have opted out under NDOO
+title: Add projects to NDOO permissions list
 labels: "tech-support-ndoo"
 assignees: ""
 ---
 
-Add a project to the National Data Opt-Out permissions list. This will grant the project permission to query patients with any NDOO status.
+Add projects to the National Data Opt-Out permissions list. This will grant the projects permission to query patients with any NDOO status.
 
-You should not create this issue if a project has requested to apply the National Data Opt-Out. ehrQL will exclude patients who have opted out under NDOO by default, so no extra configuration is needed.
-- Project number: [PROJECT NUMBER]
-- Project name: [PROJECT NAME]
+You should not include projects that have requested to apply the National Data Opt-Out. ehrQL will exclude patients who have opted out under NDOO by default, so no extra configuration is needed.
 
+- [FIRST PROJECT NUMBER]: [FIRST PROJECT NAME]
+- [SECOND PROJECT NUMBER]: [SECOND PROJECT NAME]
+- ... add more as needed
 
 When a member of the OpenSAFELY service team creates this issue, they should:
-1. Fill in the project name and number above
+1. Fill in the project names and numbers above
 1. Post a Slack message with a link to the issue, and mention tech-support
-1. Wait for tech-support to confirm that the project permissions have been updated before allowing the project to start running jobs on the backend
+1. Wait for tech-support to confirm that the project permissions have been updated before allowing the projects to start running jobs on the backend
 
-
-Whoever is on tech-support should [follow the instructions in the playbook](https://bennett.wiki/tech-group/tech-support/playbook/#requests-for-national-data-opt-out-ndoo-permissions) to configure the project.
+Whoever is on tech-support should [follow the instructions in the playbook](https://bennett.wiki/tech-group/tech-support/playbook/#requests-for-national-data-opt-out-ndoo-permissions) to configure the projects.


### PR DESCRIPTION
The service team expect to request NDOO permissions for several new projects at once. This makes it easier to pass a single bulk issue to tech-support.

See discussion: https://bennettoxford.slack.com/archives/C068NDYALSF/p1782392565655909?thread_ts=1775039902.334129&cid=C068NDYALSF