### PR TITLE
Fix Honeycomb job links

### DIFF
--- a/jobserver/honeycomb.py
+++ b/jobserver/honeycomb.py
@@ -156,7 +156,7 @@ def jobrequest_link(job_request):
     url = TemplatedUrl(
         start_time=start,
         end_time=end,
-        breakdowns=["job", "name"],
+        breakdowns=["job.id", "name"],
         calculations=[
             {"op": "CONCURRENCY"},
         ],
@@ -165,7 +165,7 @@ def jobrequest_link(job_request):
         omit_missing=True,
         filters=[
             {"column": "scope", "op": "=", "value": "ticks"},
-            {"column": "job_request", "op": "=", "value": job_request.identifier},
+            {"column": "job.request", "op": "=", "value": job_request.identifier},
         ],
     )
     return url.url
@@ -180,8 +180,12 @@ def previous_actions_link(job):
         calculations=[{"op": "HEATMAP", "column": "duration_minutes"}],
         filters=[
             {"column": "scope", "op": "=", "value": "jobs"},
-            {"column": "workspace", "op": "=", "value": job.job_request.workspace.name},
-            {"column": "action", "op": "=", "value": job.action},
+            {
+                "column": "job.workspace",
+                "op": "=",
+                "value": job.job_request.workspace.name,
+            },
+            {"column": "job.action", "op": "=", "value": job.action},
             {"column": "name", "op": "=", "value": "EXECUTING"},
         ],
     )

--- a/tests/unit/jobserver/test_honeycomb.py
+++ b/tests/unit/jobserver/test_honeycomb.py
@@ -142,7 +142,7 @@ def test_jobrequest_link(freezer):
     assert parsed.stacked
     assert parsed.omit_missing
     assert parsed.query == {
-        "breakdowns": ["job", "name"],
+        "breakdowns": ["job.id", "name"],
         "calculations": [
             {"op": "CONCURRENCY"},
         ],
@@ -150,7 +150,7 @@ def test_jobrequest_link(freezer):
         "filter_combination": "AND",
         "filters": [
             {"column": "scope", "op": "=", "value": "ticks"},
-            {"column": "job_request", "op": "=", "value": "jpbaeldzjqqiaolg"},
+            {"column": "job.request", "op": "=", "value": "jpbaeldzjqqiaolg"},
         ],
         "granularity": 0,
         "havings": [],
@@ -181,8 +181,8 @@ def test_previous_actions_link(freezer):
         "filter_combination": "AND",
         "filters": [
             {"column": "scope", "op": "=", "value": "jobs"},
-            {"column": "workspace", "op": "=", "value": "my_test_workspace"},
-            {"column": "action", "op": "=", "value": "my_sample_action"},
+            {"column": "job.workspace", "op": "=", "value": "my_test_workspace"},
+            {"column": "job.action", "op": "=", "value": "my_sample_action"},
             {"column": "name", "op": "=", "value": "EXECUTING"},
         ],
         "granularity": 0,

--- a/tests/unit/jobserver/views/test_jobs.py
+++ b/tests/unit/jobserver/views/test_jobs.py
@@ -215,7 +215,7 @@ def test_jobdetail_with_staff_area_administrator(rf, freezer):
     assert "trace_end_ts=1655380800" in response.rendered_content
     assert "Previous runs" in response.rendered_content
     assert (
-        "%22action%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22my_sample_action%22"
+        "%22job.action%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22my_sample_action%22"
         in response.rendered_content
     )
 


### PR DESCRIPTION
We namespaced the span attributes for jobs in the RAP agent, which has broken the telemetry links for job requests and previous run durations.

See:
- https://github.com/opensafely-core/job-runner/pull/1075
- https://github.com/opensafely-core/job-runner/pull/1368