### PR TITLE
Create scrubbed dump temp files in output directory

### DIFF
--- a/jobserver/jobs/yearly/dump_scrubbed_db.py
+++ b/jobserver/jobs/yearly/dump_scrubbed_db.py
@@ -28,6 +28,9 @@ class Job(YearlyJob):
         if data_scrubbing_database is None:
             raise JobError("JOBSERVER_SCRUBBING_DATABASE_URL is not set")
 
+        # Create the temporary directory beside the final dump so Path.replace()
+        # does not fail across filesystems. This can be simplified with Path.move()
+        # once we are on Python 3.14.
         with tempfile.TemporaryDirectory(
             prefix="dump-scrubbed-db-", dir=scrubbed_dump_path.parent
         ) as temp_dir_path:

--- a/jobserver/jobs/yearly/dump_scrubbed_db.py
+++ b/jobserver/jobs/yearly/dump_scrubbed_db.py
@@ -28,7 +28,9 @@ class Job(YearlyJob):
         if data_scrubbing_database is None:
             raise JobError("JOBSERVER_SCRUBBING_DATABASE_URL is not set")
 
-        with tempfile.TemporaryDirectory(prefix="dump-scrubbed-db-") as temp_dir_path:
+        with tempfile.TemporaryDirectory(
+            prefix="dump-scrubbed-db-", dir=scrubbed_dump_path.parent
+        ) as temp_dir_path:
             temp_dir_path = pathlib.Path(temp_dir_path)
             raw_dump_path = temp_dir_path / "raw.dump"
             temp_scrubbed_dump_path = temp_dir_path / scrubbed_dump_path.name
@@ -37,7 +39,6 @@ class Job(YearlyJob):
                 restore_database(data_scrubbing_database, raw_dump_path)
                 scrub_database(settings.DATA_SCRUBBING_DATABASE_ALIAS)
                 dump_database(data_scrubbing_database, temp_scrubbed_dump_path)
-                # Note: `Pathlib.replace` requires source and destination to be on the same filesystem.
                 temp_scrubbed_dump_path.replace(scrubbed_dump_path)
             finally:
                 clear_database(data_scrubbing_database)


### PR DESCRIPTION
Create the temporary directory for scrubbed dump files under the configured
output directory instead of the default system temp directory.

`Path.replace` uses `os.replace`, which fails across filesystems. Dokku
mounts `/storage` separately from `/tmp`, so keeping the temporary dump
under `/storage` ensures the final replace works and remains atomic.

Steve experienced [this](https://github.com/opensafely-core/job-server/pull/5934#discussion_r3512890872) issue, but we weren't sure whether it would happen in production as well. When testing in production, [this](https://bennettoxford.slack.com/archives/C03D1G814BA/p1783009456017439) issue happened too, therefore putting a fix in place.