### PR TITLE
Remove deprecated Honeycomb link

### DIFF
--- a/jobserver/honeycomb.py
+++ b/jobserver/honeycomb.py
@@ -130,27 +130,6 @@ def metrics_link(job):
     return url.url
 
 
-def status_link(job):
-    start, end = format_honeycomb_timestamps(job)
-    url = TemplatedUrl(
-        start_time=start,
-        end_time=end,
-        breakdowns=["name"],
-        calculations=[
-            {"op": "CONCURRENCY"},
-            {"op": "MAX", "column": "cpu_percentage"},
-            {"op": "MAX", "column": "memory_used"},
-        ],
-        stacked=True,
-        omit_missing=True,
-        filters=[
-            {"column": "scope", "op": "=", "value": "ticks"},
-            {"column": "job", "op": "=", "value": job.identifier},
-        ],
-    )
-    return url.url
-
-
 def jobrequest_link(job_request):
     start, end = format_honeycomb_timestamps(job_request)
     url = TemplatedUrl(

--- a/jobserver/views/jobs.py
+++ b/jobserver/views/jobs.py
@@ -78,9 +78,6 @@ class JobDetail(View):
             if trace_link:  # pragma: no cover
                 honeycomb_links["Job Trace"] = trace_link
             honeycomb_links["Job Metrics"] = honeycomb.metrics_link(job)
-            honeycomb_links["Status and Resources [DEPRECATED]"] = (
-                honeycomb.status_link(job)
-            )
 
             # Look this up manually, because if we use job.job_request, the
             # JobRequest will not have prefetched all associated Jobs, and

--- a/tests/unit/jobserver/test_honeycomb.py
+++ b/tests/unit/jobserver/test_honeycomb.py
@@ -67,35 +67,6 @@ def test_trace_link(freezer):
     assert "bennett-institute-for-applied-data-science" in url
 
 
-def test_status_link(freezer):
-    freezer.move_to("2022-10-12 17:00")
-
-    job = JobFactory(completed_at=timezone.now(), identifier="test_identifier")
-    url = honeycomb.status_link(job)
-    parsed = honeycomb.TemplatedUrl.parse(url)
-
-    assert parsed.stacked
-    assert parsed.query == {
-        "breakdowns": ["name"],
-        "calculations": [
-            {"op": "CONCURRENCY"},
-            {"op": "MAX", "column": "cpu_percentage"},
-            {"op": "MAX", "column": "memory_used"},
-        ],
-        "end_time": 1665594060,
-        "filter_combination": "AND",
-        "filters": [
-            {"column": "scope", "op": "=", "value": "ticks"},
-            {"column": "job", "op": "=", "value": "test_identifier"},
-        ],
-        "granularity": 0,
-        "havings": [],
-        "limit": 1000,
-        "orders": [],
-        "start_time": 1665593940,
-    }
-
-
 def test_metrics_link(freezer):
     freezer.move_to("2022-10-12 17:00")
 

--- a/tests/unit/jobserver/views/test_jobs.py
+++ b/tests/unit/jobserver/views/test_jobs.py
@@ -228,7 +228,6 @@ def test_jobdetail_with_staff_area_administrator(rf, freezer):
     assert job_request.identifier in response.rendered_content
 
     assert escape(honeycomb.metrics_link(job)) in response.rendered_content
-    assert escape(honeycomb.status_link(job)) in response.rendered_content
 
 
 @pytest.mark.slow_test


### PR DESCRIPTION
The status and resources link was deprecated last year when we changed the way CPU and memory metrics are emitted:
https://github.com/opensafely-core/job-server/pull/5099

We only keep Honeycomb data for 60 days, so this link doesn't show any data, even for historical jobs.

Users can use the job metrics link to see CPU and memory stats.