### PR TITLE
Add management command for raw database dump

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,6 +31,7 @@ dokku config:set job-server RAP_API_BASE_URL=https://controller.opensafely.org/c
 dokku config:set job-server JOBSERVER_READONLY_DATABASE_URL='xxxx'
 dokku config:set job-server JOBSERVER_SCRUBBING_DATABASE_URL='xxxx'
 dokku config:set job-server JOBSERVER_SCRUBBED_DUMP_PATH='/storage/jobserver_scrubbed.dump'
+dokku config:set job-server JOBSERVER_RAW_DUMP_PATH=/storage/jobserver.dump
 
 # Disable zero-downtime deploys for the rapstatus process (which runs the rap_status_service
 # manangement command). We don't ever want two of these loops running simultaneously

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -11,6 +11,7 @@ DATABASE_URL=postgres://user:pass@localhost:6543/jobserver
 # JOBSERVER_SCRUBBING_DATABASE_URL=postgres://user:pass@localhost:6543/jobserver_scrubbing
 # Path where the scrubbed database dump will be written.
 # JOBSERVER_SCRUBBED_DUMP_PATH=jobserver_scrubbed.dump
+JOBSERVER_RAW_DUMP_PATH=jobserver.dump
 
 # Turn on debug
 DEBUG=1

--- a/jobserver/management/commands/dump_raw_data.py
+++ b/jobserver/management/commands/dump_raw_data.py
@@ -19,8 +19,14 @@ def database_connection_args(database_config):
     ]
 
 
+# This command creates a raw JobServer database dump containing personal data.
+# Follow the personal data copying policy before running it. Only create or
+# download a raw dump when agreed with your line manager or Tech SLT.
 class Command(BaseCommand):
-    help = "Create a raw dump of the JobServer database"
+    help = (
+        "Create a raw dump of the JobServer database. "
+        "Only run this when agreed with your line manager or Tech SLT."
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/jobserver/management/commands/dump_raw_data.py
+++ b/jobserver/management/commands/dump_raw_data.py
@@ -1,0 +1,68 @@
+import os
+import pathlib
+import subprocess
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+
+def database_connection_args(database_config):
+    return [
+        "--host",
+        database_config["HOST"],
+        "--port",
+        str(database_config["PORT"]),
+        "--username",
+        database_config["USER"],
+        "--dbname",
+        database_config["NAME"],
+    ]
+
+
+class Command(BaseCommand):
+    help = "Create a raw dump of the JobServer database"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output",
+            default=settings.RAW_DATABASE_DUMP_PATH,
+            help="Path where the raw database dump should be written",
+        )
+
+    def handle(self, *args, **options):
+        database_config = settings.DATABASES["default"]
+        output_path = pathlib.Path(options["output"])
+
+        command = [
+            "pg_dump",
+            "--format=c",
+            "--no-acl",
+            "--no-owner",
+            f"--file={output_path}",
+            *database_connection_args(database_config),
+        ]
+
+        self.stdout.write(f"Creating raw JobServer database dump at {output_path}")
+
+        try:
+            subprocess.run(
+                command,
+                env={
+                    "PATH": os.environ["PATH"],
+                    "PGPASSWORD": database_config["PASSWORD"],
+                },
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as error:
+            raise CommandError(
+                "pg_dump failed\n"
+                f"returncode={error.returncode}\n"
+                f"stdout={error.stdout}\n"
+                f"stderr={error.stderr}"
+            ) from error
+
+        self.stdout.write(
+            f"Finished creating raw JobServer database dump at {output_path}"
+        )

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -461,6 +461,11 @@ SCRUBBED_DATABASE_DUMP_PATH = Path(
     os.environ.get("JOBSERVER_SCRUBBED_DUMP_PATH", default="jobserver_scrubbed.dump")
 )
 
+# Path where the dump_raw_data command writes the raw database dump
+RAW_DATABASE_DUMP_PATH = Path(
+    os.environ.get("JOBSERVER_RAW_DUMP_PATH", default="jobserver.dump")
+)
+
 # IP prefix of docker subnet on dokku 4
 TRUSTED_PROXIES = (
     [

--- a/tests/unit/jobserver/management/commands/test_dump_raw_data.py
+++ b/tests/unit/jobserver/management/commands/test_dump_raw_data.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from types import SimpleNamespace
 
 import pytest
 from django.core.management import call_command
@@ -14,22 +15,29 @@ TEST_DBNAME = "test_dbname"
 
 
 @pytest.fixture
-def default_database(settings):
-    database_config = {
-        "HOST": TEST_HOST,
-        "PORT": TEST_PORT,
-        "USER": TEST_USER,
-        "PASSWORD": TEST_PASSWORD,
-        "NAME": TEST_DBNAME,
-    }
-    settings.DATABASES["default"] = database_config
-    return database_config
+def fake_database_settings(monkeypatch, tmp_path):
+    fake_settings = SimpleNamespace(
+        DATABASES={
+            "default": {
+                "HOST": TEST_HOST,
+                "PORT": TEST_PORT,
+                "USER": TEST_USER,
+                "PASSWORD": TEST_PASSWORD,
+                "NAME": TEST_DBNAME,
+            }
+        },
+        RAW_DATABASE_DUMP_PATH=tmp_path / "jobserver.dump",
+    )
+
+    monkeypatch.setattr(
+        "jobserver.management.commands.dump_raw_data.settings", fake_settings
+    )
+
+    return fake_settings
 
 
-def test_dump_raw_data_command(
-    settings, default_database, monkeypatch, tmp_path, capsys
-):
-    settings.RAW_DATABASE_DUMP_PATH = tmp_path / "jobserver.dump"
+@pytest.fixture
+def fake_subprocess_calls(monkeypatch):
     calls = []
 
     def fake_run(command, env, capture_output, text, check):
@@ -48,28 +56,35 @@ def test_dump_raw_data_command(
         fake_run,
     )
 
+    return calls
+
+
+def test_dump_raw_data_command_with_default_path(
+    fake_database_settings, fake_subprocess_calls, capsys
+):
     call_command("dump_raw_data")
 
-    assert calls == [
+    output_path = fake_database_settings.RAW_DATABASE_DUMP_PATH
+    assert fake_subprocess_calls == [
         {
             "command": [
                 "pg_dump",
                 "--format=c",
                 "--no-acl",
                 "--no-owner",
-                f"--file={tmp_path / 'jobserver.dump'}",
+                f"--file={output_path}",
                 "--host",
-                default_database["HOST"],
+                TEST_HOST,
                 "--port",
-                default_database["PORT"],
+                TEST_PORT,
                 "--username",
-                default_database["USER"],
+                TEST_USER,
                 "--dbname",
-                default_database["NAME"],
+                TEST_DBNAME,
             ],
             "env": {
                 "PATH": os.environ["PATH"],
-                "PGPASSWORD": default_database["PASSWORD"],
+                "PGPASSWORD": TEST_PASSWORD,
             },
             "capture_output": True,
             "text": True,
@@ -78,37 +93,21 @@ def test_dump_raw_data_command(
     ]
 
     out, _ = capsys.readouterr()
-    assert (
-        f"Creating raw JobServer database dump at {tmp_path / 'jobserver.dump'}" in out
-    )
-    assert (
-        f"Finished creating raw JobServer database dump at {tmp_path / 'jobserver.dump'}"
-        in out
-    )
+    assert f"Creating raw JobServer database dump at {output_path}" in out
+    assert f"Finished creating raw JobServer database dump at {output_path}" in out
 
 
 def test_dump_raw_data_command_with_custom_path(
-    default_database, monkeypatch, tmp_path
+    fake_database_settings, fake_subprocess_calls, tmp_path
 ):
-    calls = []
-
-    def fake_run(command, **kwargs):
-        calls.append(command)
-
-    monkeypatch.setattr(
-        "jobserver.management.commands.dump_raw_data.subprocess.run",
-        fake_run,
-    )
-
     output_path = tmp_path / "custom.dump"
+
     call_command("dump_raw_data", "--output", str(output_path))
 
-    assert calls[0][4] == f"--file={output_path}"
+    assert fake_subprocess_calls[0]["command"][4] == f"--file={output_path}"
 
 
-def test_command_error(settings, default_database, monkeypatch, tmp_path):
-    settings.RAW_DATABASE_DUMP_PATH = tmp_path / "jobserver.dump"
-
+def test_dump_raw_data_command_error(fake_database_settings, monkeypatch):
     def fake_run(*args, **kwargs):
         raise subprocess.CalledProcessError(
             returncode=1,

--- a/tests/unit/jobserver/management/commands/test_dump_raw_data.py
+++ b/tests/unit/jobserver/management/commands/test_dump_raw_data.py
@@ -1,0 +1,130 @@
+import os
+import subprocess
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+TEST_HOST = "test_host"
+TEST_PORT = "test_port"
+TEST_USER = "test_user"
+TEST_PASSWORD = "test_pass"
+TEST_DBNAME = "test_dbname"
+
+
+@pytest.fixture
+def default_database(settings):
+    database_config = {
+        "HOST": TEST_HOST,
+        "PORT": TEST_PORT,
+        "USER": TEST_USER,
+        "PASSWORD": TEST_PASSWORD,
+        "NAME": TEST_DBNAME,
+    }
+    settings.DATABASES["default"] = database_config
+    return database_config
+
+
+def test_dump_raw_data_command(
+    settings, default_database, monkeypatch, tmp_path, capsys
+):
+    settings.RAW_DATABASE_DUMP_PATH = tmp_path / "jobserver.dump"
+    calls = []
+
+    def fake_run(command, env, capture_output, text, check):
+        calls.append(
+            {
+                "command": command,
+                "env": env,
+                "capture_output": capture_output,
+                "text": text,
+                "check": check,
+            }
+        )
+
+    monkeypatch.setattr(
+        "jobserver.management.commands.dump_raw_data.subprocess.run",
+        fake_run,
+    )
+
+    call_command("dump_raw_data")
+
+    assert calls == [
+        {
+            "command": [
+                "pg_dump",
+                "--format=c",
+                "--no-acl",
+                "--no-owner",
+                f"--file={tmp_path / 'jobserver.dump'}",
+                "--host",
+                default_database["HOST"],
+                "--port",
+                default_database["PORT"],
+                "--username",
+                default_database["USER"],
+                "--dbname",
+                default_database["NAME"],
+            ],
+            "env": {
+                "PATH": os.environ["PATH"],
+                "PGPASSWORD": default_database["PASSWORD"],
+            },
+            "capture_output": True,
+            "text": True,
+            "check": True,
+        }
+    ]
+
+    out, _ = capsys.readouterr()
+    assert (
+        f"Creating raw JobServer database dump at {tmp_path / 'jobserver.dump'}" in out
+    )
+    assert (
+        f"Finished creating raw JobServer database dump at {tmp_path / 'jobserver.dump'}"
+        in out
+    )
+
+
+def test_dump_raw_data_command_with_custom_path(
+    default_database, monkeypatch, tmp_path
+):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+
+    monkeypatch.setattr(
+        "jobserver.management.commands.dump_raw_data.subprocess.run",
+        fake_run,
+    )
+
+    output_path = tmp_path / "custom.dump"
+    call_command("dump_raw_data", "--output", str(output_path))
+
+    assert calls[0][4] == f"--file={output_path}"
+
+
+def test_command_error(settings, default_database, monkeypatch, tmp_path):
+    settings.RAW_DATABASE_DUMP_PATH = tmp_path / "jobserver.dump"
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["pg_dump"],
+            output="stdout",
+            stderr="stderr",
+        )
+
+    monkeypatch.setattr(
+        "jobserver.management.commands.dump_raw_data.subprocess.run",
+        fake_run,
+    )
+
+    with pytest.raises(CommandError, match="pg_dump failed") as error:
+        call_command("dump_raw_data")
+
+    assert "returncode=1" in str(error.value)
+    assert "stdout=stdout" in str(error.value)
+    assert "stderr=stderr" in str(error.value)

--- a/tests/unit/jobserver/management/commands/test_dump_raw_data.py
+++ b/tests/unit/jobserver/management/commands/test_dump_raw_data.py
@@ -1,10 +1,12 @@
 import os
 import subprocess
-from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.test import override_settings
 
 
 TEST_HOST = "test_host"
@@ -15,25 +17,23 @@ TEST_DBNAME = "test_dbname"
 
 
 @pytest.fixture
-def fake_database_settings(monkeypatch, tmp_path):
-    fake_settings = SimpleNamespace(
-        DATABASES={
-            "default": {
-                "HOST": TEST_HOST,
-                "PORT": TEST_PORT,
-                "USER": TEST_USER,
-                "PASSWORD": TEST_PASSWORD,
-                "NAME": TEST_DBNAME,
-            }
-        },
-        RAW_DATABASE_DUMP_PATH=tmp_path / "jobserver.dump",
-    )
+def dump_raw_data_settings(tmp_path):
+    database_config = {
+        **settings.DATABASES["default"],
+        "HOST": TEST_HOST,
+        "PORT": TEST_PORT,
+        "USER": TEST_USER,
+        "PASSWORD": TEST_PASSWORD,
+        "NAME": TEST_DBNAME,
+    }
 
-    monkeypatch.setattr(
-        "jobserver.management.commands.dump_raw_data.settings", fake_settings
-    )
+    output_path = tmp_path / "jobserver.dump"
 
-    return fake_settings
+    with (
+        patch.dict(settings.DATABASES["default"], database_config),
+        override_settings(RAW_DATABASE_DUMP_PATH=output_path),
+    ):
+        yield output_path
 
 
 @pytest.fixture
@@ -60,11 +60,12 @@ def fake_subprocess_calls(monkeypatch):
 
 
 def test_dump_raw_data_command_with_default_path(
-    fake_database_settings, fake_subprocess_calls, capsys
+    dump_raw_data_settings, fake_subprocess_calls, capsys
 ):
     call_command("dump_raw_data")
 
-    output_path = fake_database_settings.RAW_DATABASE_DUMP_PATH
+    output_path = dump_raw_data_settings
+
     assert fake_subprocess_calls == [
         {
             "command": [
@@ -98,7 +99,7 @@ def test_dump_raw_data_command_with_default_path(
 
 
 def test_dump_raw_data_command_with_custom_path(
-    fake_database_settings, fake_subprocess_calls, tmp_path
+    dump_raw_data_settings, fake_subprocess_calls, tmp_path
 ):
     output_path = tmp_path / "custom.dump"
 
@@ -107,7 +108,7 @@ def test_dump_raw_data_command_with_custom_path(
     assert fake_subprocess_calls[0]["command"][4] == f"--file={output_path}"
 
 
-def test_dump_raw_data_command_error(fake_database_settings, monkeypatch):
+def test_dump_raw_data_command_error(dump_raw_data_settings, monkeypatch):
     def fake_run(*args, **kwargs):
         raise subprocess.CalledProcessError(
             returncode=1,


### PR DESCRIPTION
## Description

https://github.com/opensafely-core/security/issues/53

Add a `dump_raw_data` management command to create raw JobServer database dumps manually.

The command uses the same safer subprocess pattern as the scrubbed dump job: it passes database connection details as `pg_dump` arguments, provides the password through `PGPASSWORD`, and raises `CommandError` with `stdout/stderr` when `pg_dump` fails.

Add a configurable raw dump output path so the production `/storage` location is set through environment configuration rather than hardcoded in the command.

Tip for reviewer - This script is doing the same thing as  [hourly dump job](https://github.com/opensafely-core/job-server/blob/main/jobserver/jobs/hourly/dump_db.py). Instead of a job, it is a management command with some improvements.

## Next steps

This is a step towards replacing the scheduled hourly `dump_db` job. The raw dump command should be used only when there is an approved need for a raw production copy.

Once this PR is merged and scrubbed dump is available on dokku4, I will remove the [hourly dump job](https://github.com/opensafely-core/job-server/blob/main/jobserver/jobs/hourly/dump_db.py) and will ask developers to use this management command whenever a raw dump is required. 