### PR TITLE
Remove tomodwyer from package.json codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,3 @@
 # files for approval process.
 jobserver/permissions/population_permissions/t1oo.py         @opensafely-core/ig-team
 jobserver/permissions/sqlrunner.py                           @opensafely-core/ig-team
-
-# Replacement for Dependabot reviewers
-**/package*.json @tomodwyer


### PR DESCRIPTION
This was added in #5097 as a measure for updating how we used dependabot, but is no longer required as the whole team now manages dependabot updates.