### PR TITLE
Convert scrubbed database dump from yearly to daily job

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,10 +19,6 @@
     {
       "command": "python manage.py runjobs monthly",
       "schedule": "@monthly"
-    },
-    {
-      "command": "python manage.py runjobs yearly",
-      "schedule": "0 17 10 6 *"
     }
   ],
   "healthchecks": {

--- a/jobserver/jobs/daily/dump_scrubbed_db.py
+++ b/jobserver/jobs/daily/dump_scrubbed_db.py
@@ -6,14 +6,14 @@ import tempfile
 import structlog
 from django.conf import settings
 from django.core.management import CommandError, call_command
-from django_extensions.management.jobs import JobError, YearlyJob
+from django_extensions.management.jobs import DailyJob, JobError
 
 
 logger = structlog.get_logger(__name__)
 
 
-class Job(YearlyJob):
-    help = "Scrubbed database dump job (in progress)"
+class Job(DailyJob):
+    help = "Create a scrubbed database dump"
 
     def execute(self):
         scrubbed_dump_path = settings.SCRUBBED_DATABASE_DUMP_PATH

--- a/jobserver/jobs/yearly/__init__.py
+++ b/jobserver/jobs/yearly/__init__.py
@@ -1,0 +1,2 @@
+# There is no scheduled yearly runjobs entry in app.json.
+# Jobs added to this package will not run unless app.json is updated.


### PR DESCRIPTION
## Description
https://github.com/opensafely-core/security/issues/69
Move dump_scrubbed_db from the yearly job group to the daily job group now that the dump, restore, scrub, and cleanup workflow has been tested on dokku.

This lets the existing daily runjobs schedule create the scrubbed database dump routinely for local development.

I haven't added the documentation changes yet, as [PR for raw dump](https://github.com/opensafely-core/job-server/pull/5954) is also in review. Once that PR is also merged, I will update instructions in `DEVELOPERS.md` as follows:
1. Remove instructions to copy and restore `jobserver.dump` and replace it with `jobserver_scrubbed.dump`
2. Add instructions to download the raw dump, follow the personal data copying policy and use the management command created in [above PR](https://github.com/opensafely-core/job-server/pull/5954).
3. Inform on tech slack group about this change.

## Testing
This script worked when it was yearly. And a scrubbed dump is already available on Dokku when I tested the script on dokku. You can download and restore it using the commands below:
```
1. scp dokku4:/var/lib/dokku/data/storage/job-server/jobserver_scrubbed.dump
2. just docker/restore-db jobserver_scrubbed.dump
```

To test the job in this PR locally, follow the steps:
```
1. just docker/db
2. createdb -h localhost -p 6543 -U user jobserver_scrubbing
3. python manage.py runjob dump_scrubbed_db
4. just docker/restore-db jobserver_scrubbed.dump
```