### PR TITLE
Unpin pytest-socket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ skip_covered = true
 show_contexts = true
 
 [tool.pytest.ini_options]
-addopts = "--disable-socket --tb=native --maxprocesses=6 --strict-markers"
+addopts = "--disable-socket --allow-hosts=localhost --tb=native --maxprocesses=6 --strict-markers"
 DJANGO_SETTINGS_MODULE = "jobserver.settings"
 env = [
   "JOBSERVER_GITHUB_TOKEN=empty",
@@ -277,8 +277,7 @@ dev = [
     "pytest-icdiff",
     "pytest-mock",
     "pytest-playwright",
-    # Pin temporarily due to failures with v0.8.0.
-    "pytest-socket==0.7.0",
+    "pytest-socket",
     "pytest-xdist[psutil]",
     "responses",
     "ruff",

--- a/requirements.uvmirror
+++ b/requirements.uvmirror
@@ -233,7 +233,7 @@ pytest-freezer==0.4.9
 pytest-icdiff==0.9
 pytest-mock==3.15.1
 pytest-playwright==0.8.0
-pytest-socket==0.7.0
+pytest-socket==0.8.0
 pytest-xdist==3.8.0
 python-dateutil==2.9.0.post0
     # via freezegun

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -3,7 +3,16 @@ import urllib
 
 import pytest
 import requests
-from pytest_socket import SocketBlockedError
+from pytest_socket import SocketConnectBlockedError
+
+
+# pytest-socket adds warnings on socket use.
+# In our tests, we raise errors for warnings.
+# These warnings are expected here,
+# so we should ignore for these tests only.
+# If we have a network access warning elsewhere,
+# it would be helpful to have the failure.
+pytestmark = pytest.mark.filterwarnings("ignore")
 
 
 @pytest.mark.django_db(False)
@@ -11,16 +20,23 @@ class TestNetworkBlocked:
     """Test that network/socket access is blocked during tests."""
 
     def test_network_blocked_socket(self):
-        """Test that network/socket access is blocked via `socket`."""
-        with pytest.raises(SocketBlockedError):
-            socket.socket()
+        """Test that non-localhost network/socket access is blocked via `socket`."""
+        with pytest.raises(SocketConnectBlockedError):
+            # We previously used socket.socket() to test this behaviour.
+            # But we need to allow localhost sockets for database access,
+            # as of pytest-socket v0.8.0.
+            # So test connection to a non-localhost IP
+            # that should not be connectable.
+            # 192.0.2.176 is an IP in the TEST-NET-1 range:
+            # https://datatracker.ietf.org/doc/html/rfc5737
+            socket.create_connection(("192.0.2.176", 443), timeout=0.001)
 
     def test_network_blocked_requests(self):
         """Test that network/socket access is blocked via `requests`."""
-        with pytest.raises(SocketBlockedError):
+        with pytest.raises(SocketConnectBlockedError):
             requests.get("https://example.com")
 
     def test_network_blocked_urllib(self):
         """Test that network/socket access is blocked via `urllib`."""
-        with pytest.raises(SocketBlockedError):
+        with pytest.raises(SocketConnectBlockedError):
             urllib.request.urlopen("https://example.com")

--- a/uv.lock
+++ b/uv.lock
@@ -889,7 +889,7 @@ dev = [
     { name = "pytest-icdiff" },
     { name = "pytest-mock" },
     { name = "pytest-playwright" },
-    { name = "pytest-socket", specifier = "==0.7.0" },
+    { name = "pytest-socket" },
     { name = "pytest-xdist", extras = ["psutil"] },
     { name = "responses" },
     { name = "ruff" },
@@ -1498,14 +1498,14 @@ wheels = [
 
 [[package]]
 name = "pytest-socket"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/ff/90c7e1e746baf3d62ce864c479fd53410b534818b9437413903596f81580/pytest_socket-0.7.0.tar.gz", hash = "sha256:71ab048cbbcb085c15a4423b73b619a8b35d6a307f46f78ea46be51b1b7e11b3", size = 12389, upload-time = "2024-01-28T20:17:23.177Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/3c/f9b58e57830e58980dbe8867d0e348f45701d3f3ea065672d448f4366da5/pytest_socket-0.8.0.tar.gz", hash = "sha256:af9bb5f487da72be63573a6194cfac033b6c7a1c1561e150521105970f9e99f2", size = 13912, upload-time = "2026-05-21T16:50:22.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/58/5d14cb5cb59409e491ebe816c47bf81423cd03098ea92281336320ae5681/pytest_socket-0.7.0-py3-none-any.whl", hash = "sha256:7e0f4642177d55d317bbd58fc68c6bd9048d6eadb2d46a89307fa9221336ce45", size = 6754, upload-time = "2024-01-28T20:17:22.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e8/4a8568580bae3dcd678599ed8e86a82d505a44df71c1ced4246c1aa14b4b/pytest_socket-0.8.0-py3-none-any.whl", hash = "sha256:81821ba59f07d7600fe2b551d8714f40b068bd46e8b6704c48664e9d60cdacb8", size = 8414, upload-time = "2026-05-21T16:50:21.022Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #5888.

`pytest-socket` was [introduced as a replacement](https://github.com/opensafely-core/job-server/pull/5063) for the unmaintained `pytest-network`.

There's no specific commit message explaining why `pytest-network` was added in 1b8542a3f9dd154de796933fb3e3541cd8af0ca4 (as part of #408).

The only context I can find for the use of `pytest-network` (which we replaced with `pytest-socket` in #5063) is from George in response to being asked [what is being mocked in job-server tests](https://bennettoxford.slack.com/archives/C63UXGB8E/p1619794117190700?thread_ts=1619793981.189600&cid=C63UXGB8E):

> anything with external network access, there are a few views
> where we have to hit the GitHub API for data
> I've even gone as far as adding pytest-network to throw an error
> if there's any network access in the tests

Whether we still want to enforce this is another question, but, in this context, allowing localhost seems OK here, since that will still restrict external access.