### PR TITLE
Update our jobserver workflows to use the latest v1.7.0 release of setup-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
+      - uses: opensafely-core/setup-action@d9171097dd0d37bdb7bed58f701eb03ff317ed17 # v1.7.0
         with:
           install-just: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
+      - uses: opensafely-core/setup-action@d9171097dd0d37bdb7bed58f701eb03ff317ed17 # v1.7.0
         with:
           python-version: "3.12"
           install-just: true
@@ -62,7 +62,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
+      - uses: opensafely-core/setup-action@d9171097dd0d37bdb7bed58f701eb03ff317ed17 # v1.7.0
         with:
           python-version: "3.12"
           install-just: true
@@ -127,7 +127,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
+      - uses: opensafely-core/setup-action@d9171097dd0d37bdb7bed58f701eb03ff317ed17 # v1.7.0
         with:
           install-just: true
 
@@ -161,7 +161,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
+      - uses: opensafely-core/setup-action@d9171097dd0d37bdb7bed58f701eb03ff317ed17 # v1.7.0
         with:
           install-just: true
 

--- a/.github/workflows/update-python-dependencies.yml
+++ b/.github/workflows/update-python-dependencies.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         persist-credentials: false
 
-    - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
+    - uses: opensafely-core/setup-action@d9171097dd0d37bdb7bed58f701eb03ff317ed17 # v1.7.0
       with:
         install-just: true
         install-uv: true

--- a/.github/workflows/uvmirror-check.yml
+++ b/.github/workflows/uvmirror-check.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
+      - uses: opensafely-core/setup-action@d9171097dd0d37bdb7bed58f701eb03ff317ed17 # v1.7.0
         with:
           install-just: true
           install-uv: true

--- a/.github/workflows/verification-tests.yml
+++ b/.github/workflows/verification-tests.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
+      - uses: opensafely-core/setup-action@d9171097dd0d37bdb7bed58f701eb03ff317ed17 # v1.7.0
         with:
           python-version: "3.12"
           install-just: true


### PR DESCRIPTION
Closes #5963

Update the jobserver workflows to use the SHA for the latest v1.7.0 release of [opensafely-core/setup-action](https://github.com/opensafely-core/setup-action/releases).

Previously the workflows referenced the SHA for the older `v1.6.1` release of setup-action, which internally used an older version of astral-sh/setup-uv, causing Node 20 deprecation warnings in CI.

The updated SHA corresponds to the current `v1.7.0` release of opensafely-core/setup-action which uses an updated version of astral-sh/setup-uv that uses Node24.