### PR TITLE
Add integration test for `dump_raw_data` command

### DIFF
--- a/justfile
+++ b/justfile
@@ -113,8 +113,8 @@ scrub-data: devenv
 test-ci *args: assets
     #!/bin/bash
     export COVERAGE_PROCESS_START="pyproject.toml"
-    export COVERAGE_REPORT_ARGS="--omit=jobserver/github.py,jobserver/opencodelists.py,tests/fakes.py,tests/verification/*,tests/functional/*"
-    ./scripts/test-coverage.sh -m "not verification and not functional" {{ args }}
+    export COVERAGE_REPORT_ARGS="--omit=jobserver/github.py,jobserver/opencodelists.py,tests/fakes.py,tests/verification/*,tests/functional/*,tests/integration/test_dump_raw_data.py"
+    ./scripts/test-coverage.sh -m "not verification and not functional and not docker_test" {{ args }}
 
 # Run the Python functional tests, using Playwright.
 test-functional *ARGS: devenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ markers = [
   "slow_test: mark test as being slow running",
   "verification: tests that verify fakes",
   "functional: tests that use Playwright in functional tests",
+  "docker_test: tests that require the Docker test environment or its system dependencies",
 ]
 xfail_strict=true
 

--- a/tests/integration/test_dump_raw_data.py
+++ b/tests/integration/test_dump_raw_data.py
@@ -1,0 +1,52 @@
+import subprocess
+
+import pytest
+from django.core.management import call_command
+
+from ..factories import UserFactory
+
+
+@pytest.mark.docker_test
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.slow_test
+def test_dump_raw_data_command_creates_valid_dump(tmp_path, slack_messages):
+    """Check the command creates a dump containing data from the test database."""
+    username = "TestPostgresDumpCommand"
+    UserFactory(username=username)
+
+    output_path = tmp_path / "test.dump"
+
+    call_command(
+        "dump_raw_data",
+        output=str(output_path),
+    )
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+
+    result = subprocess.run(
+        [
+            "pg_restore",
+            "--data-only",
+            "--table",
+            "jobserver_user",
+            "--file=-",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    message, _ = slack_messages[0]
+
+    assert username in result.stdout
+    assert len(slack_messages) == 1
+    assert (
+        "Someone ran `dump_raw_data` to generate a raw Job Server database dump."
+        in message
+    )
+    assert "bennett.wiki" in message
+    assert (
+        "The raw dump must be removed from the server and developer machines as soon as it is no longer required."
+        in message
+    )


### PR DESCRIPTION
Continuation of https://github.com/opensafely-core/security/issues/53
@StevenMaude suggested [this](https://github.com/opensafely-core/job-server/pull/5954#discussion_r3553653867) integration test. Since a few more changes were required, I created a separate PR for them.
