### PR TITLE
Drop old tables `auth_user_*` and `django_admin_log`

### DIFF
--- a/maintenance/migrations/0002_drop_django_auth_tables.py
+++ b/maintenance/migrations/0002_drop_django_auth_tables.py
@@ -1,0 +1,38 @@
+"""Drop unused auth_user_* tables.
+
+These tables would be used if we used the default Django User model, but we
+extend it. They can be safely dropped.
+
+These tables exist in production at the time of writing. auth_user has two rows
+of very old data that is not relevant to the application as it exists today and
+no relationship to the jobserver_user table. The other two tables are empty.
+
+Keep django_auth_group and django_auth_permission et cetera as they could be
+useful in replacing our roles implementation someday. And Django writes to
+the permission tables for each model that is created, while django.contrib.auth
+remains in INSTALLED_APPS.
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("maintenance", "0001_delete_project_kasdlkfj"),
+    ]
+
+    # Need to drop the tables with FKs to auth_user first.
+    operations = [
+        migrations.RunSQL(
+            sql="DROP TABLE IF EXISTS auth_user_user_permissions;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            sql="DROP TABLE IF EXISTS auth_user_groups;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            sql="DROP TABLE IF EXISTS auth_user;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/maintenance/migrations/0003_drop_django_admin_table.py
+++ b/maintenance/migrations/0003_drop_django_admin_table.py
@@ -1,0 +1,28 @@
+"""Drop unused auth_user_* tables.
+
+This table would be used if django.contrib.admin were in INSTALLED_APPS, but
+it is not. We use the staff pages instead.  It can be safely dropped.
+
+This tables exist in production at the time of writing. It has 29 rows of data
+recording admin actions taken in 2021 until commit
+19981b23fa3c759721d2f6ea00ee2a86072aecf7 that disabled the admin site and
+removed it from installed apps. They relate to very early setting up of
+organisations and users in Job Server.This is not relevant to the application
+as it exists today and long predates our audit log system which was added in
+2024.
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("maintenance", "0002_drop_django_auth_tables"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="DROP TABLE IF EXISTS django_admin_log;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]


### PR DESCRIPTION
Partly fixes https://github.com/opensafely-core/security/issues/55.

We noticed some old tables that don't contain personal data but can be tidied up as not needed and have no useful data.

The `auth_user_*` tables would be used if we used the default Django User model, but we extend it. They can be safely dropped.

The `django_admin_log` table would be used if `django.contrib.admin` were in `INSTALLED_APPS`, but it is not. We use the staff pages instead.  It can be safely dropped.

The migrations are idempotent and have a noop reversal. I tested it in development with the scrubbed production database and everything continues to work fine with regards to login and viewing users in the staff area and clicking around in the site.

These tables exist in production at the time of writing. `auth_user` has two rows of very old data that is not relevant to the application as it exists today and no relationship to the `jobserver_user` table. The other two auth tables are empty.

This `django_admin_log` table exists in production at the time of writing. It has 29 rows of data recording admin actions taken in 2021 until commit 19981b23fa3c759721d2f6ea00ee2a86072aecf7 that disabled the admin site and removed it from installed apps. They relate to very early setting up of organisations and users in Job Server. This is not relevant to the application as it exists today and long predates our audit log system which was added in 2024.

We should be careful when deleting data in production, but I think we can drop these tables and a migration is the safest way to do it.