### PR TITLE
Document why OrgMembership is unscrubbed Personal Data

### DIFF
--- a/jobserver/models/org_membership.py
+++ b/jobserver/models/org_membership.py
@@ -30,6 +30,22 @@ class OrgMembership(models.Model):
 
     class DataScrubbing:
         fields_to_scrub = {}
+        # Institutional affiliation as represented by the link between an Org
+        # and a User is Personal Data. User.username is also Personal Data and
+        # is not scrubbed, so it can identify the user associated with a
+        # membership. However, usernames are not especially sensitive because
+        # they are already public on the production Job Server and probably
+        # elsewhere as well.
+        #
+        # We could remove all OrgMembership data or permute the relations, but
+        # as it is relational data this is more difficult, and this would make
+        # some kinds of testing harder. We could try to pseudonymise this data
+        # somewhat by changing the Org names to fake ones, but the structure of
+        # the database still reveals which org it is when combined with which
+        # studies they are involved with et cetera.
+        #
+        # We decided the minimal privacy benefit of doing this was not worth
+        # the technical difficulty.
         allowed_fields = frozenset(
             [
                 "id",


### PR DESCRIPTION
Partly fixes https://github.com/opensafely-core/security/issues/55.

We should document the rationale for any unscrubbed Personal Data that we will
process locally for development purposes as this is a compliance requirement.

Slack thread confirming that decision:
https://bennettoxford.slack.com/archives/C069SADHP1Q/p1784203993625829
