### PR TITLE
Scrub `AuditableEvent.target_user`

### DIFF
--- a/jobserver/models/auditable_event.py
+++ b/jobserver/models/auditable_event.py
@@ -48,10 +48,15 @@ class AuditableEvent(models.Model):
     created_by = models.TextField()
 
     class DataScrubbing:
+        # Several AuditableEvent fields contain arbitrary data, so we should
+        # scrub all of these to be safe. That makes the audit logs unrealistic
+        # in the scrubbed data. The developer will just have to trigger new
+        # ones in the development environment if they need more realistic ones.
         fields_to_scrub = {
             "new": "fake new audit value",
             "old": "fake old audit value",
             "created_by": "fake audit created_by",
+            "target_user": "fake audit target_user",
         }
         allowed_fields = frozenset(
             [
@@ -62,7 +67,6 @@ class AuditableEvent(models.Model):
                 "target_field",
                 "target_id",
                 "target_model",
-                "target_user",
                 "type",
             ]
         )


### PR DESCRIPTION
Partly fixes https://github.com/opensafely-core/security/issues/55.

This corresponds to `User.username`, like `created_by`. We decided not to scrub `User.username`, but there are a mixture of GitHub usernames and e-mail addresses in that field, which are Personal Data. We don't need these in the audit logs for them to function so let's scrub `target_user`, by analogy to `created_by`, that we already scrub. This further minimises the use of `username`.

That makes the audit logs unrealistic in the scrubbed data. The developer will just have to trigger new ones in the development environment if they need more realistic ones.

Add a little commentary.