### PR TITLE
Remove user name initials generation and display

### DIFF
--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -211,13 +211,6 @@ class User(AbstractBaseUser):
         return any(self.roles + project_roles)
 
     @property
-    def initials(self):
-        if self.fullname == self.username:
-            return self.fullname[0].upper()
-
-        return "".join(w[0].upper() for w in self.fullname.split(" "))
-
-    @property
     def display_name(self):
         """Return a user's name in the format: fullname (username)"""
         return f"{self.fullname} ({self.username})"

--- a/templates/index-authenticated.html
+++ b/templates/index-authenticated.html
@@ -13,7 +13,11 @@
     <div class="bg-white shadow-sm">
       <div class="grid gap-y-2 text-center text-slate-700 py-6 px-8">
         <h1 class="text-xl/6 font-semibold text-slate-900">Your OpenSAFELY Dashboard</h1>
-        <p class="text-slate-600 text-sm/tight">Signed in as: <strong class="text-slate-900">{{ user.fullname }}</strong></p>
+        <p class="text-slate-600 text-sm/tight">
+          Logged in as:
+          <strong class="text-slate-900">{{ user.fullname }} </strong>
+          ({{ user.username }} via GitHub)
+        </p>
         <p>Continue your research, view job requests, and see recent workspace activity.</p>
       </div>
 

--- a/templates/index-authenticated.html
+++ b/templates/index-authenticated.html
@@ -9,52 +9,27 @@
 {% endblock %}
 
 {% block content %}
-  {% #card container=True class="my-6 sm:mb-12 md:mt-0" %}
-    <h2 class="sr-only" id="profile-overview-title">Profile Overview</h2>
-    <div class="flex items-center justify-center sm:justify-between">
-      <div class="sm:flex sm:space-x-5 sm:items-center">
-        <div class="shrink-0">
-          <div
-            class="flex items-center justify-center w-16 h-16 bg-oxford-100 aspect-square rounded-2xl border border-oxford-500/25 overflow-hidden shrink-0 mx-auto sm:mx-0"
-          >
-            <span class="py-2 text-oxford-600 text-2xl font-bold" role="presentation">
-              {{ user.initials }}
-            </span>
-          </div>
-        </div>
-        <div class="mt-4 text-center sm:mt-0 sm:text-left">
-          <p class="text-sm font-medium text-slate-600">Welcome back,</p>
-          <p class="text-xl font-bold text-slate-900 sm:text-2xl">{{ user.fullname }}</p>
-        </div>
+  <section class="my-6 sm:mb-12 md:mt-0">
+    <div class="bg-white shadow-sm">
+      <div class="grid gap-y-2 text-center text-slate-700 py-6 px-8">
+        <h1 class="text-xl/6 font-semibold text-slate-900">Your OpenSAFELY Dashboard</h1>
+        <p class="text-slate-600 text-sm/tight">Signed in as: <strong class="text-slate-900">{{ user.fullname }}</strong></p>
+        <p>Continue your research, view job requests, and see recent workspace activity.</p>
       </div>
-    </div>
 
-    {% #card_footer class="py-0! px-0! -mb-3! md:-mb-5!" %}
-      <ul class="grid grid-cols-1 divide-y divide-slate-200 border-t border-slate-200 bg-slate-50 sm:grid-cols-3 sm:divide-y-0 sm:divide-x">
-        <li class="px-6 py-5 text-center text-sm font-medium text-slate-600">
-          <span class="text-slate-900">{{ counts.job_requests }}</span>
-          <span class="text-slate-600">job request{{ counts.job_requests|pluralize }}</span>
+      <ul class="grid divide-y divide-slate-200 border-t border-slate-200 bg-slate-50 sm:grid-cols-3 sm:divide-y-0 sm:divide-x">
+        <li class="px-6 py-4 text-center text-base/tight font-medium text-slate-600">
+          <span class="text-slate-900">{{ counts.job_requests }}</span> job request{{ counts.job_requests|pluralize }}
         </li>
-
-        <li class="px-6 py-5 text-center text-sm font-medium">
-          <span class="text-slate-900">{{ counts.workspaces }}</span>
-          <span class="text-slate-600">workspace{{ counts.workspaces|pluralize }}</span>
+        <li class="px-6 py-4 text-center text-base/tight font-medium text-slate-600">
+          <span class="text-slate-900">{{ counts.workspaces }}</span> workspace{{ counts.workspaces|pluralize }}
         </li>
-
-        <li class="px-6 py-5 text-center text-sm font-medium">
-          <span class="text-slate-900">{{ counts.projects }}</span>
-          <span class="text-slate-600">project{{ counts.projects|pluralize }}</span>
+        <li class="px-6 py-4 text-center text-base/tight font-medium text-slate-600">
+          <span class="text-slate-900">{{ counts.projects }}</span> project{{ counts.projects|pluralize }}
         </li>
       </ul>
-    {% /card_footer %}
-  {% /card %}
-
-  <div class="border-b border-slate-200 pb-5 mb-5 text-center">
-    <h3 class="text-xl font-semibold leading-6 text-slate-900">Your OpenSAFELY Dashboard</h3>
-    <p class="mt-2 max-w-4xl text-base text-center mx-auto text-slate-700">
-      Continue your research, view job requests, see latest workspace activity
-    </p>
-  </div>
+    </div>
+  </section>
 
   <div class="grid gap-4 lg:grid-cols-2 mb-6">
     {% #card title="Job requests" subtitle="Your most recent job requests" %}

--- a/tests/unit/jobserver/models/test_user.py
+++ b/tests/unit/jobserver/models/test_user.py
@@ -198,31 +198,6 @@ def test_user_get_staff_url():
     )
 
 
-def test_user_initials_with_email():
-    user = UserFactory(email="test@example.com", username="test@example.com")
-
-    assert user.initials == "T"
-
-
-def test_user_initials_with_username_as_fullname():
-    user = UserFactory(username="Testuser", fullname="Testuser")
-
-    assert user.initials == "T"
-
-
-@pytest.mark.parametrize(
-    "name,initials",
-    [
-        ("Ben Goldacre", "BG"),
-        ("Tom O'Dwyer", "TO"),
-        ("Brian MacKenna", "BM"),
-        ("Ben Butler-Cole", "BB"),
-    ],
-)
-def test_user_initials_with_names(name, initials):
-    assert UserFactory(fullname=name).initials == initials
-
-
 def test_user_fullname():
     assert UserFactory(fullname="first last", username="test").fullname == "first last"
     assert UserFactory(username="username", fullname="username").fullname == "username"

--- a/tests/unit/jobserver/views/test_index.py
+++ b/tests/unit/jobserver/views/test_index.py
@@ -88,7 +88,7 @@ def test_index_authenticated_display_active_backend_job_requests(
 
 @pytest.mark.slow_test
 def test_index_authenticated_client(client, django_assert_num_queries):
-    user = UserFactory()
+    user = UserFactory(fullname="Test User")
     JobRequestFactory.create_batch(10)
 
     with django_assert_num_queries(41):
@@ -96,6 +96,8 @@ def test_index_authenticated_client(client, django_assert_num_queries):
         response = client.get("/")
         assert response.status_code == 200
         assert "OpenSAFELY Jobs" in response.rendered_content
+        assert "Signed in as:" in response.rendered_content
+        assert user.fullname in response.rendered_content
 
 
 def test_index_unauthenticated(rf, django_assert_num_queries):

--- a/tests/unit/jobserver/views/test_index.py
+++ b/tests/unit/jobserver/views/test_index.py
@@ -88,16 +88,16 @@ def test_index_authenticated_display_active_backend_job_requests(
 
 @pytest.mark.slow_test
 def test_index_authenticated_client(client, django_assert_num_queries):
-    user = UserFactory(fullname="Test User")
+    user = UserFactory()
     JobRequestFactory.create_batch(10)
 
     with django_assert_num_queries(41):
         client.force_login(user)
         response = client.get("/")
-        assert response.status_code == 200
-        assert "OpenSAFELY Jobs" in response.rendered_content
-        assert "Signed in as:" in response.rendered_content
-        assert user.fullname in response.rendered_content
+        content = response.rendered_content
+        assert "OpenSAFELY Jobs" in content
+        assert "Logged in as:" in content
+        assert user.fullname in content
 
 
 def test_index_unauthenticated(rf, django_assert_num_queries):


### PR DESCRIPTION
Closes #4724

We generate initials to use for authenticated users on the home page in lieu of having avatars. Instead of trying to debug every last way the initials might break our site or design, lets just change the design to remove the need for that.

## Screenshots

### Before

<img width="1656" height="1316" alt="" src="https://github.com/user-attachments/assets/1efa4f44-c9e4-4032-820e-49f846271ddb" />


### After

<img width="1657" height="1146" alt="" src="https://github.com/user-attachments/assets/1e8778e1-cb3c-46fe-8f10-7dd407cadc9f" />
