### PR TITLE
Fix react router navigation on browser forwards/back

### DIFF
--- a/assets/src/scripts/outputs-viewer/__tests__/App.test.jsx
+++ b/assets/src/scripts/outputs-viewer/__tests__/App.test.jsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import App from "../App";
 import { csvFile, fileList } from "./helpers/files";
 import props, { prepareUrl, publishUrl } from "./helpers/props";
-import { render, screen, waitFor } from "./test-utils";
+import { history, render, screen, waitFor } from "./test-utils";
 
 describe("<App />", () => {
   it("returns the file list", async () => {
@@ -75,5 +75,26 @@ describe("<App />", () => {
       expect(screen.getByText("hello")).toBeVisible();
       expect(screen.getByText("world")).toBeVisible();
     });
+  });
+
+  it("restores the previous file when navigating back", async () => {
+    const user = userEvent.setup();
+    history.replace("/");
+    fetch.mockResponseOnce(JSON.stringify({ files: fileList }));
+    render(<App {...props} />);
+
+    await screen.findByText(csvFile.shortName);
+
+    fetch.mockResponseOnce("first file");
+    await user.click(screen.getByRole("link", { name: csvFile.shortName }));
+    await screen.findByText("first file");
+
+    fetch.mockResponseOnce("second file");
+    await user.click(screen.getByRole("link", { name: fileList[2].shortName }));
+    await screen.findByText("second file");
+
+    history.back();
+
+    await waitFor(() => expect(screen.getByText("first file")).toBeVisible());
   });
 });

--- a/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
+++ b/assets/src/scripts/outputs-viewer/components/FileList/FileList.jsx
@@ -11,7 +11,7 @@ function FileList({ authToken, filesUrl, listVisible, setSelectedFile }) {
   const [files, setFiles] = useState([]);
   const [fileSort, setFileSort] = useState("nameOrder");
 
-  const { data, isError, isLoading, isSuccess } = useFileList({
+  const { data, isError, isLoading } = useFileList({
     authToken,
     filesUrl,
   });
@@ -20,7 +20,6 @@ function FileList({ authToken, filesUrl, listVisible, setSelectedFile }) {
 
   const listRef = createRef();
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ESLint to Biome legacy ignore
   useEffect(() => {
     const selectedItem = data?.find(
       (file) => `/${file.name}` === location.pathname,
@@ -31,7 +30,7 @@ function FileList({ authToken, filesUrl, listVisible, setSelectedFile }) {
     if (data) {
       setFiles(data);
     }
-  }, [isSuccess]);
+  }, [data, location.pathname, setSelectedFile]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
In `FileList` the synchronisation effect runs only when the file query succeeds, so later when `location.pathname` changes from `history.back()` the `selectedFile` is not updated.

This PR adds a test to check for that issue, and then resolves the issue by changing the `useEffect` dependencies.