### PR TITLE
Update default `restore-db` arg

### DIFF
--- a/docker/justfile
+++ b/docker/justfile
@@ -86,7 +86,7 @@ clean-volumes: clean
 
 
 # restore the db from a dump file. Will wipe and reset your current docker dev db.
-restore-db dump="jobserver.dump": clean-volumes  db
+restore-db dump="jobserver_scrubbed.dump": clean-volumes  db
     #!/bin/bash
     set -eux
     path=$(realpath ../{{ dump }})


### PR DESCRIPTION
This recipe is expected to be used with this value most often, so we may as well make that the default. This is the scrubbed data that developers should be using locally most of the time, jobserver.dump is the default name for the rawdump that should only be used exceptionally.

I did not bother updating DEVELOPERS.md for this as the version specified there still works and illustrates how to use the parameter.

See ADRs on data scrubbing and `dump_scrubbed_db` for more information.