### PR TITLE
Make code compliant with most new default Ruff v0.16 rules

### DIFF
--- a/airlock/issues.py
+++ b/airlock/issues.py
@@ -175,11 +175,11 @@ def _update_output_checking_issue(
         comment_url = data["html_url"]
 
     # if issue was not created in the first instance, try to create the issue again and stamina retries creating a comment
-    except IssueNotFound as issue_error:
+    except IssueNotFound:
         create_output_checking_issue(
             workspace_name, release_request_id, request_author, org, repo, github_api
         )
-        raise issue_error
+        raise
 
     if notify_slack:
         post_slack_update(
@@ -228,4 +228,4 @@ def update_output_checking_issue(
             updates,
             github_error_msg,
         )
-        raise error
+        raise

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -36,7 +36,7 @@ class EventType(Enum):
     REQUEST_RETURNED = "request returned"
     REQUEST_RESUBMITTED = "request resubmitted"
     REQUEST_PARTIALLY_REVIEWED = "request reviewed"
-    REQUEST_REVIEWED = "request reviewed"
+    REQUEST_REVIEWED = "request reviewed"  # noqa: PIE796
 
     def status_label(self):
         """The GitHub Issue label that should be added for this request"""

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -93,8 +93,6 @@ class AirlockEvent:
             org = ORG_OUTPUT_CHECKING_REPOS[lookup]["org"]
             repo = ORG_OUTPUT_CHECKING_REPOS[lookup]["repo"]
 
-        workspace.project
-
         return cls(
             event_type=event_type,
             updates=updates,

--- a/applications/form_spec_helpers.py
+++ b/applications/form_spec_helpers.py
@@ -136,7 +136,7 @@ class Field:
 
 @dataclass
 class Attributes:
-    type: str = "text"  # noqa: A003
+    type: str = "text"
     inputmode: str | None = None
     autocomplete: str | None = None
     autocapitalize: str | None = None

--- a/applications/models.py
+++ b/applications/models.py
@@ -722,7 +722,6 @@ class ResearcherRegistration(models.Model):
     name = models.TextField()
     job_title = models.TextField()
     email = models.TextField()
-    github_username = models.TextField()
 
     does_researcher_need_server_access = models.BooleanField(
         null=True, choices=YES_NO_CHOICES

--- a/data_scrubbing/management/commands/scrub_data.py
+++ b/data_scrubbing/management/commands/scrub_data.py
@@ -167,7 +167,7 @@ defined on the model.
 """
 
 import inspect
-from datetime import datetime
+from datetime import UTC, datetime
 
 from django.apps import apps
 from django.conf import settings
@@ -208,7 +208,7 @@ def get_fake_unique_email():
     hitting uniqueness constraints.
 
     Example fake e-mail generated: '260716073644_1@example.com'."""
-    start_time_str = datetime.now().strftime("%y%m%d%H%M%S")
+    start_time_str = datetime.now(tz=UTC).strftime("%y%m%d%H%M%S")
     count = 0
 
     while True:

--- a/jobserver/api/releases.py
+++ b/jobserver/api/releases.py
@@ -204,24 +204,24 @@ def validate_snapshot_access(request, snapshot):
 def generate_index(files):
     """Generate a JSON list of files as expected by the SPA."""
 
-    output = dict(
-        files=[
-            dict(
-                name=name,
-                id=rfile.pk,
-                url=rfile.get_api_url(),
-                user=rfile.created_by.username,
-                date=rfile.created_at.isoformat(),
-                sha256=rfile.filehash,
-                size=rfile.size,
-                is_deleted=rfile.is_deleted,
-                backend=rfile.release.backend.name,
-                metadata=rfile.metadata,
-                review=None,
-            )
+    output = {
+        "files": [
+            {
+                "name": name,
+                "id": rfile.pk,
+                "url": rfile.get_api_url(),
+                "user": rfile.created_by.username,
+                "date": rfile.created_at.isoformat(),
+                "sha256": rfile.filehash,
+                "size": rfile.size,
+                "is_deleted": rfile.is_deleted,
+                "backend": rfile.release.backend.name,
+                "metadata": rfile.metadata,
+                "review": None,
+            }
             for name, rfile in files.items()
         ],
-    )
+    }
 
     # validate our output data with the serializer, without having to encode
     # all the source lookups into the serializer itself
@@ -548,21 +548,21 @@ def build_level4_user(user):
 
     # using a DRF serializer for now, so we've *some* schema definition
     level4_user = Level4AuthenticatedUser(
-        data=dict(
-            username=user.username,
-            fullname=user.fullname,
-            workspaces=workspaces,
-            copiloted_workspaces=copiloted_workspaces,
+        data={
+            "username": user.username,
+            "fullname": user.fullname,
+            "workspaces": workspaces,
+            "copiloted_workspaces": copiloted_workspaces,
             # note, we use a generic role check here rather than a permissions
             # as its currently a global role. In future, if output checking
             # permissions applies to different projects/orgs, we'll need to
             # list the explicit workspaces that the user has this permission
             # for.
-            output_checker=has_role(user, OutputChecker),
+            "output_checker": has_role(user, OutputChecker),
             # This permission allows a user readonly access to all workspaces in Airlock
             # (and consequently, all release requests related to any workspaces)
-            readonly_access=has_permission(user, Permission.AIRLOCK_READONLY_ACCESS),
-        )
+            "readonly_access": has_permission(user, Permission.AIRLOCK_READONLY_ACCESS),
+        }
     )
     assert level4_user.is_valid(), level4_user.errors
 

--- a/jobserver/backends.py
+++ b/jobserver/backends.py
@@ -21,6 +21,4 @@ def show_warning(last_seen, threshold):
 
     delta = timezone.now() - last_seen
 
-    if delta < threshold:
-        return False
-    return True
+    return delta >= threshold

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -191,13 +191,13 @@ class GitHubAPI:
     def create_issue(self, org, repo, title, body, labels):
         if settings.DEBUG:  # pragma: no cover
             logger.info("Issue created", title=title, org=org, repo=repo, body=body)
-            print("")
+            print()
             print(f"Repo: https://github.com/{org}/{repo}/")
             print(f"Title: {title}")
             print("Message:")
             print(body)
             print(f"Labels: {labels}")
-            print("")
+            print()
             return {"html_url": "http://example.com"}
         path_segments = [
             "repos",
@@ -276,13 +276,13 @@ class GitHubAPI:
                 repo=repo,
                 body=body,
             )
-            print("")
+            print()
             print(f"Repo: https://github.com/{org}/{repo}/")
             print(f"Title text: {title_text}")
             print("Comment:")
             print(body)
             print(f"Labels: {labels}")
-            print("")
+            print()
             return {"html_url": "http://example.com/issues/comment"}
 
         if issue_number is None:
@@ -345,11 +345,11 @@ class GitHubAPI:
                 org=org,
                 repo=repo,
             )
-            print("")
+            print()
             print(f"Repo: https://github.com/{org}/{repo}/")
             print(f"Title text: {title_text}")
             print(f"Labels: {labels}")
-            print("")
+            print()
             return {"html_url": "http://example.com/issues/closed"}
 
         if issue_number is None:

--- a/jobserver/jobs/daily/clearsessions.py
+++ b/jobserver/jobs/daily/clearsessions.py
@@ -6,7 +6,7 @@ from services.sentry import monitor_config
 
 
 class Job(DailyJob):
-    help = "Run the clearsessions management command"  # noqa: A003
+    help = "Run the clearsessions management command"
 
     @monitor(monitor_slug="clearsessions", monitor_config=monitor_config("0 0 * * *"))
     def execute(self):

--- a/jobserver/jobs/daily/update_repo_has_github_outputs.py
+++ b/jobserver/jobs/daily/update_repo_has_github_outputs.py
@@ -15,7 +15,7 @@ def topics(data):
 
 
 class Job(DailyJob):
-    help = "Dump the database to storage for copying to local dev environments"  # noqa: A003
+    help = "Dump the database to storage for copying to local dev environments"
 
     @monitor(
         monitor_slug="update_repo_has_github_outputs",

--- a/jobserver/jobs/minutely/rap_update_backend_status.py
+++ b/jobserver/jobs/minutely/rap_update_backend_status.py
@@ -6,7 +6,7 @@ from services.sentry import monitor_config
 
 
 class Job(MinutelyJob):
-    help = "Run the rap_update_backend_status management command"  # noqa: A003
+    help = "Run the rap_update_backend_status management command"
 
     @monitor(
         monitor_slug="rap_update_backend_status",

--- a/jobserver/jobs/weekly/notify_impending_copilot_support_windows.py
+++ b/jobserver/jobs/weekly/notify_impending_copilot_support_windows.py
@@ -8,7 +8,7 @@ from services.sentry import monitor_config
 
 
 class Job(WeeklyJob):
-    help = "Notify slack of impending co-pilot support windows ending"  # noqa: A003
+    help = "Notify slack of impending co-pilot support windows ending"
 
     @monitor(
         monitor_slug="notify_impending_copilot_support_windows",

--- a/jobserver/management/commands/count_rows.py
+++ b/jobserver/management/commands/count_rows.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         counts = []
-        for _, app in apps.app_configs.items():
+        for app in apps.app_configs.values():
             for model in app.get_models():
                 counts.append(
                     {

--- a/jobserver/management/commands/create_bot.py
+++ b/jobserver/management/commands/create_bot.py
@@ -7,7 +7,7 @@ from ...models import User
 
 
 class Command(BaseCommand):
-    help = "Create a bot user and print its token"  # noqa: A003
+    help = "Create a bot user and print its token"
 
     def add_arguments(self, parser):
         parser.add_argument("username")

--- a/jobserver/management/commands/delete_project.py
+++ b/jobserver/management/commands/delete_project.py
@@ -14,7 +14,7 @@ def delete_project(name):
 
 
 class Command(BaseCommand):
-    help = "Delete an empty project"  # noqa: A003
+    help = "Delete an empty project"
 
     def add_arguments(self, parser):
         parser.add_argument("project_name")

--- a/jobserver/management/commands/release.py
+++ b/jobserver/management/commands/release.py
@@ -22,7 +22,7 @@ def get_or_maybe_create(create, model, lookup, **kwargs):
 
 
 class Command(BaseCommand):
-    help = "Release a directory of files to a workspace"  # noqa: A003
+    help = "Release a directory of files to a workspace"
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/jobserver/models/auditable_event.py
+++ b/jobserver/models/auditable_event.py
@@ -29,7 +29,7 @@ class AuditableEvent(models.Model):
     # what is this record auditing?
     # we use this field to make it explicit what's being audited and to look up
     # related code, eg presenters
-    type = models.TextField(choices=Type.choices)  # noqa: A003
+    type = models.TextField(choices=Type.choices)
 
     target_model = models.TextField()
     target_field = models.TextField()

--- a/jobserver/models/job_request.py
+++ b/jobserver/models/job_request.py
@@ -519,7 +519,7 @@ class JobRequest(models.Model):
             job_request_status = self.update_status(status, message)
 
         # if any status is running then the JobRequest is running
-        elif "running" in statuses:
+        elif "running" in statuses:  # noqa: SIM114
             job_request_status = self.update_status(JobRequestStatus.RUNNING)
 
         # we've eliminated all statuses being the same so any pending statuses

--- a/jobserver/models/org.py
+++ b/jobserver/models/org.py
@@ -10,7 +10,7 @@ logger = structlog.get_logger(__name__)
 
 
 def default_github_orgs():
-    return list(["opensafely"])
+    return ["opensafely"]
 
 
 class Org(models.Model):

--- a/jobserver/models/release.py
+++ b/jobserver/models/release.py
@@ -20,7 +20,7 @@ class Release(models.Model):
         APPROVED = "APPROVED", "Approved"
         REJECTED = "REJECTED", "Rejected"
 
-    id = models.CharField(  # noqa: A003
+    id = models.CharField(
         default=new_ulid_str, max_length=26, primary_key=True, editable=False
     )
 

--- a/jobserver/models/release_file.py
+++ b/jobserver/models/release_file.py
@@ -24,7 +24,7 @@ class ReleaseFile(models.Model):
     serve them via nginx.
     """
 
-    id = models.CharField(  # noqa: A003
+    id = models.CharField(
         default=new_ulid_str, max_length=26, primary_key=True, editable=False
     )
 

--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -225,7 +225,7 @@ class User(AbstractBaseUser):
 
         def flatten_perms(roles):
             permissions = itertools.chain.from_iterable(r.permissions for r in roles)
-            return list(sorted(set(permissions)))
+            return sorted(set(permissions))
 
         projects = [
             {
@@ -249,7 +249,7 @@ class User(AbstractBaseUser):
         """
 
         def role_names(roles):
-            return list(sorted(r.__name__ for r in roles))
+            return sorted(r.__name__ for r in roles)
 
         projects = [
             {"slug": m.project.slug, "roles": role_names(m.roles)}

--- a/jobserver/models/user.py
+++ b/jobserver/models/user.py
@@ -1,7 +1,7 @@
+import datetime
 import itertools
 import secrets
 import unicodedata
-from datetime import date, timedelta
 
 import structlog
 from django.contrib.auth.hashers import make_password
@@ -288,7 +288,7 @@ class User(AbstractBaseUser):
         if not secrets.compare_digest(pat_token, self.pat_token):
             return False
 
-        if self.pat_expires_at.date() < date.today():
+        if self.pat_expires_at.date() < datetime.datetime.now(tz=datetime.UTC).date():
             capture_message(f"Expired token for {self.username}")
             return False
 
@@ -296,7 +296,7 @@ class User(AbstractBaseUser):
 
     def rotate_token(self):
         # Ticket to look at signing request.
-        expires_at = timezone.now() + timedelta(days=90)
+        expires_at = timezone.now() + datetime.timedelta(days=90)
 
         # Store as datetime in case we want to compare with a datetime or
         # increase resolution later.

--- a/jobserver/opencodelists.py
+++ b/jobserver/opencodelists.py
@@ -77,7 +77,7 @@ class OpenCodelistsAPI:
         r.raise_for_status()
 
         data = self._iter_codelists(r.json()["codelists"])
-        return list(sorted(data, key=lambda c: c["name"].lower()))
+        return sorted(data, key=lambda c: c["name"].lower())
 
     def check_codelists(self, txt_content, json_content):
         path_segments = [

--- a/jobserver/permissions/population_permissions/__init__.py
+++ b/jobserver/permissions/population_permissions/__init__.py
@@ -1,4 +1,4 @@
 from . import gp_activations, ndoo, t1oo
 
 
-__all__ = ["ndoo", "gp_activations", "t1oo"]
+__all__ = ["gp_activations", "ndoo", "t1oo"]

--- a/jobserver/releases.py
+++ b/jobserver/releases.py
@@ -77,15 +77,15 @@ def build_outputs_zip(release_files, url_builder_func):
 def create_release(workspace, backend, created_by, requested_files, **kwargs):
     # If this release creation comes from Airlock, a release id will be specified in the kwargs
     release_id = kwargs.pop("id", None)
-    create_kwargs = dict(
-        workspace=workspace,
-        backend=backend,
-        defaults={
+    create_kwargs = {
+        "workspace": workspace,
+        "backend": backend,
+        "defaults": {
             "created_by": created_by,
             "requested_files": requested_files,
             **kwargs,
         },
-    )
+    }
 
     if release_id is not None:
         # We know the release id, check for an existing release

--- a/jobserver/runtime.py
+++ b/jobserver/runtime.py
@@ -9,10 +9,7 @@ class Runtime:
     total_seconds: int = 0
 
     def __bool__(self):
-        if self.hours == 0 and self.minutes == 0 and self.seconds == 0:
-            return False
-
-        return True
+        return not (self.hours == 0 and self.minutes == 0 and self.seconds == 0)
 
     def __str__(self):
         if not self:

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -70,7 +70,7 @@ if OLD_SECRET_KEY is not None:
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", default="0") == "1"
 
-DEBUG_TOOLBAR = os.environ.get("DJANGO_DEBUG_TOOLBAR", default=False) == "True"
+DEBUG_TOOLBAR = os.environ.get("DJANGO_DEBUG_TOOLBAR") == "True"
 
 # Disable migrations for the django-debug-toolbar
 MIGRATION_MODULES = {"debug_toolbar": None}
@@ -235,7 +235,7 @@ STATICFILES_DIRS = [
 STATIC_ROOT = Path(os.environ.get("STATIC_ROOT", default=BASE_DIR / "staticfiles"))
 STATIC_URL = "/static/"
 
-ASSETS_DEV_MODE = os.environ.get("ASSETS_DEV_MODE", default=False) == "True"
+ASSETS_DEV_MODE = os.environ.get("ASSETS_DEV_MODE") == "True"
 
 DJANGO_VITE = {
     "default": {
@@ -441,13 +441,14 @@ initialise_sentry()
 
 
 # PROJECT SETTINGS
-DISABLE_CREATING_JOBS = os.environ.get("DISABLE_CREATING_JOBS", default=False) == "True"
+DISABLE_CREATING_JOBS = os.environ.get("DISABLE_CREATING_JOBS") == "True"
 
+DEFAULT_RELEASE_FILE_SIZE_LIMIT = 16 * 1024 * 1024  # 16Mb
 # Released files per-file size limit
 RELEASE_FILE_SIZE_LIMIT = int(
     os.environ.get(
         "RELEASE_FILE_SIZE_LIMIT",
-        default=16 * 1024 * 1024,  # 16Mb
+        default=str(DEFAULT_RELEASE_FILE_SIZE_LIMIT),
     )
 )
 
@@ -510,7 +511,7 @@ DEFAULT_OUTPUT_CHECKING_REPO = os.environ.get(
     "DEFAULT_OUTPUT_CHECKING_REPO", default="opensafely-output-review"
 )
 DEFAULT_MAX_GITHUB_RETRIES = int(
-    os.environ.get("DEFAULT_MAX_GITHUB_RETRIES", default=3)
+    os.environ.get("DEFAULT_MAX_GITHUB_RETRIES", default="3")
 )
 
 # These orgs are not copiloted
@@ -521,7 +522,7 @@ UNIVERSITY_OF_BRISTOL_ORG_PK = 9
 
 # How long in seconds to wait between calls to the RAP API status endpoint to
 # fetch job updates
-RAP_API_POLL_INTERVAL = int(os.environ.get("RAP_API_POLL_INTERVAL", default=60))
+RAP_API_POLL_INTERVAL = int(os.environ.get("RAP_API_POLL_INTERVAL", default="60"))
 
 # GitHub token for interactions with the GitHub API.
 # See jobserver/github.py for how this is used.

--- a/jobserver/templatetags/duration_tools.py
+++ b/jobserver/templatetags/duration_tools.py
@@ -25,8 +25,8 @@ def duration(td):
     if td.days:
         output += f"{td.days} days "
 
-    days, remaining_seconds = divmod(td.total_seconds(), 86400)
-    hours, remaining_seconds = divmod(remaining_seconds, 3600)
+    # timedelta.seconds is the remainder after whole days.
+    hours, remaining_seconds = divmod(td.seconds, 3600)
     minutes, seconds = divmod(remaining_seconds, 60)
 
     if hours:

--- a/jobserver/templatetags/querystring_tools.py
+++ b/jobserver/templatetags/querystring_tools.py
@@ -45,7 +45,7 @@ def url_without_querystring(context, **kwargs):
     request = context["request"]
     f = furl(request.get_full_path())
 
-    for k in kwargs.keys():
+    for k in kwargs:
         del f.args[k]
 
     if "page" in f.args:

--- a/jobserver/templatetags/selected_filter.py
+++ b/jobserver/templatetags/selected_filter.py
@@ -28,7 +28,4 @@ def is_filter_selected(context, *, key, value, **kwargs):
     if not args:
         return False
 
-    if value not in args:
-        return False
-
-    return True
+    return value in args

--- a/jobserver/views/job_requests.py
+++ b/jobserver/views/job_requests.py
@@ -221,18 +221,18 @@ class JobRequestCreate(CreateView):
         )
 
         # Add tracing attributes to the parent span
-        tracing_attributes = dict(
-            rap_id=job_request.identifier,
-            requested_actions=job_request.requested_actions,
-        )
+        tracing_attributes = {
+            "rap_id": job_request.identifier,
+            "requested_actions": job_request.requested_actions,
+        }
         trace.get_current_span().set_attributes(tracing_attributes)
         # Trace the RAP API call
         with tracer.start_as_current_span(
             "create_rap",
-            attributes=dict(
-                rap_id=job_request.identifier,
-                requested_actions=job_request.requested_actions,
-            ),
+            attributes={
+                "rap_id": job_request.identifier,
+                "requested_actions": job_request.requested_actions,
+            },
         ):
             # Invoke the RAP API and handle RapAPIErrors.
             job_count = job_request.request_rap_creation()

--- a/jobserver/views/releases.py
+++ b/jobserver/views/releases.py
@@ -304,8 +304,8 @@ class WorkspaceReleaseList(View):
             project=workspace.project,
         )
 
-        latest_files = list(
-            sorted(workspace_files(workspace).values(), key=lambda rf: rf.name)
+        latest_files = sorted(
+            workspace_files(workspace).values(), key=lambda rf: rf.name
         )
         latest_release = {
             "can_view_files": can_view_files and bool(latest_files),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,6 @@ extend-ignore = [
   "E501", # ignore line-length. We judge case-by-case.
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
-  "B015",
   "B018",
   "BLE001",
   "C401",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "FURB105",
   "PERF102",
   "PIE794",
   "PIE796",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,6 @@ extend-ignore = [
   "E501", # ignore line-length. We judge case-by-case.
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
-  "B010",
   "B015",
   "B018",
   "BLE001",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,6 @@ extend-ignore = [
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
   "RUF012",
-  "SIM117",
   "SIM118",
   "SIM210",
   "TRY002",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "C410",
   "C413",
   "C419",
   "DTZ005",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,6 @@ extend-ignore = [
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
   "RUF012",
-  "RUF100",
   "SIM103",
   "SIM114",
   "SIM117",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,6 @@ extend-ignore = [
   "BLE001",
   "RUF012",
   "TRY002",
-  "TRY401",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,6 @@ extend-ignore = [
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
   "RUF012",
-  "SIM114",
   "SIM117",
   "SIM118",
   "SIM210",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "DTZ005",
   "DTZ011",
   "FURB105",
   "PERF102",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "PLW1508",
   "RUF012",
   "RUF022",
   "RUF059",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "PIE796",
   "PIE804",
   "PIE808",
   "PLR1733",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,6 @@ extend-ignore = [
   "E501", # ignore line-length. We judge case-by-case.
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
-  "B009",
   "B010",
   "B015",
   "B018",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "PIE794",
   "PIE796",
   "PIE804",
   "PIE808",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "PIE804",
   "PIE808",
   "PLR1733",
   "PLW1508",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,6 @@ extend-ignore = [
   "E501", # ignore line-length. We judge case-by-case.
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
-  "B018",
   "BLE001",
   "C401",
   "C403",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "C401",
   "C403",
   "C405",
   "C408",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,6 @@ extend-ignore = [
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
   "RUF012",
-  "SIM118",
   "SIM210",
   "TRY002",
   "TRY201",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,6 @@ extend-ignore = [
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
   "RUF012",
-  "RUF059",
   "RUF100",
   "SIM103",
   "SIM114",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "C419",
   "DTZ005",
   "DTZ011",
   "FURB105",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "C408",
   "C410",
   "C413",
   "C419",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "C405",
   "C408",
   "C410",
   "C413",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "PERF102",
   "PIE794",
   "PIE796",
   "PIE804",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,6 @@ extend-ignore = [
   "BLE001",
   "RUF012",
   "TRY002",
-  "TRY201",
   "TRY401",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "DTZ011",
   "FURB105",
   "PERF102",
   "PIE794",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,6 @@ extend-ignore = [
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
   "RUF012",
-  "RUF022",
   "RUF059",
   "RUF100",
   "SIM103",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "PIE808",
   "PLR1733",
   "PLW1508",
   "RUF012",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,6 @@ extend-ignore = [
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
   "RUF012",
-  "SIM210",
   "TRY002",
   "TRY201",
   "TRY401",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "C413",
   "C419",
   "DTZ005",
   "DTZ011",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "PLR1733",
   "PLW1508",
   "RUF012",
   "RUF022",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ extend-ignore = [
   # Below rules were added by Ruff v0.16.
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
-  "C403",
   "C405",
   "C408",
   "C410",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,6 @@ extend-ignore = [
   # We can fix these gradually and remove these where we think sensible.
   "BLE001",
   "RUF012",
-  "SIM103",
   "SIM114",
   "SIM117",
   "SIM118",

--- a/redirects/models.py
+++ b/redirects/models.py
@@ -145,5 +145,5 @@ class Redirect(models.Model):
         ]
 
     @property
-    def type(self):  # noqa: A003
+    def type(self):
         return self.obj.__class__.__name__

--- a/services/slack.py
+++ b/services/slack.py
@@ -20,11 +20,11 @@ def post(text, channel):
     # workspace, see dotenv-sample for required settings and where to get them
     # from.
     if settings.DEBUG:  # pragma: no cover
-        print("")
+        print()
         print(f"Channel: {channel}")
         print("Message:")
         print(text)
-        print("")
+        print()
         return
 
     try:

--- a/staff/views/dashboards/copiloting.py
+++ b/staff/views/dashboards/copiloting.py
@@ -44,9 +44,9 @@ def build_repos_by_project(projects, get_github_api=_get_github_api):
 
     try:
         github_repos = list(get_github_api().get_repos_with_status_and_url(repo_orgs))
-    except GitHubError as exc:
+    except GitHubError:
         logger.exception(
-            f"Failed to get repo status and URL from GitHub API due to: {exc}",
+            "Failed to get repo status and URL from GitHub API",
             repo_orgs=repo_orgs,
         )
         return {}

--- a/staff/views/dashboards/copiloting.py
+++ b/staff/views/dashboards/copiloting.py
@@ -170,15 +170,13 @@ class Copiloting(TemplateView):
                     "workspace_count": project.workspace_count,
                 }
 
-        projects = list(
-            sorted(
-                iter_projects(
-                    projects,
-                    file_counts_by_project,
-                    repos_by_project,
-                ),
-                key=lambda p: p["name"].lower(),
-            )
+        projects = sorted(
+            iter_projects(
+                projects,
+                file_counts_by_project,
+                repos_by_project,
+            ),
+            key=lambda p: p["name"].lower(),
         )
 
         return super().get_context_data(**kwargs) | {

--- a/staff/views/sentry.py
+++ b/staff/views/sentry.py
@@ -7,7 +7,7 @@ from jobserver.authorization.permissions import Permission
 
 @require_permission(Permission.STAFF_AREA_ACCESS)
 def error(request):
-    1 / 0
+    _ = 1 / 0
 
 
 @require_permission(Permission.STAFF_AREA_ACCESS)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -410,7 +410,7 @@ def role_factory():
             )
             setattr(jobserver.authorization.roles, name, Role)
 
-        all_roles = getattr(jobserver.authorization.global_roles, "ALL_ROLES")
+        all_roles = jobserver.authorization.global_roles.ALL_ROLES
         all_roles.add(Role)
 
         return Role

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,28 +1,28 @@
-from .application import *  # noqa: F401, F403
-from .auditable_event import *  # noqa: F401, F403
-from .backend import *  # noqa: F401, F403
-from .backend_membership import *  # noqa: F401, F403
+from .application import *
+from .auditable_event import *
+from .backend import *
+from .backend_membership import *
 from .django.contrib.sessions.session import SessionFactory  # noqa: F401
-from .job import *  # noqa: F401, F403
-from .job_request import *  # noqa: F401, F403
-from .org import *  # noqa: F401, F403
-from .org_membership import *  # noqa: F401, F403
-from .project import *  # noqa: F401, F403
-from .project_collaboration import *  # noqa: F401, F403
-from .publish_request import *  # noqa: F401, F403
-from .rap_api import *  # noqa: F401, F403
-from .redirect import *  # noqa: F401, F403
-from .release import *  # noqa: F401, F403
-from .release_file import *  # noqa: F401, F403
-from .release_file_review import *  # noqa: F401, F403
-from .repo import *  # noqa: F401, F403
-from .site_alert import *  # noqa: F401, F403
-from .snapshot import *  # noqa: F401, F403
+from .job import *
+from .job_request import *
+from .org import *
+from .org_membership import *
+from .project import *
+from .project_collaboration import *
+from .publish_request import *
+from .rap_api import *
+from .redirect import *
+from .release import *
+from .release_file import *
+from .release_file_review import *
+from .repo import *
+from .site_alert import *
+from .snapshot import *
 from .social_django.association import AssociationFactory  # noqa: F401
 from .social_django.code import CodeFactory  # noqa: F401
 from .social_django.nonce import NonceFactory  # noqa: F401
 from .social_django.partial import PartialFactory  # noqa: F401
 from .social_django.user_social_auth import UserSocialAuthFactory  # noqa: F401
-from .stats import *  # noqa: F401, F403
-from .user import *  # noqa: F401, F403
-from .workspace import *  # noqa: F401, F403
+from .stats import *
+from .user import *
+from .workspace import *

--- a/tests/integration/staff/views/test_projects.py
+++ b/tests/integration/staff/views/test_projects.py
@@ -112,7 +112,7 @@ class TestProjectCreation:
         assert AuditableEvent.objects.filter(target_id=new_project.pk).count() == 1
 
         assert len(slack_messages) == 1
-        message, channel = slack_messages[0]
+        _, channel = slack_messages[0]
         assert channel == "co-pilot-support"
 
     # parametrisation covers both empty and omitted values for each

--- a/tests/integration/test_data_scrubbing.py
+++ b/tests/integration/test_data_scrubbing.py
@@ -79,7 +79,7 @@ def test_scrub_data_command_success(freezer):
                     f"{model_class.__name__}.{field_name} should have changed"
                 )
             else:
-                expected = fields_to_scrub[field_name]
+                expected = fake_value
                 assert actual == expected, (
                     f"{model_class.__name__}.{field_name} should be {expected!r}, got {actual!r}"
                 )

--- a/tests/unit/jobserver/actions/test_projects.py
+++ b/tests/unit/jobserver/actions/test_projects.py
@@ -151,10 +151,9 @@ def test_add_project_transaction_rollback(monkeypatch):
     # Force a rollback of the outer transaction after projects.add registers on_commit.
     # This seems simpler than patching to force the action transaction to raise
     # an error when rolling back.
-    with pytest.raises(RuntimeError):
-        with transaction.atomic():
-            projects.add(name="test", number=31337, orgs=[org0, org1], by=actor)
-            raise RuntimeError("force rollback")
+    with pytest.raises(RuntimeError), transaction.atomic():
+        projects.add(name="test", number=31337, orgs=[org0, org1], by=actor)
+        raise RuntimeError("force rollback")
 
     assert not mock_notify.called
     assert not AuditableEvent.objects.exists()

--- a/tests/unit/jobserver/api/test_jobs.py
+++ b/tests/unit/jobserver/api/test_jobs.py
@@ -784,7 +784,7 @@ def test_jobrequestapilist_success(api_rf):
 
     # Call jobs_status on each job request to ensure that its private _status field isn't stale
     for job_request in JobRequest.objects.all():
-        job_request.jobs_status
+        _ = job_request.jobs_status
 
     # Now we retrive the expected 3 actually active job requests
     response = JobRequestAPIList.as_view()(request)

--- a/tests/unit/jobserver/api/test_jobs.py
+++ b/tests/unit/jobserver/api/test_jobs.py
@@ -693,7 +693,7 @@ def test_jobrequestapilist_filter_by_created_at_date(api_rf):
 
     assert response.status_code == 200, response.data
     assert len(response.data["results"]) == 2
-    assert set([jr["identifier"] for jr in response.data["results"]]) == {
+    assert {jr["identifier"] for jr in response.data["results"]} == {
         included_job_request.identifier,
         old_job_request.identifier,
     }

--- a/tests/unit/jobserver/api/test_jobs.py
+++ b/tests/unit/jobserver/api/test_jobs.py
@@ -800,7 +800,7 @@ def test_jobrequestapilist_success(api_rf):
 
     # sort results based on the manually set identifiers because we don't care
     # about ordering here
-    results = list(sorted(results, key=lambda r: r["identifier"]))
+    results = sorted(results, key=lambda r: r["identifier"])
 
     assert results == [
         {

--- a/tests/unit/jobserver/auditing/presenters/test_lookup.py
+++ b/tests/unit/jobserver/auditing/presenters/test_lookup.py
@@ -8,14 +8,14 @@ from jobserver.models import AuditableEvent
 
 def test_get_presenter_with_known_type():
     class Fake:
-        type = AuditableEvent.Type.PROJECT_MEMBER_ADDED  # noqa: A003
+        type = AuditableEvent.Type.PROJECT_MEMBER_ADDED
 
     assert get_presenter(Fake()) == project_members.added
 
 
 def test_get_presenter_with_unknown_type():
     class Fake:
-        type = None  # noqa: A003
+        type = None
 
     with pytest.raises(UnknownPresenter):
         get_presenter(Fake())

--- a/tests/unit/jobserver/authorization/test_global_roles.py
+++ b/tests/unit/jobserver/authorization/test_global_roles.py
@@ -19,42 +19,36 @@ from jobserver.authorization.roles import (
 
 
 def test_global_role_names():
-    assert set(GLOBAL_ROLE_NAMES) == set(
-        [
-            "StaffAreaAdministrator",
-            "TechSupport",
-            "ServiceAdministrator",
-            "OutputChecker",
-            "OutputPublisher",
-            "ProjectCollaborator",
-            "SignOffRepoWithOutputs",
-            "DeploymentAdministrator",
-        ]
-    )
+    assert set(GLOBAL_ROLE_NAMES) == {
+        "StaffAreaAdministrator",
+        "TechSupport",
+        "ServiceAdministrator",
+        "OutputChecker",
+        "OutputPublisher",
+        "ProjectCollaborator",
+        "SignOffRepoWithOutputs",
+        "DeploymentAdministrator",
+    }
 
 
 def test_global_roles():
-    assert set(GLOBAL_ROLES) == set(
-        [
-            StaffAreaAdministrator,
-            TechSupport,
-            ServiceAdministrator,
-            OutputChecker,
-            OutputPublisher,
-            ProjectCollaborator,
-            SignOffRepoWithOutputs,
-            DeploymentAdministrator,
-        ]
-    )
+    assert set(GLOBAL_ROLES) == {
+        StaffAreaAdministrator,
+        TechSupport,
+        ServiceAdministrator,
+        OutputChecker,
+        OutputPublisher,
+        ProjectCollaborator,
+        SignOffRepoWithOutputs,
+        DeploymentAdministrator,
+    }
 
 
 def test_project_roles():
-    assert set(PROJECT_ROLES) == set(
-        [
-            ProjectDeveloper,
-            ProjectCollaborator,
-        ]
-    )
+    assert set(PROJECT_ROLES) == {
+        ProjectDeveloper,
+        ProjectCollaborator,
+    }
 
 
 def test_all_roles():

--- a/tests/unit/jobserver/management/commands/test_create_user.py
+++ b/tests/unit/jobserver/management/commands/test_create_user.py
@@ -34,7 +34,7 @@ def test_create_user_args(capsys):
 
     assert user.email == "foo@bar.com"
     assert user.fullname == "fullname"
-    assert set(user.roles) == set([OutputChecker, StaffAreaAdministrator])
+    assert set(user.roles) == {OutputChecker, StaffAreaAdministrator}
 
     # test idempotency
     call_command(

--- a/tests/unit/jobserver/management/commands/test_release.py
+++ b/tests/unit/jobserver/management/commands/test_release.py
@@ -31,7 +31,7 @@ def assert_expected_output(stdout, expected_files, workspace):
     for rf, ef in zip(release_files, expected_files):
         assert rf.path.endswith(ef.name)
         assert rf.name.endswith(ef.name)
-        ef.read_text() == rf.absolute_path().read_text()
+        assert ef.read_text() == rf.absolute_path().read_text()
 
 
 def prepare_release_files(release_dir):

--- a/tests/unit/jobserver/management/commands/test_remove_files_from_publish_request.py
+++ b/tests/unit/jobserver/management/commands/test_remove_files_from_publish_request.py
@@ -81,7 +81,7 @@ def test_remove_files_from_publish_request(n_to_remove=2):
         ReleaseFileFactory(
             workspace=snapshot.workspace, name=f"/release/test/file_to_remove-{n}.csv"
         )
-        for n in range(0, n_to_remove)
+        for n in range(n_to_remove)
     ]
 
     snapshot.files.add(release_file_to_keep)

--- a/tests/unit/jobserver/management/commands/test_remove_files_from_publish_request.py
+++ b/tests/unit/jobserver/management/commands/test_remove_files_from_publish_request.py
@@ -91,10 +91,8 @@ def test_remove_files_from_publish_request(n_to_remove=2):
     assert snapshot.files.count() == 1 + n_to_remove
     assert release_file_to_keep in snapshot.files.all()
     assert all(
-        [
-            release_file_to_remove in snapshot.files.all()
-            for release_file_to_remove in release_files_to_remove
-        ]
+        release_file_to_remove in snapshot.files.all()
+        for release_file_to_remove in release_files_to_remove
     )
 
     call_command(
@@ -112,10 +110,8 @@ def test_remove_files_from_publish_request(n_to_remove=2):
     assert snapshot.files.count() == 1
     assert release_file_to_keep in snapshot.files.all()
     assert all(
-        [
-            release_file_to_remove not in snapshot.files.all()
-            for release_file_to_remove in release_files_to_remove
-        ]
+        release_file_to_remove not in snapshot.files.all()
+        for release_file_to_remove in release_files_to_remove
     )
 
     assert f"{n_to_remove} files removed from" in out.getvalue()

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -181,7 +181,7 @@ def test_jobrequest_num_completed_no_jobs():
 def test_jobrequest_num_completed_success():
     job_request = JobRequestFactory()
 
-    job1, job2 = JobFactory.create_batch(2, job_request=job_request, status="succeeded")
+    JobFactory.create_batch(2, job_request=job_request, status="succeeded")
 
     assert job_request.num_completed == 2
 

--- a/tests/unit/jobserver/models/test_job_request.py
+++ b/tests/unit/jobserver/models/test_job_request.py
@@ -754,7 +754,7 @@ def test_jobrequest_jobs_status_without_prefetching_jobs(django_assert_num_queri
 
     assert not hasattr(job_request, "_prefetched_objects_cache")
 
-    job_request.jobs_status
+    _ = job_request.jobs_status
 
     assert "jobs" in job_request._prefetched_objects_cache
 

--- a/tests/unit/jobserver/models/test_release_file.py
+++ b/tests/unit/jobserver/models/test_release_file.py
@@ -115,7 +115,7 @@ def test_releasefile_get_api_url_with_is_published():
     rfile = ReleaseFileFactory()
 
     # mirror the SnapshotAPI view setting this value on the ReleaseFile object.
-    setattr(rfile, "is_published", True)
+    rfile.is_published = True
 
     url = rfile.get_api_url()
 

--- a/tests/unit/jobserver/models/test_repo.py
+++ b/tests/unit/jobserver/models/test_repo.py
@@ -90,7 +90,7 @@ def test_repo_get_staff_url():
 
 def test_repo_name_no_path():
     with pytest.raises(Exception, match="not in expected format"):
-        RepoFactory(url="http://example.com").name
+        _ = RepoFactory(url="http://example.com").name
 
 
 def test_repo_name_success():
@@ -99,7 +99,7 @@ def test_repo_name_success():
 
 def test_repo_owner_no_path():
     with pytest.raises(Exception, match="not in expected format"):
-        RepoFactory(url="http://example.com").owner
+        _ = RepoFactory(url="http://example.com").owner
 
 
 def test_repo_owner_success():

--- a/tests/unit/jobserver/permissions/test_validator.py
+++ b/tests/unit/jobserver/permissions/test_validator.py
@@ -48,7 +48,7 @@ project_identifier_test_cases = [
     # so the behaviour should be as the lists.
     # An empty dict is allowed.
     (
-        dict(),
+        {},
         [],
     ),
     (

--- a/tests/unit/jobserver/permissions/test_validator.py
+++ b/tests/unit/jobserver/permissions/test_validator.py
@@ -9,17 +9,12 @@ class StubRegexPattern:
     The regex used is already tested elsewhere in the codebase."""
 
     def fullmatch(self, value):
-        return (
-            True
-            if value
-            in {
-                "123",
-                "456",
-                "POS-2026-1001",
-                "POS-2026-1002",
-            }
-            else False
-        )
+        return value in {
+            "123",
+            "456",
+            "POS-2026-1001",
+            "POS-2026-1002",
+        }
 
 
 # We use the identifiers also as names in the tests.

--- a/tests/unit/jobserver/test_honeycomb.py
+++ b/tests/unit/jobserver/test_honeycomb.py
@@ -136,7 +136,7 @@ def test_previous_actions_link(freezer):
 
     workspace = WorkspaceFactory(name="my_test_workspace")
     job_request = JobRequestFactory(identifier="jpbaeldzjqqiaolg", workspace=workspace)
-    job = JobFactory(  # noqa: F841
+    job = JobFactory(
         job_request=job_request,
         completed_at=timezone.now(),
         status="succeeded",

--- a/tests/unit/jobserver/test_icons.py
+++ b/tests/unit/jobserver/test_icons.py
@@ -15,11 +15,11 @@ def find_icon_tag_names_used():
     # We use a sorted list so that the different xdist workers get a consistent ordering.
     # https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#order-and-amount-of-test-must-be-consistent
     return sorted(
-        set(
+        {
             icon_tag_name
             for path in template_paths
             for icon_tag_name in icon_pattern.findall(path.read_text())
-        )
+        }
     )
 
 

--- a/tests/unit/jobserver/test_pipeline_config.py
+++ b/tests/unit/jobserver/test_pipeline_config.py
@@ -46,16 +46,14 @@ def link_func(path):
 
 def test_check_cohortextractor_usage():
     config = Pipeline.build(
-        **{
-            "version": 3,
-            "expectations": {"population_size": 1000},
-            "actions": {
-                "generate_study_population": {
-                    "run": "cohortextractor:latest generate_cohort",
-                    "outputs": {"highly_sensitive": {"cohort": "some/path.csv"}},
-                },
+        version=3,
+        expectations={"population_size": 1000},
+        actions={
+            "generate_study_population": {
+                "run": "cohortextractor:latest generate_cohort",
+                "outputs": {"highly_sensitive": {"cohort": "some/path.csv"}},
             },
-        }
+        },
     )
 
     with pytest.raises(ActionConfigError):
@@ -64,16 +62,14 @@ def test_check_cohortextractor_usage():
 
 def test_check_cohortextractor_usage_no_cohort_extractor_actions():
     config = Pipeline.build(
-        **{
-            "version": 3,
-            "expectations": {"population_size": 1000},
-            "actions": {
-                "generate_study_population": {
-                    "run": "ehrql:v1 generate-dataset --output some/path.csv",
-                    "outputs": {"highly_sensitive": {"dataset": "some/path.csv"}},
-                },
+        version=3,
+        expectations={"population_size": 1000},
+        actions={
+            "generate_study_population": {
+                "run": "ehrql:v1 generate-dataset --output some/path.csv",
+                "outputs": {"highly_sensitive": {"dataset": "some/path.csv"}},
             },
-        }
+        },
     )
 
     check_cohortextractor_usage(config)
@@ -81,16 +77,14 @@ def test_check_cohortextractor_usage_no_cohort_extractor_actions():
 
 def test_check_sqlrunner_permission():
     config = Pipeline.build(
-        **{
-            "version": 3,
-            "expectations": {"population_size": 1000},
-            "actions": {
-                "query": {
-                    "run": "sqlrunner:latest",
-                    "outputs": {"highly_sensitive": {"output": "some/path.csv"}},
-                },
+        version=3,
+        expectations={"population_size": 1000},
+        actions={
+            "query": {
+                "run": "sqlrunner:latest",
+                "outputs": {"highly_sensitive": {"output": "some/path.csv"}},
             },
-        }
+        },
     )
 
     # The internal project has permission
@@ -103,16 +97,14 @@ def test_check_sqlrunner_permission():
 
 def test_check_sqlrunner_permission_no_sqlrunner_actions():
     config = Pipeline.build(
-        **{
-            "version": 3,
-            "expectations": {"population_size": 1000},
-            "actions": {
-                "generate_study_population": {
-                    "run": "ehrql:v1 generate-dataset --output some/path.csv",
-                    "outputs": {"highly_sensitive": {"dataset": "some/path.csv"}},
-                },
+        version=3,
+        expectations={"population_size": 1000},
+        actions={
+            "generate_study_population": {
+                "run": "ehrql:v1 generate-dataset --output some/path.csv",
+                "outputs": {"highly_sensitive": {"dataset": "some/path.csv"}},
             },
-        }
+        },
     )
 
     # Project 1 doesn't have permission to run SQL Runner, but there are no SQL Runner,
@@ -122,16 +114,14 @@ def test_check_sqlrunner_permission_no_sqlrunner_actions():
 
 def test_get_actions_missing_needs():
     dummy = Pipeline.build(
-        **{
-            "version": 3,
-            "expectations": {"population_size": 1000},
-            "actions": {
-                "frobnicate": {
-                    "run": "test:latest",
-                    "outputs": {"highly_sensitive": {"cohort": "some/path.csv"}},
-                },
+        version=3,
+        expectations={"population_size": 1000},
+        actions={
+            "frobnicate": {
+                "run": "test:latest",
+                "outputs": {"highly_sensitive": {"cohort": "some/path.csv"}},
             },
-        }
+        },
     )
     output = list(get_actions(dummy))
 
@@ -144,21 +134,19 @@ def test_get_actions_missing_needs():
 
 def test_get_actions_no_run_all():
     dummy = Pipeline.build(
-        **{
-            "version": 3,
-            "expectations": {"population_size": 1000},
-            "actions": {
-                "frobnicate": {
-                    "run": "test1:latest",
-                    "outputs": {"highly_sensitive": {"cohort": "some/path1.csv"}},
-                },
-                "run_all": {
-                    "needs": ["frobnicate"],
-                    "run": "test2:latest",
-                    "outputs": {"highly_sensitive": {"cohort": "some/path2.csv"}},
-                },
+        version=3,
+        expectations={"population_size": 1000},
+        actions={
+            "frobnicate": {
+                "run": "test1:latest",
+                "outputs": {"highly_sensitive": {"cohort": "some/path1.csv"}},
             },
-        }
+            "run_all": {
+                "needs": ["frobnicate"],
+                "run": "test2:latest",
+                "outputs": {"highly_sensitive": {"cohort": "some/path2.csv"}},
+            },
+        },
     )
 
     output = list(get_actions(dummy))
@@ -172,16 +160,14 @@ def test_get_actions_no_run_all():
 
 def test_get_actions_success():
     content = Pipeline.build(
-        **{
-            "version": 3,
-            "expectations": {"population_size": 1000},
-            "actions": {
-                "frobnicate": {
-                    "run": "test:latest",
-                    "outputs": {"highly_sensitive": {"cohort": "some/path.csv"}},
-                },
+        version=3,
+        expectations={"population_size": 1000},
+        actions={
+            "frobnicate": {
+                "run": "test:latest",
+                "outputs": {"highly_sensitive": {"cohort": "some/path.csv"}},
             },
-        }
+        },
     )
     output = list(get_actions(content))
 
@@ -537,10 +523,6 @@ def test_render_definition():
 )
 def test_get_database_actions(actions, expected_db_actions):
     content = Pipeline.build(
-        **{
-            "version": 3,
-            "expectations": {"population_size": 1000},
-            "actions": actions,
-        }
+        version=3, expectations={"population_size": 1000}, actions=actions
     )
     assert list(get_database_actions(content)) == expected_db_actions

--- a/tests/unit/jobserver/test_releases.py
+++ b/tests/unit/jobserver/test_releases.py
@@ -88,13 +88,15 @@ def test_create_release_already_exists(build_release):
     workspace = WorkspaceFactory(name="workspace")
     backend = BackendFactory()
 
+    file_size = 4
+    file_sha256 = "hash"
     files = [
         {
             "name": "file1.txt",
             "path": "path/to/file1.txt",
             "url": "",
-            "size": 4,
-            "sha256": "hash",
+            "size": file_size,
+            "sha256": file_sha256,
             "date": "2022-08-17T13:37Z",
             "metadata": {},
         }
@@ -103,7 +105,9 @@ def test_create_release_already_exists(build_release):
     existing_release = ReleaseFactory(
         requested_files=files, workspace=workspace, backend=backend
     )
-    ReleaseFileFactory(release=existing_release, name="file1.txt")
+    ReleaseFileFactory(
+        release=existing_release, name="file1.txt", size=file_size, filehash=file_sha256
+    )
     assert Release.objects.count() == 1
 
     release = releases.create_release(
@@ -119,8 +123,8 @@ def test_create_release_already_exists(build_release):
     assert release.files.count() == 1
 
     rfile = release.files.first()
-    rfile.filehash == "hash"
-    rfile.size == 4
+    assert rfile.filehash == "hash"
+    assert rfile.size == 4
 
 
 def test_create_release_already_exists_file_mismatch():
@@ -189,8 +193,8 @@ def test_create_release_success():
     assert release.files.count() == 1
 
     rfile = release.files.first()
-    rfile.filehash == "hash"
-    rfile.size == 7
+    assert rfile.filehash == "hash"
+    assert rfile.size == 7
 
 
 def test_handle_release_upload_file_created(build_release, file_content):

--- a/tests/unit/services/test_logging.py
+++ b/tests/unit/services/test_logging.py
@@ -34,11 +34,11 @@ def test_missing_variable_error_filter_with_ignored_prefix():
     template = Template("*{{ my_missing_variable }}*", name="admin/index.html")
     context = Context({"my_variable": "my_value"})
 
-    template.render(context) == "**"
+    assert template.render(context) == "**"
 
 
 def test_missing_variable_error_filter_with_ignored_variable_name():
     template = Template("*{{ csp_nonce }}*", name="index.html")
     context = Context({"csp_nonce": "csp_nonce_value"})
 
-    template.render(context) == "*csp_nonce_value*"
+    assert template.render(context) == "*csp_nonce_value*"

--- a/tests/unit/services/test_logging.py
+++ b/tests/unit/services/test_logging.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from django.template import Context, Template
@@ -9,11 +9,11 @@ from services.logging import timestamper
 def test_timestamper_with_debug(monkeypatch, freezer):
     monkeypatch.setattr("services.logging.DEBUG", True)
 
-    now = datetime.now()
+    now = datetime.now(tz=UTC)
     freezer.move_to(now)
 
     log = timestamper(None, None, {"event": "derp"})
-    assert log == {"event": "derp", "timestamp": now.isoformat() + "Z"}
+    assert log == {"event": "derp", "timestamp": now.isoformat().replace("+00:00", "Z")}
 
 
 def test_timestamper_without_debug(monkeypatch):

--- a/tests/unit/staff/views/test_applications.py
+++ b/tests/unit/staff/views/test_applications.py
@@ -430,7 +430,7 @@ def test_applicationdetail_post_with_incomplete_application(
 
     # Check that a page instance has not been created
     with pytest.raises(ObjectDoesNotExist):
-        application.researcherdetailspage
+        _ = application.researcherdetailspage
 
 
 def test_applicationedit_get_success(rf, staff_area_administrator):

--- a/tests/unit/staff/views/test_workspaces.py
+++ b/tests/unit/staff/views/test_workspaces.py
@@ -80,7 +80,7 @@ def test_workspaceedit_post_success(rf, staff_area_administrator):
     assert workspace.uses_new_release_flow
     assert workspace.purpose == "new value"
 
-    Redirect.objects.count() == 1
+    assert Redirect.objects.count() == 1
     redirect = Redirect.objects.first()
     assert redirect.workspace == workspace
     assert redirect.old_url == workspace.get_absolute_url().replace(

--- a/tests/verification/utils.py
+++ b/tests/verification/utils.py
@@ -29,7 +29,7 @@ def assert_deep_type_equality(fake, real):
         assert key in real and isinstance(value, type(real[key]))
 
         if isinstance(value, dict):
-            assert_deep_type_equality(fake[key], real[key])
+            assert_deep_type_equality(value, real[key])
 
 
 def _get_public_method_signatures(cls, ignored_methods):


### PR DESCRIPTION
See #6033.

This PR fixes our code to be compliant with most of the new default rules in Ruff v0.16.

The remaining new rules not yet enabled are listed in [a comment in #6033](https://github.com/opensafely-core/job-server/issues/6033#issuecomment-5207296503).

Many of these fixes are the autogenerated ones by Ruff. A few needed manual review and editing of the automated fixes, or more extensive intervention. In entirely automated cases, I reviewed the fixed diffs.